### PR TITLE
fix(ui): increase update banner height for Mac traffic-light alignment

### DIFF
--- a/apps/desktop/src/renderer/src/components/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/UpdateBanner.tsx
@@ -13,7 +13,7 @@ export function UpdateBanner(): React.JSX.Element | null {
 
   if (update.status === 'available') {
     return (
-      <div className="flex items-center justify-between pl-20 pr-3 py-1.5 bg-blue-600 text-white text-xs">
+      <div className="flex items-center justify-between pl-20 pr-3 py-2.5 bg-blue-600 text-white text-xs">
         <span>Update available: v{update.version}</span>
         <button
           type="button"
@@ -28,7 +28,7 @@ export function UpdateBanner(): React.JSX.Element | null {
 
   if (update.status === 'downloading') {
     return (
-      <div className="flex items-center gap-3 pl-20 pr-3 py-1.5 bg-blue-600 text-white text-xs">
+      <div className="flex items-center gap-3 pl-20 pr-3 py-2.5 bg-blue-600 text-white text-xs">
         <span>Downloading update…</span>
         <div className="flex-1 bg-blue-400 rounded-full h-1.5 max-w-32">
           <div
@@ -43,7 +43,7 @@ export function UpdateBanner(): React.JSX.Element | null {
 
   if (update.status === 'ready') {
     return (
-      <div className="flex items-center justify-between pl-20 pr-3 py-1.5 bg-green-600 text-white text-xs">
+      <div className="flex items-center justify-between pl-20 pr-3 py-2.5 bg-green-600 text-white text-xs">
         <span>v{update.version} ready to install</span>
         <button
           type="button"
@@ -58,7 +58,7 @@ export function UpdateBanner(): React.JSX.Element | null {
 
   if (update.status === 'error') {
     return (
-      <div className="flex items-center justify-between pl-20 pr-3 py-1.5 bg-yellow-600 text-white text-xs">
+      <div className="flex items-center justify-between pl-20 pr-3 py-2.5 bg-yellow-600 text-white text-xs">
         <span>
           Update check failed —{' '}
           <button


### PR DESCRIPTION
## Summary
- Increased vertical padding on the update banner from `py-1.5` to `py-2.5` so the banner text vertically aligns with the macOS traffic light buttons
- Applied Biome formatting to the file

Fixes ONT-106

## Test plan
- [ ] Trigger an app update (or mock the `ready` state) and verify the green banner text aligns vertically with the Mac window control dots
- [ ] Check `available`, `downloading`, and `error` banner states look correct too

🤖 Generated with [Claude Code](https://claude.com/claude-code)