### PR TITLE
feat: core marketing message and website redesign

### DIFF
--- a/Marketing/core-messaging.md
+++ b/Marketing/core-messaging.md
@@ -1,60 +1,66 @@
 # Core Messaging
 
+## Strategic Context
+
+Ontologies are becoming critical infrastructure for AI-first applications. Platforms like TrustGraph demonstrate that ontologies ground AI agents in verified, typed knowledge — eliminating hallucination and enabling explainability. But the bottleneck is ontology creation itself: it requires domain expertise, iterative refinement, and complex tooling.
+
+**Ontograph removes this bottleneck.** We make ontology creation accessible to AI Product Engineers — the people building the next generation of AI-first apps.
+
 ## Messaging Direction
 
-**Positive-first.** We lead with what Ontograph uniquely enables, not what competitors lack. The two differentiators that define our positioning:
+**Positive-first, outcome-oriented.** We lead with what Ontograph uniquely enables for AI builders, not what competitors lack. Three core differentiators:
 
-1. **Deep AI/LLM integration** - Claude understands OWL semantics and helps you build, refine, and validate ontologies through natural language conversation
-2. **Modern visual editor** - A graph-first interface where you see your knowledge structure take shape as you build it
+1. **Deep AI/LLM integration** — Describe your domain in natural language; Claude builds the formal OWL structure
+2. **Modern visual editor** — See your ontology as a living, interactive graph as you build it
+3. **Built for the AI stack** — Create ontologies that power RAG pipelines, AI agents, and context graphs
 
 ## Tagline
 
 **"Where knowledge takes shape."**
 
-This remains strong — it's positive, evocative, and captures both the visual (shape) and conceptual (knowledge) aspects of the product.
+Strong brand anchor — captures both the visual (shape) and semantic (knowledge) aspects.
 
 ## Hero Headlines — Revised Options
 
-The previous hero headline ("Building ontologies shouldn't feel like writing XML in a 2005 Java app") is effective as a pain point but frames us negatively against competitors. Here are positive alternatives:
-
 ### Option A (Recommended)
-> **Describe your domain. Watch your ontology emerge.**
+> **Build the knowledge layer your AI agents need.**
 >
-> Ontograph pairs a visual graph editor with AI that understands OWL — so you can build formal ontologies through natural language conversation.
+> Ontograph pairs a visual graph editor with AI that understands OWL — so you can create production-ready ontologies through natural language.
 
-Why: Leads with the magical moment (describe -> emerge). Positions AI as the primary differentiator. Action-oriented.
+Why: Speaks directly to AI Product Engineers. Frames ontologies as infrastructure their AI apps need. Positions Ontograph as the fastest path to get there.
 
 ### Option B
-> **The AI-native ontology editor.**
+> **Describe your domain. Watch your ontology emerge.**
 >
-> Build, visualize, and validate ontologies with Claude — an AI that speaks OWL, RDF, and plain English.
+> Create the structured knowledge that powers reliable AI — through conversation, not configuration.
 
-Why: "AI-native" is a strong category claim. Compact and memorable. Positions Claude as a first-class feature.
+Why: Leads with the magical moment. The sub-headline connects ontology creation to AI reliability.
 
 ### Option C
-> **Think in structures. Build with language.**
+> **The AI-native ontology editor.**
 >
-> Ontograph combines a visual graph editor with Claude AI to turn natural language into formal, standards-compliant ontologies.
+> Build the ontologies that ground your AI agents — with an editor that speaks OWL, RDF, and plain English.
 
-Why: Captures the dual nature (visual + conversational). Appeals to knowledge engineers who think structurally.
+Why: "AI-native" is a strong category claim. Explicitly connects to the AI agent ecosystem.
 
 ### Option D
-> **Your ontology, shaped by conversation.**
+> **Your AI agents are only as smart as the knowledge behind them.**
 >
-> Tell Claude what you need. See it as a graph. Validate it in real time. Export to OWL, RDF, or Turtle.
+> Ontograph lets you build, visualize, and validate formal ontologies — the structured knowledge layer that makes AI reliable.
 
-Why: Most concrete — walks through the workflow. Good for audiences who need to understand what the product actually does.
+Why: Problem-aware without being negative. Positions ontologies as essential AI infrastructure.
 
 ## Sub-headline / Supporting Copy
 
-**"Where knowledge takes shape."** — keep as the brand tagline, appearing below or above the hero headline.
+**"Where knowledge takes shape."** — brand tagline, appearing below or above the hero headline.
 
 ## Value Proposition Framework
 
 | Pillar | Message | Evidence |
 |--------|---------|----------|
-| AI-First | Build ontologies through conversation with an AI that understands OWL semantics | Claude integration, natural language to formal ontology |
+| AI-First Creation | Build ontologies through conversation with an AI that understands OWL semantics | Claude integration, natural language to formal ontology |
 | Visual | See your knowledge structure as a living, interactive graph | Drag-and-drop canvas, real-time graph rendering |
+| AI-Stack Ready | Create ontologies that plug into RAG pipelines, context graphs, and agent architectures | OWL/RDF export, compatible with TrustGraph, LangChain, etc. |
 | Validated | AI-powered quality scoring catches gaps and inconsistencies as you build | Coverage, consistency, and completeness analysis |
 | Standards | Full OWL/RDF/Turtle support with zero vendor lock-in | Import/export to all standard formats, open source |
 
@@ -64,19 +70,36 @@ Why: Most concrete — walks through the workflow. Good for audiences who need t
 - **Confident** — We're building a genuinely new category of tool. State what we do, don't hedge.
 - **Approachable** — Ontology engineering sounds intimidating. Our copy should make it feel accessible.
 - **Never dismissive** — Don't mock existing tools or their users. Focus on what we enable.
+- **Builder-oriented** — Speak to engineers who ship products, not academics writing papers.
 
 ## Key Phrases / Copy Blocks
 
-- "Chat with Claude to build ontologies in natural language"
+- "Build the knowledge layer your AI agents need"
+- "From natural language to formal ontology in minutes"
+- "The ontology editor built for the AI era"
 - "See your ontology as a living graph"
+- "Create ontologies that ground your AI — not guesswork"
 - "AI-powered validation scores your ontology as you build"
 - "Full OWL/RDF/Turtle support — no vendor lock-in"
 - "Open source and free"
-- "From conversation to formal ontology"
+- "The missing tool between your data and your AI agents"
+
+## Use-Case Messaging
+
+### For RAG / Retrieval Pipelines
+> Ontology RAG delivers 10x more precise retrieval than unstructured vector search. Ontograph makes building those ontologies effortless.
+
+### For AI Agent Architectures
+> Your agents need structured, typed knowledge to make reliable decisions. Ontograph lets you build that knowledge layer through conversation.
+
+### For Knowledge Graph Construction
+> Stop hand-coding RDF triples. Describe your domain, let AI build the ontology, then export to your graph database.
 
 ## Previous Messaging (Archived)
 
 The original hero headline:
 > "Building ontologies shouldn't feel like writing XML in a 2005 Java app."
 
-**Decision (2026-03-28):** CEO directed shift to positive messaging. The pain-point framing is valid but defines us by what we're against rather than what we enable. Retained as possible secondary/social copy but removed from hero position.
+**Decision (2026-03-28):** CEO directed shift to positive messaging. Retained as possible secondary/social copy.
+
+**Previous Option A (2026-03-28):** "Describe your domain. Watch your ontology emerge." — Refined to better target AI Product Engineers per CEO feedback.

--- a/Marketing/market-research.md
+++ b/Marketing/market-research.md
@@ -2,23 +2,37 @@
 
 ## Target Audience
 
-### Primary: AI Researchers & AI Engineers
-- Building knowledge graphs and ontologies for AI systems (RAG pipelines, knowledge bases, domain models)
-- Technical but may not be ontology specialists
-- Value: speed, AI assistance, modern tooling
+### Primary: AI Product Engineers
+- Building AI-first applications that need structured knowledge (RAG pipelines, AI agents, context graphs)
+- Need ontologies to ground AI in reliable, typed knowledge — but aren't ontology specialists
+- Inspired by platforms like TrustGraph that use ontologies for AI reliability
+- Value: speed, AI assistance, production-ready output, integration with AI stack
+- Pain: ontology creation requires domain expertise and complex tooling they don't have time to learn
+
+### Secondary: AI Researchers & ML Engineers
+- Building knowledge graphs and ontologies for AI systems
+- Technical, exploring ontology-driven approaches (Ontology RAG, GraphRAG)
+- Value: rapid prototyping, modern tooling, standards compliance
 - Pain: existing tools have steep learning curves and dated UX
 
-### Secondary: Knowledge Engineers & Ontology Specialists
+### Tertiary: Knowledge Engineers & Ontology Specialists
 - Deep domain expertise in OWL/RDF/RDFS
 - Currently using Protege, TopBraid, or similar
-- Value: standards compliance, validation, interoperability
+- Value: AI-assisted refinement, validation, modern interface
 - Pain: existing tools lack AI assistance and modern interfaces
 
-### Tertiary: Data Scientists & Architects
-- Need structured domain models for data pipelines
-- May not know formal ontology standards
-- Value: approachability, AI guidance, visual interface
-- Pain: ontology creation feels inaccessible without specialist knowledge
+## The Market Insight
+
+**Ontologies are becoming the critical infrastructure layer for AI-first applications.**
+
+TrustGraph (open source, enterprise clients including Cisco, Accenture, McKinsey) has demonstrated that:
+- AI agents grounded in ontology-driven knowledge graphs are dramatically more reliable
+- Ontology RAG delivers higher precision than unstructured vector search
+- Ontologies provide the semantic layer that makes AI responses explainable and auditable
+
+**But ontology creation is the bottleneck.** TrustGraph's own docs acknowledge: "Creating comprehensive ontologies requires domain expertise and iterative refinement." Existing tools (Protege, TopBraid) were built for semantic web academics, not AI product engineers shipping apps.
+
+**Ontograph fills this gap** — the fastest path from "I need an ontology for my AI app" to a production-ready OWL schema.
 
 ## Competitive Landscape
 
@@ -28,25 +42,39 @@
 | TopBraid Composer | Enterprise features, SHACL support | Commercial/expensive, no AI assistance, complex |
 | WebVOWL | Good visualization | Read-only visualization, no editing, no AI |
 | OWLGrEd | Visual editing | Limited platform support, no AI, niche community |
+| TrustGraph | Excellent AI agent platform, uses ontologies for grounding | Not an ontology editor — requires pre-built ontologies. Ontograph is complementary. |
+
+## Adjacent / Complementary Ecosystem
+
+| Platform | Relationship to Ontograph |
+|----------|--------------------------|
+| TrustGraph | Uses OWL ontologies for context graphs → Ontograph creates those ontologies |
+| LangChain / LlamaIndex | RAG pipelines benefit from ontology-structured knowledge |
+| Neo4j / FalkorDB | Graph databases that store ontology-derived knowledge graphs |
+| MCP (Model Context Protocol) | Emerging standard for AI tool interoperability |
 
 ## Positioning
 
-**Category:** AI-powered ontology editor
-**Differentiation:** Only ontology editor with deep LLM integration for building and validating ontologies through natural language
-**Analogy:** "The Linear of ontology editing" — modern, fast, design-led, opinionated
+**Category:** AI-powered ontology editor for the AI era
+**Differentiation:** The only ontology editor with deep LLM integration, purpose-built for AI Product Engineers who need ontologies to power their AI applications
+**Analogy:** "Cursor for ontology engineering" — AI-native, modern, makes the complex accessible
 
 ## Unique Selling Points (ranked)
 
-1. **AI-powered ontology building** — Describe what you need in plain English, Claude builds the formal OWL structure
-2. **Visual graph editor** — Interactive canvas that makes complex hierarchies intuitive
-3. **AI validation & scoring** — Real-time quality analysis (coverage, consistency, completeness)
-4. **Modern UX** — Dark-first, responsive, designed for focus
-5. **Open source & free** — MIT license, no vendor lock-in
-6. **Standards-first** — Full OWL/RDF/Turtle import/export
+1. **AI-powered ontology building** — Describe your domain in plain English, Claude builds the formal OWL structure
+2. **Built for AI builders** — Create ontologies that plug into RAG pipelines, AI agents, and context graphs
+3. **Visual graph editor** — Interactive canvas that makes complex hierarchies intuitive
+4. **AI validation & scoring** — Real-time quality analysis (coverage, consistency, completeness)
+5. **Modern UX** — Dark-first, responsive, designed for focus
+6. **Open source & free** — MIT license, no vendor lock-in
+7. **Standards-first** — Full OWL/RDF/Turtle import/export
 
 ## Market Signals
 
-- Growing demand for knowledge graphs in AI/ML pipelines (RAG, agent architectures)
+- Ontologies emerging as critical AI infrastructure (TrustGraph, enterprise adoption by Cisco/Accenture/McKinsey)
+- Ontology RAG shown to deliver higher precision than unstructured vector search
+- Growing demand for knowledge graphs in AI agent architectures
 - LLM-augmented developer tools gaining traction (Cursor, v0, etc.)
 - Ontology tooling hasn't seen significant innovation in 10+ years
 - Open source + AI is a strong acquisition channel for developer tools
+- AI Product Engineer emerging as a distinct role (building AI-first applications, not just ML models)

--- a/Marketing/seo-strategy.md
+++ b/Marketing/seo-strategy.md
@@ -6,34 +6,53 @@
 |---------|--------|----------|
 | AI ontology builder | Commercial | High |
 | ontology editor | Commercial | High |
+| ontology for AI agents | Commercial | High |
 | OWL ontology editor | Commercial | High |
+| knowledge graph ontology tool | Commercial | High |
+| ontology RAG | Informational/Commercial | High |
 | RDF knowledge graph tool | Commercial | Medium |
 | visual ontology editor | Commercial | Medium |
 | ontology visualization tool | Informational/Commercial | Medium |
 
 ## Long-tail Keywords
 
-- "how to build an ontology with AI"
+- "how to build an ontology for AI agents"
+- "ontology for RAG pipeline"
+- "create ontology for knowledge graph"
 - "natural language ontology creation"
+- "ontology driven knowledge extraction"
+- "how to build an ontology with AI"
 - "open source ontology editor"
 - "protege alternative"
 - "OWL editor for mac"
 - "knowledge graph builder AI"
-- "RDF editor modern"
+- "ontology for context graph"
 - "ontology validation tool"
+- "structured knowledge for AI applications"
 
 ## Content Strategy (Future)
 
 ### Use-Case Landing Pages
-- `/use-cases/ai-knowledge-graphs` — Building ontologies for RAG and AI systems
+- `/use-cases/ai-agents` — Building ontologies that ground AI agents in reliable knowledge
+- `/use-cases/ontology-rag` — Create ontologies for precision retrieval in RAG pipelines
+- `/use-cases/knowledge-graphs` — Build the schema layer for production knowledge graphs
 - `/use-cases/biomedical-ontologies` — Domain-specific ontology creation
 - `/use-cases/enterprise-data-modeling` — Structured data architectures
 
-### Blog / Guides
-- "Getting started with ontologies using AI"
-- "OWL ontology best practices"
-- "From unstructured data to knowledge graph"
-- "Why knowledge graphs matter for AI agents"
+### Blog / Guides (Priority Order)
+1. "Why your AI agents need ontologies" — Awareness piece, links to TrustGraph ecosystem
+2. "Ontology RAG explained: schema-driven knowledge for reliable AI" — Educational, SEO-rich
+3. "From natural language to OWL: building ontologies with AI" — Product-led tutorial
+4. "Getting started with Ontograph in 5 minutes" — Conversion piece
+5. "Ontologies vs. unstructured vector search: when precision matters" — Comparison/thought leadership
+6. "OWL ontology best practices for AI applications" — Reference content
+7. "From unstructured data to knowledge graph" — Pipeline walkthrough
+
+### Distribution Channels
+- Dev communities: Hacker News, Reddit r/MachineLearning, r/LanguageTechnology
+- AI newsletters: The Batch, AI Weekly, TLDR AI
+- GitHub: README optimization, awesome-lists (awesome-knowledge-graph, awesome-ontology)
+- TrustGraph community (Discord) — complementary tool, not competitor
 
 ## Technical SEO
 


### PR DESCRIPTION
## Summary

- Added Marketing folder with core messaging strategy, market research, and SEO strategy docs
- Redesigned marketing website with cropped screenshots, two-column AI section, and refined copy targeting AI Product Engineers
- Added logo mark SVG, favicon, and apple-touch-icon
- Adopted full shadcn CSS variable naming with light/dark mode support
- Refined marketing angle: positive focus on AI-native ontology editing rather than competitor criticism

Resolves ONT-31.

## Test plan

- [ ] Verify marketing site renders correctly on desktop and mobile
- [ ] Check all images load properly (cropped screenshots)
- [ ] Verify favicon and logo mark display
- [ ] Review light/dark mode CSS variable transitions
- [ ] Confirm Marketing docs are well-structured

🤖 Generated with [Claude Code](https://claude.com/claude-code)