### PR TITLE
chore: bump version to v0.8.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontograph/desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A modern ontology editor with Claude integration",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/DaveHudson/Ontograph",


### PR DESCRIPTION
## Summary
- Bumps desktop app version from v0.8.0 to v0.8.1
- Patch release for dev tooling improvements (Storybook + Playwright E2E)

## Changes since v0.8.0
- **feat**: Add Storybook UI testing and Playwright E2E tests (Phase 5+6) (#42)
- **fix**: Correct import ordering in Storybook config (#43)

## Release
After merge, tag `v0.8.1` and push to trigger GitHub Actions release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>