### PR TITLE
feat(web): add test suite and coverage thresholds (Phase 3+4)

### DIFF
--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -16,6 +16,12 @@ export default defineConfig({
         'src/renderer/src/env.d.ts',
         'src/renderer/src/components/ui/**',
       ],
+      thresholds: {
+        statements: 50,
+        branches: 70,
+        functions: 50,
+        lines: 50,
+      },
     },
   },
   resolve: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "NODE_ENV=production next build",
     "start": "next start",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
@@ -27,10 +28,15 @@
   "devDependencies": {
     "@next/bundle-analyzer": "^16.2.1",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.5.2",
+    "jsdom": "^29.0.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.1"
   }
 }

--- a/apps/web/tests/components/consent-banner.test.tsx
+++ b/apps/web/tests/components/consent-banner.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const { mockOptIn, mockOptOut } = vi.hoisted(() => ({
+  mockOptIn: vi.fn(),
+  mockOptOut: vi.fn(),
+}));
+
+vi.mock('posthog-js/react', () => ({
+  usePostHog: () => ({
+    opt_in_capturing: mockOptIn,
+    opt_out_capturing: mockOptOut,
+  }),
+}));
+
+import { ConsentBanner } from '@/components/consent-banner';
+
+describe('ConsentBanner', () => {
+  it('renders when no consent stored', () => {
+    render(<ConsentBanner />);
+    expect(screen.getByText(/privacy-friendly analytics/i)).toBeInTheDocument();
+    expect(screen.getByText('Accept')).toBeInTheDocument();
+    expect(screen.getByText('Decline')).toBeInTheDocument();
+  });
+
+  it('hides when consent already granted', () => {
+    localStorage.setItem('ontograph-analytics-consent', 'granted');
+    const { container } = render(<ConsentBanner />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('hides when consent already denied', () => {
+    localStorage.setItem('ontograph-analytics-consent', 'denied');
+    const { container } = render(<ConsentBanner />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('stores granted consent and hides on accept', () => {
+    render(<ConsentBanner />);
+    fireEvent.click(screen.getByText('Accept'));
+    expect(localStorage.getItem('ontograph-analytics-consent')).toBe('granted');
+    expect(screen.queryByText('Accept')).not.toBeInTheDocument();
+  });
+
+  it('stores denied consent and hides on decline', () => {
+    render(<ConsentBanner />);
+    fireEvent.click(screen.getByText('Decline'));
+    expect(localStorage.getItem('ontograph-analytics-consent')).toBe('denied');
+    expect(screen.queryByText('Decline')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/components/tracked-link.test.tsx
+++ b/apps/web/tests/components/tracked-link.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const { mockCapture } = vi.hoisted(() => ({
+  mockCapture: vi.fn(),
+}));
+
+vi.mock('posthog-js/react', () => ({
+  usePostHog: () => ({ capture: mockCapture }),
+}));
+
+import { TrackedLink } from '@/components/tracked-link';
+
+describe('TrackedLink', () => {
+  it('renders children and passes props', () => {
+    render(
+      <TrackedLink event="test_click" href="https://example.com" data-testid="link">
+        Click me
+      </TrackedLink>,
+    );
+    const link = screen.getByTestId('link');
+    expect(link).toHaveTextContent('Click me');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('captures event on click', () => {
+    render(
+      <TrackedLink event="cta_click" properties={{ source: 'hero' }}>
+        CTA
+      </TrackedLink>,
+    );
+    fireEvent.click(screen.getByText('CTA'));
+    expect(mockCapture).toHaveBeenCalledWith('cta_click', { source: 'hero' });
+  });
+
+  it('calls original onClick handler', () => {
+    const onClick = vi.fn();
+    render(
+      <TrackedLink event="nav_click" onClick={onClick}>
+        Nav
+      </TrackedLink>,
+    );
+    fireEvent.click(screen.getByText('Nav'));
+    expect(onClick).toHaveBeenCalled();
+    expect(mockCapture).toHaveBeenCalledWith('nav_click', undefined);
+  });
+});

--- a/apps/web/tests/lib/analytics.test.ts
+++ b/apps/web/tests/lib/analytics.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockCapture } = vi.hoisted(() => ({
+  mockCapture: vi.fn(),
+}));
+
+vi.mock('@/lib/posthog', () => ({
+  posthog: { capture: mockCapture },
+}));
+
+vi.mock('@/lib/visitor-id', () => ({
+  getVisitorId: vi.fn(() => 'test-visitor-id'),
+}));
+
+import { analytics } from '@/lib/analytics';
+
+describe('analytics', () => {
+  beforeEach(() => {
+    mockCapture.mockClear();
+  });
+
+  it('tracks hero CTA click', () => {
+    analytics.heroCTAClick();
+    expect(mockCapture).toHaveBeenCalledWith('hero_cta_click', { platform: 'web' });
+  });
+
+  it('tracks download click with OS and visitor_id', () => {
+    analytics.downloadClick('macos');
+    expect(mockCapture).toHaveBeenCalledWith('download_click', {
+      os: 'macos',
+      platform: 'web',
+      visitor_id: 'test-visitor-id',
+    });
+  });
+
+  it('tracks pricing page view', () => {
+    analytics.pricingPageView();
+    expect(mockCapture).toHaveBeenCalledWith('pricing_page_view', { platform: 'web' });
+  });
+
+  it('tracks github click', () => {
+    analytics.githubClick();
+    expect(mockCapture).toHaveBeenCalledWith('github_click', { platform: 'web' });
+  });
+
+  it('tracks features section view', () => {
+    analytics.featuresSectionView();
+    expect(mockCapture).toHaveBeenCalledWith('features_section_view', { platform: 'web' });
+  });
+});

--- a/apps/web/tests/lib/attribution.test.ts
+++ b/apps/web/tests/lib/attribution.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockRegister, mockSetPersonPropertiesForFlags } = vi.hoisted(() => ({
+  mockRegister: vi.fn(),
+  mockSetPersonPropertiesForFlags: vi.fn(),
+}));
+
+vi.mock('@/lib/posthog', () => ({
+  posthog: {
+    register: mockRegister,
+    setPersonPropertiesForFlags: mockSetPersonPropertiesForFlags,
+  },
+}));
+
+import { captureAttribution } from '@/lib/attribution';
+
+describe('captureAttribution', () => {
+  beforeEach(() => {
+    mockRegister.mockClear();
+    mockSetPersonPropertiesForFlags.mockClear();
+    Object.defineProperty(window, 'location', {
+      value: { search: '', pathname: '/', hostname: 'localhost' },
+      writable: true,
+    });
+    Object.defineProperty(document, 'referrer', { value: '', configurable: true });
+  });
+
+  it('does nothing without UTMs or referrer', () => {
+    captureAttribution();
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('captures UTM params and registers them', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        search: '?utm_source=google&utm_medium=cpc&utm_campaign=launch',
+        pathname: '/download',
+        hostname: 'localhost',
+      },
+      writable: true,
+    });
+
+    captureAttribution();
+
+    expect(mockRegister).toHaveBeenCalledWith({
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'launch',
+      landing_page: '/download',
+    });
+
+    expect(mockSetPersonPropertiesForFlags).toHaveBeenCalledWith({
+      first_touch_source: 'google',
+      first_touch_medium: 'cpc',
+      first_touch_campaign: 'launch',
+    });
+  });
+
+  it('captures referrer when present', () => {
+    Object.defineProperty(document, 'referrer', {
+      value: 'https://example.com',
+      configurable: true,
+    });
+
+    captureAttribution();
+
+    expect(mockRegister).toHaveBeenCalledWith({
+      landing_page: '/',
+      referrer: 'https://example.com',
+    });
+  });
+});

--- a/apps/web/tests/lib/utils.test.ts
+++ b/apps/web/tests/lib/utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from '@/lib/utils';
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('handles conditional classes', () => {
+    expect(cn('base', false && 'hidden', 'extra')).toBe('base extra');
+  });
+
+  it('deduplicates tailwind conflicts', () => {
+    expect(cn('p-4', 'p-2')).toBe('p-2');
+  });
+
+  it('returns empty string for no input', () => {
+    expect(cn()).toBe('');
+  });
+});

--- a/apps/web/tests/lib/visitor-id.test.ts
+++ b/apps/web/tests/lib/visitor-id.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/posthog', () => ({
+  posthog: {
+    get_distinct_id: vi.fn(),
+  },
+}));
+
+import { getVisitorId } from '@/lib/visitor-id';
+import { posthog } from '@/lib/posthog';
+
+describe('getVisitorId', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns stored id if present', () => {
+    localStorage.setItem('ontograph-visitor-id', 'existing-id');
+    expect(getVisitorId()).toBe('existing-id');
+  });
+
+  it('uses posthog distinct_id if available', () => {
+    vi.mocked(posthog.get_distinct_id).mockReturnValue('ph-id-123');
+    const id = getVisitorId();
+    expect(id).toBe('ph-id-123');
+    expect(localStorage.getItem('ontograph-visitor-id')).toBe('ph-id-123');
+  });
+
+  it('falls back to crypto.randomUUID when posthog returns falsy', () => {
+    vi.mocked(posthog.get_distinct_id).mockReturnValue('');
+    const id = getVisitorId();
+    expect(id).toBeTruthy();
+    expect(id).not.toBe('');
+    expect(localStorage.getItem('ontograph-visitor-id')).toBe(id);
+  });
+
+  it('caches id in localStorage for subsequent calls', () => {
+    vi.mocked(posthog.get_distinct_id).mockReturnValue('ph-id');
+    const first = getVisitorId();
+    const second = getVisitorId();
+    expect(first).toBe(second);
+  });
+});

--- a/apps/web/tests/setup.ts
+++ b/apps/web/tests/setup.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    include: ['tests/**/*.test.{ts,tsx}'],
+    environment: 'jsdom',
+    setupFiles: ['tests/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/app/globals.css', 'src/instrumentation.ts', 'src/components/ui/**'],
+      thresholds: {
+        statements: 40,
+        branches: 40,
+        functions: 40,
+        lines: 40,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve('src'),
+    },
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "apps/desktop": {
       "name": "@ontograph/desktop",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.83",
         "@electron-toolkit/preload": "^3.0.1",
@@ -92,11 +92,16 @@
       "devDependencies": {
         "@next/bundle-analyzer": "^16.2.1",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^4.5.2",
+        "jsdom": "^29.0.1",
         "tailwindcss": "^4",
         "typescript": "^5",
+        "vitest": "^3.2.1",
       },
     },
   },


### PR DESCRIPTION
## Summary

- **Phase 3**: Add Vitest + Testing Library test infrastructure for `@ontograph/web` (24 tests across 6 files)
  - Lib tests: `cn`, `captureAttribution`, `getVisitorId`, `analytics` event tracking
  - Component tests: `ConsentBanner` consent flow, `TrackedLink` event capture
- **Phase 4**: Add coverage thresholds to both apps
  - Desktop: 50% statements/lines/functions, 70% branches (current: ~54%/81%/60%/54%)
  - Web: 40% across all metrics (starting baseline for new test suite)
- Total test count: 265 (241 desktop + 24 web), all passing via `turbo test`

Related: ONT-104

## Test plan

- [ ] `bun run test` passes from repo root (both apps)
- [ ] `bun run typecheck` clean
- [ ] `bun run lint` — 0 errors (224 existing warnings)
- [ ] CI checks pass on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)