### PR TITLE
fix(tests): update Toolbar and StatusBar tests to match current UI

### DIFF
--- a/apps/desktop/tests/components/StatusBar.test.tsx
+++ b/apps/desktop/tests/components/StatusBar.test.tsx
@@ -11,9 +11,9 @@ describe('StatusBar', () => {
   beforeEach(resetStores)
   afterEach(cleanup)
 
-  it('shows "No file open" when no file loaded', () => {
+  it('shows "Saved" when no unsaved changes', () => {
     render(<StatusBar />)
-    expect(screen.getByText('No file open')).toBeInTheDocument()
+    expect(screen.getByText('Saved')).toBeInTheDocument()
   })
 
   it('shows file path when file loaded', () => {
@@ -22,11 +22,11 @@ describe('StatusBar', () => {
     expect(screen.getByText('/path/to/ontology.ttl')).toBeInTheDocument()
   })
 
-  it('shows dirty indicator', () => {
+  it('shows unsaved changes indicator when dirty', () => {
     useOntologyStore.getState().loadFromTurtle('', '/test.ttl')
     useOntologyStore.getState().addClass('http://ex/A')
     render(<StatusBar />)
-    expect(screen.getByText('/test.ttl *')).toBeInTheDocument()
+    expect(screen.getByText('Unsaved changes')).toBeInTheDocument()
   })
 
   it('shows class and property counts', () => {

--- a/apps/desktop/tests/components/Toolbar.test.tsx
+++ b/apps/desktop/tests/components/Toolbar.test.tsx
@@ -12,31 +12,23 @@ const { Toolbar } = await import('@renderer/components/toolbar/Toolbar')
 describe('Toolbar', () => {
   afterEach(cleanup)
 
-  it('renders file operation buttons', () => {
-    render(<Toolbar onNew={() => {}} onOpen={() => {}} onSave={() => {}} onSaveAs={() => {}} />)
-    expect(screen.getByTitle('New ontology')).toBeInTheDocument()
-    expect(screen.getByTitle('Open (⌘O)')).toBeInTheDocument()
-    expect(screen.getByTitle('Save (⌘S)')).toBeInTheDocument()
-    expect(screen.getByTitle('Save As (⇧⌘S)')).toBeInTheDocument()
+  it('renders search bar', () => {
+    render(<Toolbar />)
+    expect(screen.getByPlaceholderText('Search label, URI, comment…')).toBeInTheDocument()
   })
 
   it('renders theme toggle', () => {
-    render(<Toolbar onNew={() => {}} onOpen={() => {}} onSave={() => {}} onSaveAs={() => {}} />)
+    render(<Toolbar />)
     expect(screen.getByTitle('Toggle theme')).toBeInTheDocument()
   })
 
   it('renders Claude settings button', () => {
-    render(<Toolbar onNew={() => {}} onOpen={() => {}} onSave={() => {}} onSaveAs={() => {}} />)
+    render(<Toolbar />)
     expect(screen.getByTitle('Claude settings')).toBeInTheDocument()
   })
 
   it('renders sidebar toggle', () => {
-    render(<Toolbar onNew={() => {}} onOpen={() => {}} onSave={() => {}} onSaveAs={() => {}} />)
+    render(<Toolbar />)
     expect(screen.getByTitle('Toggle sidebar')).toBeInTheDocument()
-  })
-
-  it('renders search bar', () => {
-    render(<Toolbar onNew={() => {}} onOpen={() => {}} onSave={() => {}} onSaveAs={() => {}} />)
-    expect(screen.getByPlaceholderText('Search label, URI, comment…')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Removed stale `renders file operation buttons` test from Toolbar (file ops buttons no longer exist)
- Updated Toolbar tests to render `<Toolbar />` without removed props
- Updated StatusBar tests: "No file open" → "Saved", dirty indicator "/test.ttl *" → "Unsaved changes"

Fixes ONT-101. All 241 tests now pass (was 238/241).

## Test plan
- [x] `bun run test` — 241/241 pass, 26 files
- [x] `bun run build` — passes
- [x] `bun run typecheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)