### PR TITLE
docs: add root and web app README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Ontograph
+
+Create and maintain ontologies using natural language. Ontograph is a visual OWL ontology editor powered by Claude AI, built for AI Researchers and AI Engineers.
+
+## Repository Structure
+
+This is a Turborepo monorepo with two apps:
+
+| App | Path | Description | Deployment |
+|-----|------|-------------|------------|
+| **Desktop** | [`apps/desktop/`](apps/desktop/) | Electron desktop ontology editor | GitHub Releases (tagged) |
+| **Web** | [`apps/web/`](apps/web/) | Marketing website (Next.js) | Vercel (auto-deploy on merge to main) |
+
+## Prerequisites
+
+- [Bun](https://bun.sh) (package manager)
+- [Node.js](https://nodejs.org) 18+
+
+## Getting Started
+
+```bash
+# Install dependencies
+bun install
+
+# Run all apps in dev mode
+bun run dev
+
+# Build all apps
+bun run build
+
+# Run tests
+bun run test
+
+# Type check
+bun run typecheck
+```
+
+## Tech Stack
+
+- **Monorepo**: Turborepo, Bun workspaces
+- **Desktop**: Electron 35, React 19, TypeScript, Vite, Zustand, React Flow, Claude Agent SDK
+- **Web**: Next.js 15, React 19, TypeScript, Tailwind CSS 4, shadcn/ui
+
+## License
+
+MIT

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,37 @@
+# @ontograph/web
+
+The Ontograph marketing website built with Next.js.
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | Next.js 15 (Turbopack) |
+| UI | React 19, TypeScript |
+| Styling | Tailwind CSS 4, shadcn/ui |
+| Fonts | Geist |
+| Syntax Highlighting | Shiki |
+
+## Development
+
+```bash
+# From the monorepo root
+bun run dev
+
+# Or directly
+cd apps/web
+bun run dev
+```
+
+## Deployment
+
+Deploys automatically to Vercel on every merge to `main`. No tags or manual releases required.
+
+## Scripts
+
+| Command | Description |
+|---------|-------------|
+| `bun run dev` | Start dev server with Turbopack |
+| `bun run build` | Production build |
+| `bun run start` | Start production server |
+| `bun run typecheck` | Run TypeScript checks |


### PR DESCRIPTION
## Summary
- Added monorepo root `README.md` with repo structure, prerequisites, getting started, and tech stack overview
- Added `apps/web/README.md` with marketing site tech stack, dev instructions, and deployment info
- Existing `apps/desktop/README.md` already covered the desktop app

Closes ONT-50

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm links to `apps/desktop/` and `apps/web/` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)