### PR TITLE
feat: cross-platform PostHog identity linking (ONT-64)

### DIFF
--- a/apps/desktop/src/renderer/src/lib/analytics.ts
+++ b/apps/desktop/src/renderer/src/lib/analytics.ts
@@ -57,7 +57,7 @@ export function getAnonymousId(): string | undefined {
  * the marketing website download flow).
  */
 export function linkWebVisitor(webVisitorId: string): void {
-  if (!POSTHOG_KEY || !webVisitorId) return
+  if (!POSTHOG_KEY || !webVisitorId || posthog.has_opted_out_capturing()) return
 
   const alreadyLinked = localStorage.getItem(LINKED_VISITOR_KEY)
   if (alreadyLinked === webVisitorId) return
@@ -73,6 +73,6 @@ export function linkWebVisitor(webVisitorId: string): void {
  * that used the same identifier.
  */
 export function identifyUser(userId: string, properties?: Record<string, string>): void {
-  if (!POSTHOG_KEY || !userId) return
+  if (!POSTHOG_KEY || !userId || posthog.has_opted_out_capturing()) return
   posthog.identify(userId, properties)
 }

--- a/apps/desktop/src/renderer/src/lib/analytics.ts
+++ b/apps/desktop/src/renderer/src/lib/analytics.ts
@@ -4,6 +4,7 @@ const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY as string | undefined
 const POSTHOG_HOST = (import.meta.env.VITE_POSTHOG_HOST as string) || 'https://eu.i.posthog.com'
 
 const OPT_OUT_KEY = 'ontograph-analytics-opt-out'
+const LINKED_VISITOR_KEY = 'ontograph-linked-visitor-id'
 
 function isOptedOut(): boolean {
   return localStorage.getItem(OPT_OUT_KEY) === 'true'
@@ -23,7 +24,7 @@ export function initAnalytics(): void {
   })
 
   if (!isOptedOut()) {
-    track('app_launched')
+    track('app_launched', { platform: 'desktop' })
   }
 }
 
@@ -48,4 +49,30 @@ export function track(event: string, properties?: Record<string, unknown>): void
 export function getAnonymousId(): string | undefined {
   if (!POSTHOG_KEY) return undefined
   return posthog.get_distinct_id()
+}
+
+/**
+ * Link this desktop session to a website visitor by aliasing PostHog identities.
+ * Call this when a shared identifier becomes available (e.g. the visitor_id from
+ * the marketing website download flow).
+ */
+export function linkWebVisitor(webVisitorId: string): void {
+  if (!POSTHOG_KEY || !webVisitorId) return
+
+  const alreadyLinked = localStorage.getItem(LINKED_VISITOR_KEY)
+  if (alreadyLinked === webVisitorId) return
+
+  posthog.alias(webVisitorId)
+  posthog.setPersonProperties({ web_visitor_id: webVisitorId, linked_from: 'desktop' })
+  localStorage.setItem(LINKED_VISITOR_KEY, webVisitorId)
+}
+
+/**
+ * Identify the user with a stable identifier (e.g. email).
+ * This merges the anonymous desktop session with any web session
+ * that used the same identifier.
+ */
+export function identifyUser(userId: string, properties?: Record<string, string>): void {
+  if (!POSTHOG_KEY || !userId) return
+  posthog.identify(userId, properties)
 }

--- a/apps/web/src/app/download/page.tsx
+++ b/apps/web/src/app/download/page.tsx
@@ -12,10 +12,15 @@ export default function DownloadPage() {
   useEffect(() => {
     const visitorId = getVisitorId()
 
-    ph?.capture('download_initiated', {
-      visitor_id: visitorId,
-      referrer: document.referrer || undefined,
-    })
+    ph?.capture(
+      'download_initiated',
+      {
+        visitor_id: visitorId,
+        platform: 'web',
+        referrer: document.referrer || undefined,
+      },
+      { send_instantly: true }
+    )
 
     // Set visitor_id as a person property so it can be used
     // to link this web visitor to their desktop app session

--- a/apps/web/src/app/download/page.tsx
+++ b/apps/web/src/app/download/page.tsx
@@ -12,19 +12,12 @@ export default function DownloadPage() {
   useEffect(() => {
     const visitorId = getVisitorId()
 
-    ph?.capture(
-      'download_initiated',
-      {
-        visitor_id: visitorId,
-        platform: 'web',
-        referrer: document.referrer || undefined,
-      },
-      { send_instantly: true }
-    )
-
-    // Set visitor_id as a person property so it can be used
-    // to link this web visitor to their desktop app session
-    ph?.setPersonProperties({ visitor_id: visitorId })
+    ph?.capture('download_initiated', {
+      visitor_id: visitorId,
+      platform: 'web',
+      referrer: document.referrer || undefined,
+      $set: { visitor_id: visitorId },
+    }, { send_instantly: true })
 
     const timeout = setTimeout(() => {
       window.location.href = GITHUB_RELEASES_URL

--- a/apps/web/src/app/download/page.tsx
+++ b/apps/web/src/app/download/page.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePostHog } from 'posthog-js/react'
+import { getVisitorId } from '@/lib/visitor-id'
+
+const GITHUB_RELEASES_URL = 'https://github.com/DaveHudson/Ontograph/releases/latest'
+
+export default function DownloadPage() {
+  const ph = usePostHog()
+
+  useEffect(() => {
+    const visitorId = getVisitorId()
+
+    ph?.capture('download_initiated', {
+      visitor_id: visitorId,
+      referrer: document.referrer || undefined,
+    })
+
+    // Set visitor_id as a person property so it can be used
+    // to link this web visitor to their desktop app session
+    ph?.setPersonProperties({ visitor_id: visitorId })
+
+    const timeout = setTimeout(() => {
+      window.location.href = GITHUB_RELEASES_URL
+    }, 500)
+
+    return () => clearTimeout(timeout)
+  }, [ph])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="text-center">
+        <p className="text-lg font-medium mb-2">Redirecting to download&hellip;</p>
+        <p className="text-sm text-muted-foreground">
+          If you are not redirected,{' '}
+          <a href={GITHUB_RELEASES_URL} className="underline hover:text-foreground transition-colors">
+            click here
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -392,7 +392,7 @@ export default function Home() {
           <TrackedLink
             event="download_click"
             properties={{ os: 'unknown', location: 'footer_cta' }}
-            href="https://github.com/DaveHudson/Ontograph/releases/latest"
+            href="/download"
             className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-8 py-3.5 rounded-lg font-medium hover:opacity-90 transition-opacity"
           >
             <Download className="size-4" />

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,23 +1,24 @@
 import { posthog } from './posthog'
+import { getVisitorId } from './visitor-id'
 
 export const analytics = {
   heroCTAClick() {
-    posthog.capture('hero_cta_click')
+    posthog.capture('hero_cta_click', { platform: 'web' })
   },
 
   downloadClick(os: string) {
-    posthog.capture('download_click', { os })
+    posthog.capture('download_click', { os, platform: 'web', visitor_id: getVisitorId() })
   },
 
   pricingPageView() {
-    posthog.capture('pricing_page_view')
+    posthog.capture('pricing_page_view', { platform: 'web' })
   },
 
   githubClick() {
-    posthog.capture('github_click')
+    posthog.capture('github_click', { platform: 'web' })
   },
 
   featuresSectionView() {
-    posthog.capture('features_section_view')
+    posthog.capture('features_section_view', { platform: 'web' })
   },
 }

--- a/apps/web/src/lib/visitor-id.ts
+++ b/apps/web/src/lib/visitor-id.ts
@@ -1,0 +1,14 @@
+import { posthog } from './posthog'
+
+const VISITOR_ID_KEY = 'ontograph-visitor-id'
+
+export function getVisitorId(): string {
+  if (typeof window === 'undefined') return ''
+
+  const stored = localStorage.getItem(VISITOR_ID_KEY)
+  if (stored) return stored
+
+  const id = posthog.get_distinct_id?.() || crypto.randomUUID()
+  localStorage.setItem(VISITOR_ID_KEY, id)
+  return id
+}

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "apps/desktop": {
       "name": "@ontograph/desktop",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.83",
         "@electron-toolkit/preload": "^3.0.1",


### PR DESCRIPTION
## Summary

- Adds `/download` redirect page on the marketing website that captures `visitor_id` as a PostHog person property before redirecting to GitHub releases
- Generates persistent `visitor_id` on the marketing site using PostHog's `distinct_id` or a crypto UUID fallback
- Adds `linkWebVisitor()` and `identifyUser()` utilities to the desktop app's analytics module for cross-platform session merging via PostHog `alias()`
- Adds `platform` property to all analytics events for cross-platform funnel segmentation

This enables the full funnel: `$pageview` (web) → `download_click` (web) → `download_initiated` (web) → `app_launched` (desktop) → `first_ontology_created` (desktop)

## Test plan

- [ ] Visit marketing site, click "Download latest release" → verify redirect goes through `/download` page
- [ ] Check PostHog for `download_initiated` event with `visitor_id` property
- [ ] Verify `visitor_id` persists in localStorage across page loads
- [ ] Verify desktop app `app_launched` event includes `platform: desktop`
- [ ] Verify `linkWebVisitor()` calls `posthog.alias()` and stores linked state
- [ ] Verify type checks pass for both web and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)