### PR TITLE
test(fixtures): add diverse ontology fixtures with OWL 2 constructs

### DIFF
--- a/apps/desktop/resources/sample-ontologies/ecommerce.ttl
+++ b/apps/desktop/resources/sample-ontologies/ecommerce.ttl
@@ -1,0 +1,191 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ecom: <http://example.org/ecommerce#> .
+
+# --- Agents ---
+
+ecom:Agent a owl:Class ;
+    rdfs:label "Agent" ;
+    rdfs:comment "An actor in the e-commerce system" .
+
+ecom:Customer a owl:Class ;
+    rdfs:label "Customer" ;
+    rdfs:comment "A person who purchases products" ;
+    rdfs:subClassOf ecom:Agent .
+
+ecom:Vendor a owl:Class ;
+    rdfs:label "Vendor" ;
+    rdfs:comment "A seller of products" ;
+    rdfs:subClassOf ecom:Agent ;
+    owl:disjointWith ecom:Customer .
+
+# --- Product hierarchy ---
+
+ecom:Product a owl:Class ;
+    rdfs:label "Product" ;
+    rdfs:comment "A purchasable item" .
+
+ecom:PhysicalProduct a owl:Class ;
+    rdfs:label "Physical Product" ;
+    rdfs:subClassOf ecom:Product .
+
+ecom:DigitalProduct a owl:Class ;
+    rdfs:label "Digital Product" ;
+    rdfs:subClassOf ecom:Product ;
+    owl:disjointWith ecom:PhysicalProduct .
+
+ecom:Subscription a owl:Class ;
+    rdfs:label "Subscription" ;
+    rdfs:comment "A recurring digital product" ;
+    rdfs:subClassOf ecom:DigitalProduct .
+
+ecom:Category a owl:Class ;
+    rdfs:label "Category" ;
+    rdfs:comment "A product classification" .
+
+# --- Order model ---
+
+ecom:Order a owl:Class ;
+    rdfs:label "Order" ;
+    rdfs:comment "A purchase transaction" .
+
+ecom:OrderItem a owl:Class ;
+    rdfs:label "Order Item" ;
+    rdfs:comment "A line item within an order" .
+
+ecom:Payment a owl:Class ;
+    rdfs:label "Payment" ;
+    rdfs:comment "A financial transaction" .
+
+ecom:Shipment a owl:Class ;
+    rdfs:label "Shipment" ;
+    rdfs:comment "A delivery of physical goods" .
+
+ecom:Review a owl:Class ;
+    rdfs:label "Review" ;
+    rdfs:comment "A customer review of a product" .
+
+ecom:Address a owl:Class ;
+    rdfs:label "Address" ;
+    rdfs:comment "A postal address" .
+
+# --- Object Properties ---
+
+ecom:placedBy a owl:ObjectProperty ;
+    rdfs:label "placed by" ;
+    rdfs:domain ecom:Order ;
+    rdfs:range ecom:Customer .
+
+ecom:containsItem a owl:ObjectProperty ;
+    rdfs:label "contains item" ;
+    rdfs:domain ecom:Order ;
+    rdfs:range ecom:OrderItem .
+
+ecom:forProduct a owl:ObjectProperty ;
+    rdfs:label "for product" ;
+    rdfs:domain ecom:OrderItem ;
+    rdfs:range ecom:Product .
+
+ecom:soldBy a owl:ObjectProperty ;
+    rdfs:label "sold by" ;
+    rdfs:domain ecom:Product ;
+    rdfs:range ecom:Vendor .
+
+ecom:belongsToCategory a owl:ObjectProperty ;
+    rdfs:label "belongs to category" ;
+    rdfs:domain ecom:Product ;
+    rdfs:range ecom:Category .
+
+ecom:hasSubCategory a owl:ObjectProperty ;
+    rdfs:label "has sub-category" ;
+    rdfs:domain ecom:Category ;
+    rdfs:range ecom:Category .
+
+ecom:paidWith a owl:ObjectProperty ;
+    rdfs:label "paid with" ;
+    rdfs:domain ecom:Order ;
+    rdfs:range ecom:Payment .
+
+ecom:shippedVia a owl:ObjectProperty ;
+    rdfs:label "shipped via" ;
+    rdfs:domain ecom:Order ;
+    rdfs:range ecom:Shipment .
+
+ecom:shipsTo a owl:ObjectProperty ;
+    rdfs:label "ships to" ;
+    rdfs:domain ecom:Shipment ;
+    rdfs:range ecom:Address .
+
+ecom:reviewOf a owl:ObjectProperty ;
+    rdfs:label "review of" ;
+    rdfs:domain ecom:Review ;
+    rdfs:range ecom:Product .
+
+ecom:writtenBy a owl:ObjectProperty ;
+    rdfs:label "written by" ;
+    rdfs:domain ecom:Review ;
+    rdfs:range ecom:Customer .
+
+# --- Datatype Properties (varied XSD types) ---
+
+ecom:productName a owl:DatatypeProperty ;
+    rdfs:label "product name" ;
+    rdfs:domain ecom:Product ;
+    rdfs:range xsd:string .
+
+ecom:price a owl:DatatypeProperty ;
+    rdfs:label "price" ;
+    rdfs:domain ecom:Product ;
+    rdfs:range xsd:decimal .
+
+ecom:weight a owl:DatatypeProperty ;
+    rdfs:label "weight (kg)" ;
+    rdfs:domain ecom:PhysicalProduct ;
+    rdfs:range xsd:double .
+
+ecom:sku a owl:DatatypeProperty ;
+    rdfs:label "SKU" ;
+    rdfs:domain ecom:Product ;
+    rdfs:range xsd:string .
+
+ecom:quantity a owl:DatatypeProperty ;
+    rdfs:label "quantity" ;
+    rdfs:domain ecom:OrderItem ;
+    rdfs:range xsd:positiveInteger .
+
+ecom:orderDate a owl:DatatypeProperty ;
+    rdfs:label "order date" ;
+    rdfs:domain ecom:Order ;
+    rdfs:range xsd:dateTime .
+
+ecom:rating a owl:DatatypeProperty ;
+    rdfs:label "rating" ;
+    rdfs:domain ecom:Review ;
+    rdfs:range xsd:integer .
+
+ecom:downloadUrl a owl:DatatypeProperty ;
+    rdfs:label "download URL" ;
+    rdfs:domain ecom:DigitalProduct ;
+    rdfs:range xsd:anyURI .
+
+ecom:isInStock a owl:DatatypeProperty ;
+    rdfs:label "is in stock" ;
+    rdfs:domain ecom:Product ;
+    rdfs:range xsd:boolean .
+
+ecom:renewalDate a owl:DatatypeProperty ;
+    rdfs:label "renewal date" ;
+    rdfs:domain ecom:Subscription ;
+    rdfs:range xsd:date .
+
+ecom:streetAddress a owl:DatatypeProperty ;
+    rdfs:label "street address" ;
+    rdfs:domain ecom:Address ;
+    rdfs:range xsd:string .
+
+ecom:postalCode a owl:DatatypeProperty ;
+    rdfs:label "postal code" ;
+    rdfs:domain ecom:Address ;
+    rdfs:range xsd:string .

--- a/apps/desktop/resources/sample-ontologies/ecommerce.ttl
+++ b/apps/desktop/resources/sample-ontologies/ecommerce.ttl
@@ -4,6 +4,11 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix ecom: <http://example.org/ecommerce#> .
 
+<http://example.org/ecommerce> a owl:Ontology ;
+    rdfs:label "E-Commerce Ontology" ;
+    owl:versionInfo "1.0.0" ;
+    rdfs:comment "Test fixture modelling products, orders, and customers" .
+
 # --- Agents ---
 
 ecom:Agent a owl:Class ;
@@ -98,7 +103,7 @@ ecom:belongsToCategory a owl:ObjectProperty ;
     rdfs:domain ecom:Product ;
     rdfs:range ecom:Category .
 
-ecom:hasSubCategory a owl:ObjectProperty ;
+ecom:hasSubCategory a owl:ObjectProperty, owl:TransitiveProperty ;
     rdfs:label "has sub-category" ;
     rdfs:domain ecom:Category ;
     rdfs:range ecom:Category .
@@ -145,7 +150,7 @@ ecom:weight a owl:DatatypeProperty ;
     rdfs:domain ecom:PhysicalProduct ;
     rdfs:range xsd:double .
 
-ecom:sku a owl:DatatypeProperty ;
+ecom:sku a owl:DatatypeProperty, owl:FunctionalProperty ;
     rdfs:label "SKU" ;
     rdfs:domain ecom:Product ;
     rdfs:range xsd:string .

--- a/apps/desktop/resources/sample-ontologies/edge-cases.ttl
+++ b/apps/desktop/resources/sample-ontologies/edge-cases.ttl
@@ -4,6 +4,10 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix edge: <http://example.org/edge-cases#> .
 
+<http://example.org/edge-cases> a owl:Ontology ;
+    rdfs:label "Edge Cases Ontology" ;
+    rdfs:comment "Test fixture exercising unusual OWL patterns" .
+
 # --- Class with no label (should trigger validation warning) ---
 
 edge:UnlabeledClass a owl:Class .
@@ -11,7 +15,7 @@ edge:UnlabeledClass a owl:Class .
 # --- Class with unicode label ---
 
 edge:UnicodeClass a owl:Class ;
-    rdfs:label "Classe avec des accents: eaeio uuee" ;
+    rdfs:label "Classe avec des accents: éàèîö üùêë" ;
     rdfs:comment "Tests parsing of non-ASCII characters in labels" .
 
 # --- Class with very long label ---
@@ -24,7 +28,7 @@ edge:VerboseClass a owl:Class ;
 
 edge:SpecialCharsClass a owl:Class ;
     rdfs:label "Special Characters" ;
-    rdfs:comment "Contains <angle brackets>, \"quotes\", & ampersands, and newlines\\nlike this" .
+    rdfs:comment "Contains <angle brackets>, \"quotes\", & ampersands, and newlines\nlike this" .
 
 # --- Deep hierarchy (5 levels) ---
 
@@ -86,6 +90,8 @@ edge:orphanProp a owl:ObjectProperty ;
     rdfs:range edge:SelfRefClass .
 
 # --- Property with multiple domains ---
+# NOTE: In OWL, multiple rdfs:domain assertions are INTERSECTED, not unioned.
+# So multiDomainProp requires its subject to be both DomainA AND DomainB.
 
 edge:DomainA a owl:Class ;
     rdfs:label "Domain A" .

--- a/apps/desktop/resources/sample-ontologies/edge-cases.ttl
+++ b/apps/desktop/resources/sample-ontologies/edge-cases.ttl
@@ -1,0 +1,140 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix edge: <http://example.org/edge-cases#> .
+
+# --- Class with no label (should trigger validation warning) ---
+
+edge:UnlabeledClass a owl:Class .
+
+# --- Class with unicode label ---
+
+edge:UnicodeClass a owl:Class ;
+    rdfs:label "Classe avec des accents: eaeio uuee" ;
+    rdfs:comment "Tests parsing of non-ASCII characters in labels" .
+
+# --- Class with very long label ---
+
+edge:VerboseClass a owl:Class ;
+    rdfs:label "A class with a particularly long and descriptive label that might challenge UI rendering assumptions about maximum label length" ;
+    rdfs:comment "Edge case for UI truncation logic" .
+
+# --- Class with special characters in comment ---
+
+edge:SpecialCharsClass a owl:Class ;
+    rdfs:label "Special Characters" ;
+    rdfs:comment "Contains <angle brackets>, \"quotes\", & ampersands, and newlines\\nlike this" .
+
+# --- Deep hierarchy (5 levels) ---
+
+edge:Level0 a owl:Class ;
+    rdfs:label "Level 0" .
+
+edge:Level1 a owl:Class ;
+    rdfs:label "Level 1" ;
+    rdfs:subClassOf edge:Level0 .
+
+edge:Level2 a owl:Class ;
+    rdfs:label "Level 2" ;
+    rdfs:subClassOf edge:Level1 .
+
+edge:Level3 a owl:Class ;
+    rdfs:label "Level 3" ;
+    rdfs:subClassOf edge:Level2 .
+
+edge:Level4 a owl:Class ;
+    rdfs:label "Level 4" ;
+    rdfs:subClassOf edge:Level3 .
+
+edge:Level5 a owl:Class ;
+    rdfs:label "Level 5" ;
+    rdfs:subClassOf edge:Level4 .
+
+# --- Multiple inheritance (diamond) ---
+
+edge:DiamondTop a owl:Class ;
+    rdfs:label "Diamond Top" .
+
+edge:DiamondLeft a owl:Class ;
+    rdfs:label "Diamond Left" ;
+    rdfs:subClassOf edge:DiamondTop .
+
+edge:DiamondRight a owl:Class ;
+    rdfs:label "Diamond Right" ;
+    rdfs:subClassOf edge:DiamondTop .
+
+edge:DiamondBottom a owl:Class ;
+    rdfs:label "Diamond Bottom" ;
+    rdfs:subClassOf edge:DiamondLeft ;
+    rdfs:subClassOf edge:DiamondRight .
+
+# --- Self-referencing object property (domain = range) ---
+
+edge:SelfRefClass a owl:Class ;
+    rdfs:label "Self-Referencing" .
+
+edge:relatesTo a owl:ObjectProperty ;
+    rdfs:label "relates to" ;
+    rdfs:domain edge:SelfRefClass ;
+    rdfs:range edge:SelfRefClass .
+
+# --- Property with no domain (should trigger validation warning) ---
+
+edge:orphanProp a owl:ObjectProperty ;
+    rdfs:label "orphan property" ;
+    rdfs:range edge:SelfRefClass .
+
+# --- Property with multiple domains ---
+
+edge:DomainA a owl:Class ;
+    rdfs:label "Domain A" .
+
+edge:DomainB a owl:Class ;
+    rdfs:label "Domain B" .
+
+edge:Target a owl:Class ;
+    rdfs:label "Target" .
+
+edge:multiDomainProp a owl:ObjectProperty ;
+    rdfs:label "multi-domain property" ;
+    rdfs:domain edge:DomainA ;
+    rdfs:domain edge:DomainB ;
+    rdfs:range edge:Target .
+
+# --- Mutual disjointness ---
+
+edge:DisjointA a owl:Class ;
+    rdfs:label "Disjoint A" ;
+    owl:disjointWith edge:DisjointB ;
+    owl:disjointWith edge:DisjointC .
+
+edge:DisjointB a owl:Class ;
+    rdfs:label "Disjoint B" ;
+    owl:disjointWith edge:DisjointA .
+
+edge:DisjointC a owl:Class ;
+    rdfs:label "Disjoint C" ;
+    owl:disjointWith edge:DisjointA .
+
+# --- Datatype properties with less common XSD types ---
+
+edge:durationVal a owl:DatatypeProperty ;
+    rdfs:label "time value" ;
+    rdfs:domain edge:Level0 ;
+    rdfs:range xsd:time .
+
+edge:byteVal a owl:DatatypeProperty ;
+    rdfs:label "byte value" ;
+    rdfs:domain edge:Level0 ;
+    rdfs:range xsd:byte .
+
+edge:shortVal a owl:DatatypeProperty ;
+    rdfs:label "short value" ;
+    rdfs:domain edge:Level0 ;
+    rdfs:range xsd:short .
+
+edge:longVal a owl:DatatypeProperty ;
+    rdfs:label "long value" ;
+    rdfs:domain edge:Level0 ;
+    rdfs:range xsd:long .

--- a/apps/desktop/resources/sample-ontologies/healthcare.ttl
+++ b/apps/desktop/resources/sample-ontologies/healthcare.ttl
@@ -1,0 +1,175 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix health: <http://example.org/healthcare#> .
+
+# --- Top-level classes ---
+
+health:LivingEntity a owl:Class ;
+    rdfs:label "Living Entity" ;
+    rdfs:comment "Any entity that is alive or was once alive" .
+
+health:Person a owl:Class ;
+    rdfs:label "Person" ;
+    rdfs:comment "A human being" ;
+    rdfs:subClassOf health:LivingEntity .
+
+health:Animal a owl:Class ;
+    rdfs:label "Animal" ;
+    rdfs:comment "A non-human animal" ;
+    rdfs:subClassOf health:LivingEntity ;
+    owl:disjointWith health:Person .
+
+# --- Healthcare provider hierarchy (3 levels deep) ---
+
+health:HealthcareProvider a owl:Class ;
+    rdfs:label "Healthcare Provider" ;
+    rdfs:comment "A person who provides healthcare services" ;
+    rdfs:subClassOf health:Person .
+
+health:Physician a owl:Class ;
+    rdfs:label "Physician" ;
+    rdfs:comment "A medical doctor" ;
+    rdfs:subClassOf health:HealthcareProvider .
+
+health:Surgeon a owl:Class ;
+    rdfs:label "Surgeon" ;
+    rdfs:comment "A physician specializing in surgery" ;
+    rdfs:subClassOf health:Physician .
+
+health:Nurse a owl:Class ;
+    rdfs:label "Nurse" ;
+    rdfs:comment "A registered nurse" ;
+    rdfs:subClassOf health:HealthcareProvider ;
+    owl:disjointWith health:Physician .
+
+health:Pharmacist a owl:Class ;
+    rdfs:label "Pharmacist" ;
+    rdfs:comment "A licensed pharmacist" ;
+    rdfs:subClassOf health:HealthcareProvider ;
+    owl:disjointWith health:Physician ;
+    owl:disjointWith health:Nurse .
+
+# --- Patient ---
+
+health:Patient a owl:Class ;
+    rdfs:label "Patient" ;
+    rdfs:comment "A person receiving healthcare" ;
+    rdfs:subClassOf health:Person .
+
+# --- Clinical entities ---
+
+health:MedicalCondition a owl:Class ;
+    rdfs:label "Medical Condition" ;
+    rdfs:comment "A disease, disorder, or health condition" .
+
+health:Treatment a owl:Class ;
+    rdfs:label "Treatment" ;
+    rdfs:comment "A therapeutic intervention" .
+
+health:Medication a owl:Class ;
+    rdfs:label "Medication" ;
+    rdfs:comment "A pharmaceutical substance" ;
+    rdfs:subClassOf health:Treatment .
+
+health:SurgicalProcedure a owl:Class ;
+    rdfs:label "Surgical Procedure" ;
+    rdfs:comment "An invasive surgical intervention" ;
+    rdfs:subClassOf health:Treatment ;
+    owl:disjointWith health:Medication .
+
+health:Facility a owl:Class ;
+    rdfs:label "Healthcare Facility" ;
+    rdfs:comment "A place where healthcare is delivered" .
+
+health:Hospital a owl:Class ;
+    rdfs:label "Hospital" ;
+    rdfs:subClassOf health:Facility .
+
+health:Clinic a owl:Class ;
+    rdfs:label "Clinic" ;
+    rdfs:subClassOf health:Facility ;
+    owl:disjointWith health:Hospital .
+
+# --- Object Properties ---
+
+health:treats a owl:ObjectProperty ;
+    rdfs:label "treats" ;
+    rdfs:comment "A provider treats a patient" ;
+    rdfs:domain health:HealthcareProvider ;
+    rdfs:range health:Patient ;
+    owl:inverseOf health:treatedBy .
+
+health:treatedBy a owl:ObjectProperty ;
+    rdfs:label "treated by" ;
+    rdfs:domain health:Patient ;
+    rdfs:range health:HealthcareProvider ;
+    owl:inverseOf health:treats .
+
+health:diagnoses a owl:ObjectProperty ;
+    rdfs:label "diagnoses" ;
+    rdfs:domain health:Physician ;
+    rdfs:range health:MedicalCondition .
+
+health:hasTreatment a owl:ObjectProperty ;
+    rdfs:label "has treatment" ;
+    rdfs:domain health:MedicalCondition ;
+    rdfs:range health:Treatment .
+
+health:prescribes a owl:ObjectProperty ;
+    rdfs:label "prescribes" ;
+    rdfs:domain health:Physician ;
+    rdfs:range health:Medication .
+
+health:performedAt a owl:ObjectProperty ;
+    rdfs:label "performed at" ;
+    rdfs:domain health:Treatment ;
+    rdfs:range health:Facility .
+
+health:worksAt a owl:ObjectProperty ;
+    rdfs:label "works at" ;
+    rdfs:domain health:HealthcareProvider ;
+    rdfs:range health:Facility .
+
+# --- Datatype Properties ---
+
+health:dateOfBirth a owl:DatatypeProperty ;
+    rdfs:label "date of birth" ;
+    rdfs:domain health:Person ;
+    rdfs:range xsd:date .
+
+health:fullName a owl:DatatypeProperty ;
+    rdfs:label "full name" ;
+    rdfs:domain health:Person ;
+    rdfs:range xsd:string .
+
+health:licenseNumber a owl:DatatypeProperty ;
+    rdfs:label "license number" ;
+    rdfs:domain health:HealthcareProvider ;
+    rdfs:range xsd:string .
+
+health:dosageMg a owl:DatatypeProperty ;
+    rdfs:label "dosage (mg)" ;
+    rdfs:domain health:Medication ;
+    rdfs:range xsd:float .
+
+health:icdCode a owl:DatatypeProperty ;
+    rdfs:label "ICD code" ;
+    rdfs:domain health:MedicalCondition ;
+    rdfs:range xsd:string .
+
+health:admissionDate a owl:DatatypeProperty ;
+    rdfs:label "admission date" ;
+    rdfs:domain health:Patient ;
+    rdfs:range xsd:dateTime .
+
+health:isActive a owl:DatatypeProperty ;
+    rdfs:label "is active" ;
+    rdfs:domain health:Facility ;
+    rdfs:range xsd:boolean .
+
+health:bedCount a owl:DatatypeProperty ;
+    rdfs:label "bed count" ;
+    rdfs:domain health:Hospital ;
+    rdfs:range xsd:nonNegativeInteger .

--- a/apps/desktop/resources/sample-ontologies/healthcare.ttl
+++ b/apps/desktop/resources/sample-ontologies/healthcare.ttl
@@ -4,6 +4,11 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix health: <http://example.org/healthcare#> .
 
+<http://example.org/healthcare> a owl:Ontology ;
+    rdfs:label "Healthcare Ontology" ;
+    owl:versionInfo "1.0.0" ;
+    rdfs:comment "Test fixture modelling healthcare providers, patients, and clinical entities" .
+
 # --- Top-level classes ---
 
 health:LivingEntity a owl:Class ;
@@ -36,20 +41,26 @@ health:Physician a owl:Class ;
 health:Surgeon a owl:Class ;
     rdfs:label "Surgeon" ;
     rdfs:comment "A physician specializing in surgery" ;
-    rdfs:subClassOf health:Physician .
+    rdfs:subClassOf health:Physician ;
+    rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty health:performs ;
+        owl:someValuesFrom health:SurgicalProcedure
+    ] .
 
 health:Nurse a owl:Class ;
     rdfs:label "Nurse" ;
     rdfs:comment "A registered nurse" ;
-    rdfs:subClassOf health:HealthcareProvider ;
-    owl:disjointWith health:Physician .
+    rdfs:subClassOf health:HealthcareProvider .
 
 health:Pharmacist a owl:Class ;
     rdfs:label "Pharmacist" ;
     rdfs:comment "A licensed pharmacist" ;
-    rdfs:subClassOf health:HealthcareProvider ;
-    owl:disjointWith health:Physician ;
-    owl:disjointWith health:Nurse .
+    rdfs:subClassOf health:HealthcareProvider .
+
+# OWL 2 AllDisjointClasses — cleaner than pairwise disjointWith
+[] a owl:AllDisjointClasses ;
+    owl:members ( health:Physician health:Nurse health:Pharmacist ) .
 
 # --- Patient ---
 
@@ -173,3 +184,19 @@ health:bedCount a owl:DatatypeProperty ;
     rdfs:label "bed count" ;
     rdfs:domain health:Hospital ;
     rdfs:range xsd:nonNegativeInteger .
+
+health:performs a owl:ObjectProperty ;
+    rdfs:label "performs" ;
+    rdfs:domain health:Physician ;
+    rdfs:range health:Treatment .
+
+# --- Named Individuals (ABox) ---
+
+health:drSmith a health:Surgeon ;
+    health:fullName "Dr. Alice Smith" ;
+    health:licenseNumber "MED-2024-0042" .
+
+health:generalHospital a health:Hospital ;
+    rdfs:label "General Hospital" ;
+    health:isActive true ;
+    health:bedCount "250"^^xsd:nonNegativeInteger .

--- a/apps/desktop/resources/sample-ontologies/minimal.ttl
+++ b/apps/desktop/resources/sample-ontologies/minimal.ttl
@@ -2,6 +2,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix ex: <http://example.org/minimal#> .
 
+<http://example.org/minimal> a owl:Ontology .
+
 ex:Thing a owl:Class ;
     rdfs:label "Thing" ;
     rdfs:comment "The only class in this minimal ontology" .

--- a/apps/desktop/resources/sample-ontologies/minimal.ttl
+++ b/apps/desktop/resources/sample-ontologies/minimal.ttl
@@ -1,0 +1,7 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <http://example.org/minimal#> .
+
+ex:Thing a owl:Class ;
+    rdfs:label "Thing" ;
+    rdfs:comment "The only class in this minimal ontology" .

--- a/apps/desktop/resources/sample-ontologies/university.ttl
+++ b/apps/desktop/resources/sample-ontologies/university.ttl
@@ -1,0 +1,407 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix uni: <http://example.org/university#> .
+
+# ============================================================
+# University ontology — large fixture for performance testing
+# 50+ classes, 30+ properties, deep hierarchy, cross-cutting
+# ============================================================
+
+# --- Top-level ---
+
+uni:Thing a owl:Class ;
+    rdfs:label "Thing" .
+
+uni:Agent a owl:Class ;
+    rdfs:label "Agent" ;
+    rdfs:subClassOf uni:Thing .
+
+uni:Organization a owl:Class ;
+    rdfs:label "Organization" ;
+    rdfs:subClassOf uni:Agent .
+
+uni:Person a owl:Class ;
+    rdfs:label "Person" ;
+    rdfs:comment "A human individual" ;
+    rdfs:subClassOf uni:Agent ;
+    owl:disjointWith uni:Organization .
+
+# --- People hierarchy ---
+
+uni:Student a owl:Class ;
+    rdfs:label "Student" ;
+    rdfs:subClassOf uni:Person .
+
+uni:UndergraduateStudent a owl:Class ;
+    rdfs:label "Undergraduate Student" ;
+    rdfs:subClassOf uni:Student .
+
+uni:GraduateStudent a owl:Class ;
+    rdfs:label "Graduate Student" ;
+    rdfs:subClassOf uni:Student .
+
+uni:MastersStudent a owl:Class ;
+    rdfs:label "Masters Student" ;
+    rdfs:subClassOf uni:GraduateStudent .
+
+uni:DoctoralStudent a owl:Class ;
+    rdfs:label "Doctoral Student" ;
+    rdfs:subClassOf uni:GraduateStudent ;
+    owl:disjointWith uni:MastersStudent .
+
+uni:PostDoc a owl:Class ;
+    rdfs:label "Post-Doctoral Researcher" ;
+    rdfs:subClassOf uni:Person .
+
+uni:Staff a owl:Class ;
+    rdfs:label "Staff" ;
+    rdfs:subClassOf uni:Person .
+
+uni:AcademicStaff a owl:Class ;
+    rdfs:label "Academic Staff" ;
+    rdfs:subClassOf uni:Staff .
+
+uni:Professor a owl:Class ;
+    rdfs:label "Professor" ;
+    rdfs:subClassOf uni:AcademicStaff .
+
+uni:AssistantProfessor a owl:Class ;
+    rdfs:label "Assistant Professor" ;
+    rdfs:subClassOf uni:AcademicStaff .
+
+uni:AssociateProfessor a owl:Class ;
+    rdfs:label "Associate Professor" ;
+    rdfs:subClassOf uni:AcademicStaff .
+
+uni:Lecturer a owl:Class ;
+    rdfs:label "Lecturer" ;
+    rdfs:subClassOf uni:AcademicStaff .
+
+uni:Researcher a owl:Class ;
+    rdfs:label "Researcher" ;
+    rdfs:subClassOf uni:AcademicStaff .
+
+uni:AdministrativeStaff a owl:Class ;
+    rdfs:label "Administrative Staff" ;
+    rdfs:subClassOf uni:Staff ;
+    owl:disjointWith uni:AcademicStaff .
+
+uni:TechnicalStaff a owl:Class ;
+    rdfs:label "Technical Staff" ;
+    rdfs:subClassOf uni:Staff .
+
+uni:Librarian a owl:Class ;
+    rdfs:label "Librarian" ;
+    rdfs:subClassOf uni:AdministrativeStaff .
+
+uni:Registrar a owl:Class ;
+    rdfs:label "Registrar" ;
+    rdfs:subClassOf uni:AdministrativeStaff .
+
+# --- Organization hierarchy ---
+
+uni:University a owl:Class ;
+    rdfs:label "University" ;
+    rdfs:subClassOf uni:Organization .
+
+uni:Faculty a owl:Class ;
+    rdfs:label "Faculty" ;
+    rdfs:comment "An academic division of a university" ;
+    rdfs:subClassOf uni:Organization .
+
+uni:Department a owl:Class ;
+    rdfs:label "Department" ;
+    rdfs:subClassOf uni:Organization .
+
+uni:ResearchGroup a owl:Class ;
+    rdfs:label "Research Group" ;
+    rdfs:subClassOf uni:Organization .
+
+uni:ResearchCenter a owl:Class ;
+    rdfs:label "Research Center" ;
+    rdfs:subClassOf uni:Organization .
+
+uni:Institute a owl:Class ;
+    rdfs:label "Institute" ;
+    rdfs:subClassOf uni:Organization .
+
+uni:Library a owl:Class ;
+    rdfs:label "Library" ;
+    rdfs:subClassOf uni:Organization .
+
+# --- Academic entities ---
+
+uni:AcademicEntity a owl:Class ;
+    rdfs:label "Academic Entity" ;
+    rdfs:subClassOf uni:Thing .
+
+uni:Course a owl:Class ;
+    rdfs:label "Course" ;
+    rdfs:subClassOf uni:AcademicEntity .
+
+uni:GraduateCourse a owl:Class ;
+    rdfs:label "Graduate Course" ;
+    rdfs:subClassOf uni:Course .
+
+uni:UndergraduateCourse a owl:Class ;
+    rdfs:label "Undergraduate Course" ;
+    rdfs:subClassOf uni:Course ;
+    owl:disjointWith uni:GraduateCourse .
+
+uni:Seminar a owl:Class ;
+    rdfs:label "Seminar" ;
+    rdfs:subClassOf uni:Course .
+
+uni:Program a owl:Class ;
+    rdfs:label "Program" ;
+    rdfs:comment "A degree program" ;
+    rdfs:subClassOf uni:AcademicEntity .
+
+uni:BachelorsProgram a owl:Class ;
+    rdfs:label "Bachelors Program" ;
+    rdfs:subClassOf uni:Program .
+
+uni:MastersProgram a owl:Class ;
+    rdfs:label "Masters Program" ;
+    rdfs:subClassOf uni:Program .
+
+uni:DoctoralProgram a owl:Class ;
+    rdfs:label "Doctoral Program" ;
+    rdfs:subClassOf uni:Program .
+
+uni:Curriculum a owl:Class ;
+    rdfs:label "Curriculum" ;
+    rdfs:subClassOf uni:AcademicEntity .
+
+# --- Research entities ---
+
+uni:ResearchEntity a owl:Class ;
+    rdfs:label "Research Entity" ;
+    rdfs:subClassOf uni:Thing .
+
+uni:Publication a owl:Class ;
+    rdfs:label "Publication" ;
+    rdfs:subClassOf uni:ResearchEntity .
+
+uni:JournalArticle a owl:Class ;
+    rdfs:label "Journal Article" ;
+    rdfs:subClassOf uni:Publication .
+
+uni:ConferencePaper a owl:Class ;
+    rdfs:label "Conference Paper" ;
+    rdfs:subClassOf uni:Publication .
+
+uni:TechnicalReport a owl:Class ;
+    rdfs:label "Technical Report" ;
+    rdfs:subClassOf uni:Publication .
+
+uni:Thesis a owl:Class ;
+    rdfs:label "Thesis" ;
+    rdfs:subClassOf uni:Publication .
+
+uni:ResearchProject a owl:Class ;
+    rdfs:label "Research Project" ;
+    rdfs:subClassOf uni:ResearchEntity .
+
+uni:Grant a owl:Class ;
+    rdfs:label "Grant" ;
+    rdfs:subClassOf uni:ResearchEntity .
+
+uni:Patent a owl:Class ;
+    rdfs:label "Patent" ;
+    rdfs:subClassOf uni:ResearchEntity .
+
+# --- Infrastructure ---
+
+uni:PhysicalEntity a owl:Class ;
+    rdfs:label "Physical Entity" ;
+    rdfs:subClassOf uni:Thing .
+
+uni:Building a owl:Class ;
+    rdfs:label "Building" ;
+    rdfs:subClassOf uni:PhysicalEntity .
+
+uni:Room a owl:Class ;
+    rdfs:label "Room" ;
+    rdfs:subClassOf uni:PhysicalEntity .
+
+uni:Classroom a owl:Class ;
+    rdfs:label "Classroom" ;
+    rdfs:subClassOf uni:Room .
+
+uni:Laboratory a owl:Class ;
+    rdfs:label "Laboratory" ;
+    rdfs:subClassOf uni:Room .
+
+uni:Office a owl:Class ;
+    rdfs:label "Office" ;
+    rdfs:subClassOf uni:Room .
+
+# --- Object Properties ---
+
+uni:memberOf a owl:ObjectProperty ;
+    rdfs:label "member of" ;
+    rdfs:domain uni:Person ;
+    rdfs:range uni:Organization .
+
+uni:headOf a owl:ObjectProperty ;
+    rdfs:label "head of" ;
+    rdfs:domain uni:AcademicStaff ;
+    rdfs:range uni:Department .
+
+uni:teaches a owl:ObjectProperty ;
+    rdfs:label "teaches" ;
+    rdfs:domain uni:AcademicStaff ;
+    rdfs:range uni:Course .
+
+uni:enrolledIn a owl:ObjectProperty ;
+    rdfs:label "enrolled in" ;
+    rdfs:domain uni:Student ;
+    rdfs:range uni:Course .
+
+uni:advisedBy a owl:ObjectProperty ;
+    rdfs:label "advised by" ;
+    rdfs:domain uni:GraduateStudent ;
+    rdfs:range uni:Professor ;
+    owl:inverseOf uni:advises .
+
+uni:advises a owl:ObjectProperty ;
+    rdfs:label "advises" ;
+    rdfs:domain uni:Professor ;
+    rdfs:range uni:GraduateStudent ;
+    owl:inverseOf uni:advisedBy .
+
+uni:offeredBy a owl:ObjectProperty ;
+    rdfs:label "offered by" ;
+    rdfs:domain uni:Course ;
+    rdfs:range uni:Department .
+
+uni:partOfProgram a owl:ObjectProperty ;
+    rdfs:label "part of program" ;
+    rdfs:domain uni:Course ;
+    rdfs:range uni:Program .
+
+uni:authorOf a owl:ObjectProperty ;
+    rdfs:label "author of" ;
+    rdfs:domain uni:Person ;
+    rdfs:range uni:Publication .
+
+uni:fundedBy a owl:ObjectProperty ;
+    rdfs:label "funded by" ;
+    rdfs:domain uni:ResearchProject ;
+    rdfs:range uni:Grant .
+
+uni:locatedIn a owl:ObjectProperty ;
+    rdfs:label "located in" ;
+    rdfs:domain uni:Room ;
+    rdfs:range uni:Building .
+
+uni:hasRoom a owl:ObjectProperty ;
+    rdfs:label "has room" ;
+    rdfs:domain uni:Building ;
+    rdfs:range uni:Room ;
+    owl:inverseOf uni:locatedIn .
+
+uni:worksIn a owl:ObjectProperty ;
+    rdfs:label "works in" ;
+    rdfs:domain uni:Staff ;
+    rdfs:range uni:Office .
+
+uni:subOrganizationOf a owl:ObjectProperty ;
+    rdfs:label "sub-organization of" ;
+    rdfs:domain uni:Organization ;
+    rdfs:range uni:Organization .
+
+uni:publishedIn a owl:ObjectProperty ;
+    rdfs:label "published in" ;
+    rdfs:domain uni:Publication ;
+    rdfs:range uni:ResearchEntity .
+
+uni:collaboratesWith a owl:ObjectProperty ;
+    rdfs:label "collaborates with" ;
+    rdfs:domain uni:Researcher ;
+    rdfs:range uni:Researcher .
+
+# --- Datatype Properties ---
+
+uni:name a owl:DatatypeProperty ;
+    rdfs:label "name" ;
+    rdfs:domain uni:Thing ;
+    rdfs:range xsd:string .
+
+uni:email a owl:DatatypeProperty ;
+    rdfs:label "email" ;
+    rdfs:domain uni:Person ;
+    rdfs:range xsd:string .
+
+uni:studentId a owl:DatatypeProperty ;
+    rdfs:label "student ID" ;
+    rdfs:domain uni:Student ;
+    rdfs:range xsd:string .
+
+uni:gpa a owl:DatatypeProperty ;
+    rdfs:label "GPA" ;
+    rdfs:domain uni:Student ;
+    rdfs:range xsd:float .
+
+uni:enrollmentDate a owl:DatatypeProperty ;
+    rdfs:label "enrollment date" ;
+    rdfs:domain uni:Student ;
+    rdfs:range xsd:date .
+
+uni:creditHours a owl:DatatypeProperty ;
+    rdfs:label "credit hours" ;
+    rdfs:domain uni:Course ;
+    rdfs:range xsd:integer .
+
+uni:courseCode a owl:DatatypeProperty ;
+    rdfs:label "course code" ;
+    rdfs:domain uni:Course ;
+    rdfs:range xsd:string .
+
+uni:maxEnrollment a owl:DatatypeProperty ;
+    rdfs:label "max enrollment" ;
+    rdfs:domain uni:Course ;
+    rdfs:range xsd:positiveInteger .
+
+uni:publicationYear a owl:DatatypeProperty ;
+    rdfs:label "publication year" ;
+    rdfs:domain uni:Publication ;
+    rdfs:range xsd:integer .
+
+uni:doi a owl:DatatypeProperty ;
+    rdfs:label "DOI" ;
+    rdfs:domain uni:Publication ;
+    rdfs:range xsd:anyURI .
+
+uni:grantAmount a owl:DatatypeProperty ;
+    rdfs:label "grant amount" ;
+    rdfs:domain uni:Grant ;
+    rdfs:range xsd:decimal .
+
+uni:startDate a owl:DatatypeProperty ;
+    rdfs:label "start date" ;
+    rdfs:domain uni:ResearchProject ;
+    rdfs:range xsd:date .
+
+uni:endDate a owl:DatatypeProperty ;
+    rdfs:label "end date" ;
+    rdfs:domain uni:ResearchProject ;
+    rdfs:range xsd:date .
+
+uni:capacity a owl:DatatypeProperty ;
+    rdfs:label "capacity" ;
+    rdfs:domain uni:Room ;
+    rdfs:range xsd:nonNegativeInteger .
+
+uni:floorNumber a owl:DatatypeProperty ;
+    rdfs:label "floor number" ;
+    rdfs:domain uni:Room ;
+    rdfs:range xsd:integer .
+
+uni:isActive a owl:DatatypeProperty ;
+    rdfs:label "is active" ;
+    rdfs:domain uni:Organization ;
+    rdfs:range xsd:boolean .

--- a/apps/desktop/resources/sample-ontologies/university.ttl
+++ b/apps/desktop/resources/sample-ontologies/university.ttl
@@ -4,6 +4,11 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix uni: <http://example.org/university#> .
 
+<http://example.org/university> a owl:Ontology ;
+    rdfs:label "University Ontology" ;
+    owl:versionInfo "1.0.0" ;
+    rdfs:comment "Large test fixture modelling university domains — people, orgs, academics, research, infrastructure" .
+
 # ============================================================
 # University ontology — large fixture for performance testing
 # 50+ classes, 30+ properties, deep hierarchy, cross-cutting
@@ -11,12 +16,12 @@
 
 # --- Top-level ---
 
-uni:Thing a owl:Class ;
-    rdfs:label "Thing" .
+uni:Entity a owl:Class ;
+    rdfs:label "Entity" .
 
 uni:Agent a owl:Class ;
     rdfs:label "Agent" ;
-    rdfs:subClassOf uni:Thing .
+    rdfs:subClassOf uni:Entity .
 
 uni:Organization a owl:Class ;
     rdfs:label "Organization" ;
@@ -135,7 +140,7 @@ uni:Library a owl:Class ;
 
 uni:AcademicEntity a owl:Class ;
     rdfs:label "Academic Entity" ;
-    rdfs:subClassOf uni:Thing .
+    rdfs:subClassOf uni:Entity .
 
 uni:Course a owl:Class ;
     rdfs:label "Course" ;
@@ -179,7 +184,7 @@ uni:Curriculum a owl:Class ;
 
 uni:ResearchEntity a owl:Class ;
     rdfs:label "Research Entity" ;
-    rdfs:subClassOf uni:Thing .
+    rdfs:subClassOf uni:Entity .
 
 uni:Publication a owl:Class ;
     rdfs:label "Publication" ;
@@ -213,11 +218,16 @@ uni:Patent a owl:Class ;
     rdfs:label "Patent" ;
     rdfs:subClassOf uni:ResearchEntity .
 
+uni:Venue a owl:Class ;
+    rdfs:label "Venue" ;
+    rdfs:comment "A publication venue (journal, conference proceedings, etc.)" ;
+    rdfs:subClassOf uni:ResearchEntity .
+
 # --- Infrastructure ---
 
 uni:PhysicalEntity a owl:Class ;
     rdfs:label "Physical Entity" ;
-    rdfs:subClassOf uni:Thing .
+    rdfs:subClassOf uni:Entity .
 
 uni:Building a owl:Class ;
     rdfs:label "Building" ;
@@ -309,7 +319,7 @@ uni:worksIn a owl:ObjectProperty ;
     rdfs:domain uni:Staff ;
     rdfs:range uni:Office .
 
-uni:subOrganizationOf a owl:ObjectProperty ;
+uni:subOrganizationOf a owl:ObjectProperty, owl:TransitiveProperty ;
     rdfs:label "sub-organization of" ;
     rdfs:domain uni:Organization ;
     rdfs:range uni:Organization .
@@ -317,9 +327,9 @@ uni:subOrganizationOf a owl:ObjectProperty ;
 uni:publishedIn a owl:ObjectProperty ;
     rdfs:label "published in" ;
     rdfs:domain uni:Publication ;
-    rdfs:range uni:ResearchEntity .
+    rdfs:range uni:Venue .
 
-uni:collaboratesWith a owl:ObjectProperty ;
+uni:collaboratesWith a owl:ObjectProperty, owl:SymmetricProperty ;
     rdfs:label "collaborates with" ;
     rdfs:domain uni:Researcher ;
     rdfs:range uni:Researcher .
@@ -328,7 +338,7 @@ uni:collaboratesWith a owl:ObjectProperty ;
 
 uni:name a owl:DatatypeProperty ;
     rdfs:label "name" ;
-    rdfs:domain uni:Thing ;
+    rdfs:domain uni:Entity ;
     rdfs:range xsd:string .
 
 uni:email a owl:DatatypeProperty ;

--- a/apps/desktop/tests/model/fixtures.test.ts
+++ b/apps/desktop/tests/model/fixtures.test.ts
@@ -59,14 +59,15 @@ describe('all fixtures: parse and round-trip', () => {
 describe('healthcare.ttl', () => {
   const turtle = loadFixture('healthcare.ttl')
 
-  it('parses 16 classes', () => {
+  it('parses 16 named classes (plus blank nodes from restrictions)', () => {
     const o = parseTurtle(turtle)
-    expect(o.classes.size).toBe(16)
+    const namedClasses = [...o.classes.keys()].filter((k) => k.startsWith('http'))
+    expect(namedClasses.length).toBe(16)
   })
 
   it('has deep hierarchy: Surgeon -> Physician -> HealthcareProvider -> Person -> LivingEntity', () => {
     const o = parseTurtle(turtle)
-    expect(o.classes.get(`${HEALTH}Surgeon`)!.subClassOf).toEqual([`${HEALTH}Physician`])
+    expect(o.classes.get(`${HEALTH}Surgeon`)!.subClassOf).toContain(`${HEALTH}Physician`)
     expect(o.classes.get(`${HEALTH}Physician`)!.subClassOf).toEqual([`${HEALTH}HealthcareProvider`])
     expect(o.classes.get(`${HEALTH}HealthcareProvider`)!.subClassOf).toEqual([`${HEALTH}Person`])
     expect(o.classes.get(`${HEALTH}Person`)!.subClassOf).toEqual([`${HEALTH}LivingEntity`])

--- a/apps/desktop/tests/model/fixtures.test.ts
+++ b/apps/desktop/tests/model/fixtures.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'fs'
+import { resolve } from 'path'
+import { parseTurtle, parseTurtleWithWarnings } from '@renderer/model/parse'
+import { serializeToTurtle } from '@renderer/model/serialize'
+
+const FIXTURES_DIR = resolve(__dirname, '../../resources/sample-ontologies')
+
+const HEALTH = 'http://example.org/healthcare#'
+const ECOM = 'http://example.org/ecommerce#'
+const EDGE = 'http://example.org/edge-cases#'
+const UNI = 'http://example.org/university#'
+
+function loadFixture(name: string): string {
+  return readFileSync(resolve(FIXTURES_DIR, name), 'utf-8')
+}
+
+// ---- Generic: every .ttl fixture should parse and round-trip ----
+
+describe('all fixtures: parse and round-trip', () => {
+  const files = readdirSync(FIXTURES_DIR).filter((f) => f.endsWith('.ttl'))
+
+  for (const file of files) {
+    describe(file, () => {
+      const turtle = loadFixture(file)
+
+      it('parses without errors', () => {
+        const { warnings } = parseTurtleWithWarnings(turtle)
+        const errors = warnings.filter((w) => w.severity === 'error')
+        expect(errors).toEqual([])
+      })
+
+      it('round-trips: class count preserved', () => {
+        const original = parseTurtle(turtle)
+        const serialized = serializeToTurtle(original)
+        const reparsed = parseTurtle(serialized)
+        expect(reparsed.classes.size).toBe(original.classes.size)
+      })
+
+      it('round-trips: object property count preserved', () => {
+        const original = parseTurtle(turtle)
+        const serialized = serializeToTurtle(original)
+        const reparsed = parseTurtle(serialized)
+        expect(reparsed.objectProperties.size).toBe(original.objectProperties.size)
+      })
+
+      it('round-trips: datatype property count preserved', () => {
+        const original = parseTurtle(turtle)
+        const serialized = serializeToTurtle(original)
+        const reparsed = parseTurtle(serialized)
+        expect(reparsed.datatypeProperties.size).toBe(original.datatypeProperties.size)
+      })
+    })
+  }
+})
+
+// ---- Healthcare fixture ----
+
+describe('healthcare.ttl', () => {
+  const turtle = loadFixture('healthcare.ttl')
+
+  it('parses 16 classes', () => {
+    const o = parseTurtle(turtle)
+    expect(o.classes.size).toBe(16)
+  })
+
+  it('has deep hierarchy: Surgeon -> Physician -> HealthcareProvider -> Person -> LivingEntity', () => {
+    const o = parseTurtle(turtle)
+    expect(o.classes.get(`${HEALTH}Surgeon`)!.subClassOf).toEqual([`${HEALTH}Physician`])
+    expect(o.classes.get(`${HEALTH}Physician`)!.subClassOf).toEqual([`${HEALTH}HealthcareProvider`])
+    expect(o.classes.get(`${HEALTH}HealthcareProvider`)!.subClassOf).toEqual([`${HEALTH}Person`])
+    expect(o.classes.get(`${HEALTH}Person`)!.subClassOf).toEqual([`${HEALTH}LivingEntity`])
+  })
+
+  it('parses disjointWith between Person and Animal', () => {
+    const animal = o().classes.get(`${HEALTH}Animal`)!
+    expect(animal.disjointWith).toContain(`${HEALTH}Person`)
+  })
+
+  it('parses inverse properties treats/treatedBy', () => {
+    const treats = o().objectProperties.get(`${HEALTH}treats`)!
+    expect(treats.inverseOf).toBe(`${HEALTH}treatedBy`)
+  })
+
+  it('parses varied XSD datatypes', () => {
+    const o2 = parseTurtle(turtle)
+    expect(o2.datatypeProperties.get(`${HEALTH}dosageMg`)!.range).toBe(
+      'http://www.w3.org/2001/XMLSchema#float'
+    )
+    expect(o2.datatypeProperties.get(`${HEALTH}isActive`)!.range).toBe(
+      'http://www.w3.org/2001/XMLSchema#boolean'
+    )
+    expect(o2.datatypeProperties.get(`${HEALTH}bedCount`)!.range).toBe(
+      'http://www.w3.org/2001/XMLSchema#nonNegativeInteger'
+    )
+  })
+
+  function o() {
+    return parseTurtle(turtle)
+  }
+})
+
+// ---- E-commerce fixture ----
+
+describe('ecommerce.ttl', () => {
+  const turtle = loadFixture('ecommerce.ttl')
+
+  it('parses 14 classes', () => {
+    const o = parseTurtle(turtle)
+    expect(o.classes.size).toBe(14)
+  })
+
+  it('parses 11 object properties', () => {
+    const o = parseTurtle(turtle)
+    expect(o.objectProperties.size).toBe(11)
+  })
+
+  it('parses 12 datatype properties', () => {
+    const o = parseTurtle(turtle)
+    expect(o.datatypeProperties.size).toBe(12)
+  })
+
+  it('has Product hierarchy with disjoint physical/digital', () => {
+    const o = parseTurtle(turtle)
+    const digital = o.classes.get(`${ECOM}DigitalProduct`)!
+    expect(digital.subClassOf).toContain(`${ECOM}Product`)
+    expect(digital.disjointWith).toContain(`${ECOM}PhysicalProduct`)
+  })
+
+  it('parses Subscription as subclass of DigitalProduct', () => {
+    const o = parseTurtle(turtle)
+    expect(o.classes.get(`${ECOM}Subscription`)!.subClassOf).toContain(`${ECOM}DigitalProduct`)
+  })
+
+  it('parses decimal, double, anyURI, positiveInteger XSD types', () => {
+    const o = parseTurtle(turtle)
+    const XSD = 'http://www.w3.org/2001/XMLSchema#'
+    expect(o.datatypeProperties.get(`${ECOM}price`)!.range).toBe(`${XSD}decimal`)
+    expect(o.datatypeProperties.get(`${ECOM}weight`)!.range).toBe(`${XSD}double`)
+    expect(o.datatypeProperties.get(`${ECOM}downloadUrl`)!.range).toBe(`${XSD}anyURI`)
+    expect(o.datatypeProperties.get(`${ECOM}quantity`)!.range).toBe(`${XSD}positiveInteger`)
+  })
+})
+
+// ---- Edge cases fixture ----
+
+describe('edge-cases.ttl', () => {
+  const turtle = loadFixture('edge-cases.ttl')
+
+  it('parses class with no label', () => {
+    const o = parseTurtle(turtle)
+    const cls = o.classes.get(`${EDGE}UnlabeledClass`)!
+    expect(cls).toBeDefined()
+    expect(cls.label).toBeUndefined()
+  })
+
+  it('parses unicode label', () => {
+    const o = parseTurtle(turtle)
+    const cls = o.classes.get(`${EDGE}UnicodeClass`)!
+    expect(cls.label).toContain('accents')
+  })
+
+  it('parses very long label', () => {
+    const o = parseTurtle(turtle)
+    const cls = o.classes.get(`${EDGE}VerboseClass`)!
+    expect(cls.label!.length).toBeGreaterThan(50)
+  })
+
+  it('parses 6-level deep hierarchy', () => {
+    const o = parseTurtle(turtle)
+    expect(o.classes.get(`${EDGE}Level5`)!.subClassOf).toEqual([`${EDGE}Level4`])
+    expect(o.classes.get(`${EDGE}Level4`)!.subClassOf).toEqual([`${EDGE}Level3`])
+    expect(o.classes.get(`${EDGE}Level3`)!.subClassOf).toEqual([`${EDGE}Level2`])
+  })
+
+  it('parses diamond multiple inheritance', () => {
+    const o = parseTurtle(turtle)
+    const bottom = o.classes.get(`${EDGE}DiamondBottom`)!
+    expect(bottom.subClassOf).toContain(`${EDGE}DiamondLeft`)
+    expect(bottom.subClassOf).toContain(`${EDGE}DiamondRight`)
+    expect(bottom.subClassOf.length).toBe(2)
+  })
+
+  it('parses self-referencing property', () => {
+    const o = parseTurtle(turtle)
+    const prop = o.objectProperties.get(`${EDGE}relatesTo`)!
+    expect(prop.domain).toEqual([`${EDGE}SelfRefClass`])
+    expect(prop.range).toEqual([`${EDGE}SelfRefClass`])
+  })
+
+  it('parses property with multiple domains', () => {
+    const o = parseTurtle(turtle)
+    const prop = o.objectProperties.get(`${EDGE}multiDomainProp`)!
+    expect(prop.domain).toContain(`${EDGE}DomainA`)
+    expect(prop.domain).toContain(`${EDGE}DomainB`)
+    expect(prop.domain.length).toBe(2)
+  })
+
+  it('parses mutual disjointness', () => {
+    const o = parseTurtle(turtle)
+    const a = o.classes.get(`${EDGE}DisjointA`)!
+    expect(a.disjointWith).toContain(`${EDGE}DisjointB`)
+    expect(a.disjointWith).toContain(`${EDGE}DisjointC`)
+  })
+
+  it('parses less common XSD types (byte, short, long, time)', () => {
+    const o = parseTurtle(turtle)
+    const XSD = 'http://www.w3.org/2001/XMLSchema#'
+    expect(o.datatypeProperties.get(`${EDGE}byteVal`)!.range).toBe(`${XSD}byte`)
+    expect(o.datatypeProperties.get(`${EDGE}shortVal`)!.range).toBe(`${XSD}short`)
+    expect(o.datatypeProperties.get(`${EDGE}longVal`)!.range).toBe(`${XSD}long`)
+    expect(o.datatypeProperties.get(`${EDGE}durationVal`)!.range).toBe(`${XSD}time`)
+  })
+})
+
+// ---- Minimal fixture ----
+
+describe('minimal.ttl', () => {
+  it('parses exactly 1 class, 0 properties', () => {
+    const o = parseTurtle(loadFixture('minimal.ttl'))
+    expect(o.classes.size).toBe(1)
+    expect(o.objectProperties.size).toBe(0)
+    expect(o.datatypeProperties.size).toBe(0)
+  })
+
+  it('has correct label and comment', () => {
+    const o = parseTurtle(loadFixture('minimal.ttl'))
+    const cls = o.classes.get('http://example.org/minimal#Thing')!
+    expect(cls.label).toBe('Thing')
+    expect(cls.comment).toBe('The only class in this minimal ontology')
+  })
+})
+
+// ---- University fixture (performance) ----
+
+describe('university.ttl', () => {
+  const turtle = loadFixture('university.ttl')
+
+  it('parses 50+ classes', () => {
+    const o = parseTurtle(turtle)
+    expect(o.classes.size).toBeGreaterThanOrEqual(50)
+  })
+
+  it('parses 16 object properties', () => {
+    const o = parseTurtle(turtle)
+    expect(o.objectProperties.size).toBe(16)
+  })
+
+  it('parses 16 datatype properties', () => {
+    const o = parseTurtle(turtle)
+    expect(o.datatypeProperties.size).toBe(16)
+  })
+
+  it('round-trips all labels', () => {
+    const original = parseTurtle(turtle)
+    const serialized = serializeToTurtle(original)
+    const reparsed = parseTurtle(serialized)
+
+    for (const [uri, cls] of original.classes) {
+      expect(reparsed.classes.get(uri)!.label).toBe(cls.label)
+    }
+  })
+
+  it('parses and round-trips within 500ms', () => {
+    const start = performance.now()
+    const original = parseTurtle(turtle)
+    serializeToTurtle(original)
+    const elapsed = performance.now() - start
+    expect(elapsed).toBeLessThan(500)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds 5 test ontology fixtures in `apps/desktop/resources/sample-ontologies/` for use as realistic test data
- Fixtures reviewed by OntologyExpert for domain accuracy and OWL 2 coverage
- 51 new tests (all passing) covering parse, round-trip, and domain-specific assertions

### Fixtures
- **healthcare.ttl** — 16 classes, restrictions, AllDisjointClasses, named individuals
- **ecommerce.ttl** — 14 classes, FunctionalProperty (SKU), TransitiveProperty (hasSubCategory)
- **university.ttl** — 51+ classes, SymmetricProperty, TransitiveProperty, Venue class
- **edge-cases.ttl** — Diamond inheritance, unicode labels, multi-domain (intersection semantics), deep hierarchy
- **minimal.ttl** — Single class boundary case

All fixtures include `owl:Ontology` declarations per OWL 2 best practice.

## Test plan

- [x] All 51 fixture tests pass
- [x] Round-trip (parse → serialize → reparse) preserves class/property counts
- [x] Performance benchmark: university.ttl parses+serializes < 500ms
- [x] Pre-existing 3 failures (Toolbar/StatusBar) unrelated

Closes ONT-99

🤖 Generated with [Claude Code](https://claude.com/claude-code)