### PR TITLE
chore: release v0.8.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontograph/desktop",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A modern ontology editor with Claude integration",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/DaveHudson/Ontograph",

--- a/apps/web/tests/components/consent-banner.test.tsx
+++ b/apps/web/tests/components/consent-banner.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 const { mockOptIn, mockOptOut } = vi.hoisted(() => ({
   mockOptIn: vi.fn(),

--- a/apps/web/tests/components/tracked-link.test.tsx
+++ b/apps/web/tests/components/tracked-link.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 const { mockCapture } = vi.hoisted(() => ({
   mockCapture: vi.fn(),

--- a/apps/web/tests/lib/analytics.test.ts
+++ b/apps/web/tests/lib/analytics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockCapture } = vi.hoisted(() => ({
   mockCapture: vi.fn(),

--- a/apps/web/tests/lib/attribution.test.ts
+++ b/apps/web/tests/lib/attribution.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockRegister, mockSetPersonPropertiesForFlags } = vi.hoisted(() => ({
   mockRegister: vi.fn(),

--- a/apps/web/tests/lib/utils.test.ts
+++ b/apps/web/tests/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { cn } from '@/lib/utils';
 
 describe('cn', () => {

--- a/apps/web/tests/lib/visitor-id.test.ts
+++ b/apps/web/tests/lib/visitor-id.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/lib/posthog', () => ({
   posthog: {
@@ -6,8 +6,8 @@ vi.mock('@/lib/posthog', () => ({
   },
 }));
 
-import { getVisitorId } from '@/lib/visitor-id';
 import { posthog } from '@/lib/posthog';
+import { getVisitorId } from '@/lib/visitor-id';
 
 describe('getVisitorId', () => {
   beforeEach(() => {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vitest/config';
 import { resolve } from 'node:path';
 import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- Fix import ordering lint errors in web test files (7 files)
- Bump desktop app version to v0.8.0

## Release v0.8.0

### Features
- Biome linting/formatting and CI quality gate — `bun check` enforces lint + format as errors, CI blocks violations (PR #36)
- Web app test suite with coverage thresholds — 24 Vitest tests for `@ontograph/web`, coverage minimums enforced (PR #39)

### Fixes
- Resolved all 117 Biome lint warnings across 103 files, promoted all rules from warn to error (PR #40)

### Verification
- ✅ Tests: 241/241 desktop, 24/24 web
- ✅ Build: Desktop build succeeds
- ✅ Typecheck: Clean (both apps)
- ✅ Lint: 148 files, 0 errors
- ✅ QA Release Ready ticket: ONT-109

🤖 Generated with [Claude Code](https://claude.com/claude-code)