### PR TITLE
fix: ONT-23 marketing website styling

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,10 +9,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "geist": "^1.7.0",
+    "lucide-react": "^1.6.0",
     "next": "15.3.3",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "lucide-react": "^1.6.0"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,21 +1,20 @@
-@import url('https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap');
 @import 'tailwindcss';
 
 :root {
-  --background: oklch(0.15 0.015 270);
-  --foreground: oklch(0.95 0.003 270);
-  --primary: oklch(0.65 0.12 280);
-  --primary-deep: oklch(0.45 0.15 270);
-  --accent: oklch(0.75 0.15 195);
-  --muted: oklch(0.25 0.010 270);
-  --muted-foreground: oklch(0.65 0.015 270);
-  --border: oklch(0.30 0.008 270);
-  --card: oklch(0.20 0.012 270);
+  --background: #0f0d1a;
+  --foreground: #eeedf2;
+  --primary: #818cf8;
+  --primary-deep: #4f46e5;
+  --accent: #22d3ee;
+  --muted: #1e1b2e;
+  --muted-foreground: #9490a8;
+  --border: #2a2740;
+  --card: #1a1728;
 }
 
 @theme inline {
-  --font-sans: 'Geist', sans-serif;
-  --font-mono: 'Geist Mono', monospace;
+  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-primary: var(--primary);
@@ -34,7 +33,7 @@
 }
 
 body {
-  font-family: 'Geist', sans-serif;
+  font-family: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
   background: var(--background);
   color: var(--foreground);
   -webkit-font-smoothing: antialiased;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import { GeistSans } from 'geist/font/sans'
+import { GeistMono } from 'geist/font/mono'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -14,7 +16,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
       <body className="min-h-screen bg-background text-foreground antialiased">
         {children}
       </body>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -46,7 +46,7 @@ export default function Home() {
             </a>
             <a
               href="#download"
-              className="bg-primary text-background px-4 py-1.5 rounded-lg text-sm font-medium hover:opacity-90 transition-opacity"
+              className="bg-primary text-white px-4 py-1.5 rounded-lg text-sm font-medium hover:opacity-90 transition-opacity"
             >
               Download
             </a>
@@ -55,7 +55,7 @@ export default function Home() {
       </nav>
 
       {/* Hero */}
-      <section className="relative pt-32 pb-24 px-6">
+      <section className="relative pt-40 pb-24 px-6">
         {/* Dot grid background */}
         <div
           className="absolute inset-0 opacity-[0.04]"
@@ -83,7 +83,7 @@ export default function Home() {
           <div className="flex items-center justify-center gap-4">
             <a
               href="#download"
-              className="inline-flex items-center gap-2 bg-primary text-background px-6 py-3 rounded-lg font-medium hover:opacity-90 transition-opacity"
+              className="inline-flex items-center gap-2 bg-primary text-white px-6 py-3 rounded-lg font-medium hover:opacity-90 transition-opacity"
             >
               <Download className="size-4" />
               Download for free

--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,7 @@
       "name": "@ontograph/web",
       "version": "0.1.0",
       "dependencies": {
+        "geist": "^1.7.0",
         "lucide-react": "^1.6.0",
         "next": "15.3.3",
         "react": "^19.1.0",
@@ -1108,6 +1109,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "geist": ["geist@1.7.0", "", { "peerDependencies": { "next": ">=13.2.0" } }, "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 


### PR DESCRIPTION
## Summary
Fixes styling issues reported by the board:
- **Font loading**: Replaced broken Google Fonts import (Geist isn't on GFonts) with the `geist` npm package + `next/font` integration
- **Colors**: Switched from OKLCH to hex values for consistent cross-browser rendering
- **Contrast**: Button text now uses explicit white instead of theme background color
- **Spacing**: Increased hero section top padding to prevent nav overlap

## Test plan
- [x] Verified in browser — fonts, colors, and layout all rendering correctly
- [x] Build passes
- [ ] Visual review by board

🤖 Generated with [Claude Code](https://claude.com/claude-code)