### PR TITLE
chore: bump version to v0.4.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontograph/desktop",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A modern ontology editor with Claude integration",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/DaveHudson/Ontograph",


### PR DESCRIPTION
## Summary
- Bumps desktop app version from v0.3.0 to v0.4.0
- Release triggered by QA "Release Ready" ticket ONT-58

### Desktop Changelog (v0.4.0)

#### Features
- Align desktop app design tokens with brand guidelines

#### Fixes
- Use subtle primary-derived colour for desktop icon hover states (ONT-57)

**Note:** Marketing website changes (mobile layout, brand page, favicon/SEO, etc.) deploy automatically via Vercel and are not part of this desktop release.

## Test plan
- [ ] Verify version bump in `apps/desktop/package.json`
- [ ] Merge and tag `v0.4.0` to trigger GitHub Actions release workflow
- [ ] Verify GitHub Release is created with build artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)