### PR TITLE
fix: add homepage for Linux deb build

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -37,6 +37,8 @@ linux:
     - deb
   maintainer: applification.co.uk
   category: Development
+deb:
+  artifactName: ${productName}-${version}-${arch}.${ext}
 appImage:
   artifactName: ${productName}-${version}.${ext}
 npmRebuild: false

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "description": "A modern ontology editor with Claude integration",
   "main": "./out/main/index.js",
+  "homepage": "https://github.com/DaveHudson/Ontograph",
   "author": "Applification Ltd",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add `homepage` field to `apps/desktop/package.json` — required by electron-builder's FPM target for `.deb` packaging
- Add explicit `deb.artifactName` using `${productName}` to avoid scoped package name in artifact filenames

## Context
v0.2.0 release CI failed on Linux because the `.deb` build requires project homepage metadata. AppImage and all other platforms succeeded.

## Test plan
- [ ] Verify Linux CI builds both AppImage and .deb successfully
- [ ] Verify macOS and Windows builds still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)