### PR TITLE
fix: use productName in electron-builder artifact names

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -15,7 +15,7 @@ win:
   executableName: Ontograph
   icon: build/icon.ico
 nsis:
-  artifactName: ${name}-${version}-setup.${ext}
+  artifactName: ${productName}-${version}-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
@@ -29,7 +29,7 @@ mac:
     - dmg
     - zip
 dmg:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: ${productName}-${version}.${ext}
 linux:
   icon: build/icon.png
   target:
@@ -38,7 +38,7 @@ linux:
   maintainer: applification.co.uk
   category: Development
 appImage:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: ${productName}-${version}.${ext}
 npmRebuild: false
 publish:
   provider: github


### PR DESCRIPTION
## Summary
- Scoped package name `@ontograph/desktop` resolves `${name}` to a path with `/`, causing `mksquashfs` to fail with "No such file or directory"
- Switch all `artifactName` templates from `${name}` to `${productName}` (resolves to `Ontograph`)
- Fixes Linux AppImage, macOS DMG, and Windows NSIS installer artifact paths

## Context
v0.2.0 release CI failed on Linux build due to this issue. After merging, we'll need to re-tag and re-release.

## Test plan
- [ ] Merge and re-run release workflow
- [ ] Verify all three platform builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>