### PR TITLE
feat: ONT-23 brand design system update

### DIFF
--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Oxanium:wght@200..800&family=Geist+Mono:wght@100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap');
 @import 'tailwindcss';
 @import 'streamdown/styles.css';
 
@@ -7,102 +7,102 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.147 0.004 49.3);
+  --background: oklch(0.985 0.003 270);
+  --foreground: oklch(0.15 0.015 270);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.147 0.004 49.3);
+  --card-foreground: oklch(0.15 0.015 270);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.147 0.004 49.3);
-  --primary: oklch(0.52 0.105 223.128);
-  --primary-foreground: oklch(0.984 0.019 200.873);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.96 0.002 17.2);
-  --muted-foreground: oklch(0.547 0.021 43.1);
-  --accent: oklch(0.96 0.002 17.2);
-  --accent-foreground: oklch(0.214 0.009 43.1);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0.005 34.3);
-  --input: oklch(0.922 0.005 34.3);
-  --ring: oklch(0.714 0.014 41.2);
-  --chart-1: oklch(0.879 0.169 91.605);
-  --chart-2: oklch(0.769 0.188 70.08);
-  --chart-3: oklch(0.666 0.179 58.318);
-  --chart-4: oklch(0.555 0.163 48.998);
-  --chart-5: oklch(0.473 0.137 46.201);
-  --radius: 0.625rem;
-  --success: oklch(0.45 0.15 145);
+  --popover-foreground: oklch(0.15 0.015 270);
+  --primary: oklch(0.45 0.15 270);
+  --primary-foreground: oklch(0.99 0 0);
+  --secondary: oklch(0.96 0.005 270);
+  --secondary-foreground: oklch(0.20 0.015 270);
+  --muted: oklch(0.96 0.005 270);
+  --muted-foreground: oklch(0.50 0.02 270);
+  --accent: oklch(0.75 0.15 195);
+  --accent-foreground: oklch(0.15 0.015 270);
+  --destructive: oklch(0.60 0.22 15);
+  --destructive-foreground: oklch(0.60 0.22 15);
+  --border: oklch(0.92 0.005 270);
+  --input: oklch(0.92 0.005 270);
+  --ring: oklch(0.65 0.12 280);
+  --chart-1: oklch(0.55 0.15 270);
+  --chart-2: oklch(0.75 0.15 195);
+  --chart-3: oklch(0.80 0.16 80);
+  --chart-4: oklch(0.55 0.17 155);
+  --chart-5: oklch(0.60 0.22 15);
+  --radius: 0.5rem;
+  --success: oklch(0.55 0.17 155);
   --success-foreground: oklch(0.985 0 0);
-  --warning: oklch(0.65 0.18 75);
+  --warning: oklch(0.80 0.16 80);
   --warning-foreground: oklch(0.145 0 0);
 
   /* Graph-specific tokens */
-  --primary-display: oklch(0.52 0.105 223.128);
+  --primary-display: oklch(0.45 0.15 270);
 
-  --graph-bg: oklch(0.96 0.002 17.2);
-  --graph-node-class: oklch(0.52 0.105 223.128);
-  --graph-node-header-bg: oklch(0.52 0.105 223.128 / 0.9);
-  --graph-node-header-text: oklch(0.984 0.019 200.873);
-  --graph-node-body-bg: oklch(0.96 0.002 17.2 / 0.85);
-  --graph-node-border: oklch(0.52 0.105 223.128 / 0.25);
-  --graph-node-selected: var(--chart-2);
-  --graph-node-selected-bg: oklch(0.769 0.188 70.08 / 0.1);
-  --graph-node-adjacent: oklch(0.769 0.188 70.08 / 0.45);
-  --graph-edge-property: oklch(0.52 0.045 223.128);
-  --graph-edge-disjoint: oklch(0.50 0.055 27.325);
-  --graph-edge-subclass: oklch(0.45 0.05 49.3);
+  --graph-bg: oklch(0.96 0.005 270);
+  --graph-node-class: oklch(0.45 0.15 270);
+  --graph-node-header-bg: oklch(0.45 0.15 270 / 0.9);
+  --graph-node-header-text: oklch(0.99 0 0);
+  --graph-node-body-bg: oklch(0.96 0.005 270 / 0.85);
+  --graph-node-border: oklch(0.45 0.15 270 / 0.25);
+  --graph-node-selected: oklch(0.75 0.15 195);
+  --graph-node-selected-bg: oklch(0.75 0.15 195 / 0.1);
+  --graph-node-adjacent: oklch(0.75 0.15 195 / 0.45);
+  --graph-edge-property: oklch(0.65 0.12 280);
+  --graph-edge-disjoint: oklch(0.60 0.12 15);
+  --graph-edge-subclass: oklch(0.50 0.02 270);
 }
 
 .dark {
-  --background: oklch(0.147 0.004 49.3);
-  --foreground: oklch(0.986 0.002 67.8);
-  --card: oklch(0.214 0.009 43.1);
-  --card-foreground: oklch(0.986 0.002 67.8);
-  --popover: oklch(0.214 0.009 43.1);
-  --popover-foreground: oklch(0.986 0.002 67.8);
-  --primary: oklch(0.45 0.085 224.283);
-  --primary-foreground: oklch(0.984 0.019 200.873);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.268 0.011 36.5);
-  --muted-foreground: oklch(0.714 0.014 41.2);
-  --accent: oklch(0.268 0.011 36.5);
-  --accent-foreground: oklch(0.986 0.002 67.8);
-  --destructive: oklch(0.704 0.191 22.216);
-  --destructive-foreground: oklch(0.986 0.002 67.8);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.547 0.021 43.1);
-  --chart-1: oklch(0.879 0.169 91.605);
-  --chart-2: oklch(0.769 0.188 70.08);
-  --chart-3: oklch(0.666 0.179 58.318);
-  --chart-4: oklch(0.555 0.163 48.998);
-  --chart-5: oklch(0.473 0.137 46.201);
-  --success: oklch(0.55 0.18 145);
-  --success-foreground: oklch(0.145 0 0);
-  --warning: oklch(0.75 0.18 75);
-  --warning-foreground: oklch(0.145 0 0);
+  --background: oklch(0.15 0.015 270);
+  --foreground: oklch(0.95 0.003 270);
+  --card: oklch(0.20 0.012 270);
+  --card-foreground: oklch(0.95 0.003 270);
+  --popover: oklch(0.20 0.012 270);
+  --popover-foreground: oklch(0.95 0.003 270);
+  --primary: oklch(0.65 0.12 280);
+  --primary-foreground: oklch(0.99 0 0);
+  --secondary: oklch(0.25 0.010 270);
+  --secondary-foreground: oklch(0.95 0.003 270);
+  --muted: oklch(0.25 0.010 270);
+  --muted-foreground: oklch(0.65 0.015 270);
+  --accent: oklch(0.75 0.15 195);
+  --accent-foreground: oklch(0.95 0.003 270);
+  --destructive: oklch(0.65 0.20 15);
+  --destructive-foreground: oklch(0.95 0.003 270);
+  --border: oklch(0.30 0.008 270);
+  --input: oklch(0.30 0.012 270);
+  --ring: oklch(0.65 0.12 280);
+  --chart-1: oklch(0.65 0.12 280);
+  --chart-2: oklch(0.75 0.15 195);
+  --chart-3: oklch(0.80 0.16 80);
+  --chart-4: oklch(0.55 0.17 155);
+  --chart-5: oklch(0.65 0.20 15);
+  --success: oklch(0.55 0.17 155);
+  --success-foreground: oklch(0.15 0.015 270);
+  --warning: oklch(0.80 0.16 80);
+  --warning-foreground: oklch(0.15 0.015 270);
 
   /* Graph-specific tokens (dark) */
-  --primary-display: oklch(0.715 0.143 215.221);
+  --primary-display: oklch(0.65 0.12 280);
 
-  --graph-bg: oklch(0.214 0.009 43.1);
-  --graph-node-class: oklch(0.715 0.143 215.221);
-  --graph-node-header-bg: oklch(0.45 0.085 224.283 / 0.9);
-  --graph-node-header-text: oklch(0.984 0.019 200.873);
-  --graph-node-body-bg: oklch(0.214 0.009 43.1 / 0.92);
-  --graph-node-border: oklch(1 0 0 / 0.08);
-  --graph-node-selected: var(--chart-2);
-  --graph-node-selected-bg: oklch(0.769 0.188 70.08 / 0.1);
-  --graph-node-adjacent: oklch(0.769 0.188 70.08 / 0.45);
-  --graph-edge-property: oklch(0.65 0.04 215.221);
-  --graph-edge-disjoint: oklch(0.65 0.055 22.216);
-  --graph-edge-subclass: oklch(0.714 0.014 41.2);
+  --graph-bg: oklch(0.20 0.012 270);
+  --graph-node-class: oklch(0.65 0.12 280);
+  --graph-node-header-bg: oklch(0.45 0.15 270 / 0.9);
+  --graph-node-header-text: oklch(0.99 0 0);
+  --graph-node-body-bg: oklch(0.20 0.012 270 / 0.92);
+  --graph-node-border: oklch(0.30 0.008 270);
+  --graph-node-selected: oklch(0.75 0.15 195);
+  --graph-node-selected-bg: oklch(0.75 0.15 195 / 0.1);
+  --graph-node-adjacent: oklch(0.75 0.15 195 / 0.45);
+  --graph-edge-property: oklch(0.65 0.08 280);
+  --graph-edge-disjoint: oklch(0.65 0.12 15);
+  --graph-edge-subclass: oklch(0.65 0.015 270);
 }
 
 @theme inline {
-  --font-sans: 'Oxanium', sans-serif;
+  --font-sans: 'Geist', sans-serif;
   --font-mono: 'Geist Mono', monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -167,7 +167,7 @@
 
 body {
   @apply bg-background text-foreground;
-  font-family: 'Oxanium', sans-serif;
+  font-family: 'Geist', sans-serif;
   margin: 0;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- **Typography**: Replaced Oxanium with Geist Sans (keeping Geist Mono) for better readability and modern feel
- **Colors**: New indigo primary (`oklch(0.45 0.15 270)`) + electric cyan accent (`oklch(0.75 0.15 195)`) replacing the previous teal/warm-neutral palette
- **Neutrals**: Cool-tinted (270° hue) neutrals for cohesive indigo feel across light and dark modes
- **Graph tokens**: Updated all graph-specific color tokens to use new palette
- **Radius**: Adjusted from 0.625rem to 0.5rem (8px)

Part of ONT-23 Brand Design. Approved by board — all recommendations accepted.

## Test plan
- [ ] Visual inspection of light mode
- [ ] Visual inspection of dark mode
- [ ] Graph canvas node/edge colors render correctly
- [ ] Font renders as Geist Sans (not Oxanium)
- [ ] All shadcn/ui components inherit new tokens properly
- [ ] Build passes (`bun run build` ✅)
- [ ] Typecheck passes (`bun run typecheck` ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)