### PR TITLE
feat(metrics): ontology metrics dashboard

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -13,6 +13,7 @@ import { ActivityBar } from './components/activity-bar/ActivityBar';
 import { ChatPanel } from './components/chat/ChatPanel';
 import { DetailPanel } from './components/detail/DetailPanel';
 import { EvalPanel } from './components/eval/EvalPanel';
+import { MetricsPanel } from './components/metrics/MetricsPanel';
 import { GraphBackground } from './components/graph/GraphBackground';
 import { GraphCanvas } from './components/graph/GraphCanvas';
 import { ImprovementHUD } from './components/hud/ImprovementHUD';
@@ -339,6 +340,9 @@ function App(): React.JSX.Element {
               </div>
               <div className={activeTab !== 'eval' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
                 <EvalPanel />
+              </div>
+              <div className={activeTab !== 'metrics' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
+                <MetricsPanel />
               </div>
             </div>
 

--- a/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
+++ b/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
@@ -1,5 +1,5 @@
 import type { SidebarTab } from '@renderer/store/ui';
-import { ClipboardList, MessageSquare, MousePointer2 } from 'lucide-react';
+import { BarChart3, ClipboardList, MessageSquare, MousePointer2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ActivityBarProps {
@@ -11,6 +11,7 @@ const TABS: Array<{ id: SidebarTab; icon: React.ReactNode; label: string }> = [
   { id: 'properties', icon: <MousePointer2 className="size-4" />, label: 'Properties' },
   { id: 'chat', icon: <MessageSquare className="size-4" />, label: 'Chat' },
   { id: 'eval', icon: <ClipboardList className="size-4" />, label: 'Eval' },
+  { id: 'metrics', icon: <BarChart3 className="size-4" />, label: 'Metrics' },
 ];
 
 export function ActivityBar({ activeTab, onTabChange }: ActivityBarProps): React.JSX.Element {

--- a/apps/desktop/src/renderer/src/components/metrics/MetricsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/metrics/MetricsPanel.tsx
@@ -1,0 +1,155 @@
+import { BarChart3, TriangleAlert } from 'lucide-react';
+import { useMemo } from 'react';
+import { useOntologyStore } from '@renderer/store/ontology';
+import { computeMetrics } from '@renderer/services/metrics';
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-xs tracking-wider uppercase text-muted-foreground pt-4 pb-1.5 px-4 font-medium">
+      {children}
+    </div>
+  );
+}
+
+function MetricRow({
+  label,
+  value,
+  warn,
+  format,
+}: {
+  label: string;
+  value: number;
+  warn?: boolean;
+  format?: 'percent' | 'decimal' | 'integer';
+}) {
+  const fmt = format ?? 'integer';
+  let display: string;
+  if (fmt === 'percent') display = `${(value * 100).toFixed(0)}%`;
+  else if (fmt === 'decimal') display = value.toFixed(1);
+  else display = String(value);
+
+  return (
+    <div className="flex items-center justify-between px-4 py-1">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span
+        className={`text-sm font-medium ${warn ? 'text-warning flex items-center gap-1' : 'text-foreground'}`}
+      >
+        {warn && <TriangleAlert className="size-3" />}
+        {display}
+      </span>
+    </div>
+  );
+}
+
+function KpiCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/50 p-3 text-center flex-1 min-w-0">
+      <div className="text-2xl font-semibold text-foreground tabular-nums">{value}</div>
+      <div className="text-xs text-muted-foreground mt-0.5 truncate">{label}</div>
+    </div>
+  );
+}
+
+export function MetricsPanel(): React.JSX.Element {
+  const ontology = useOntologyStore((s) => s.ontology);
+  const hasContent = ontology.classes.size > 0;
+
+  const metrics = useMemo(() => (hasContent ? computeMetrics(ontology) : null), [ontology, hasContent]);
+
+  if (!hasContent || !metrics) {
+    return (
+      <Empty className="border-0 p-4">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <BarChart3 />
+          </EmptyMedia>
+          <EmptyTitle className="text-sm font-medium">No ontology loaded</EmptyTitle>
+          <EmptyDescription className="text-xs">
+            Open a .ttl file to see ontology metrics.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  const { summary, structure, connectivity, properties, coverage } = metrics;
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="px-4 py-3 border-b border-border">
+        <h2 className="text-sm font-medium text-foreground">Ontology Metrics</h2>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="flex gap-2 px-4 pt-3">
+        <KpiCard label="Classes" value={summary.totalClasses} />
+        <KpiCard label="Obj Props" value={summary.objectProperties} />
+        <KpiCard label="Data Props" value={summary.datatypeProperties} />
+      </div>
+
+      {/* Structure */}
+      <SectionLabel>Structure</SectionLabel>
+      <MetricRow label="Max depth" value={structure.maxDepth} />
+      <MetricRow label="Avg breadth" value={structure.avgBreadth} format="decimal" />
+      <MetricRow label="Root classes" value={structure.rootClasses} />
+      <MetricRow label="Leaf classes" value={structure.leafClasses} />
+      <MetricRow label="Orphan nodes" value={structure.orphanNodes} warn={structure.orphanNodes > 0} />
+      <MetricRow
+        label="Multi-parent classes"
+        value={structure.multiParentClasses}
+        warn={structure.multiParentClasses > 0}
+      />
+
+      {/* Connectivity */}
+      <SectionLabel>Connectivity</SectionLabel>
+      <MetricRow label="Avg degree" value={connectivity.avgDegree} format="decimal" />
+      <MetricRow label="Max degree" value={connectivity.maxDegree} />
+      <MetricRow label="Connected components" value={connectivity.connectedComponents} />
+      <MetricRow
+        label="Isolated classes"
+        value={connectivity.isolatedClasses}
+        warn={connectivity.isolatedClasses > 0}
+      />
+      <MetricRow
+        label="Disjointness coverage"
+        value={connectivity.disjointnessCoverage}
+        format="percent"
+      />
+
+      {/* Properties */}
+      <SectionLabel>Properties</SectionLabel>
+      <MetricRow label="Obj/Datatype ratio" value={properties.objDatatypeRatio} format="decimal" />
+      <MetricRow label="Avg props/class" value={properties.avgPropsPerClass} format="decimal" />
+      <MetricRow label="Classes w/o props" value={properties.classesWithoutProps} />
+      <MetricRow label="Inverse coverage" value={properties.inverseCoverage} format="percent" />
+      <MetricRow
+        label="Domain-less props"
+        value={properties.domainlessProps}
+        warn={properties.domainlessProps > 0}
+      />
+      <MetricRow
+        label="Range-less obj props"
+        value={properties.rangelessObjProps}
+        warn={properties.rangelessObjProps > 0}
+      />
+
+      {/* Coverage */}
+      <SectionLabel>Coverage</SectionLabel>
+      <MetricRow label="Annotation coverage" value={coverage.annotationCoverage} format="percent" />
+      <MetricRow
+        label="Documentation coverage"
+        value={coverage.documentationCoverage}
+        format="percent"
+      />
+
+      <div className="h-4" />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/services/metrics.ts
+++ b/apps/desktop/src/renderer/src/services/metrics.ts
@@ -1,0 +1,301 @@
+import type { Ontology } from '../model/types';
+
+export interface OntologyMetrics {
+  summary: {
+    totalClasses: number;
+    objectProperties: number;
+    datatypeProperties: number;
+  };
+  structure: {
+    maxDepth: number;
+    avgBreadth: number;
+    rootClasses: number;
+    leafClasses: number;
+    orphanNodes: number;
+    multiParentClasses: number;
+  };
+  connectivity: {
+    avgDegree: number;
+    maxDegree: number;
+    connectedComponents: number;
+    isolatedClasses: number;
+    disjointnessCoverage: number;
+  };
+  properties: {
+    objDatatypeRatio: number;
+    avgPropsPerClass: number;
+    classesWithoutProps: number;
+    inverseCoverage: number;
+    domainlessProps: number;
+    rangelessObjProps: number;
+  };
+  coverage: {
+    annotationCoverage: number;
+    documentationCoverage: number;
+  };
+}
+
+export function computeMetrics(ontology: Ontology): OntologyMetrics {
+  const { classes, objectProperties, datatypeProperties } = ontology;
+
+  const totalClasses = classes.size;
+  const totalObjProps = objectProperties.size;
+  const totalDtProps = datatypeProperties.size;
+
+  // Build parent→children map and child→parents map
+  const childrenOf = new Map<string, string[]>();
+  const parentsOf = new Map<string, string[]>();
+  for (const [uri, cls] of classes) {
+    if (!childrenOf.has(uri)) childrenOf.set(uri, []);
+    parentsOf.set(uri, cls.subClassOf);
+    for (const parent of cls.subClassOf) {
+      const existing = childrenOf.get(parent);
+      if (existing) existing.push(uri);
+      else childrenOf.set(parent, [uri]);
+    }
+  }
+
+  // Root classes: empty subClassOf
+  const roots: string[] = [];
+  for (const [uri, cls] of classes) {
+    if (cls.subClassOf.length === 0) roots.push(uri);
+  }
+
+  // Leaf classes: no children
+  let leafCount = 0;
+  for (const [uri] of classes) {
+    const children = childrenOf.get(uri);
+    if (!children || children.length === 0) leafCount++;
+  }
+
+  // Multi-parent classes
+  let multiParentCount = 0;
+  for (const [, cls] of classes) {
+    if (cls.subClassOf.length > 1) multiParentCount++;
+  }
+
+  // Max hierarchy depth — cycle-safe longest path to root per class
+  const depthCache = new Map<string, number>();
+  function maxDepthOf(uri: string, visiting: Set<string>): number {
+    if (depthCache.has(uri)) return depthCache.get(uri)!;
+    const cls = classes.get(uri);
+    if (!cls || cls.subClassOf.length === 0) {
+      depthCache.set(uri, 0);
+      return 0;
+    }
+    if (visiting.has(uri)) return 0; // cycle
+    visiting.add(uri);
+    let max = 0;
+    for (const parent of cls.subClassOf) {
+      if (classes.has(parent)) {
+        max = Math.max(max, 1 + maxDepthOf(parent, visiting));
+      }
+    }
+    visiting.delete(uri);
+    depthCache.set(uri, max);
+    return max;
+  }
+  let maxDepth = 0;
+  for (const [uri] of classes) {
+    maxDepth = Math.max(maxDepth, maxDepthOf(uri, new Set()));
+  }
+
+  // Avg breadth: average children per non-leaf class
+  let nonLeafCount = 0;
+  let totalChildren = 0;
+  for (const [uri] of classes) {
+    const children = childrenOf.get(uri);
+    if (children && children.length > 0) {
+      nonLeafCount++;
+      totalChildren += children.length;
+    }
+  }
+  const avgBreadth = nonLeafCount > 0 ? totalChildren / nonLeafCount : 0;
+
+  // Degree computation (subClassOf + obj prop domain/range, excluding disjointWith)
+  const degree = new Map<string, number>();
+  for (const [uri] of classes) degree.set(uri, 0);
+
+  // subClassOf edges
+  for (const [uri, cls] of classes) {
+    for (const parent of cls.subClassOf) {
+      if (classes.has(parent)) {
+        degree.set(uri, (degree.get(uri) ?? 0) + 1);
+        degree.set(parent, (degree.get(parent) ?? 0) + 1);
+      }
+    }
+  }
+
+  // Object property domain/range edges
+  const classesInDomainOrRange = new Set<string>();
+  for (const [, prop] of objectProperties) {
+    for (const d of prop.domain) {
+      if (classes.has(d)) {
+        degree.set(d, (degree.get(d) ?? 0) + 1);
+        classesInDomainOrRange.add(d);
+      }
+    }
+    for (const r of prop.range) {
+      if (classes.has(r)) {
+        degree.set(r, (degree.get(r) ?? 0) + 1);
+        classesInDomainOrRange.add(r);
+      }
+    }
+  }
+
+  // Datatype property domain references
+  const classesInAnyDomain = new Set<string>();
+  for (const [, prop] of objectProperties) {
+    for (const d of prop.domain) classesInAnyDomain.add(d);
+  }
+  for (const [, prop] of datatypeProperties) {
+    for (const d of prop.domain) classesInAnyDomain.add(d);
+  }
+
+  let totalDegree = 0;
+  let maxDeg = 0;
+  let isolatedCount = 0;
+  for (const [, deg] of degree) {
+    totalDegree += deg;
+    if (deg > maxDeg) maxDeg = deg;
+    if (deg === 0) isolatedCount++;
+  }
+  const avgDegree = totalClasses > 0 ? totalDegree / totalClasses : 0;
+
+  // Connected components (union-find on structural edges)
+  const parent = new Map<string, string>();
+  for (const [uri] of classes) parent.set(uri, uri);
+
+  function find(x: string): string {
+    while (parent.get(x) !== x) {
+      parent.set(x, parent.get(parent.get(x)!)!);
+      x = parent.get(x)!;
+    }
+    return x;
+  }
+  function union(a: string, b: string): void {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent.set(ra, rb);
+  }
+
+  for (const [uri, cls] of classes) {
+    for (const p of cls.subClassOf) {
+      if (classes.has(p)) union(uri, p);
+    }
+  }
+  for (const [, prop] of objectProperties) {
+    const domainClasses = prop.domain.filter((d) => classes.has(d));
+    const rangeClasses = prop.range.filter((r) => classes.has(r));
+    for (let i = 1; i < domainClasses.length; i++) union(domainClasses[0], domainClasses[i]);
+    for (let i = 1; i < rangeClasses.length; i++) union(rangeClasses[0], rangeClasses[i]);
+    if (domainClasses.length > 0 && rangeClasses.length > 0) {
+      union(domainClasses[0], rangeClasses[0]);
+    }
+  }
+
+  const componentRoots = new Set<string>();
+  for (const [uri] of classes) componentRoots.add(find(uri));
+
+  // Orphan nodes: no subClassOf, no subclasses, not in any property domain/range
+  let orphanCount = 0;
+  for (const [uri, cls] of classes) {
+    if (cls.subClassOf.length > 0) continue;
+    const children = childrenOf.get(uri);
+    if (children && children.length > 0) continue;
+    if (classesInDomainOrRange.has(uri)) continue;
+    orphanCount++;
+  }
+
+  // Disjointness coverage: % of sibling class pairs with disjointWith
+  let siblingPairs = 0;
+  let disjointPairs = 0;
+  for (const [, children] of childrenOf) {
+    if (children.length < 2) continue;
+    for (let i = 0; i < children.length; i++) {
+      for (let j = i + 1; j < children.length; j++) {
+        siblingPairs++;
+        const clsI = classes.get(children[i]);
+        if (clsI?.disjointWith.includes(children[j])) disjointPairs++;
+        else {
+          const clsJ = classes.get(children[j]);
+          if (clsJ?.disjointWith.includes(children[i])) disjointPairs++;
+        }
+      }
+    }
+  }
+  const disjointnessCoverage = siblingPairs > 0 ? disjointPairs / siblingPairs : 0;
+
+  // Property metrics
+  const objDatatypeRatio = totalDtProps > 0 ? totalObjProps / totalDtProps : totalObjProps;
+
+  let totalDomainRefs = 0;
+  let domainlessCount = 0;
+  let rangelessObjCount = 0;
+  for (const [, prop] of objectProperties) {
+    totalDomainRefs += prop.domain.length;
+    if (prop.domain.length === 0) domainlessCount++;
+    if (prop.range.length === 0) rangelessObjCount++;
+  }
+  for (const [, prop] of datatypeProperties) {
+    totalDomainRefs += prop.domain.length;
+    if (prop.domain.length === 0) domainlessCount++;
+  }
+  const avgPropsPerClass = totalClasses > 0 ? totalDomainRefs / totalClasses : 0;
+
+  let classesWithoutPropsCount = 0;
+  for (const [uri] of classes) {
+    if (!classesInAnyDomain.has(uri)) classesWithoutPropsCount++;
+  }
+
+  let inverseCount = 0;
+  for (const [, prop] of objectProperties) {
+    if (prop.inverseOf) inverseCount++;
+  }
+  const inverseCoverage = totalObjProps > 0 ? inverseCount / totalObjProps : 0;
+
+  // Coverage metrics
+  let labelCount = 0;
+  let commentCount = 0;
+  for (const [, cls] of classes) {
+    if (cls.label) labelCount++;
+    if (cls.comment) commentCount++;
+  }
+  const annotationCoverage = totalClasses > 0 ? labelCount / totalClasses : 0;
+  const documentationCoverage = totalClasses > 0 ? commentCount / totalClasses : 0;
+
+  return {
+    summary: {
+      totalClasses,
+      objectProperties: totalObjProps,
+      datatypeProperties: totalDtProps,
+    },
+    structure: {
+      maxDepth,
+      avgBreadth,
+      rootClasses: roots.length,
+      leafClasses: leafCount,
+      orphanNodes: orphanCount,
+      multiParentClasses: multiParentCount,
+    },
+    connectivity: {
+      avgDegree,
+      maxDegree: maxDeg,
+      connectedComponents: componentRoots.size,
+      isolatedClasses: isolatedCount,
+      disjointnessCoverage,
+    },
+    properties: {
+      objDatatypeRatio,
+      avgPropsPerClass,
+      classesWithoutProps: classesWithoutPropsCount,
+      inverseCoverage,
+      domainlessProps: domainlessCount,
+      rangelessObjProps: rangelessObjCount,
+    },
+    coverage: {
+      annotationCoverage,
+      documentationCoverage,
+    },
+  };
+}

--- a/apps/desktop/src/renderer/src/store/ui.ts
+++ b/apps/desktop/src/renderer/src/store/ui.ts
@@ -26,7 +26,7 @@ const DEFAULT_LAYOUT: GraphLayout = {
   nodeSpacing: 180,
 };
 
-export type SidebarTab = 'properties' | 'chat' | 'eval';
+export type SidebarTab = 'properties' | 'chat' | 'eval' | 'metrics';
 
 interface UIState {
   selectedNodeId: string | null;


### PR DESCRIPTION
## Summary

- Adds a new **Metrics** sidebar tab showing at-a-glance ontology health metrics
- Pure computation layer in `services/metrics.ts` (cycle-safe depth, union-find connectivity)
- Metrics include: structure (depth, breadth, orphans), connectivity (degree, components, disjointness coverage), property quality (domain/range/inverse coverage), and annotation coverage
- Plan refined with [@OntologyExpert](agent://ed37f269-ca61-4dd9-a914-589e2ee1fcd1) review feedback

## Test plan

- [ ] Load sample ontology → verify KPI cards show correct counts
- [ ] Check structure metrics match manual inspection of hierarchy
- [ ] Verify warning indicators appear for orphan nodes, domain-less properties
- [ ] Empty state shown when no ontology loaded
- [ ] Tab switching works correctly between all 4 sidebar tabs
- [ ] All existing tests pass (241/241 ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)