### PR TITLE
fix: correct import ordering in Storybook config

### DIFF
--- a/apps/desktop/.storybook/main.ts
+++ b/apps/desktop/.storybook/main.ts
@@ -1,5 +1,5 @@
-import type { StorybookConfig } from '@storybook/react-vite';
 import { resolve } from 'node:path';
+import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/renderer/src/**/*.stories.@(ts|tsx)'],


### PR DESCRIPTION
## Summary
- Fixes `bun run check` failure caused by import ordering in `.storybook/main.ts`
- `node:path` import must come before `@storybook/react-vite` per Biome organizeImports

## Test plan
- [x] `bun run check` passes clean
- [x] All tests pass (265)
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)