### PR TITLE
feat(desktop): support owl:NamedIndividual (instances)

### DIFF
--- a/apps/desktop/resources/sample-ontologies/individuals.ttl
+++ b/apps/desktop/resources/sample-ontologies/individuals.ttl
@@ -1,0 +1,61 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://example.org/ontology#> .
+
+## Classes
+
+ex:Person a owl:Class ;
+    rdfs:label "Person" ;
+    rdfs:comment "A human being" .
+
+ex:Organisation a owl:Class ;
+    rdfs:label "Organisation" ;
+    rdfs:comment "A formal group of people" .
+
+ex:Employee a owl:Class ;
+    rdfs:label "Employee" ;
+    rdfs:subClassOf ex:Person .
+
+## Object Properties
+
+ex:worksFor a owl:ObjectProperty ;
+    rdfs:label "works for" ;
+    rdfs:domain ex:Employee ;
+    rdfs:range ex:Organisation .
+
+## Datatype Properties
+
+ex:name a owl:DatatypeProperty ;
+    rdfs:label "name" ;
+    rdfs:domain ex:Person ;
+    rdfs:range xsd:string .
+
+ex:age a owl:DatatypeProperty ;
+    rdfs:label "age" ;
+    rdfs:domain ex:Person ;
+    rdfs:range xsd:integer .
+
+## Named Individuals
+
+ex:john a owl:NamedIndividual, ex:Employee ;
+    rdfs:label "John Smith" ;
+    rdfs:comment "An example employee" ;
+    ex:name "John Smith" ;
+    ex:age "42"^^xsd:integer ;
+    ex:worksFor ex:acmeCorp .
+
+ex:jane a owl:NamedIndividual, ex:Employee ;
+    rdfs:label "Jane Doe" ;
+    ex:name "Jane Doe" ;
+    ex:age "35"^^xsd:integer ;
+    ex:worksFor ex:acmeCorp .
+
+ex:acmeCorp a owl:NamedIndividual, ex:Organisation ;
+    rdfs:label "Acme Corp" ;
+    ex:name "Acme Corporation" .
+
+ex:bob a owl:NamedIndividual, ex:Person, ex:Employee ;
+    rdfs:label "Bob Multi" ;
+    rdfs:comment "An individual with multiple type assertions" .

--- a/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
@@ -11,6 +11,85 @@ export function DetailPanel(): React.JSX.Element | null {
   if (selectedNodeId) {
     const cls = ontology.classes.get(selectedNodeId);
     if (cls) return <ClassDetail key={cls.uri} cls={cls} />;
+
+    const ind = ontology.individuals.get(selectedNodeId);
+    if (ind) {
+      return (
+        <div className="p-3 space-y-4 text-sm">
+          <div>
+            <div className="text-xs text-muted-foreground mb-0.5">Individual</div>
+            <div className="font-medium">
+              {ind.label ||
+                (() => {
+                  const idx = Math.max(ind.uri.lastIndexOf('#'), ind.uri.lastIndexOf('/'));
+                  return idx >= 0 ? ind.uri.substring(idx + 1) : ind.uri;
+                })()}
+            </div>
+            <div className="text-xs text-muted-foreground break-all mt-0.5">{ind.uri}</div>
+          </div>
+          {ind.types.length > 0 && (
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">Type assertions</div>
+              <div className="space-y-0.5">
+                {ind.types.map((typeUri) => {
+                  const cls = ontology.classes.get(typeUri);
+                  const idx = Math.max(typeUri.lastIndexOf('#'), typeUri.lastIndexOf('/'));
+                  const name = cls?.label || (idx >= 0 ? typeUri.substring(idx + 1) : typeUri);
+                  return (
+                    <div key={typeUri} className="text-xs bg-secondary rounded px-2 py-1">
+                      {name}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+          {ind.objectPropertyAssertions.length > 0 && (
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">Object property assertions</div>
+              <div className="space-y-0.5">
+                {ind.objectPropertyAssertions.map((a) => {
+                  const pIdx = Math.max(a.property.lastIndexOf('#'), a.property.lastIndexOf('/'));
+                  const tIdx = Math.max(a.target.lastIndexOf('#'), a.target.lastIndexOf('/'));
+                  return (
+                    <div
+                      key={`${a.property}-${a.target}`}
+                      className="text-xs bg-secondary rounded px-2 py-1"
+                    >
+                      <span className="font-medium">
+                        {pIdx >= 0 ? a.property.substring(pIdx + 1) : a.property}
+                      </span>{' '}
+                      → {tIdx >= 0 ? a.target.substring(tIdx + 1) : a.target}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+          {ind.dataPropertyAssertions.length > 0 && (
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">Data property assertions</div>
+              <div className="space-y-0.5">
+                {ind.dataPropertyAssertions.map((a) => {
+                  const pIdx = Math.max(a.property.lastIndexOf('#'), a.property.lastIndexOf('/'));
+                  return (
+                    <div
+                      key={`${a.property}-${a.value}`}
+                      className="text-xs bg-secondary rounded px-2 py-1"
+                    >
+                      <span className="font-medium">
+                        {pIdx >= 0 ? a.property.substring(pIdx + 1) : a.property}
+                      </span>{' '}
+                      = &quot;{a.value}&quot;
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    }
   }
 
   if (selectedEdgeId) {

--- a/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
@@ -17,12 +17,22 @@ const EDGE_ITEMS = [
     color: 'var(--graph-edge-disjoint)',
     dash: '3,4',
   },
+  {
+    label: 'Type (instance-of)',
+    color: 'var(--graph-edge-typeof, oklch(0.65 0.15 160))',
+    dash: '4,3',
+  },
 ] as const;
 
 const NODE_ITEMS = [
-  { label: 'Class', border: 'var(--graph-node-border)' },
-  { label: 'Selected', border: 'var(--graph-node-selected)' },
-  { label: 'Adjacent', border: 'var(--graph-node-adjacent)' },
+  { label: 'Class', border: 'var(--graph-node-border)', style: 'solid' as const },
+  {
+    label: 'Individual',
+    border: 'var(--graph-node-individual-border, oklch(0.65 0.15 160))',
+    style: 'dashed' as const,
+  },
+  { label: 'Selected', border: 'var(--graph-node-selected)', style: 'solid' as const },
+  { label: 'Adjacent', border: 'var(--graph-node-adjacent)', style: 'solid' as const },
 ] as const;
 
 export const GraphLegend = memo(function GraphLegend() {
@@ -73,7 +83,8 @@ export const GraphLegend = memo(function GraphLegend() {
                 <div
                   className="size-3.5 rounded shrink-0"
                   style={{
-                    border: `2px solid ${item.border}`,
+                    border: `2px ${item.style} ${item.border}`,
+                    borderRadius: item.style === 'dashed' ? 6 : undefined,
                     background: 'var(--graph-node-body-bg)',
                   }}
                 />

--- a/apps/desktop/src/renderer/src/components/graph/ReactFlowCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/ReactFlowCanvas.tsx
@@ -232,7 +232,8 @@ function GraphFlow(): React.JSX.Element {
         prev.map((n) => {
           if (n.type !== 'class' && n.type !== 'individual') return n;
           const updated = newNodes.find((nn) => nn.id === n.id);
-          return updated ? { ...n, data: updated.data } : n;
+          if (!updated) return n;
+          return { ...n, data: updated.data } as typeof n;
         }),
       );
       setEdges(newEdges);

--- a/apps/desktop/src/renderer/src/components/graph/ReactFlowCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/ReactFlowCanvas.tsx
@@ -21,6 +21,7 @@ import { useLayoutSidecar } from '@renderer/hooks/useLayoutSidecar';
 import {
   type ClassNode,
   type GroupNode,
+  type IndividualNode,
   ontologyToReactFlowElements,
 } from '@renderer/model/reactflow';
 import { validateOntology } from '@renderer/services/validation';
@@ -31,12 +32,15 @@ import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { DisjointWithEdge } from './edges/DisjointWithEdge';
 import { ObjectPropertyEdge } from './edges/ObjectPropertyEdge';
 import { SubClassOfEdge } from './edges/SubClassOfEdge';
+import { TypeOfEdge } from './edges/TypeOfEdge';
 import { GraphLegend } from './GraphLegend';
 import { ClassNode as ClassNodeComponent } from './nodes/ClassNode';
 import { GroupNode as GroupNodeComponent } from './nodes/GroupNode';
+import { IndividualNode as IndividualNodeComponent } from './nodes/IndividualNode';
 
 const NODE_TYPES: NodeTypes = {
   class: ClassNodeComponent as unknown as NodeTypes['class'],
+  individual: IndividualNodeComponent as unknown as NodeTypes['individual'],
   group: GroupNodeComponent as unknown as NodeTypes['group'],
 };
 
@@ -44,6 +48,7 @@ const EDGE_TYPES: EdgeTypes = {
   subClassOf: SubClassOfEdge,
   objectProperty: ObjectPropertyEdge as EdgeTypes[string],
   disjointWith: DisjointWithEdge,
+  typeOf: TypeOfEdge,
 };
 
 interface ContextMenuState {
@@ -74,7 +79,9 @@ function GraphFlow(): React.JSX.Element {
   const focusNodeId = useUIStore((s) => s.focusNodeId);
   const setFocusNode = useUIStore((s) => s.setFocusNode);
 
-  const [nodes, setNodes, onNodesChange] = useNodesState<ClassNode | GroupNode>([]);
+  const [nodes, setNodes, onNodesChange] = useNodesState<ClassNode | IndividualNode | GroupNode>(
+    [],
+  );
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
 
@@ -223,7 +230,7 @@ function GraphFlow(): React.JSX.Element {
       // Data-only change: update node data without repositioning
       setNodes((prev) =>
         prev.map((n) => {
-          if (n.type !== 'class') return n;
+          if (n.type !== 'class' && n.type !== 'individual') return n;
           const updated = newNodes.find((nn) => nn.id === n.id);
           return updated ? { ...n, data: updated.data } : n;
         }),
@@ -267,8 +274,14 @@ function GraphFlow(): React.JSX.Element {
     if (e.type === 'subClassOf' && !graphFilters.showSubClassOf) return false;
     if (e.type === 'disjointWith' && !graphFilters.showDisjointWith) return false;
     if (e.type === 'objectProperty' && !graphFilters.showObjectProperties) return false;
+    if (e.type === 'typeOf' && !graphFilters.showTypeOf) return false;
     return true;
   });
+
+  // Filter individual nodes
+  const filteredNodes = graphFilters.showIndividuals
+    ? nodes
+    : nodes.filter((n) => n.type !== 'individual');
 
   // Filter nodes by minimum degree
   const visibleNodeIds = new Set<string>();
@@ -278,25 +291,27 @@ function GraphFlow(): React.JSX.Element {
       degreeMap.set(e.source, (degreeMap.get(e.source) ?? 0) + 1);
       degreeMap.set(e.target, (degreeMap.get(e.target) ?? 0) + 1);
     });
-    nodes.forEach((n) => {
+    filteredNodes.forEach((n) => {
       if (n.type === 'group' || (degreeMap.get(n.id) ?? 0) >= graphFilters.minDegree) {
         visibleNodeIds.add(n.id);
       }
     });
   }
   const visibleNodes =
-    graphFilters.minDegree > 0 ? nodes.filter((n) => visibleNodeIds.has(n.id)) : nodes;
+    graphFilters.minDegree > 0
+      ? filteredNodes.filter((n) => visibleNodeIds.has(n.id))
+      : filteredNodes;
 
   // Save positions to sidecar when nodes change (debounced via the 'onNodesChange' handler)
   const handleNodesChange = useCallback(
-    (changes: NodeChange<ClassNode | GroupNode>[]) => {
+    (changes: NodeChange<ClassNode | IndividualNode | GroupNode>[]) => {
       onNodesChange(changes);
       // Save positions after drag ends
       const hasDragStop = changes.some((c) => c.type === 'position' && !c.dragging);
       if (hasDragStop) {
         const posData: Record<string, { x: number; y: number }> = {};
         nodesRef.current.forEach((n) => {
-          if (n.type === 'class') posData[n.id] = n.position;
+          if (n.type === 'class' || n.type === 'individual') posData[n.id] = n.position;
         });
         savePositions({ positions: posData });
       }

--- a/apps/desktop/src/renderer/src/components/graph/edges/TypeOfEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/TypeOfEdge.tsx
@@ -1,0 +1,88 @@
+import { useUIStore } from '@renderer/store/ui';
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  type EdgeProps,
+  getBezierPath,
+  useInternalNode,
+} from '@xyflow/react';
+import { memo } from 'react';
+import { getFloatingEdgeParams } from './floating-edge-utils';
+
+function autoRotation(sx: number, sy: number, tx: number, ty: number): number {
+  let angle = Math.atan2(ty - sy, tx - sx) * (180 / Math.PI);
+  if (angle > 90 || angle < -90) angle += 180;
+  return angle;
+}
+
+export const TypeOfEdge = memo(function TypeOfEdge({ id, source, target, selected }: EdgeProps) {
+  const sourceNode = useInternalNode(source);
+  const targetNode = useInternalNode(target);
+  const selectedNodeId = useUIStore((s) => s.selectedNodeId);
+  const adjacentEdgeIds = useUIStore((s) => s.adjacentEdgeIds);
+
+  if (!sourceNode || !targetNode) return null;
+
+  const { sx, sy, tx, ty, sourcePosition, targetPosition } = getFloatingEdgeParams(
+    sourceNode,
+    targetNode,
+  );
+
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX: sx,
+    sourceY: sy,
+    sourcePosition,
+    targetX: tx,
+    targetY: ty,
+    targetPosition,
+  });
+
+  const isAdjacent = adjacentEdgeIds.includes(id);
+  const isDimmed = selectedNodeId !== null && !isAdjacent;
+  const color = 'var(--graph-edge-typeof, oklch(0.65 0.15 160))';
+  const markerId = `typeof-arrow-${id}`;
+  const rotation = autoRotation(sx, sy, tx, ty);
+
+  return (
+    <>
+      <g style={{ opacity: isDimmed ? 0.15 : 1, transition: 'opacity 0.15s ease' }}>
+        <defs>
+          <marker id={markerId} markerWidth={8} markerHeight={6} refX={7} refY={3} orient="auto">
+            <polygon points="0 0, 8 3, 0 6" fill={color} stroke={color} strokeWidth={1} />
+          </marker>
+        </defs>
+        <BaseEdge
+          id={id}
+          path={edgePath}
+          style={{
+            stroke: color,
+            strokeWidth: selected ? 3 : isAdjacent ? 3 : 1.5,
+            strokeDasharray: '4,3',
+            markerEnd: `url(#${markerId})`,
+          }}
+        />
+      </g>
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: 'absolute',
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px) rotate(${rotation}deg)`,
+            fontSize: 10,
+            fontWeight: 500,
+            color: '#fff',
+            background: color,
+            padding: '2px 5px',
+            borderRadius: 4,
+            pointerEvents: 'none',
+            whiteSpace: 'nowrap',
+            opacity: isDimmed ? 0.15 : 1,
+            transition: 'opacity 0.15s ease',
+          }}
+          className="nodrag nopan"
+        >
+          rdf:type
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+});

--- a/apps/desktop/src/renderer/src/components/graph/nodes/IndividualNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/IndividualNode.tsx
@@ -1,0 +1,152 @@
+import type { IndividualNode as IndividualNodeType } from '@renderer/model/reactflow';
+import { useUIStore } from '@renderer/store/ui';
+import { Handle, type NodeProps, Position } from '@xyflow/react';
+import { memo } from 'react';
+
+export const IndividualNode = memo(function IndividualNode({
+  data,
+  id,
+}: NodeProps<IndividualNodeType>) {
+  const selectedNodeId = useUIStore((s) => s.selectedNodeId);
+  const adjacentNodeIds = useUIStore((s) => s.adjacentNodeIds);
+  const isSelected = selectedNodeId === id;
+  const isAdjacent = !isSelected && adjacentNodeIds.includes(id);
+  const isDimmed = selectedNodeId !== null && !isSelected && !isAdjacent;
+  const hasErrors = data.errorCount > 0;
+
+  return (
+    <div
+      className="ontograph-individual-node"
+      style={{
+        minWidth: 160,
+        maxWidth: 220,
+        borderRadius: 12,
+        overflow: 'hidden',
+        backdropFilter: 'blur(8px)',
+        border: isSelected
+          ? '2px solid var(--graph-node-selected)'
+          : isAdjacent
+            ? '2px solid var(--graph-node-adjacent)'
+            : hasErrors
+              ? '1px solid var(--destructive)'
+              : '1px dashed var(--graph-node-individual-border, oklch(0.65 0.15 160))',
+        boxShadow: '0 2px 8px oklch(0 0 0 / 0.15), 0 0 1px oklch(0 0 0 / 0.1)',
+        background: isSelected ? 'var(--graph-node-selected-bg)' : 'transparent',
+        opacity: isDimmed ? 0.2 : 1,
+        transition: 'opacity 0.15s ease',
+      }}
+    >
+      <Handle
+        type="target"
+        position={Position.Left}
+        style={{ opacity: 0, top: '50%', left: '50%' }}
+      />
+      <Handle
+        type="source"
+        position={Position.Left}
+        style={{ opacity: 0, top: '50%', left: '50%' }}
+      />
+
+      <div
+        style={{
+          padding: '6px 10px',
+          fontSize: 12,
+          fontWeight: 600,
+          color: 'var(--graph-node-header-text)',
+          background: 'var(--graph-node-individual-header-bg, oklch(0.25 0.06 160))',
+          letterSpacing: '0.01em',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            opacity: 0.6,
+            flexShrink: 0,
+          }}
+        >
+          ◆
+        </span>
+        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{data.label}</span>
+        {(data.errorCount > 0 || data.warningCount > 0) && (
+          <span style={{ display: 'flex', gap: 3, flexShrink: 0, marginLeft: 'auto' }}>
+            {data.errorCount > 0 && (
+              <span
+                title={`${data.errorCount} error${data.errorCount > 1 ? 's' : ''}`}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  minWidth: 16,
+                  height: 16,
+                  borderRadius: 8,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  background: 'var(--destructive)',
+                  color: 'var(--destructive-foreground)',
+                  padding: '0 4px',
+                  lineHeight: 1,
+                }}
+              >
+                {data.errorCount}
+              </span>
+            )}
+            {data.warningCount > 0 && (
+              <span
+                title={`${data.warningCount} warning${data.warningCount > 1 ? 's' : ''}`}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  minWidth: 16,
+                  height: 16,
+                  borderRadius: 8,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  background: 'oklch(0.75 0.18 85)',
+                  color: 'oklch(0.25 0.05 85)',
+                  padding: '0 4px',
+                  lineHeight: 1,
+                }}
+              >
+                {data.warningCount}
+              </span>
+            )}
+          </span>
+        )}
+      </div>
+
+      {data.typeLabels.length > 0 && (
+        <div
+          style={{
+            padding: '4px 10px',
+            background: 'var(--graph-node-body-bg)',
+          }}
+        >
+          {data.typeLabels.map((typeLabel, i) => (
+            <div
+              key={data.types[i]}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '2px 0',
+                fontSize: 10,
+                gap: 4,
+              }}
+            >
+              <span style={{ color: 'var(--muted-foreground)', fontStyle: 'italic' }}>
+                a {typeLabel}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/apps/desktop/src/renderer/src/components/metrics/MetricsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/metrics/MetricsPanel.tsx
@@ -93,6 +93,7 @@ export function MetricsPanel(): React.JSX.Element {
       {/* KPI Cards */}
       <div className="flex gap-2 px-4 pt-3">
         <KpiCard label="Classes" value={summary.totalClasses} />
+        <KpiCard label="Individuals" value={summary.individuals} />
         <KpiCard label="Obj Props" value={summary.objectProperties} />
         <KpiCard label="Data Props" value={summary.datatypeProperties} />
       </div>

--- a/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
@@ -66,6 +66,18 @@ export function GraphControlsPanel({ onClose }: Props): React.JSX.Element {
           checked={graphFilters.showDatatypeProperties}
           onChange={(v) => setGraphFilter({ showDatatypeProperties: v })}
         />
+        <FilterCheckbox
+          id="filter-individuals"
+          label="Individuals"
+          checked={graphFilters.showIndividuals}
+          onChange={(v) => setGraphFilter({ showIndividuals: v })}
+        />
+        <FilterCheckbox
+          id="filter-typeof"
+          label="Type-of edges"
+          checked={graphFilters.showTypeOf}
+          onChange={(v) => setGraphFilter({ showTypeOf: v })}
+        />
         <div className="flex items-center gap-2 pt-0.5">
           <span className="text-xs text-muted-foreground w-28">Min connections</span>
           <Slider

--- a/apps/desktop/src/renderer/src/components/toolbar/GraphSearchBar.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphSearchBar.tsx
@@ -60,6 +60,17 @@ export function GraphSearchBar(): React.JSX.Element {
         matches.push({ id: cls.uri, label: `${label} (comment)`, matchType: 'comment' });
       }
     }
+    // Search individuals
+    for (const ind of ontology.individuals.values()) {
+      const label = ind.label || localName(ind.uri);
+      if (label.toLowerCase().includes(q)) {
+        matches.push({ id: ind.uri, label: `${label} ◆`, matchType: 'label' });
+      } else if (ind.uri.toLowerCase().includes(q)) {
+        matches.push({ id: ind.uri, label: `${label} ◆ (URI)`, matchType: 'uri' });
+      } else if (ind.comment?.toLowerCase().includes(q)) {
+        matches.push({ id: ind.uri, label: `${label} ◆ (comment)`, matchType: 'comment' });
+      }
+    }
     // Also search object properties (match shows domain class)
     for (const prop of ontology.objectProperties.values()) {
       const propLabel = prop.label || localName(prop.uri);
@@ -78,7 +89,7 @@ export function GraphSearchBar(): React.JSX.Element {
     setResults(matches.slice(0, 10));
     setActiveIndex(0);
     setOpen(matches.length > 0);
-  }, [query, classes, ontology.objectProperties.values]);
+  }, [query, classes, ontology.objectProperties.values, ontology.individuals.values]);
 
   // Click outside to close
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/model/parse.ts
+++ b/apps/desktop/src/renderer/src/model/parse.ts
@@ -1,5 +1,11 @@
 import { Parser, type Quad } from 'n3';
-import type { DatatypeProperty, ObjectProperty, Ontology, OntologyClass } from './types';
+import type {
+  DatatypeProperty,
+  Individual,
+  ObjectProperty,
+  Ontology,
+  OntologyClass,
+} from './types';
 import { createEmptyOntology } from './types';
 
 const OWL = 'http://www.w3.org/2002/07/owl#';
@@ -57,6 +63,15 @@ function getOrCreateDatatypeProperty(ontology: Ontology, uri: string): DatatypeP
   return prop;
 }
 
+function getOrCreateIndividual(ontology: Ontology, uri: string): Individual {
+  let ind = ontology.individuals.get(uri);
+  if (!ind) {
+    ind = { uri, types: [], objectPropertyAssertions: [], dataPropertyAssertions: [] };
+    ontology.individuals.set(uri, ind);
+  }
+  return ind;
+}
+
 export interface ParseWarning {
   message: string;
   severity: 'error' | 'warning';
@@ -99,7 +114,7 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
   }
 
   // Track declared types to distinguish ObjectProperty from DatatypeProperty
-  const declaredTypes = new Map<string, string>();
+  const declaredTypes = new Map<string, Set<string>>();
 
   // First pass: collect type declarations
   for (const quad of quads) {
@@ -108,7 +123,8 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
     const o = quad.object.value;
 
     if (p === `${RDF}type`) {
-      declaredTypes.set(s, o);
+      if (!declaredTypes.has(s)) declaredTypes.set(s, new Set());
+      declaredTypes.get(s)?.add(o);
 
       if (o === `${OWL}Class`) {
         getOrCreateClass(ontology, s);
@@ -116,6 +132,16 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
         getOrCreateObjectProperty(ontology, s);
       } else if (o === `${OWL}DatatypeProperty`) {
         getOrCreateDatatypeProperty(ontology, s);
+      } else if (o === `${OWL}NamedIndividual`) {
+        // Skip blank node individuals
+        if (quad.subject.termType === 'BlankNode') {
+          warnings.push({
+            severity: 'warning',
+            message: `Blank node individual ignored: ${s}`,
+          });
+        } else {
+          getOrCreateIndividual(ontology, s);
+        }
       }
     }
   }
@@ -126,19 +152,29 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
     const p = quad.predicate.value;
     const o = quad.object.value;
 
-    if (p === `${RDF}type`) continue;
+    if (p === `${RDF}type`) {
+      // Record type assertions for individuals (e.g., :john rdf:type :Person)
+      const ind = ontology.individuals.get(s);
+      if (ind && o !== `${OWL}NamedIndividual`) {
+        if (!ind.types.includes(o)) ind.types.push(o);
+      }
+      continue;
+    }
 
     if (p === `${RDFS}label`) {
       const literal = quad.object.termType === 'Literal' ? quad.object.value : o;
       const cls = ontology.classes.get(s);
       const objProp = ontology.objectProperties.get(s);
       const dtProp = ontology.datatypeProperties.get(s);
+      const ind = ontology.individuals.get(s);
       if (cls) {
         cls.label = literal;
       } else if (objProp) {
         objProp.label = literal;
       } else if (dtProp) {
         dtProp.label = literal;
+      } else if (ind) {
+        ind.label = literal;
       }
       continue;
     }
@@ -148,12 +184,15 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
       const cls = ontology.classes.get(s);
       const objProp = ontology.objectProperties.get(s);
       const dtProp = ontology.datatypeProperties.get(s);
+      const ind = ontology.individuals.get(s);
       if (cls) {
         cls.comment = literal;
       } else if (objProp) {
         objProp.comment = literal;
       } else if (dtProp) {
         dtProp.comment = literal;
+      } else if (ind) {
+        ind.comment = literal;
       }
       continue;
     }
@@ -208,6 +247,22 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
       if (prop) {
         prop.inverseOf = o;
       }
+      continue;
+    }
+
+    // Individual property assertions
+    const ind = ontology.individuals.get(s);
+    if (ind) {
+      if (quad.object.termType === 'Literal') {
+        const datatype = (quad.object as { datatype?: { value: string } }).datatype?.value;
+        ind.dataPropertyAssertions.push({
+          property: p,
+          value: o,
+          datatype: datatype || undefined,
+        });
+      } else if (quad.object.termType === 'NamedNode') {
+        ind.objectPropertyAssertions.push({ property: p, target: o });
+      }
     }
   }
 
@@ -217,7 +272,6 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
     `${OWL}Restriction`,
     `${OWL}AllDifferent`,
     `${OWL}AnnotationProperty`,
-    `${OWL}NamedIndividual`,
     `${OWL}Ontology`,
   ];
   for (const quad of quads) {
@@ -236,7 +290,8 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
   if (
     ontology.classes.size === 0 &&
     ontology.objectProperties.size === 0 &&
-    ontology.datatypeProperties.size === 0
+    ontology.datatypeProperties.size === 0 &&
+    ontology.individuals.size === 0
   ) {
     warnings.push({
       severity: 'warning',

--- a/apps/desktop/src/renderer/src/model/reactflow.ts
+++ b/apps/desktop/src/renderer/src/model/reactflow.ts
@@ -11,13 +11,24 @@ export interface ClassNodeData extends Record<string, unknown> {
   warningCount: number;
 }
 
+export interface IndividualNodeData extends Record<string, unknown> {
+  label: string;
+  uri: string;
+  comment?: string;
+  types: string[];
+  typeLabels: string[];
+  errorCount: number;
+  warningCount: number;
+}
+
 export interface GroupNodeData extends Record<string, unknown> {
   label: string;
 }
 
 export type ClassNode = Node<ClassNodeData, 'class'>;
+export type IndividualNode = Node<IndividualNodeData, 'individual'>;
 export type GroupNode = Node<GroupNodeData, 'group'>;
-export type OntographNode = ClassNode | GroupNode;
+export type OntographNode = ClassNode | IndividualNode | GroupNode;
 
 export interface ObjPropEdgeData extends Record<string, unknown> {
   label: string;
@@ -40,7 +51,7 @@ function localName(uri: string): string {
 }
 
 export interface ReactFlowElements {
-  nodes: ClassNode[];
+  nodes: (ClassNode | IndividualNode)[];
   edges: Edge[];
 }
 
@@ -60,7 +71,7 @@ export function ontologyToReactFlowElements(
       }
     }
   }
-  const nodes: ClassNode[] = [];
+  const nodes: (ClassNode | IndividualNode)[] = [];
   const edges: Edge[] = [];
 
   // Build map of datatype properties by domain class
@@ -133,6 +144,40 @@ export function ontologyToReactFlowElements(
           data: { label, uri: prop.uri },
         });
       }
+    }
+  }
+
+  // Individual nodes
+  const totalAll = ontology.classes.size + ontology.individuals.size;
+  const cols = Math.ceil(Math.sqrt(totalAll));
+  for (const ind of ontology.individuals.values()) {
+    const row = Math.floor(idx / cols);
+    const col = idx % cols;
+    nodes.push({
+      id: ind.uri,
+      type: 'individual',
+      position: { x: col * 260, y: row * 160 },
+      data: {
+        label: ind.label || localName(ind.uri),
+        uri: ind.uri,
+        comment: ind.comment,
+        types: ind.types,
+        typeLabels: ind.types.map((t) => ontology.classes.get(t)?.label || localName(t)),
+        errorCount: errorCounts.get(ind.uri) ?? 0,
+        warningCount: warningCounts.get(ind.uri) ?? 0,
+      },
+    } as IndividualNode);
+    idx++;
+
+    // rdf:type edges from individual to its classes
+    for (const typeUri of ind.types) {
+      edges.push({
+        id: `typeof-${ind.uri}-${typeUri}`,
+        source: ind.uri,
+        target: typeUri,
+        type: 'typeOf',
+        data: { label: 'rdf:type' },
+      });
     }
   }
 

--- a/apps/desktop/src/renderer/src/model/serialize.ts
+++ b/apps/desktop/src/renderer/src/model/serialize.ts
@@ -76,6 +76,37 @@ export function serializeToTurtle(ontology: Ontology): string {
     writer.addQuad(subject, namedNode(`${RDFS}range`), namedNode(prop.range));
   }
 
+  // Write individuals
+  for (const ind of ontology.individuals.values()) {
+    const subject = namedNode(ind.uri);
+
+    writer.addQuad(subject, namedNode(`${RDF}type`), namedNode(`${OWL}NamedIndividual`));
+
+    for (const typeUri of ind.types) {
+      writer.addQuad(subject, namedNode(`${RDF}type`), namedNode(typeUri));
+    }
+    if (ind.label) {
+      writer.addQuad(subject, namedNode(`${RDFS}label`), literal(ind.label));
+    }
+    if (ind.comment) {
+      writer.addQuad(subject, namedNode(`${RDFS}comment`), literal(ind.comment));
+    }
+    for (const assertion of ind.objectPropertyAssertions) {
+      writer.addQuad(subject, namedNode(assertion.property), namedNode(assertion.target));
+    }
+    for (const assertion of ind.dataPropertyAssertions) {
+      if (assertion.datatype) {
+        writer.addQuad(
+          subject,
+          namedNode(assertion.property),
+          literal(assertion.value, namedNode(assertion.datatype)),
+        );
+      } else {
+        writer.addQuad(subject, namedNode(assertion.property), literal(assertion.value));
+      }
+    }
+  }
+
   let result = '';
   writer.end((_error, output) => {
     result = output;

--- a/apps/desktop/src/renderer/src/model/types.ts
+++ b/apps/desktop/src/renderer/src/model/types.ts
@@ -3,6 +3,7 @@ export interface Ontology {
   classes: Map<string, OntologyClass>;
   objectProperties: Map<string, ObjectProperty>;
   datatypeProperties: Map<string, DatatypeProperty>;
+  individuals: Map<string, Individual>;
 }
 
 export interface OntologyClass {
@@ -34,6 +35,15 @@ export interface DatatypeProperty {
   maxCardinality?: number;
 }
 
+export interface Individual {
+  uri: string;
+  label?: string;
+  comment?: string;
+  types: string[];
+  objectPropertyAssertions: { property: string; target: string }[];
+  dataPropertyAssertions: { property: string; value: string; datatype?: string }[];
+}
+
 export function createEmptyOntology(): Ontology {
   return {
     prefixes: new Map([
@@ -45,5 +55,6 @@ export function createEmptyOntology(): Ontology {
     classes: new Map(),
     objectProperties: new Map(),
     datatypeProperties: new Map(),
+    individuals: new Map(),
   };
 }

--- a/apps/desktop/src/renderer/src/services/metrics.ts
+++ b/apps/desktop/src/renderer/src/services/metrics.ts
@@ -5,6 +5,7 @@ export interface OntologyMetrics {
     totalClasses: number;
     objectProperties: number;
     datatypeProperties: number;
+    individuals: number;
   };
   structure: {
     maxDepth: number;
@@ -36,11 +37,12 @@ export interface OntologyMetrics {
 }
 
 export function computeMetrics(ontology: Ontology): OntologyMetrics {
-  const { classes, objectProperties, datatypeProperties } = ontology;
+  const { classes, objectProperties, datatypeProperties, individuals } = ontology;
 
   const totalClasses = classes.size;
   const totalObjProps = objectProperties.size;
   const totalDtProps = datatypeProperties.size;
+  const totalIndividuals = individuals.size;
 
   // Build parent→children map and child→parents map
   const childrenOf = new Map<string, string[]>();
@@ -270,6 +272,7 @@ export function computeMetrics(ontology: Ontology): OntologyMetrics {
       totalClasses,
       objectProperties: totalObjProps,
       datatypeProperties: totalDtProps,
+      individuals: totalIndividuals,
     },
     structure: {
       maxDepth,

--- a/apps/desktop/src/renderer/src/services/validation.ts
+++ b/apps/desktop/src/renderer/src/services/validation.ts
@@ -4,7 +4,7 @@ export interface ValidationError {
   severity: 'error' | 'warning';
   message: string;
   elementUri: string;
-  elementType: 'class' | 'objectProperty' | 'datatypeProperty';
+  elementType: 'class' | 'objectProperty' | 'datatypeProperty' | 'individual';
 }
 
 export function validateOntology(ontology: Ontology): ValidationError[] {
@@ -108,6 +108,41 @@ export function validateOntology(ontology: Ontology): ValidationError[] {
         message: `Inverse property "${localName(prop.inverseOf)}" does not exist`,
         elementUri: prop.uri,
         elementType: 'objectProperty',
+      });
+    }
+  }
+
+  // Check individuals
+  for (const ind of ontology.individuals.values()) {
+    // Type assertions should reference existing classes
+    for (const typeUri of ind.types) {
+      if (!ontology.classes.has(typeUri)) {
+        errors.push({
+          severity: 'warning',
+          message: `Type class "${localName(typeUri)}" does not exist`,
+          elementUri: ind.uri,
+          elementType: 'individual',
+        });
+      }
+    }
+
+    // Individual with no type assertion
+    if (ind.types.length === 0) {
+      errors.push({
+        severity: 'warning',
+        message: 'Individual has no type assertion',
+        elementUri: ind.uri,
+        elementType: 'individual',
+      });
+    }
+
+    // Individual with no label
+    if (!ind.label) {
+      errors.push({
+        severity: 'warning',
+        message: 'Individual has no label',
+        elementUri: ind.uri,
+        elementType: 'individual',
       });
     }
   }

--- a/apps/desktop/src/renderer/src/store/ontology.ts
+++ b/apps/desktop/src/renderer/src/store/ontology.ts
@@ -2,7 +2,13 @@ import { create } from 'zustand';
 import { track } from '../lib/analytics';
 import { type ParseWarning, parseTurtleWithWarnings } from '../model/parse';
 import { serializeToTurtle } from '../model/serialize';
-import type { DatatypeProperty, ObjectProperty, Ontology, OntologyClass } from '../model/types';
+import type {
+  DatatypeProperty,
+  Individual,
+  ObjectProperty,
+  Ontology,
+  OntologyClass,
+} from '../model/types';
 import { createEmptyOntology } from '../model/types';
 
 interface OntologyState {
@@ -34,6 +40,11 @@ interface OntologyState {
   updateDatatypeProperty: (uri: string, changes: Partial<DatatypeProperty>) => void;
   removeDatatypeProperty: (uri: string) => void;
 
+  // Individual operations
+  addIndividual: (uri: string, ind?: Partial<Individual>) => void;
+  updateIndividual: (uri: string, changes: Partial<Individual>) => void;
+  removeIndividual: (uri: string) => void;
+
   // Undo/redo support
   restoreOntology: (ontology: Ontology) => void;
 }
@@ -49,6 +60,7 @@ export const useOntologyStore = create<OntologyState>((set, get) => ({
     set({ ontology, filePath: filePath ?? null, isDirty: false, importWarnings: warnings });
     track('ontology_loaded', {
       classCount: ontology.classes.size,
+      individualCount: ontology.individuals.size,
       source: filePath?.startsWith('Sample') ? 'sample' : 'file',
     });
   },
@@ -69,12 +81,7 @@ export const useOntologyStore = create<OntologyState>((set, get) => ({
 
   addClass: (uri, partial) => {
     set((state) => {
-      const ontology = structuredClone(state.ontology);
-      // structuredClone converts Maps to plain objects, so reconstruct
-      ontology.prefixes = new Map(state.ontology.prefixes);
-      ontology.classes = new Map(state.ontology.classes);
-      ontology.objectProperties = new Map(state.ontology.objectProperties);
-      ontology.datatypeProperties = new Map(state.ontology.datatypeProperties);
+      const ontology = cloneOntology(state.ontology);
 
       const isFirst = ontology.classes.size === 0;
       ontology.classes.set(uri, {
@@ -195,6 +202,40 @@ export const useOntologyStore = create<OntologyState>((set, get) => ({
     });
   },
 
+  addIndividual: (uri, partial) => {
+    set((state) => {
+      const ontology = cloneOntology(state.ontology);
+      ontology.individuals.set(uri, {
+        uri,
+        types: [],
+        objectPropertyAssertions: [],
+        dataPropertyAssertions: [],
+        ...partial,
+      });
+      track('individual_added');
+      return { ontology, isDirty: true };
+    });
+  },
+
+  updateIndividual: (uri, changes) => {
+    set((state) => {
+      const existing = state.ontology.individuals.get(uri);
+      if (!existing) return state;
+
+      const ontology = cloneOntology(state.ontology);
+      ontology.individuals.set(uri, { ...existing, ...changes });
+      return { ontology, isDirty: true };
+    });
+  },
+
+  removeIndividual: (uri) => {
+    set((state) => {
+      const ontology = cloneOntology(state.ontology);
+      ontology.individuals.delete(uri);
+      return { ontology, isDirty: true };
+    });
+  },
+
   restoreOntology: (ontology) => set({ ontology: cloneOntology(ontology), isDirty: true }),
 }));
 
@@ -217,6 +258,17 @@ function cloneOntology(ontology: Ontology): Ontology {
       Array.from(ontology.datatypeProperties.entries()).map(([k, v]) => [
         k,
         { ...v, domain: [...v.domain] },
+      ]),
+    ),
+    individuals: new Map(
+      Array.from(ontology.individuals.entries()).map(([k, v]) => [
+        k,
+        {
+          ...v,
+          types: [...v.types],
+          objectPropertyAssertions: v.objectPropertyAssertions.map((a) => ({ ...a })),
+          dataPropertyAssertions: v.dataPropertyAssertions.map((a) => ({ ...a })),
+        },
       ]),
     ),
   };

--- a/apps/desktop/src/renderer/src/store/ui.ts
+++ b/apps/desktop/src/renderer/src/store/ui.ts
@@ -7,6 +7,8 @@ export interface GraphFilters {
   showDisjointWith: boolean;
   showObjectProperties: boolean;
   showDatatypeProperties: boolean;
+  showIndividuals: boolean;
+  showTypeOf: boolean;
   minDegree: number;
 }
 
@@ -19,6 +21,8 @@ const DEFAULT_FILTERS: GraphFilters = {
   showDisjointWith: true,
   showObjectProperties: true,
   showDatatypeProperties: true,
+  showIndividuals: true,
+  showTypeOf: true,
   minDegree: 0,
 };
 

--- a/apps/desktop/tests/model/parse.test.ts
+++ b/apps/desktop/tests/model/parse.test.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { parseTurtle } from '@renderer/model/parse';
-import type { DatatypeProperty, ObjectProperty, OntologyClass } from '@renderer/model/types';
+import { parseTurtle, parseTurtleWithWarnings } from '@renderer/model/parse';
+import type {
+  DatatypeProperty,
+  Individual,
+  ObjectProperty,
+  OntologyClass,
+} from '@renderer/model/types';
 import { describe, expect, it } from 'vitest';
 
 const EX = 'http://example.org/ontology#';
@@ -9,6 +14,11 @@ const XSD = 'http://www.w3.org/2001/XMLSchema#';
 
 const peopleTurtle = readFileSync(
   resolve(__dirname, '../../resources/sample-ontologies/people.ttl'),
+  'utf-8',
+);
+
+const individualsTurtle = readFileSync(
+  resolve(__dirname, '../../resources/sample-ontologies/individuals.ttl'),
   'utf-8',
 );
 
@@ -92,5 +102,111 @@ describe('parseTurtle', () => {
     expect(thing.uri).toBe('http://example.org/Thing');
     expect(thing.label).toBeUndefined();
     expect(thing.subClassOf).toEqual([]);
+  });
+});
+
+describe('parseTurtle — individuals', () => {
+  it('parses individuals from fixture', () => {
+    const ontology = parseTurtle(individualsTurtle);
+    expect(ontology.individuals.size).toBe(4);
+    expect(ontology.individuals.has(`${EX}john`)).toBe(true);
+    expect(ontology.individuals.has(`${EX}jane`)).toBe(true);
+    expect(ontology.individuals.has(`${EX}acmeCorp`)).toBe(true);
+    expect(ontology.individuals.has(`${EX}bob`)).toBe(true);
+  });
+
+  it('parses individual labels and comments', () => {
+    const ontology = parseTurtle(individualsTurtle);
+    const john = ontology.individuals.get(`${EX}john`) as Individual;
+    expect(john.label).toBe('John Smith');
+    expect(john.comment).toBe('An example employee');
+  });
+
+  it('parses type assertions', () => {
+    const ontology = parseTurtle(individualsTurtle);
+    const john = ontology.individuals.get(`${EX}john`) as Individual;
+    expect(john.types).toContain(`${EX}Employee`);
+  });
+
+  it('parses multiple type assertions', () => {
+    const ontology = parseTurtle(individualsTurtle);
+    const bob = ontology.individuals.get(`${EX}bob`) as Individual;
+    expect(bob.types).toContain(`${EX}Person`);
+    expect(bob.types).toContain(`${EX}Employee`);
+  });
+
+  it('parses data property assertions', () => {
+    const ontology = parseTurtle(individualsTurtle);
+    const john = ontology.individuals.get(`${EX}john`) as Individual;
+    const nameAssertion = john.dataPropertyAssertions.find((a) => a.property === `${EX}name`);
+    expect(nameAssertion).toBeDefined();
+    expect(nameAssertion?.value).toBe('John Smith');
+  });
+
+  it('parses object property assertions', () => {
+    const ontology = parseTurtle(individualsTurtle);
+    const john = ontology.individuals.get(`${EX}john`) as Individual;
+    const worksFor = john.objectPropertyAssertions.find((a) => a.property === `${EX}worksFor`);
+    expect(worksFor).toBeDefined();
+    expect(worksFor?.target).toBe(`${EX}acmeCorp`);
+  });
+
+  it('parses classes alongside individuals', () => {
+    const ontology = parseTurtle(individualsTurtle);
+    expect(ontology.classes.size).toBe(3);
+    expect(ontology.individuals.size).toBe(4);
+  });
+
+  it('does not add NamedIndividual to unsupported warnings', () => {
+    const { warnings } = parseTurtleWithWarnings(individualsTurtle);
+    const unsupportedWarning = warnings.find(
+      (w) => w.message.includes('Unsupported') && w.message.includes('NamedIndividual'),
+    );
+    expect(unsupportedWarning).toBeUndefined();
+  });
+
+  it('handles OWL 2 punning — same URI as class and individual', () => {
+    const turtle = `
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix ex: <http://example.org/> .
+      ex:Foo a owl:Class .
+      ex:Foo a owl:NamedIndividual .
+    `;
+    const ontology = parseTurtle(turtle);
+    expect(ontology.classes.has('http://example.org/Foo')).toBe(true);
+    expect(ontology.individuals.has('http://example.org/Foo')).toBe(true);
+  });
+
+  it('skips blank node individuals with warning', () => {
+    const turtle = `
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      _:b0 a owl:NamedIndividual .
+    `;
+    const { ontology, warnings } = parseTurtleWithWarnings(turtle);
+    expect(ontology.individuals.size).toBe(0);
+    expect(warnings.some((w) => w.message.includes('Blank node individual'))).toBe(true);
+  });
+
+  it('handles individual with no type assertion', () => {
+    const turtle = `
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix ex: <http://example.org/> .
+      ex:orphan a owl:NamedIndividual .
+    `;
+    const ontology = parseTurtle(turtle);
+    const orphan = ontology.individuals.get('http://example.org/orphan') as Individual;
+    expect(orphan).toBeDefined();
+    expect(orphan.types).toEqual([]);
+  });
+
+  it('handles individual referencing undeclared class', () => {
+    const turtle = `
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix ex: <http://example.org/> .
+      ex:thing a owl:NamedIndividual, ex:UndeclaredClass .
+    `;
+    const ontology = parseTurtle(turtle);
+    const thing = ontology.individuals.get('http://example.org/thing') as Individual;
+    expect(thing.types).toContain('http://example.org/UndeclaredClass');
   });
 });

--- a/apps/desktop/tests/model/reactflow.test.ts
+++ b/apps/desktop/tests/model/reactflow.test.ts
@@ -1,4 +1,4 @@
-import type { ClassNode } from '@renderer/model/reactflow';
+import type { ClassNode, IndividualNode } from '@renderer/model/reactflow';
 import { ontologyToReactFlowElements } from '@renderer/model/reactflow';
 import type { Ontology } from '@renderer/model/types';
 import { createEmptyOntology } from '@renderer/model/types';
@@ -114,5 +114,78 @@ describe('ontologyToReactFlowElements', () => {
     const positions = result.nodes.map((n) => n.position);
     // All positions should be defined
     expect(positions.every((p) => typeof p.x === 'number' && typeof p.y === 'number')).toBe(true);
+  });
+});
+
+function buildOntologyWithIndividuals(): Ontology {
+  const ont = buildOntology();
+  ont.individuals.set('http://ex/john', {
+    uri: 'http://ex/john',
+    label: 'John',
+    types: ['http://ex/Person'],
+    objectPropertyAssertions: [{ property: 'http://ex/worksAt', target: 'http://ex/acme' }],
+    dataPropertyAssertions: [{ property: 'http://ex/name', value: 'John Smith' }],
+  });
+  ont.individuals.set('http://ex/acme', {
+    uri: 'http://ex/acme',
+    types: [],
+    objectPropertyAssertions: [],
+    dataPropertyAssertions: [],
+  });
+  return ont;
+}
+
+describe('ontologyToReactFlowElements — individuals', () => {
+  it('creates individual nodes', () => {
+    const result = ontologyToReactFlowElements(buildOntologyWithIndividuals());
+    const indNodes = result.nodes.filter((n) => n.type === 'individual');
+    expect(indNodes).toHaveLength(2);
+  });
+
+  it('sets individual node data correctly', () => {
+    const result = ontologyToReactFlowElements(buildOntologyWithIndividuals());
+    const johnNode = result.nodes.find((n) => n.id === 'http://ex/john') as IndividualNode;
+    expect(johnNode).toBeDefined();
+    expect(johnNode.type).toBe('individual');
+    expect(johnNode.data.label).toBe('John');
+    expect(johnNode.data.uri).toBe('http://ex/john');
+    expect(johnNode.data.types).toContain('http://ex/Person');
+    expect(johnNode.data.typeLabels).toContain('Person');
+  });
+
+  it('creates typeOf edges from individuals to classes', () => {
+    const result = ontologyToReactFlowElements(buildOntologyWithIndividuals());
+    const typeOfEdges = result.edges.filter((e) => e.type === 'typeOf');
+    expect(typeOfEdges).toHaveLength(1);
+    expect(typeOfEdges[0].source).toBe('http://ex/john');
+    expect(typeOfEdges[0].target).toBe('http://ex/Person');
+  });
+
+  it('does not create typeOf edges for untyped individuals', () => {
+    const result = ontologyToReactFlowElements(buildOntologyWithIndividuals());
+    const acmeTypeOfEdges = result.edges.filter(
+      (e) => e.type === 'typeOf' && e.source === 'http://ex/acme',
+    );
+    expect(acmeTypeOfEdges).toHaveLength(0);
+  });
+
+  it('uses localName when individual has no label', () => {
+    const result = ontologyToReactFlowElements(buildOntologyWithIndividuals());
+    const acmeNode = result.nodes.find((n) => n.id === 'http://ex/acme') as IndividualNode;
+    expect(acmeNode.data.label).toBe('acme');
+  });
+
+  it('includes both class and individual nodes', () => {
+    const result = ontologyToReactFlowElements(buildOntologyWithIndividuals());
+    const classNodes = result.nodes.filter((n) => n.type === 'class');
+    const indNodes = result.nodes.filter((n) => n.type === 'individual');
+    expect(classNodes.length).toBe(3);
+    expect(indNodes.length).toBe(2);
+  });
+
+  it('positions individual nodes', () => {
+    const result = ontologyToReactFlowElements(buildOntologyWithIndividuals());
+    const indNodes = result.nodes.filter((n) => n.type === 'individual');
+    expect(indNodes.every((n) => typeof n.position.x === 'number')).toBe(true);
   });
 });

--- a/apps/desktop/tests/model/serialize.test.ts
+++ b/apps/desktop/tests/model/serialize.test.ts
@@ -2,7 +2,12 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parseTurtle } from '@renderer/model/parse';
 import { serializeToTurtle } from '@renderer/model/serialize';
-import type { DatatypeProperty, ObjectProperty, OntologyClass } from '@renderer/model/types';
+import type {
+  DatatypeProperty,
+  Individual,
+  ObjectProperty,
+  OntologyClass,
+} from '@renderer/model/types';
 import { createEmptyOntology } from '@renderer/model/types';
 import { describe, expect, it } from 'vitest';
 
@@ -11,6 +16,11 @@ const _XSD = 'http://www.w3.org/2001/XMLSchema#';
 
 const peopleTurtle = readFileSync(
   resolve(__dirname, '../../resources/sample-ontologies/people.ttl'),
+  'utf-8',
+);
+
+const individualsTurtle = readFileSync(
+  resolve(__dirname, '../../resources/sample-ontologies/individuals.ttl'),
   'utf-8',
 );
 
@@ -76,5 +86,79 @@ describe('serializeToTurtle', () => {
     // Should at least have prefix declarations
     const reparsed = parseTurtle(serialized);
     expect(reparsed.classes.size).toBe(0);
+  });
+});
+
+describe('serializeToTurtle — individuals', () => {
+  it('round-trips: preserves individuals', () => {
+    const original = parseTurtle(individualsTurtle);
+    const serialized = serializeToTurtle(original);
+    const reparsed = parseTurtle(serialized);
+
+    expect(reparsed.individuals.size).toBe(original.individuals.size);
+    for (const [uri, ind] of original.individuals) {
+      const reparsedInd = reparsed.individuals.get(uri) as Individual;
+      expect(reparsedInd).toBeDefined();
+      expect(reparsedInd.label).toBe(ind.label);
+      expect(reparsedInd.comment).toBe(ind.comment);
+      expect(reparsedInd.types.sort()).toEqual(ind.types.sort());
+    }
+  });
+
+  it('round-trips: preserves individual type assertions', () => {
+    const original = parseTurtle(individualsTurtle);
+    const serialized = serializeToTurtle(original);
+    const reparsed = parseTurtle(serialized);
+
+    const john = reparsed.individuals.get(`${EX}john`) as Individual;
+    expect(john.types).toContain(`${EX}Employee`);
+
+    const bob = reparsed.individuals.get(`${EX}bob`) as Individual;
+    expect(bob.types).toContain(`${EX}Person`);
+    expect(bob.types).toContain(`${EX}Employee`);
+  });
+
+  it('round-trips: preserves object property assertions', () => {
+    const original = parseTurtle(individualsTurtle);
+    const serialized = serializeToTurtle(original);
+    const reparsed = parseTurtle(serialized);
+
+    const john = reparsed.individuals.get(`${EX}john`) as Individual;
+    const worksFor = john.objectPropertyAssertions.find((a) => a.property === `${EX}worksFor`);
+    expect(worksFor).toBeDefined();
+    expect(worksFor?.target).toBe(`${EX}acmeCorp`);
+  });
+
+  it('round-trips: preserves data property assertions', () => {
+    const original = parseTurtle(individualsTurtle);
+    const serialized = serializeToTurtle(original);
+    const reparsed = parseTurtle(serialized);
+
+    const john = reparsed.individuals.get(`${EX}john`) as Individual;
+    const name = john.dataPropertyAssertions.find((a) => a.property === `${EX}name`);
+    expect(name).toBeDefined();
+    expect(name?.value).toBe('John Smith');
+  });
+
+  it('round-trips: preserves classes alongside individuals', () => {
+    const original = parseTurtle(individualsTurtle);
+    const serialized = serializeToTurtle(original);
+    const reparsed = parseTurtle(serialized);
+
+    expect(reparsed.classes.size).toBe(original.classes.size);
+    expect(reparsed.individuals.size).toBe(original.individuals.size);
+  });
+
+  it('serializes individual with no assertions', () => {
+    const ont = createEmptyOntology();
+    ont.individuals.set('http://ex/empty', {
+      uri: 'http://ex/empty',
+      types: [],
+      objectPropertyAssertions: [],
+      dataPropertyAssertions: [],
+    });
+    const serialized = serializeToTurtle(ont);
+    const reparsed = parseTurtle(serialized);
+    expect(reparsed.individuals.has('http://ex/empty')).toBe(true);
   });
 });

--- a/apps/desktop/tests/services/validation.test.ts
+++ b/apps/desktop/tests/services/validation.test.ts
@@ -169,3 +169,93 @@ describe('validateOntology', () => {
     ).toBe(true);
   });
 });
+
+describe('validateOntology — individuals', () => {
+  it('returns no errors for valid individual', () => {
+    const o = makeOntology((o) => {
+      o.classes.set(`${EX}Person`, {
+        uri: `${EX}Person`,
+        label: 'Person',
+        subClassOf: [],
+        disjointWith: [],
+      });
+      o.individuals.set(`${EX}john`, {
+        uri: `${EX}john`,
+        label: 'John',
+        types: [`${EX}Person`],
+        objectPropertyAssertions: [],
+        dataPropertyAssertions: [],
+      });
+    });
+    const errors = validateOntology(o).filter((e) => e.elementType === 'individual');
+    expect(errors).toEqual([]);
+  });
+
+  it('warns on individual with no type assertion', () => {
+    const o = makeOntology((o) => {
+      o.individuals.set(`${EX}orphan`, {
+        uri: `${EX}orphan`,
+        label: 'Orphan',
+        types: [],
+        objectPropertyAssertions: [],
+        dataPropertyAssertions: [],
+      });
+    });
+    const errors = validateOntology(o);
+    expect(
+      errors.some(
+        (e) =>
+          e.elementType === 'individual' &&
+          e.severity === 'warning' &&
+          e.message.includes('no type assertion'),
+      ),
+    ).toBe(true);
+  });
+
+  it('warns on individual with dangling type reference', () => {
+    const o = makeOntology((o) => {
+      o.individuals.set(`${EX}thing`, {
+        uri: `${EX}thing`,
+        label: 'Thing',
+        types: [`${EX}NonExistentClass`],
+        objectPropertyAssertions: [],
+        dataPropertyAssertions: [],
+      });
+    });
+    const errors = validateOntology(o);
+    expect(
+      errors.some(
+        (e) =>
+          e.elementType === 'individual' &&
+          e.severity === 'warning' &&
+          e.message.includes('does not exist'),
+      ),
+    ).toBe(true);
+  });
+
+  it('warns on individual with no label', () => {
+    const o = makeOntology((o) => {
+      o.classes.set(`${EX}Person`, {
+        uri: `${EX}Person`,
+        label: 'Person',
+        subClassOf: [],
+        disjointWith: [],
+      });
+      o.individuals.set(`${EX}noLabel`, {
+        uri: `${EX}noLabel`,
+        types: [`${EX}Person`],
+        objectPropertyAssertions: [],
+        dataPropertyAssertions: [],
+      });
+    });
+    const errors = validateOntology(o);
+    expect(
+      errors.some(
+        (e) =>
+          e.elementType === 'individual' &&
+          e.severity === 'warning' &&
+          e.message.includes('no label'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/tests/store/ontology.test.ts
+++ b/apps/desktop/tests/store/ontology.test.ts
@@ -228,4 +228,74 @@ describe('useOntologyStore', () => {
       expect(useOntologyStore.getState().isDirty).toBe(true);
     });
   });
+
+  describe('individual operations', () => {
+    it('adds an individual with defaults', () => {
+      useOntologyStore.getState().addIndividual('http://ex/john');
+      const ind = useOntologyStore.getState().ontology.individuals.get('http://ex/john');
+      expect(ind).toBeDefined();
+      expect(ind?.uri).toBe('http://ex/john');
+      expect(ind?.types).toEqual([]);
+      expect(ind?.objectPropertyAssertions).toEqual([]);
+      expect(ind?.dataPropertyAssertions).toEqual([]);
+      expect(useOntologyStore.getState().isDirty).toBe(true);
+    });
+
+    it('adds an individual with partial data', () => {
+      useOntologyStore.getState().addIndividual('http://ex/john', {
+        label: 'John',
+        types: ['http://ex/Person'],
+      });
+      const ind = useOntologyStore.getState().ontology.individuals.get('http://ex/john');
+      expect(ind?.label).toBe('John');
+      expect(ind?.types).toEqual(['http://ex/Person']);
+    });
+
+    it('updates an existing individual', () => {
+      useOntologyStore.getState().addIndividual('http://ex/john', { label: 'John' });
+      useOntologyStore.getState().updateIndividual('http://ex/john', { label: 'John Smith' });
+      expect(useOntologyStore.getState().ontology.individuals.get('http://ex/john')?.label).toBe(
+        'John Smith',
+      );
+    });
+
+    it('does nothing for non-existent individual', () => {
+      const before = useOntologyStore.getState().ontology;
+      useOntologyStore.getState().updateIndividual('http://ex/nope', { label: 'X' });
+      expect(useOntologyStore.getState().ontology).toBe(before);
+    });
+
+    it('removes an individual', () => {
+      useOntologyStore.getState().addIndividual('http://ex/john');
+      useOntologyStore.getState().removeIndividual('http://ex/john');
+      expect(useOntologyStore.getState().ontology.individuals.has('http://ex/john')).toBe(false);
+    });
+
+    it('loads individuals from turtle', () => {
+      const turtle = `
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix : <http://example.org/> .
+
+        :Person a owl:Class ; rdfs:label "Person" .
+        :john a owl:NamedIndividual, :Person ;
+            rdfs:label "John" .
+      `;
+      useOntologyStore.getState().loadFromTurtle(turtle);
+      const { ontology } = useOntologyStore.getState();
+      expect(ontology.individuals.size).toBe(1);
+      expect(ontology.individuals.has('http://example.org/john')).toBe(true);
+      expect(ontology.individuals.get('http://example.org/john')?.label).toBe('John');
+    });
+
+    it('exports individuals in turtle round-trip', () => {
+      useOntologyStore.getState().addIndividual('http://ex/john', {
+        label: 'John',
+        types: ['http://ex/Person'],
+      });
+      const exported = useOntologyStore.getState().exportToTurtle();
+      expect(exported).toContain('John');
+      expect(exported).toContain('NamedIndividual');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds full `owl:NamedIndividual` support across the desktop app: model, parser, serializer, Zustand store, ReactFlow visualization, search, validation, and metrics
- Individuals render as distinct nodes (diamond icon, dashed green border) with `rdf:type` edges connecting them to their classes
- Includes visibility toggles, detail panel for property assertions, and blank node/punning edge case handling

## Changes

**Model** (`types.ts`): `Individual` interface with `types`, `objectPropertyAssertions`, `dataPropertyAssertions`

**Parser** (`parse.ts`): Removed `NamedIndividual` from `UNSUPPORTED_TYPES`. Parses type assertions, object/data property assertions. Skips blank node individuals with warning. Supports OWL 2 punning (same URI as both class and individual).

**Serializer** (`serialize.ts`): Round-trip serialization of individuals including type assertions and property assertions with datatypes.

**Store** (`ontology.ts`): `addIndividual`, `updateIndividual`, `removeIndividual` with proper cloning.

**ReactFlow**: New `IndividualNode` component, `TypeOfEdge` component, registered in canvas with node/edge types.

**UI**: `showIndividuals` and `showTypeOf` filter toggles, search includes individuals (◆ marker), detail panel shows type/object/data assertions, graph legend updated.

**Validation** (`validation.ts`): Warnings for missing type assertions, dangling type references, missing labels.

**Metrics**: Individual count added to summary KPIs.

## Test plan

- [ ] Load an OWL file containing `owl:NamedIndividual` declarations — individuals appear as distinct nodes
- [ ] Verify `rdf:type` edges connect individuals to their declared classes
- [ ] Toggle "Individuals" and "Type-of edges" visibility in Graph Controls
- [ ] Search for an individual by label/URI/comment
- [ ] Select an individual node — detail panel shows type and property assertions
- [ ] Export/save and re-import — individuals round-trip correctly
- [ ] Load a file with OWL 2 punning (same URI as class + individual) — both appear
- [ ] Load a file with blank node individuals — skipped with warning, no crash
- [ ] Validation panel shows warnings for individuals without type assertions
- [ ] Metrics panel shows individual count

🤖 Generated with [Claude Code](https://claude.com/claude-code)