### PR TITLE
fix(desktop): make warnings popover scrollable

### DIFF
--- a/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -103,7 +103,7 @@ export function StatusBar(): React.JSX.Element {
                 {warnCount > 0 && `${warnCount} warning${warnCount !== 1 ? 's' : ''}`}
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="p-0 w-80" side="top" align="end">
+            <PopoverContent className="p-0 w-80 max-h-64 overflow-y-auto" side="top" align="end">
               {errors.map((error) => (
                 <button
                   type="button"


### PR DESCRIPTION
## Summary

- Adds `max-h-64 overflow-y-auto` to the warnings `PopoverContent` so long validation lists scroll instead of overflowing the viewport.

Closes ONT-113 (scrollable warnings part)

## Test plan

- Open an ontology with many validation warnings
- Click the warnings button in the status bar
- Verify the popover is scrollable and doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)