### PR TITLE
fix(web): skip PostHog init on localhost and fix EU host fallback

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,6 +1,6 @@
 # PostHog
 NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=phc_your_key_here
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 
 # Sentry
 NEXT_PUBLIC_SENTRY_DSN=https://your_dsn@sentry.io/your_project

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -5,9 +5,10 @@ export function initPostHog() {
   if (posthog.__loaded) return;
 
   const key = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
-  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.i.posthog.com";
 
   if (!key) return;
+  if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") return;
 
   posthog.init(key, {
     api_host: host,


### PR DESCRIPTION
## Summary
- Prevents PostHog from initializing on `localhost` / `127.0.0.1`, eliminating dev traffic pollution (86% of pageviews were from `localhost:3000`)
- Corrects API host fallback from `us.i.posthog.com` to `eu.i.posthog.com` to match the actual PostHog project region
- Updates `.env.example` to reflect correct EU host

## Additional findings (ONT-74)

**Autocapture (`$autocapture`):** Intentionally disabled via `autocapture: false` in both web and desktop SDK configs. Zero autocapture events is expected behavior, not a misconfiguration.

**Project structure:** Single PostHog project is sufficient. Web traffic is distinguishable by `$host` property (`ontograph-web.vercel.app` vs desktop). Desktop sends unique events (`app_launched`, `ontology_loaded`). No need for a second project.

**Recommended PostHog UI action:** Add a project-level test account filter in PostHog Settings > Project > Filter out internal and test users:
- `$host` does not contain `localhost`

This provides a safety net for any future event sources that bypass the code-level check.

## Test plan
- [ ] Verify PostHog does NOT initialize when running `npm run dev` (localhost:3000)
- [ ] Verify PostHog initializes correctly on Vercel preview/production deploys
- [ ] Confirm no new localhost pageviews appear in PostHog after merge

Refs: ONT-74

🤖 Generated with [Claude Code](https://claude.com/claude-code)