### PR TITLE
fix(desktop): show 'Ontograph' in About and Quit menu items

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -48,6 +48,8 @@ function createWindow(): BrowserWindow {
   return mainWindow;
 }
 
+app.setName('Ontograph');
+
 app.whenReady().then(() => {
   electronApp.setAppUserModelId('com.applification.ontograph');
 


### PR DESCRIPTION
## Summary
- Adds `app.setName('Ontograph')` before `app.whenReady()` so macOS role-based menu items ("About", "Quit") display "Ontograph" instead of the package name `@ontograph/desktop`
- The menu template label was already correct, but `role: 'about'` and `role: 'quit'` use `app.getName()` which defaults to `package.json` `name`

## Test plan
- [ ] Launch the app on macOS and verify the app menu shows "About Ontograph" and "Quit Ontograph"
- [ ] Verify no regression on Windows/Linux menu behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>