### PR TITLE
feat(chat): multi-chat threads with history

### DIFF
--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -1,8 +1,10 @@
-import { useState, useRef, useEffect, useMemo } from 'react'
-import { RotateCcw, BotMessageSquare, ArrowUp, Square } from 'lucide-react'
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
+import { List, SquarePen, BotMessageSquare, ArrowUp, Square } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 import { code } from '@streamdown/code'
 import { useClaude, type ChatMessage, type ModelId, type ThinkingBudget } from './useClaude'
+import { useChatHistory } from './useChatHistory'
+import { ChatThreadList } from './ChatThreadList'
 import { useUIStore } from '@renderer/store/ui'
 import { useOntologyStore } from '@renderer/store/ontology'
 import { Button } from '@/components/ui/button'
@@ -13,18 +15,73 @@ import { cn } from '@/lib/utils'
 
 export function ChatPanel(): React.JSX.Element {
   const {
-    messages, isLoading, authMode, isReady,
+    messages, setMessages, isLoading, authMode, isReady,
     model, setModel, thinkingBudget, setThinkingBudget,
     sendMessage, resetSession
   } = useClaude()
+  const history = useChatHistory()
   const [input, setInput] = useState('')
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const prevMessagesRef = useRef<ChatMessage[]>([])
 
   const chatDraft = useUIStore((s) => s.chatDraft)
   const setChatDraft = useUIStore((s) => s.setChatDraft)
   const pendingChatMessage = useUIStore((s) => s.pendingChatMessage)
   const setPendingChatMessage = useUIStore((s) => s.setPendingChatMessage)
+
+  // Restore active thread on mount
+  useEffect(() => {
+    const thread = history.getActiveThread()
+    if (thread && thread.messages.length > 0) {
+      setMessages(thread.messages)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Auto-save messages to active thread when messages change
+  useEffect(() => {
+    if (history.activeThreadId && messages.length > 0 && messages !== prevMessagesRef.current) {
+      history.updateThreadMessages(history.activeThreadId, messages)
+    }
+    prevMessagesRef.current = messages
+  }, [messages, history.activeThreadId, history.updateThreadMessages])
+
+  // Auto-create thread on first message if none active
+  useEffect(() => {
+    if (!history.activeThreadId && messages.length > 0) {
+      history.createThread(model)
+    }
+  }, [messages.length, history.activeThreadId, history.createThread, model])
+
+  const handleNewChat = useCallback(() => {
+    // Don't save empty threads
+    if (history.activeThreadId && messages.length === 0) {
+      history.deleteThread(history.activeThreadId)
+    }
+    const id = history.createThread(model)
+    setMessages([])
+    resetSession()
+    history.setShowThreadList(false)
+    return id
+  }, [history, messages.length, model, setMessages, resetSession])
+
+  const handleSwitchThread = useCallback((id: string) => {
+    const thread = history.switchThread(id)
+    if (thread) {
+      setMessages(thread.messages)
+      resetSession()
+    }
+  }, [history, setMessages, resetSession])
+
+  const handleDeleteThread = useCallback((id: string) => {
+    const wasActive = id === history.activeThreadId
+    history.deleteThread(id)
+    if (wasActive) {
+      setMessages([])
+      resetSession()
+    }
+  }, [history, setMessages, resetSession])
 
   useEffect(() => {
     if (chatDraft) {
@@ -94,152 +151,175 @@ export function ChatPanel(): React.JSX.Element {
     }
   }
 
+  const activeThread = history.getActiveThread()
+  const headerTitle = activeThread?.title && activeThread.title !== 'New chat'
+    ? activeThread.title
+    : 'Claude'
+
   return (
     <div className="flex-1 flex flex-col min-h-0">
-      <div className="px-3 py-2 border-b border-border flex items-center justify-between">
-        <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Claude
+      <div className="px-3 py-2 border-b border-border flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 shrink-0"
+          onClick={() => history.setShowThreadList(!history.showThreadList)}
+          title={history.showThreadList ? 'Hide chat history' : 'Show chat history'}
+        >
+          <List className="size-3.5" />
+        </Button>
+        <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide truncate flex-1">
+          {history.showThreadList ? 'Chat History' : headerTitle}
         </h2>
-        {messages.length > 0 && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-6"
-            onClick={resetSession}
-            title="New conversation"
-          >
-            <RotateCcw className="size-3.5" />
-          </Button>
-        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 shrink-0"
+          onClick={handleNewChat}
+          title="New chat"
+        >
+          <SquarePen className="size-3.5" />
+        </Button>
       </div>
 
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto p-3 space-y-3">
-        {messages.length === 0 && (
-          <Empty className="border-0 p-4">
-            <EmptyHeader>
-              {isReady && (
-                <EmptyMedia variant="icon">
-                  <BotMessageSquare />
-                </EmptyMedia>
-              )}
-              <EmptyTitle className="text-sm font-medium">
-                {isReady ? 'Start a conversation' : 'Not connected'}
-              </EmptyTitle>
-              <EmptyDescription className="text-xs">
-                {isReady
-                  ? 'Describe the ontology you want to create or select a node to get context-aware suggestions.'
-                  : authMode === 'max'
-                    ? 'Claude CLI not detected. Configure in toolbar.'
-                    : 'Set your API key in the toolbar to start chatting.'}
-              </EmptyDescription>
-            </EmptyHeader>
-          </Empty>
-        )}
-        {messages.map((msg, i) => (
-          <MessageBubble key={i} message={msg} />
-        ))}
-        {isLoading && (
-          <div className="flex gap-1 items-center text-xs text-muted-foreground">
-            <span className="animate-pulse">●</span>
-            <span>Claude is thinking...</span>
-          </div>
-        )}
-        <div ref={messagesEndRef} />
-      </div>
-
-      {/* Selection Context Badge */}
-      {selectionContext && (
-        <div className="px-3 pt-2">
-          <Badge className="inline-flex gap-1.5 px-2.5 py-1 rounded-full max-w-full text-xs font-normal h-auto bg-primary-display/10 text-primary-display border border-primary-display hover:bg-primary-display/10">
-            <span className="opacity-60">{selectionContext.type === 'class' ? '◆' : '→'}</span>
-            <span className="truncate">{selectionContext.label}</span>
-            <button
-              onClick={() => selectionContext.type === 'class' ? setSelectedNode(null) : setSelectedEdge(null)}
-              className="text-muted-foreground hover:text-foreground ml-0.5 shrink-0"
-            >
-              ×
-            </button>
-          </Badge>
-        </div>
-      )}
-
-      {/* Input */}
-      <form onSubmit={handleSubmit} className="p-3 border-t border-border">
-        <div className={cn(
-          'rounded-xl border border-input bg-card transition-shadow',
-          'focus-within:ring-1 focus-within:ring-ring',
-          (!isReady || isLoading) && 'opacity-60'
-        )}>
-          <textarea
-            ref={textareaRef}
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={isReady ? 'Ask anything...' : 'Configure auth first...'}
-            disabled={!isReady || isLoading}
-            rows={1}
-            className={cn(
-              'w-full resize-none bg-transparent px-3 pt-3 pb-2 text-sm',
-              'placeholder:text-muted-foreground focus:outline-none',
-              'disabled:cursor-not-allowed max-h-32 overflow-y-auto'
-            )}
-          />
-          <div className="flex items-center gap-1.5 px-2 pb-2">
-            <Select value={model} onValueChange={(v) => setModel(v as ModelId)}>
-              <SelectTrigger className="w-24 h-7 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectLabel>Model</SelectLabel>
-                  <SelectItem value="claude-haiku-4-5-20251001">Haiku</SelectItem>
-                  <SelectItem value="claude-sonnet-4-6">Sonnet</SelectItem>
-                  <SelectItem value="claude-opus-4-6">Opus</SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-            <Select value={thinkingBudget} onValueChange={(v) => setThinkingBudget(v as ThinkingBudget)}>
-              <SelectTrigger className="w-20 h-7 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectLabel>Effort</SelectLabel>
-                  <SelectItem value="auto">Auto</SelectItem>
-                  <SelectItem value="low">Low</SelectItem>
-                  <SelectItem value="med">Med</SelectItem>
-                  <SelectItem value="high">High</SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-            <div className="ml-auto">
-              {isLoading ? (
-                <button
-                  type="button"
-                  onClick={() => window.api.abortClaude()}
-                  className="size-7 rounded-lg flex items-center justify-center bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors"
-                >
-                  <Square className="size-3.5 fill-current" />
-                </button>
-              ) : (
-                <button
-                  type="submit"
-                  disabled={!isReady || !input.trim()}
-                  className={cn(
-                    'size-7 rounded-lg flex items-center justify-center transition-colors',
-                    isReady && input.trim()
-                      ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-                      : 'bg-muted text-muted-foreground cursor-not-allowed'
+      {history.showThreadList ? (
+        <ChatThreadList
+          threads={history.threads}
+          activeThreadId={history.activeThreadId}
+          onSelect={handleSwitchThread}
+          onDelete={handleDeleteThread}
+        />
+      ) : (
+        <>
+          {/* Messages */}
+          <div className="flex-1 overflow-y-auto p-3 space-y-3">
+            {messages.length === 0 && (
+              <Empty className="border-0 p-4">
+                <EmptyHeader>
+                  {isReady && (
+                    <EmptyMedia variant="icon">
+                      <BotMessageSquare />
+                    </EmptyMedia>
                   )}
-                >
-                  <ArrowUp className="size-3.5" />
-                </button>
-              )}
-            </div>
+                  <EmptyTitle className="text-sm font-medium">
+                    {isReady ? 'Start a conversation' : 'Not connected'}
+                  </EmptyTitle>
+                  <EmptyDescription className="text-xs">
+                    {isReady
+                      ? 'Describe the ontology you want to create or select a node to get context-aware suggestions.'
+                      : authMode === 'max'
+                        ? 'Claude CLI not detected. Configure in toolbar.'
+                        : 'Set your API key in the toolbar to start chatting.'}
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            )}
+            {messages.map((msg, i) => (
+              <MessageBubble key={i} message={msg} />
+            ))}
+            {isLoading && (
+              <div className="flex gap-1 items-center text-xs text-muted-foreground">
+                <span className="animate-pulse">●</span>
+                <span>Claude is thinking...</span>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
           </div>
-        </div>
-      </form>
+
+          {/* Selection Context Badge */}
+          {selectionContext && (
+            <div className="px-3 pt-2">
+              <Badge className="inline-flex gap-1.5 px-2.5 py-1 rounded-full max-w-full text-xs font-normal h-auto bg-primary-display/10 text-primary-display border border-primary-display hover:bg-primary-display/10">
+                <span className="opacity-60">{selectionContext.type === 'class' ? '◆' : '→'}</span>
+                <span className="truncate">{selectionContext.label}</span>
+                <button
+                  onClick={() => selectionContext.type === 'class' ? setSelectedNode(null) : setSelectedEdge(null)}
+                  className="text-muted-foreground hover:text-foreground ml-0.5 shrink-0"
+                >
+                  ×
+                </button>
+              </Badge>
+            </div>
+          )}
+
+          {/* Input */}
+          <form onSubmit={handleSubmit} className="p-3 border-t border-border">
+            <div className={cn(
+              'rounded-xl border border-input bg-card transition-shadow',
+              'focus-within:ring-1 focus-within:ring-ring',
+              (!isReady || isLoading) && 'opacity-60'
+            )}>
+              <textarea
+                ref={textareaRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={isReady ? 'Ask anything...' : 'Configure auth first...'}
+                disabled={!isReady || isLoading}
+                rows={1}
+                className={cn(
+                  'w-full resize-none bg-transparent px-3 pt-3 pb-2 text-sm',
+                  'placeholder:text-muted-foreground focus:outline-none',
+                  'disabled:cursor-not-allowed max-h-32 overflow-y-auto'
+                )}
+              />
+              <div className="flex items-center gap-1.5 px-2 pb-2">
+                <Select value={model} onValueChange={(v) => setModel(v as ModelId)}>
+                  <SelectTrigger className="w-24 h-7 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>Model</SelectLabel>
+                      <SelectItem value="claude-haiku-4-5-20251001">Haiku</SelectItem>
+                      <SelectItem value="claude-sonnet-4-6">Sonnet</SelectItem>
+                      <SelectItem value="claude-opus-4-6">Opus</SelectItem>
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                <Select value={thinkingBudget} onValueChange={(v) => setThinkingBudget(v as ThinkingBudget)}>
+                  <SelectTrigger className="w-20 h-7 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>Effort</SelectLabel>
+                      <SelectItem value="auto">Auto</SelectItem>
+                      <SelectItem value="low">Low</SelectItem>
+                      <SelectItem value="med">Med</SelectItem>
+                      <SelectItem value="high">High</SelectItem>
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                <div className="ml-auto">
+                  {isLoading ? (
+                    <button
+                      type="button"
+                      onClick={() => window.api.abortClaude()}
+                      className="size-7 rounded-lg flex items-center justify-center bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors"
+                    >
+                      <Square className="size-3.5 fill-current" />
+                    </button>
+                  ) : (
+                    <button
+                      type="submit"
+                      disabled={!isReady || !input.trim()}
+                      className={cn(
+                        'size-7 rounded-lg flex items-center justify-center transition-colors',
+                        isReady && input.trim()
+                          ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                          : 'bg-muted text-muted-foreground cursor-not-allowed'
+                      )}
+                    >
+                      <ArrowUp className="size-3.5" />
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          </form>
+        </>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -67,11 +67,12 @@ export function ChatPanel(): React.JSX.Element {
   }, [history, messages.length, model, setMessages, resetSession])
 
   const handleSwitchThread = useCallback((id: string) => {
-    const thread = history.switchThread(id)
+    const thread = history.threads.find((t) => t.id === id)
     if (thread) {
       setMessages(thread.messages)
       resetSession()
     }
+    history.switchThread(id)
   }, [history, setMessages, resetSession])
 
   const handleDeleteThread = useCallback((id: string) => {

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -69,11 +69,11 @@ export function ChatPanel(): React.JSX.Element {
   const handleSwitchThread = useCallback((id: string) => {
     const thread = history.threads.find((t) => t.id === id)
     if (thread) {
+      window.api.resetSession()
       setMessages(thread.messages)
-      resetSession()
     }
     history.switchThread(id)
-  }, [history, setMessages, resetSession])
+  }, [history, setMessages])
 
   const handleDeleteThread = useCallback((id: string) => {
     const wasActive = id === history.activeThreadId

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -77,12 +77,17 @@ export function ChatPanel(): React.JSX.Element {
 
   const handleDeleteThread = useCallback((id: string) => {
     const wasActive = id === history.activeThreadId
-    history.deleteThread(id)
     if (wasActive) {
-      setMessages([])
-      resetSession()
+      const remaining = history.threads.filter((t) => t.id !== id)
+      window.api.resetSession()
+      if (remaining.length > 0) {
+        setMessages(remaining[0].messages)
+      } else {
+        setMessages([])
+      }
     }
-  }, [history, setMessages, resetSession])
+    history.deleteThread(id)
+  }, [history, setMessages])
 
   useEffect(() => {
     if (chatDraft) {

--- a/apps/desktop/src/renderer/src/components/chat/ChatThreadList.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatThreadList.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { ChatThread } from './useChatHistory'
+
+function formatDate(ts: number): string {
+  const date = new Date(ts)
+  const now = new Date()
+  const diff = now.getTime() - date.getTime()
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
+  if (days === 0) return 'Today'
+  if (days === 1) return 'Yesterday'
+  if (days < 7) return `${days}d ago`
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+interface ChatThreadListProps {
+  threads: ChatThread[]
+  activeThreadId: string | null
+  onSelect: (id: string) => void
+  onDelete: (id: string) => void
+}
+
+export function ChatThreadList({ threads, activeThreadId, onSelect, onDelete }: ChatThreadListProps): React.JSX.Element {
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+
+  if (threads.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-4">
+        <p className="text-xs text-muted-foreground text-center">
+          No chat history yet. Start a conversation below.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      {threads.map((thread) => {
+        const messageCount = thread.messages.filter((m) => m.role !== 'tool').length
+        const isActive = thread.id === activeThreadId
+
+        return (
+          <div
+            key={thread.id}
+            className={cn(
+              'group relative px-3 py-2.5 cursor-pointer border-b border-border/50',
+              'hover:bg-secondary/60 transition-colors',
+              isActive && 'bg-secondary/40'
+            )}
+            onClick={() => onSelect(thread.id)}
+          >
+            <div className="flex items-start gap-2">
+              {isActive && (
+                <span className="mt-1.5 size-1.5 rounded-full bg-primary shrink-0" />
+              )}
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium truncate">{thread.title}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {formatDate(thread.updatedAt)} · {messageCount} message{messageCount !== 1 ? 's' : ''}
+                </p>
+              </div>
+              <div className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+                {confirmDeleteId === thread.id ? (
+                  <div className="flex gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-6 text-destructive hover:text-destructive"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onDelete(thread.id)
+                        setConfirmDeleteId(null)
+                      }}
+                      title="Confirm delete"
+                    >
+                      <Trash2 className="size-3" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-6"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setConfirmDeleteId(null)
+                      }}
+                      title="Cancel"
+                    >
+                      ×
+                    </Button>
+                  </div>
+                ) : (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-6 text-muted-foreground hover:text-destructive"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setConfirmDeleteId(thread.id)
+                    }}
+                    title="Delete chat"
+                  >
+                    <Trash2 className="size-3" />
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/chat/useChatHistory.ts
+++ b/apps/desktop/src/renderer/src/components/chat/useChatHistory.ts
@@ -28,7 +28,17 @@ function loadThreads(): ChatThread[] {
 }
 
 function saveThreads(threads: ChatThread[]): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(threads))
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(threads))
+  } catch {
+    // Quota exceeded — prune oldest half and retry once
+    try {
+      const pruned = threads.slice(0, Math.ceil(threads.length / 2))
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(pruned))
+    } catch {
+      // Storage completely full — silently skip
+    }
+  }
 }
 
 function titleFromMessage(message: string): string {

--- a/apps/desktop/src/renderer/src/components/chat/useChatHistory.ts
+++ b/apps/desktop/src/renderer/src/components/chat/useChatHistory.ts
@@ -97,14 +97,13 @@ export function useChatHistory(): UseChatHistoryReturn {
   }, [threads, setActiveThreadId])
 
   const deleteThread = useCallback((id: string) => {
-    setThreads((prev) => prev.filter((t) => t.id !== id))
-    if (activeThreadId === id) {
-      setThreads((prev) => {
-        const remaining = prev.filter((t) => t.id !== id)
+    setThreads((prev) => {
+      const remaining = prev.filter((t) => t.id !== id)
+      if (activeThreadId === id) {
         setActiveThreadId(remaining.length > 0 ? remaining[0].id : null)
-        return remaining
-      })
-    }
+      }
+      return remaining
+    })
   }, [activeThreadId, setActiveThreadId])
 
   const updateThreadMessages = useCallback((id: string, messages: ChatMessage[]) => {

--- a/apps/desktop/src/renderer/src/components/chat/useChatHistory.ts
+++ b/apps/desktop/src/renderer/src/components/chat/useChatHistory.ts
@@ -1,0 +1,146 @@
+import { useState, useCallback, useEffect } from 'react'
+import type { ChatMessage, ModelId } from './useClaude'
+
+export interface ChatThread {
+  id: string
+  title: string
+  messages: ChatMessage[]
+  model: ModelId
+  createdAt: number
+  updatedAt: number
+}
+
+const STORAGE_KEY = 'ontograph-chat-threads'
+const ACTIVE_THREAD_KEY = 'ontograph-active-thread'
+const MAX_THREADS = 50
+
+function generateId(): string {
+  return crypto.randomUUID()
+}
+
+function loadThreads(): ChatThread[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+function saveThreads(threads: ChatThread[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(threads))
+}
+
+function titleFromMessage(message: string): string {
+  return message.length > 50 ? message.slice(0, 50) + '…' : message
+}
+
+export interface UseChatHistoryReturn {
+  threads: ChatThread[]
+  activeThreadId: string | null
+  showThreadList: boolean
+  setShowThreadList: (show: boolean) => void
+  createThread: (model: ModelId) => string
+  switchThread: (id: string) => ChatThread | undefined
+  deleteThread: (id: string) => void
+  updateThreadMessages: (id: string, messages: ChatMessage[]) => void
+  updateThreadTitle: (id: string, title: string) => void
+  getActiveThread: () => ChatThread | undefined
+  setActiveThreadId: (id: string | null) => void
+}
+
+export function useChatHistory(): UseChatHistoryReturn {
+  const [threads, setThreads] = useState<ChatThread[]>(loadThreads)
+  const [activeThreadId, setActiveThreadIdState] = useState<string | null>(
+    () => localStorage.getItem(ACTIVE_THREAD_KEY)
+  )
+  const [showThreadList, setShowThreadList] = useState(false)
+
+  // Persist threads on change
+  useEffect(() => {
+    saveThreads(threads)
+  }, [threads])
+
+  // Persist active thread id
+  const setActiveThreadId = useCallback((id: string | null) => {
+    setActiveThreadIdState(id)
+    if (id) {
+      localStorage.setItem(ACTIVE_THREAD_KEY, id)
+    } else {
+      localStorage.removeItem(ACTIVE_THREAD_KEY)
+    }
+  }, [])
+
+  const createThread = useCallback((model: ModelId): string => {
+    const id = generateId()
+    const thread: ChatThread = {
+      id,
+      title: 'New chat',
+      messages: [],
+      model,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
+    }
+    setThreads((prev) => {
+      const updated = [thread, ...prev]
+      // Prune oldest beyond limit
+      return updated.slice(0, MAX_THREADS)
+    })
+    setActiveThreadId(id)
+    return id
+  }, [setActiveThreadId])
+
+  const switchThread = useCallback((id: string): ChatThread | undefined => {
+    setActiveThreadId(id)
+    setShowThreadList(false)
+    return threads.find((t) => t.id === id)
+  }, [threads, setActiveThreadId])
+
+  const deleteThread = useCallback((id: string) => {
+    setThreads((prev) => prev.filter((t) => t.id !== id))
+    if (activeThreadId === id) {
+      setThreads((prev) => {
+        const remaining = prev.filter((t) => t.id !== id)
+        setActiveThreadId(remaining.length > 0 ? remaining[0].id : null)
+        return remaining
+      })
+    }
+  }, [activeThreadId, setActiveThreadId])
+
+  const updateThreadMessages = useCallback((id: string, messages: ChatMessage[]) => {
+    setThreads((prev) =>
+      prev.map((t) => {
+        if (t.id !== id) return t
+        const title =
+          t.title === 'New chat' && messages.length > 0
+            ? titleFromMessage(messages.find((m) => m.role === 'user')?.content || 'New chat')
+            : t.title
+        return { ...t, messages, title, updatedAt: Date.now() }
+      })
+    )
+  }, [])
+
+  const updateThreadTitle = useCallback((id: string, title: string) => {
+    setThreads((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, title, updatedAt: Date.now() } : t))
+    )
+  }, [])
+
+  const getActiveThread = useCallback((): ChatThread | undefined => {
+    return threads.find((t) => t.id === activeThreadId)
+  }, [threads, activeThreadId])
+
+  return {
+    threads,
+    activeThreadId,
+    showThreadList,
+    setShowThreadList,
+    createThread,
+    switchThread,
+    deleteThread,
+    updateThreadMessages,
+    updateThreadTitle,
+    getActiveThread,
+    setActiveThreadId
+  }
+}

--- a/apps/desktop/src/renderer/src/components/chat/useClaude.ts
+++ b/apps/desktop/src/renderer/src/components/chat/useClaude.ts
@@ -26,6 +26,7 @@ const THINKING_TOKENS: Record<ThinkingBudget, number | undefined> = {
 
 interface UseClaudeReturn {
   messages: ChatMessage[]
+  setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>
   isLoading: boolean
   authMode: AuthMode
   setAuthMode: (mode: AuthMode) => void
@@ -235,5 +236,5 @@ export function useClaude(): UseClaudeReturn {
     window.api.resetSession()
   }, [])
 
-  return { messages, isLoading, authMode, setAuthMode, apiKey, setApiKey, model, setModel, thinkingBudget, setThinkingBudget, cliDetected, isReady, sendMessage, resetSession }
+  return { messages, setMessages, isLoading, authMode, setAuthMode, apiKey, setApiKey, model, setModel, thinkingBudget, setThinkingBudget, cliDetected, isReady, sendMessage, resetSession }
 }


### PR DESCRIPTION
## Summary

- Adds multi-chat thread support to the Claude chat panel with localStorage persistence (last 50 threads)
- New header with thread list toggle and new chat button replaces the old reset button
- Thread titles auto-generated from first user message, threads auto-saved on each message
- Restores last active thread on app reopen

## Files Changed

- `useChatHistory.ts` (new) — thread CRUD hook with localStorage persistence
- `ChatThreadList.tsx` (new) — scrollable thread list with delete confirmation
- `ChatPanel.tsx` — new header layout, conditional thread list vs messages view
- `useClaude.ts` — exposed `setMessages` for thread switching

## Test plan

- [ ] Create a new chat, send messages, verify thread auto-saves
- [ ] Click thread list toggle, verify history shows with correct titles/dates
- [ ] Switch between threads, verify messages restore correctly
- [ ] Delete a thread with confirmation, verify it's removed
- [ ] Create new chat via SquarePen button, verify fresh thread starts
- [ ] Close and reopen app, verify last active thread restores
- [ ] Verify empty threads are not persisted

Closes ONT-77

🤖 Generated with [Claude Code](https://claude.com/claude-code)