### PR TITLE
fix(chat): scope chat history per ontology file

### DIFF
--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -47,10 +47,15 @@ export function ChatPanel(): React.JSX.Element {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const prevMessagesRef = useRef<ChatMessage[]>([]);
 
+  const filePath = useOntologyStore((s) => s.filePath);
+
   const chatDraft = useUIStore((s) => s.chatDraft);
   const setChatDraft = useUIStore((s) => s.setChatDraft);
   const pendingChatMessage = useUIStore((s) => s.pendingChatMessage);
   const setPendingChatMessage = useUIStore((s) => s.setPendingChatMessage);
+
+  // Track previous filePath to detect ontology file changes
+  const prevFilePathRef = useRef<string | null | undefined>(undefined);
 
   // Restore active thread on mount
   useEffect(() => {
@@ -60,6 +65,28 @@ export function ChatPanel(): React.JSX.Element {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [history.getActiveThread, setMessages]);
+
+  // When ontology file changes, switch to the most recent thread for that file (or clear)
+  useEffect(() => {
+    if (prevFilePathRef.current === undefined) {
+      // Initial mount — don't switch, the restore-active-thread effect handles it
+      prevFilePathRef.current = filePath;
+      return;
+    }
+    if (prevFilePathRef.current === filePath) return;
+    prevFilePathRef.current = filePath;
+
+    const fileThreads = history.threadsForFile(filePath);
+    if (fileThreads.length > 0) {
+      const latest = fileThreads[0];
+      history.switchThread(latest.id);
+      setMessages(latest.messages);
+    } else {
+      history.setActiveThreadId(null);
+      setMessages([]);
+      resetSession();
+    }
+  }, [filePath, history, setMessages, resetSession]);
 
   // Auto-save messages to active thread when messages change
   useEffect(() => {
@@ -72,21 +99,21 @@ export function ChatPanel(): React.JSX.Element {
   // Auto-create thread on first message if none active
   useEffect(() => {
     if (!history.activeThreadId && messages.length > 0) {
-      history.createThread(model);
+      history.createThread(model, filePath);
     }
-  }, [messages.length, history.activeThreadId, history.createThread, model]);
+  }, [messages.length, history.activeThreadId, history.createThread, model, filePath]);
 
   const handleNewChat = useCallback(() => {
     // Don't save empty threads
     if (history.activeThreadId && messages.length === 0) {
       history.deleteThread(history.activeThreadId);
     }
-    const id = history.createThread(model);
+    const id = history.createThread(model, filePath);
     setMessages([]);
     resetSession();
     history.setShowThreadList(false);
     return id;
-  }, [history, messages.length, model, setMessages, resetSession]);
+  }, [history, messages.length, model, filePath, setMessages, resetSession]);
 
   const handleSwitchThread = useCallback(
     (id: string) => {
@@ -193,6 +220,11 @@ export function ChatPanel(): React.JSX.Element {
     }
   };
 
+  const fileThreads = useMemo(
+    () => history.threadsForFile(filePath),
+    [history.threadsForFile, filePath],
+  );
+
   const activeThread = history.getActiveThread();
   const headerTitle =
     activeThread?.title && activeThread.title !== 'New chat' ? activeThread.title : 'Claude';
@@ -225,7 +257,7 @@ export function ChatPanel(): React.JSX.Element {
 
       {history.showThreadList ? (
         <ChatThreadList
-          threads={history.threads}
+          threads={fileThreads}
           activeThreadId={history.activeThreadId}
           onSelect={handleSwitchThread}
           onDelete={handleDeleteThread}

--- a/apps/desktop/src/renderer/src/components/chat/useChatHistory.ts
+++ b/apps/desktop/src/renderer/src/components/chat/useChatHistory.ts
@@ -6,6 +6,7 @@ export interface ChatThread {
   title: string;
   messages: ChatMessage[];
   model: ModelId;
+  filePath: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -22,8 +23,9 @@ function loadThreads(): ChatThread[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     const threads: ChatThread[] = raw ? JSON.parse(raw) : [];
-    // Migrate: ensure all messages have an id (older saved threads may lack them)
+    // Migrate: ensure all messages have an id and filePath (older saved threads may lack them)
     for (const thread of threads) {
+      if (thread.filePath === undefined) thread.filePath = null;
       for (const msg of thread.messages) {
         if (!msg.id) msg.id = msgId();
       }
@@ -57,7 +59,8 @@ export interface UseChatHistoryReturn {
   activeThreadId: string | null;
   showThreadList: boolean;
   setShowThreadList: (show: boolean) => void;
-  createThread: (model: ModelId) => string;
+  createThread: (model: ModelId, filePath?: string | null) => string;
+  threadsForFile: (filePath: string | null) => ChatThread[];
   switchThread: (id: string) => ChatThread | undefined;
   deleteThread: (id: string) => void;
   updateThreadMessages: (id: string, messages: ChatMessage[]) => void;
@@ -89,13 +92,14 @@ export function useChatHistory(): UseChatHistoryReturn {
   }, []);
 
   const createThread = useCallback(
-    (model: ModelId): string => {
+    (model: ModelId, filePath?: string | null): string => {
       const id = generateId();
       const thread: ChatThread = {
         id,
         title: 'New chat',
         messages: [],
         model,
+        filePath: filePath ?? null,
         createdAt: Date.now(),
         updatedAt: Date.now(),
       };
@@ -155,6 +159,13 @@ export function useChatHistory(): UseChatHistoryReturn {
     return threads.find((t) => t.id === activeThreadId);
   }, [threads, activeThreadId]);
 
+  const threadsForFile = useCallback(
+    (filePath: string | null): ChatThread[] => {
+      return threads.filter((t) => t.filePath === filePath);
+    },
+    [threads],
+  );
+
   return {
     threads,
     activeThreadId,
@@ -167,5 +178,6 @@ export function useChatHistory(): UseChatHistoryReturn {
     updateThreadTitle,
     getActiveThread,
     setActiveThreadId,
+    threadsForFile,
   };
 }

--- a/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -96,7 +96,7 @@ export function StatusBar(): React.JSX.Element {
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-6 px-2 text-xs text-destructive font-medium hover:text-destructive/80"
+                className="h-6 px-2 text-xs font-medium"
               >
                 {errorCount > 0 && `${errorCount} error${errorCount !== 1 ? 's' : ''}`}
                 {errorCount > 0 && warnCount > 0 && ' · '}

--- a/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -93,11 +93,7 @@ export function StatusBar(): React.JSX.Element {
         {hasIssues && (
           <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
             <PopoverTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-6 px-2 text-xs font-medium"
-              >
+              <Button variant="ghost" size="sm" className="h-6 px-2 text-xs font-medium">
                 {errorCount > 0 && `${errorCount} error${errorCount !== 1 ? 's' : ''}`}
                 {errorCount > 0 && warnCount > 0 && ' · '}
                 {warnCount > 0 && `${warnCount} warning${warnCount !== 1 ? 's' : ''}`}


### PR DESCRIPTION
## Summary
- Associates chat threads with the ontology file open when they were created
- Auto-switches chat threads when loading a different ontology file
- Thread list only shows threads for the currently open file
- Existing threads migrated with `filePath=null` (visible when no file is open)

## Test plan
- [ ] Open ontology file A, send chat messages
- [ ] Open ontology file B, verify chat history is empty
- [ ] Send messages in file B context
- [ ] Switch back to file A, verify original messages are restored
- [ ] Check thread list only shows threads for current file
- [ ] Verify existing (pre-migration) threads appear when no file is open

Closes ONT-114

🤖 Generated with [Claude Code](https://claude.com/claude-code)