### PR TITLE
fix: resolve typecheck failures blocking v0.2.0 release

### DIFF
--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -50,6 +50,20 @@ declare global {
       onClaudeRemoveElement: (callback: (uri: string, type: string) => void) => () => void
       onClaudeValidate: (callback: () => void) => () => void
 
+      // Eval operations
+      runEval: (payload: {
+        turtle: string
+        domain: string
+        intendedUse: string
+        auth: { mode: 'api-key'; key: string } | { mode: 'max' }
+        model: string
+        effort: string
+      }) => Promise<void>
+      abortEval: () => Promise<void>
+      onEvalText: (callback: (text: string) => void) => () => void
+      onEvalResult: (callback: (reportJson: string) => void) => () => void
+      onEvalError: (callback: (error: string) => void) => () => void
+
       // Respond to main process
       respondOntology: (turtle: string) => void
       respondValidation: (errors: string) => void

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useRef, useState, useMemo } from 'react'
+import { useEffect, useCallback, useRef, useState } from 'react'
 import { GraphCanvas } from './components/graph/GraphCanvas'
 import { DetailPanel } from './components/detail/DetailPanel'
 import { ChatPanel } from './components/chat/ChatPanel'
@@ -191,7 +191,7 @@ function App(): React.JSX.Element {
 
       <ResizablePanelGroup orientation="horizontal" className="flex-1 overflow-hidden" id="main-layout">
         {/* Graph Canvas */}
-        <ResizablePanel id="graph-panel" defaultSize="70%" minSize="30%" order={1}>
+        <ResizablePanel id="graph-panel" defaultSize="70%" minSize="30%">
           <div className="relative w-full h-full">
             {/* Graph controls overlay — top left */}
             <div className="absolute top-2 left-2 z-10">
@@ -264,7 +264,6 @@ function App(): React.JSX.Element {
           collapsible
           collapsedSize={0}
           panelRef={sidebarRef}
-          order={2}
         >
           <div className="flex h-full bg-background">
             {/* Panel content */}

--- a/apps/desktop/src/renderer/src/components/chat/useClaude.ts
+++ b/apps/desktop/src/renderer/src/components/chat/useClaude.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useOntologyStore } from '@renderer/store/ontology'
+import type { OntologyClass } from '@renderer/model/types'
 import { serializeToTurtle } from '@renderer/model/serialize'
 import { validateOntology } from '@renderer/services/validation'
 
@@ -144,7 +145,7 @@ export function useClaude(): UseClaudeReturn {
 
       // Modify class
       window.api.onClaudeModifyClass((uri: string, changes: Record<string, unknown>) => {
-        store.getState().updateClass(uri, changes as Parameters<typeof store.getState['updateClass']>[1])
+        store.getState().updateClass(uri, changes as Partial<OntologyClass>)
       }),
 
       // Remove element

--- a/apps/desktop/tsconfig.node.json
+++ b/apps/desktop/tsconfig.node.json
@@ -6,6 +6,7 @@
     "src/preload/**/*"
   ],
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "types": ["electron-vite/node"]
   }
 }


### PR DESCRIPTION
## Summary
- Set `moduleResolution` to `"bundler"` in `tsconfig.node.json` to fix `@tailwindcss/vite` module resolution
- Add missing eval IPC method types (`runEval`, `abortEval`, `onEvalText`, `onEvalResult`, `onEvalError`) to `preload/index.d.ts`
- Fix `updateClass` type access in `useClaude.ts`
- Remove unused `useMemo` import and invalid `order` prop in `App.tsx`

## Test plan
- [x] `bun run typecheck` passes (both node and web configs)
- [x] `bun run test` — 191/191 tests pass
- [ ] QA re-validation for release readiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>