### PR TITLE
feat(desktop): add restriction rendering with inline display and edges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,19 @@
+## CI Checks
+
+After pushing to a PR branch, verify CI passes before requesting review:
+
+```bash
+# Check PR status
+gh pr view <number> --json statusCheckRollup --jq '.statusCheckRollup[] | [.name, .conclusion] | @tsv'
+
+# Get failed job logs
+gh run view <run-id> --log-failed | head -60
+```
+
+- If CI fails, fix the issue and push again.
+- Run `bun run format:check` and `bun run lint` locally before pushing to catch issues early.
+- Do not request review or mark a PR as ready while CI is failing.
+
 ## Versioning & Releases
 
 - Semver versioning: vMAJOR.MINOR.PATCH

--- a/apps/desktop/resources/sample-ontologies/restrictions.ttl
+++ b/apps/desktop/resources/sample-ontologies/restrictions.ttl
@@ -1,0 +1,98 @@
+@prefix : <http://example.org/restrictions#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+### Classes
+:Person a owl:Class .
+:Organization a owl:Class .
+:Department a owl:Class .
+:Project a owl:Class .
+:AcmeCorp a owl:NamedIndividual, :Organization .
+
+### Properties
+:worksFor a owl:ObjectProperty ;
+    rdfs:domain :Person ;
+    rdfs:range :Organization .
+
+:memberOf a owl:ObjectProperty ;
+    rdfs:domain :Person ;
+    rdfs:range :Department .
+
+:hasEmail a owl:DatatypeProperty ;
+    rdfs:domain :Person ;
+    rdfs:range xsd:string .
+
+:manages a owl:ObjectProperty ;
+    rdfs:domain :Person ;
+    rdfs:range :Project .
+
+### Test Case 1: someValuesFrom
+# "Every Person works for at least one Organization"
+:Person rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty :worksFor ;
+    owl:someValuesFrom :Organization
+] .
+
+### Test Case 2: allValuesFrom
+# "A Person can only be a member of Departments"
+:Person rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty :memberOf ;
+    owl:allValuesFrom :Department
+] .
+
+### Test Case 3: hasValue
+# "Every Employee works for AcmeCorp specifically"
+:Employee a owl:Class ;
+    rdfs:subClassOf :Person ;
+    rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty :worksFor ;
+        owl:hasValue :AcmeCorp
+    ] .
+
+### Test Case 4: minCardinality
+# "A Person has at least 1 email"
+:Person rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty :hasEmail ;
+    owl:minCardinality "1"^^xsd:nonNegativeInteger
+] .
+
+### Test Case 5: maxCardinality
+# "A Person manages at most 5 projects"
+:Person rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty :manages ;
+    owl:maxCardinality "5"^^xsd:nonNegativeInteger
+] .
+
+### Test Case 6: exactCardinality (owl:cardinality)
+# "A Department has exactly 1 manager"
+:Department rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty :manages ;
+    owl:cardinality "1"^^xsd:nonNegativeInteger
+] .
+
+### Test Case 7: Multiple restrictions on one class
+# Person already has someValuesFrom, allValuesFrom, minCardinality, maxCardinality above
+# This tests that all 4 are collected correctly on the Person class
+
+### Edge Case: Restriction with undeclared property
+:Contractor a owl:Class ;
+    rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty :undeclaredProp ;
+        owl:someValuesFrom :Organization
+    ] .
+
+### Edge Case: Restriction without onProperty (should warn and skip)
+:BadRestriction a owl:Class ;
+    rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:someValuesFrom :Organization
+    ] .

--- a/apps/desktop/src/renderer/src/components/detail/ClassDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/ClassDetail.tsx
@@ -1,4 +1,4 @@
-import type { DatatypeProperty, OntologyClass } from '@renderer/model/types';
+import type { DatatypeProperty, OntologyClass, Restriction } from '@renderer/model/types';
 import { useOntologyStore } from '@renderer/store/ontology';
 import { useUIStore } from '@renderer/store/ui';
 import { Input } from '@/components/ui/input';
@@ -163,6 +163,22 @@ export function ClassDetail({ cls }: Props): React.JSX.Element {
           </div>
         </div>
       )}
+
+      {cls.restrictions && cls.restrictions.length > 0 && (
+        <div>
+          <div className="text-xs text-muted-foreground mb-1">Restrictions</div>
+          <div className="space-y-0.5">
+            {cls.restrictions.map((r) => (
+              <RestrictionPill
+                key={`${r.onProperty}-${r.type}-${r.value}`}
+                restriction={r}
+                ontology={ontology}
+                onFocus={setFocusNode}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -240,6 +256,52 @@ function DatatypePropertyRow({
           className="h-6 text-xs w-14 px-1.5"
         />
       </div>
+    </div>
+  );
+}
+
+function formatRestrictionLabel(r: Restriction): { text: string; targetUri?: string } {
+  const prop = localName(r.onProperty);
+  switch (r.type) {
+    case 'someValuesFrom':
+      return { text: `${prop} some`, targetUri: r.value };
+    case 'allValuesFrom':
+      return { text: `${prop} only`, targetUri: r.value };
+    case 'hasValue':
+      return { text: `${prop} = ${localName(r.value)}` };
+    case 'minCardinality':
+      return { text: `${prop} [${r.value}..*]` };
+    case 'maxCardinality':
+      return { text: `${prop} [0..${r.value}]` };
+    case 'exactCardinality':
+      return { text: `${prop} [${r.value}..${r.value}]` };
+    default:
+      return { text: `${prop} ${r.type} ${localName(r.value)}` };
+  }
+}
+
+function RestrictionPill({
+  restriction,
+  ontology,
+  onFocus,
+}: {
+  restriction: Restriction;
+  ontology: import('@renderer/model/types').Ontology;
+  onFocus: (uri: string) => void;
+}): React.JSX.Element {
+  const { text, targetUri } = formatRestrictionLabel(restriction);
+  return (
+    <div className="text-xs bg-secondary rounded px-2 py-1 flex items-center gap-1 flex-wrap">
+      <span className="font-medium">{text}</span>
+      {targetUri && (
+        <button
+          type="button"
+          className="text-primary underline underline-offset-2 decoration-primary/40 hover:decoration-primary cursor-pointer transition-colors"
+          onClick={() => onFocus(targetUri)}
+        >
+          {ontology.classes.get(targetUri)?.label || localName(targetUri)}
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
@@ -22,6 +22,11 @@ const EDGE_ITEMS = [
     color: 'var(--graph-edge-typeof, oklch(0.65 0.15 160))',
     dash: '4,3',
   },
+  {
+    label: 'Restriction',
+    color: 'var(--graph-edge-restriction)',
+    dash: '6,3',
+  },
 ] as const;
 
 const NODE_ITEMS = [

--- a/apps/desktop/src/renderer/src/components/graph/ReactFlowCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/ReactFlowCanvas.tsx
@@ -31,6 +31,7 @@ import { AnimatePresence } from 'motion/react';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { DisjointWithEdge } from './edges/DisjointWithEdge';
 import { ObjectPropertyEdge } from './edges/ObjectPropertyEdge';
+import { RestrictionEdge } from './edges/RestrictionEdge';
 import { SubClassOfEdge } from './edges/SubClassOfEdge';
 import { TypeOfEdge } from './edges/TypeOfEdge';
 import { GraphLegend } from './GraphLegend';
@@ -49,6 +50,7 @@ const EDGE_TYPES: EdgeTypes = {
   objectProperty: ObjectPropertyEdge as EdgeTypes[string],
   disjointWith: DisjointWithEdge,
   typeOf: TypeOfEdge,
+  restriction: RestrictionEdge as EdgeTypes[string],
 };
 
 interface ContextMenuState {
@@ -276,6 +278,7 @@ function GraphFlow(): React.JSX.Element {
     if (e.type === 'disjointWith' && !graphFilters.showDisjointWith) return false;
     if (e.type === 'objectProperty' && !graphFilters.showObjectProperties) return false;
     if (e.type === 'typeOf' && !graphFilters.showTypeOf) return false;
+    if (e.type === 'restriction' && !graphFilters.showRestrictions) return false;
     return true;
   });
 

--- a/apps/desktop/src/renderer/src/components/graph/edges/RestrictionEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/RestrictionEdge.tsx
@@ -1,0 +1,100 @@
+import type { RestrictionEdgeData } from '@renderer/model/reactflow';
+import { useUIStore } from '@renderer/store/ui';
+import {
+  BaseEdge,
+  type Edge,
+  EdgeLabelRenderer,
+  type EdgeProps,
+  getBezierPath,
+  useInternalNode,
+} from '@xyflow/react';
+import { memo } from 'react';
+import { getFloatingEdgeParams } from './floating-edge-utils';
+
+type RestrictionEdgeType = Edge<RestrictionEdgeData>;
+
+function autoRotation(sx: number, sy: number, tx: number, ty: number): number {
+  let angle = Math.atan2(ty - sy, tx - sx) * (180 / Math.PI);
+  if (angle > 90 || angle < -90) angle += 180;
+  return angle;
+}
+
+export const RestrictionEdge = memo(function RestrictionEdge({
+  id,
+  source,
+  target,
+  data,
+  selected,
+}: EdgeProps<RestrictionEdgeType>) {
+  const sourceNode = useInternalNode(source);
+  const targetNode = useInternalNode(target);
+  const selectedNodeId = useUIStore((s) => s.selectedNodeId);
+  const adjacentEdgeIds = useUIStore((s) => s.adjacentEdgeIds);
+
+  if (!sourceNode || !targetNode) return null;
+
+  const { sx, sy, tx, ty, sourcePosition, targetPosition } = getFloatingEdgeParams(
+    sourceNode,
+    targetNode,
+  );
+
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX: sx,
+    sourceY: sy,
+    sourcePosition,
+    targetX: tx,
+    targetY: ty,
+    targetPosition,
+  });
+
+  const isAdjacent = adjacentEdgeIds.includes(id);
+  const isDimmed = selectedNodeId !== null && !isAdjacent;
+  const color = 'var(--graph-edge-restriction)';
+  const markerId = `restriction-arrow-${id}`;
+  const rotation = autoRotation(sx, sy, tx, ty);
+
+  return (
+    <>
+      <g style={{ opacity: isDimmed ? 0.15 : 1, transition: 'opacity 0.15s ease' }}>
+        <defs>
+          <marker id={markerId} markerWidth={8} markerHeight={6} refX={7} refY={3} orient="auto">
+            <polygon points="0 0, 8 3, 0 6" fill="none" stroke={color} strokeWidth={1.2} />
+          </marker>
+        </defs>
+        <BaseEdge
+          id={id}
+          path={edgePath}
+          style={{
+            stroke: color,
+            strokeWidth: selected ? 3 : isAdjacent ? 2.5 : 1.5,
+            strokeDasharray: '6,3',
+            markerEnd: `url(#${markerId})`,
+          }}
+        />
+      </g>
+      {data?.label && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px) rotate(${rotation}deg)`,
+              fontSize: 10,
+              fontWeight: 500,
+              color: '#fff',
+              background: color,
+              padding: '2px 5px',
+              borderRadius: 4,
+              pointerEvents: 'none',
+              whiteSpace: 'nowrap',
+              opacity: isDimmed ? 0.15 : 1,
+              transition: 'opacity 0.15s ease',
+            }}
+            className="nodrag nopan"
+          >
+            {data.label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+});

--- a/apps/desktop/src/renderer/src/components/graph/nodes/ClassNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/ClassNode.tsx
@@ -1,12 +1,39 @@
 import type { ClassNode as ClassNodeType } from '@renderer/model/reactflow';
+import type { Restriction } from '@renderer/model/types';
 // Floating edges use useInternalNode to compute real intersection points,
 // so handles are invisible and centered — they exist only for RF's connection model.
 import { useUIStore } from '@renderer/store/ui';
 import { Handle, type NodeProps, Position } from '@xyflow/react';
 import { memo } from 'react';
 
+function localName(uri: string): string {
+  const idx = Math.max(uri.lastIndexOf('#'), uri.lastIndexOf('/'));
+  return idx >= 0 ? uri.substring(idx + 1) : uri;
+}
+
+function formatRestriction(r: Restriction): string {
+  const prop = localName(r.onProperty);
+  switch (r.type) {
+    case 'someValuesFrom':
+      return `${prop} some ${localName(r.value)}`;
+    case 'allValuesFrom':
+      return `${prop} only ${localName(r.value)}`;
+    case 'hasValue':
+      return `${prop} = ${localName(r.value)}`;
+    case 'minCardinality':
+      return `${prop} [${r.value}..*]`;
+    case 'maxCardinality':
+      return `${prop} [0..${r.value}]`;
+    case 'exactCardinality':
+      return `${prop} [${r.value}..${r.value}]`;
+    default:
+      return `${prop} ${r.type} ${localName(r.value)}`;
+  }
+}
+
 export const ClassNode = memo(function ClassNode({ data, id }: NodeProps<ClassNodeType>) {
   const showDatatypeProperties = useUIStore((s) => s.graphFilters.showDatatypeProperties);
+  const showRestrictions = useUIStore((s) => s.graphFilters.showRestrictions);
   const selectedNodeId = useUIStore((s) => s.selectedNodeId);
   const adjacentNodeIds = useUIStore((s) => s.adjacentNodeIds);
   const isSelected = selectedNodeId === id;
@@ -143,6 +170,34 @@ export const ClassNode = memo(function ClassNode({ data, id }: NodeProps<ClassNo
               >
                 {prop.range}
               </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showRestrictions && data.restrictions.length > 0 && (
+        <div
+          style={{
+            padding: '4px 0',
+            background: 'var(--graph-node-body-bg)',
+            borderTop: '1px solid var(--graph-node-border)',
+          }}
+        >
+          {data.restrictions.map((r) => (
+            <div
+              key={`${r.onProperty}-${r.type}-${r.value}`}
+              style={{
+                padding: '2px 10px',
+                fontSize: 9,
+                color: 'var(--muted-foreground)',
+                fontWeight: 400,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              <span style={{ marginRight: 4 }}>&#8849;</span>
+              {formatRestriction(r)}
             </div>
           ))}
         </div>

--- a/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
@@ -78,6 +78,12 @@ export function GraphControlsPanel({ onClose }: Props): React.JSX.Element {
           checked={graphFilters.showTypeOf}
           onChange={(v) => setGraphFilter({ showTypeOf: v })}
         />
+        <FilterCheckbox
+          id="filter-restrictions"
+          label="Restrictions"
+          checked={graphFilters.showRestrictions}
+          onChange={(v) => setGraphFilter({ showRestrictions: v })}
+        />
         <div className="flex items-center gap-2 pt-0.5">
           <span className="text-xs text-muted-foreground w-28">Min connections</span>
           <Slider

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -53,6 +53,7 @@
   --graph-edge-property: oklch(0.65 0.12 280);
   --graph-edge-disjoint: oklch(0.60 0.12 15);
   --graph-edge-subclass: oklch(0.50 0.02 270);
+  --graph-edge-restriction: oklch(0.65 0.15 280);
 }
 
 .dark {
@@ -101,6 +102,7 @@
   --graph-edge-property: oklch(0.65 0.08 280);
   --graph-edge-disjoint: oklch(0.65 0.12 15);
   --graph-edge-subclass: oklch(0.65 0.015 270);
+  --graph-edge-restriction: oklch(0.65 0.15 280);
 }
 
 @theme inline {

--- a/apps/desktop/src/renderer/src/model/parse.ts
+++ b/apps/desktop/src/renderer/src/model/parse.ts
@@ -333,11 +333,7 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
 
   // Detect unsupported OWL constructs
   const unsupported = new Set<string>();
-  const UNSUPPORTED_TYPES = [
-    `${OWL}AllDifferent`,
-    `${OWL}AnnotationProperty`,
-    `${OWL}Ontology`,
-  ];
+  const UNSUPPORTED_TYPES = [`${OWL}AllDifferent`, `${OWL}AnnotationProperty`, `${OWL}Ontology`];
   for (const quad of quads) {
     if (quad.predicate.value === `${RDF}type` && UNSUPPORTED_TYPES.includes(quad.object.value)) {
       const name = quad.object.value.split('#').pop() || quad.object.value;

--- a/apps/desktop/src/renderer/src/model/parse.ts
+++ b/apps/desktop/src/renderer/src/model/parse.ts
@@ -5,6 +5,8 @@ import type {
   ObjectProperty,
   Ontology,
   OntologyClass,
+  Restriction,
+  RestrictionType,
 } from './types';
 import { createEmptyOntology } from './types';
 
@@ -146,6 +148,48 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
     }
   }
 
+  // Restriction pass: collect blank nodes typed as owl:Restriction
+  const restrictionBlankNodes = new Set<string>();
+  const restrictionProps = new Map<
+    string,
+    { onProperty?: string; type?: RestrictionType; value?: string }
+  >();
+
+  const RESTRICTION_VALUE_PREDICATES: Record<string, RestrictionType> = {
+    [`${OWL}someValuesFrom`]: 'someValuesFrom',
+    [`${OWL}allValuesFrom`]: 'allValuesFrom',
+    [`${OWL}hasValue`]: 'hasValue',
+    [`${OWL}minCardinality`]: 'minCardinality',
+    [`${OWL}maxCardinality`]: 'maxCardinality',
+    [`${OWL}cardinality`]: 'exactCardinality',
+    [`${OWL}minQualifiedCardinality`]: 'minCardinality',
+    [`${OWL}maxQualifiedCardinality`]: 'maxCardinality',
+    [`${OWL}qualifiedCardinality`]: 'exactCardinality',
+  };
+
+  for (const quad of quads) {
+    const s = quad.subject.value;
+    const p = quad.predicate.value;
+    const o = quad.object.value;
+
+    if (p === `${RDF}type` && o === `${OWL}Restriction`) {
+      restrictionBlankNodes.add(s);
+      if (!restrictionProps.has(s)) restrictionProps.set(s, {});
+    }
+
+    if (p === `${OWL}onProperty`) {
+      if (!restrictionProps.has(s)) restrictionProps.set(s, {});
+      restrictionProps.get(s)!.onProperty = o;
+    }
+
+    const rType = RESTRICTION_VALUE_PREDICATES[p];
+    if (rType) {
+      if (!restrictionProps.has(s)) restrictionProps.set(s, {});
+      restrictionProps.get(s)!.type = rType;
+      restrictionProps.get(s)!.value = o;
+    }
+  }
+
   // Second pass: process properties and relationships
   for (const quad of quads) {
     const s = quad.subject.value;
@@ -198,6 +242,27 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
     }
 
     if (p === `${RDFS}subClassOf`) {
+      if (restrictionBlankNodes.has(o)) {
+        const rData = restrictionProps.get(o);
+        if (!rData?.onProperty) {
+          warnings.push({
+            severity: 'warning',
+            message: `Restriction on ${s} missing owl:onProperty — skipped`,
+          });
+          continue;
+        }
+        if (rData.type && rData.value !== undefined) {
+          const cls = getOrCreateClass(ontology, s);
+          const restriction: Restriction = {
+            onProperty: rData.onProperty,
+            type: rData.type,
+            value: rData.value,
+          };
+          if (!cls.restrictions) cls.restrictions = [];
+          cls.restrictions.push(restriction);
+        }
+        continue;
+      }
       const cls = getOrCreateClass(ontology, s);
       getOrCreateClass(ontology, o);
       if (!cls.subClassOf.includes(o)) {
@@ -269,7 +334,6 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
   // Detect unsupported OWL constructs
   const unsupported = new Set<string>();
   const UNSUPPORTED_TYPES = [
-    `${OWL}Restriction`,
     `${OWL}AllDifferent`,
     `${OWL}AnnotationProperty`,
     `${OWL}Ontology`,

--- a/apps/desktop/src/renderer/src/model/parse.ts
+++ b/apps/desktop/src/renderer/src/model/parse.ts
@@ -178,15 +178,17 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
     }
 
     if (p === `${OWL}onProperty`) {
-      if (!restrictionProps.has(s)) restrictionProps.set(s, {});
-      restrictionProps.get(s)!.onProperty = o;
+      const entry = restrictionProps.get(s) ?? {};
+      entry.onProperty = o;
+      restrictionProps.set(s, entry);
     }
 
     const rType = RESTRICTION_VALUE_PREDICATES[p];
     if (rType) {
-      if (!restrictionProps.has(s)) restrictionProps.set(s, {});
-      restrictionProps.get(s)!.type = rType;
-      restrictionProps.get(s)!.value = o;
+      const entry = restrictionProps.get(s) ?? {};
+      entry.type = rType;
+      entry.value = o;
+      restrictionProps.set(s, entry);
     }
   }
 

--- a/apps/desktop/src/renderer/src/model/reactflow.ts
+++ b/apps/desktop/src/renderer/src/model/reactflow.ts
@@ -136,30 +136,16 @@ export function ontologyToReactFlowElements(
         data: { label: 'disjointWith' },
       });
     }
-
-    // Restriction edges for someValuesFrom / allValuesFrom targeting other classes
-    if (cls.restrictions) {
-      for (const r of cls.restrictions) {
-        if (r.type !== 'someValuesFrom' && r.type !== 'allValuesFrom') continue;
-        // Only create edge if the target is a known class
-        if (!ontology.classes.has(r.value)) continue;
-        const qualifier = r.type === 'someValuesFrom' ? 'some' : 'only';
-        edges.push({
-          id: `restriction-${cls.uri}-${r.onProperty}-${r.type}-${r.value}`,
-          source: cls.uri,
-          target: r.value,
-          type: 'restriction',
-          data: { label: `${localName(r.onProperty)} [${qualifier}]`, qualifier },
-        });
-      }
-    }
   }
 
-  // Object property edges
+  // Build set of (source, target, property) tuples covered by object property edges
+  // so restriction edges can skip duplicates
+  const objPropEdgePairs = new Set<string>();
   for (const prop of ontology.objectProperties.values()) {
     const label = prop.label || localName(prop.uri);
     for (const domainUri of prop.domain) {
       for (const rangeUri of prop.range) {
+        objPropEdgePairs.add(`${domainUri}|${rangeUri}|${prop.uri}`);
         edges.push({
           id: `objprop-${prop.uri}-${domainUri}-${rangeUri}`,
           source: domainUri,
@@ -168,6 +154,25 @@ export function ontologyToReactFlowElements(
           data: { label, uri: prop.uri },
         });
       }
+    }
+  }
+
+  // Restriction edges for someValuesFrom / allValuesFrom targeting other classes
+  // Skip when an object property edge already covers the same source→target→property
+  for (const cls of ontology.classes.values()) {
+    if (!cls.restrictions) continue;
+    for (const r of cls.restrictions) {
+      if (r.type !== 'someValuesFrom' && r.type !== 'allValuesFrom') continue;
+      if (!ontology.classes.has(r.value)) continue;
+      if (objPropEdgePairs.has(`${cls.uri}|${r.value}|${r.onProperty}`)) continue;
+      const qualifier = r.type === 'someValuesFrom' ? 'some' : 'only';
+      edges.push({
+        id: `restriction-${cls.uri}-${r.onProperty}-${r.type}-${r.value}`,
+        source: cls.uri,
+        target: r.value,
+        type: 'restriction',
+        data: { label: `${localName(r.onProperty)} [${qualifier}]`, qualifier },
+      });
     }
   }
 

--- a/apps/desktop/src/renderer/src/model/reactflow.ts
+++ b/apps/desktop/src/renderer/src/model/reactflow.ts
@@ -1,12 +1,13 @@
 import type { Edge, Node } from '@xyflow/react';
 import type { ValidationError } from '../services/validation';
-import type { Ontology } from './types';
+import type { Ontology, Restriction } from './types';
 
 export interface ClassNodeData extends Record<string, unknown> {
   label: string;
   uri: string;
   comment?: string;
   datatypeProperties: { uri: string; label: string; range: string }[];
+  restrictions: Restriction[];
   errorCount: number;
   warningCount: number;
 }
@@ -41,6 +42,11 @@ export interface SubClassEdgeData extends Record<string, unknown> {
 
 export interface DisjointEdgeData extends Record<string, unknown> {
   label: string;
+}
+
+export interface RestrictionEdgeData extends Record<string, unknown> {
+  label: string;
+  qualifier: string;
 }
 
 function localName(uri: string): string {
@@ -101,6 +107,7 @@ export function ontologyToReactFlowElements(
         uri: cls.uri,
         comment: cls.comment,
         datatypeProperties: dtPropsByDomain.get(cls.uri) || [],
+        restrictions: cls.restrictions || [],
         errorCount: errorCounts.get(cls.uri) ?? 0,
         warningCount: warningCounts.get(cls.uri) ?? 0,
       },
@@ -128,6 +135,23 @@ export function ontologyToReactFlowElements(
         type: 'disjointWith',
         data: { label: 'disjointWith' },
       });
+    }
+
+    // Restriction edges for someValuesFrom / allValuesFrom targeting other classes
+    if (cls.restrictions) {
+      for (const r of cls.restrictions) {
+        if (r.type !== 'someValuesFrom' && r.type !== 'allValuesFrom') continue;
+        // Only create edge if the target is a known class
+        if (!ontology.classes.has(r.value)) continue;
+        const qualifier = r.type === 'someValuesFrom' ? 'some' : 'only';
+        edges.push({
+          id: `restriction-${cls.uri}-${r.onProperty}-${r.type}-${r.value}`,
+          source: cls.uri,
+          target: r.value,
+          type: 'restriction',
+          data: { label: `${localName(r.onProperty)} [${qualifier}]`, qualifier },
+        });
+      }
     }
   }
 

--- a/apps/desktop/src/renderer/src/model/types.ts
+++ b/apps/desktop/src/renderer/src/model/types.ts
@@ -6,12 +6,27 @@ export interface Ontology {
   individuals: Map<string, Individual>;
 }
 
+export type RestrictionType =
+  | 'someValuesFrom'
+  | 'allValuesFrom'
+  | 'hasValue'
+  | 'minCardinality'
+  | 'maxCardinality'
+  | 'exactCardinality';
+
+export interface Restriction {
+  onProperty: string;
+  type: RestrictionType;
+  value: string;
+}
+
 export interface OntologyClass {
   uri: string;
   label?: string;
   comment?: string;
   subClassOf: string[];
   disjointWith: string[];
+  restrictions?: Restriction[];
 }
 
 export interface ObjectProperty {

--- a/apps/desktop/src/renderer/src/store/ui.ts
+++ b/apps/desktop/src/renderer/src/store/ui.ts
@@ -9,6 +9,7 @@ export interface GraphFilters {
   showDatatypeProperties: boolean;
   showIndividuals: boolean;
   showTypeOf: boolean;
+  showRestrictions: boolean;
   minDegree: number;
 }
 
@@ -23,6 +24,7 @@ const DEFAULT_FILTERS: GraphFilters = {
   showDatatypeProperties: true,
   showIndividuals: true,
   showTypeOf: true,
+  showRestrictions: true,
   minDegree: 0,
 };
 

--- a/apps/desktop/tests/model/reactflow.test.ts
+++ b/apps/desktop/tests/model/reactflow.test.ts
@@ -189,3 +189,61 @@ describe('ontologyToReactFlowElements — individuals', () => {
     expect(indNodes.every((n) => typeof n.position.x === 'number')).toBe(true);
   });
 });
+
+describe('ontologyToReactFlowElements — restriction edges', () => {
+  it('creates restriction edge when no object property edge covers the same pair', () => {
+    const ont = createEmptyOntology();
+    ont.classes.set('http://ex/A', {
+      uri: 'http://ex/A',
+      subClassOf: [],
+      disjointWith: [],
+      restrictions: [{ onProperty: 'http://ex/rel', type: 'someValuesFrom', value: 'http://ex/B' }],
+    });
+    ont.classes.set('http://ex/B', { uri: 'http://ex/B', subClassOf: [], disjointWith: [] });
+    const result = ontologyToReactFlowElements(ont);
+    const restrictionEdges = result.edges.filter((e) => e.type === 'restriction');
+    expect(restrictionEdges).toHaveLength(1);
+    expect(restrictionEdges[0].source).toBe('http://ex/A');
+    expect(restrictionEdges[0].target).toBe('http://ex/B');
+  });
+
+  it('skips restriction edge when object property edge already covers the same source→target→property', () => {
+    const ont = createEmptyOntology();
+    ont.classes.set('http://ex/A', {
+      uri: 'http://ex/A',
+      subClassOf: [],
+      disjointWith: [],
+      restrictions: [{ onProperty: 'http://ex/rel', type: 'someValuesFrom', value: 'http://ex/B' }],
+    });
+    ont.classes.set('http://ex/B', { uri: 'http://ex/B', subClassOf: [], disjointWith: [] });
+    ont.objectProperties.set('http://ex/rel', {
+      uri: 'http://ex/rel',
+      domain: ['http://ex/A'],
+      range: ['http://ex/B'],
+    });
+    const result = ontologyToReactFlowElements(ont);
+    const restrictionEdges = result.edges.filter((e) => e.type === 'restriction');
+    expect(restrictionEdges).toHaveLength(0);
+    const objEdges = result.edges.filter((e) => e.type === 'objectProperty');
+    expect(objEdges).toHaveLength(1);
+  });
+
+  it('keeps restriction edge when object property covers a different property', () => {
+    const ont = createEmptyOntology();
+    ont.classes.set('http://ex/A', {
+      uri: 'http://ex/A',
+      subClassOf: [],
+      disjointWith: [],
+      restrictions: [{ onProperty: 'http://ex/rel2', type: 'allValuesFrom', value: 'http://ex/B' }],
+    });
+    ont.classes.set('http://ex/B', { uri: 'http://ex/B', subClassOf: [], disjointWith: [] });
+    ont.objectProperties.set('http://ex/rel1', {
+      uri: 'http://ex/rel1',
+      domain: ['http://ex/A'],
+      range: ['http://ex/B'],
+    });
+    const result = ontologyToReactFlowElements(ont);
+    const restrictionEdges = result.edges.filter((e) => e.type === 'restriction');
+    expect(restrictionEdges).toHaveLength(1);
+  });
+});

--- a/apps/desktop/tests/model/restrictions.test.ts
+++ b/apps/desktop/tests/model/restrictions.test.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseTurtle, parseTurtleWithWarnings } from '@renderer/model/parse';
+import type { OntologyClass } from '@renderer/model/types';
+import { describe, expect, it } from 'vitest';
+
+const EX = 'http://example.org/restrictions#';
+
+const restrictionsTurtle = readFileSync(
+  resolve(__dirname, '../../resources/sample-ontologies/restrictions.ttl'),
+  'utf-8',
+);
+
+describe('parseTurtle — owl:Restriction support', () => {
+  it('parses without errors', () => {
+    const { warnings } = parseTurtleWithWarnings(restrictionsTurtle);
+    const errors = warnings.filter((w) => w.severity === 'error');
+    expect(errors).toEqual([]);
+  });
+
+  it('does not emit "Unsupported" warning for owl:Restriction', () => {
+    const { warnings } = parseTurtleWithWarnings(restrictionsTurtle);
+    const unsupported = warnings.find(
+      (w) => w.message.includes('Unsupported') && w.message.includes('Restriction'),
+    );
+    expect(unsupported).toBeUndefined();
+  });
+
+  it('does not create blank node restrictions as standalone classes', () => {
+    const ontology = parseTurtle(restrictionsTurtle);
+    const blankNodeClasses = [...ontology.classes.keys()].filter(
+      (k) => k.startsWith('_:') || k.startsWith('n3-'),
+    );
+    expect(blankNodeClasses).toEqual([]);
+  });
+
+  describe('someValuesFrom', () => {
+    it('Person has someValuesFrom restriction on worksFor -> Organization', () => {
+      const ontology = parseTurtle(restrictionsTurtle);
+      const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
+      expect(person.restrictions).toBeDefined();
+      const svf = person.restrictions!.find(
+        (r) => r.type === 'someValuesFrom' && r.onProperty === `${EX}worksFor`,
+      );
+      expect(svf).toBeDefined();
+      expect(svf!.value).toBe(`${EX}Organization`);
+    });
+  });
+
+  describe('allValuesFrom', () => {
+    it('Person has allValuesFrom restriction on memberOf -> Department', () => {
+      const ontology = parseTurtle(restrictionsTurtle);
+      const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
+      const avf = person.restrictions!.find(
+        (r) => r.type === 'allValuesFrom' && r.onProperty === `${EX}memberOf`,
+      );
+      expect(avf).toBeDefined();
+      expect(avf!.value).toBe(`${EX}Department`);
+    });
+  });
+
+  describe('hasValue', () => {
+    it('Employee has hasValue restriction on worksFor -> AcmeCorp', () => {
+      const ontology = parseTurtle(restrictionsTurtle);
+      const employee = ontology.classes.get(`${EX}Employee`) as OntologyClass;
+      expect(employee.restrictions).toBeDefined();
+      const hv = employee.restrictions!.find(
+        (r) => r.type === 'hasValue' && r.onProperty === `${EX}worksFor`,
+      );
+      expect(hv).toBeDefined();
+      expect(hv!.value).toBe(`${EX}AcmeCorp`);
+    });
+
+    it('Employee also has regular subClassOf Person', () => {
+      const ontology = parseTurtle(restrictionsTurtle);
+      const employee = ontology.classes.get(`${EX}Employee`) as OntologyClass;
+      expect(employee.subClassOf).toContain(`${EX}Person`);
+    });
+  });
+
+  describe('minCardinality', () => {
+    it('Person has minCardinality 1 on hasEmail', () => {
+      const ontology = parseTurtle(restrictionsTurtle);
+      const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
+      const mc = person.restrictions!.find(
+        (r) => r.type === 'minCardinality' && r.onProperty === `${EX}hasEmail`,
+      );
+      expect(mc).toBeDefined();
+      expect(mc!.value).toBe('1');
+    });
+  });
+
+  describe('maxCardinality', () => {
+    it('Person has maxCardinality 5 on manages', () => {
+      const ontology = parseTurtle(restrictionsTurtle);
+      const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
+      const mc = person.restrictions!.find(
+        (r) => r.type === 'maxCardinality' && r.onProperty === `${EX}manages`,
+      );
+      expect(mc).toBeDefined();
+      expect(mc!.value).toBe('5');
+    });
+  });
+
+  describe('exactCardinality', () => {
+    it('Department has exactCardinality 1 on manages', () => {
+      const ontology = parseTurtle(restrictionsTurtle);
+      const dept = ontology.classes.get(`${EX}Department`) as OntologyClass;
+      expect(dept.restrictions).toBeDefined();
+      const ec = dept.restrictions!.find(
+        (r) => r.type === 'exactCardinality' && r.onProperty === `${EX}manages`,
+      );
+      expect(ec).toBeDefined();
+      expect(ec!.value).toBe('1');
+    });
+  });
+
+  describe('multiple restrictions on one class', () => {
+    it('Person has exactly 4 restrictions', () => {
+      const ontology = parseTurtle(restrictionsTurtle);
+      const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
+      expect(person.restrictions).toBeDefined();
+      expect(person.restrictions!.length).toBe(4);
+    });
+
+    it('Person restrictions cover 4 different types', () => {
+      const ontology = parseTurtle(restrictionsTurtle);
+      const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
+      const types = new Set(person.restrictions!.map((r) => r.type));
+      expect(types).toContain('someValuesFrom');
+      expect(types).toContain('allValuesFrom');
+      expect(types).toContain('minCardinality');
+      expect(types).toContain('maxCardinality');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('restriction with undeclared property parses with warning', () => {
+      const { ontology, warnings } = parseTurtleWithWarnings(restrictionsTurtle);
+      const contractor = ontology.classes.get(`${EX}Contractor`) as OntologyClass;
+      expect(contractor.restrictions).toBeDefined();
+      expect(contractor.restrictions!.length).toBe(1);
+      expect(contractor.restrictions![0].onProperty).toBe(`${EX}undeclaredProp`);
+    });
+
+    it('restriction without onProperty emits warning and is skipped', () => {
+      const { ontology, warnings } = parseTurtleWithWarnings(restrictionsTurtle);
+      const bad = ontology.classes.get(`${EX}BadRestriction`) as OntologyClass;
+      expect(bad.restrictions ?? []).toEqual([]);
+      const warning = warnings.find((w) => w.message.includes('onProperty'));
+      expect(warning).toBeDefined();
+    });
+  });
+});

--- a/apps/desktop/tests/model/restrictions.test.ts
+++ b/apps/desktop/tests/model/restrictions.test.ts
@@ -39,11 +39,11 @@ describe('parseTurtle — owl:Restriction support', () => {
       const ontology = parseTurtle(restrictionsTurtle);
       const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
       expect(person.restrictions).toBeDefined();
-      const svf = person.restrictions!.find(
+      const svf = person.restrictions?.find(
         (r) => r.type === 'someValuesFrom' && r.onProperty === `${EX}worksFor`,
       );
       expect(svf).toBeDefined();
-      expect(svf!.value).toBe(`${EX}Organization`);
+      expect(svf?.value).toBe(`${EX}Organization`);
     });
   });
 
@@ -51,11 +51,11 @@ describe('parseTurtle — owl:Restriction support', () => {
     it('Person has allValuesFrom restriction on memberOf -> Department', () => {
       const ontology = parseTurtle(restrictionsTurtle);
       const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
-      const avf = person.restrictions!.find(
+      const avf = person.restrictions?.find(
         (r) => r.type === 'allValuesFrom' && r.onProperty === `${EX}memberOf`,
       );
       expect(avf).toBeDefined();
-      expect(avf!.value).toBe(`${EX}Department`);
+      expect(avf?.value).toBe(`${EX}Department`);
     });
   });
 
@@ -64,11 +64,11 @@ describe('parseTurtle — owl:Restriction support', () => {
       const ontology = parseTurtle(restrictionsTurtle);
       const employee = ontology.classes.get(`${EX}Employee`) as OntologyClass;
       expect(employee.restrictions).toBeDefined();
-      const hv = employee.restrictions!.find(
+      const hv = employee.restrictions?.find(
         (r) => r.type === 'hasValue' && r.onProperty === `${EX}worksFor`,
       );
       expect(hv).toBeDefined();
-      expect(hv!.value).toBe(`${EX}AcmeCorp`);
+      expect(hv?.value).toBe(`${EX}AcmeCorp`);
     });
 
     it('Employee also has regular subClassOf Person', () => {
@@ -82,11 +82,11 @@ describe('parseTurtle — owl:Restriction support', () => {
     it('Person has minCardinality 1 on hasEmail', () => {
       const ontology = parseTurtle(restrictionsTurtle);
       const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
-      const mc = person.restrictions!.find(
+      const mc = person.restrictions?.find(
         (r) => r.type === 'minCardinality' && r.onProperty === `${EX}hasEmail`,
       );
       expect(mc).toBeDefined();
-      expect(mc!.value).toBe('1');
+      expect(mc?.value).toBe('1');
     });
   });
 
@@ -94,11 +94,11 @@ describe('parseTurtle — owl:Restriction support', () => {
     it('Person has maxCardinality 5 on manages', () => {
       const ontology = parseTurtle(restrictionsTurtle);
       const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
-      const mc = person.restrictions!.find(
+      const mc = person.restrictions?.find(
         (r) => r.type === 'maxCardinality' && r.onProperty === `${EX}manages`,
       );
       expect(mc).toBeDefined();
-      expect(mc!.value).toBe('5');
+      expect(mc?.value).toBe('5');
     });
   });
 
@@ -107,11 +107,11 @@ describe('parseTurtle — owl:Restriction support', () => {
       const ontology = parseTurtle(restrictionsTurtle);
       const dept = ontology.classes.get(`${EX}Department`) as OntologyClass;
       expect(dept.restrictions).toBeDefined();
-      const ec = dept.restrictions!.find(
+      const ec = dept.restrictions?.find(
         (r) => r.type === 'exactCardinality' && r.onProperty === `${EX}manages`,
       );
       expect(ec).toBeDefined();
-      expect(ec!.value).toBe('1');
+      expect(ec?.value).toBe('1');
     });
   });
 
@@ -120,13 +120,13 @@ describe('parseTurtle — owl:Restriction support', () => {
       const ontology = parseTurtle(restrictionsTurtle);
       const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
       expect(person.restrictions).toBeDefined();
-      expect(person.restrictions!.length).toBe(4);
+      expect(person.restrictions?.length).toBe(4);
     });
 
     it('Person restrictions cover 4 different types', () => {
       const ontology = parseTurtle(restrictionsTurtle);
       const person = ontology.classes.get(`${EX}Person`) as OntologyClass;
-      const types = new Set(person.restrictions!.map((r) => r.type));
+      const types = new Set(person.restrictions?.map((r) => r.type));
       expect(types).toContain('someValuesFrom');
       expect(types).toContain('allValuesFrom');
       expect(types).toContain('minCardinality');
@@ -136,11 +136,11 @@ describe('parseTurtle — owl:Restriction support', () => {
 
   describe('edge cases', () => {
     it('restriction with undeclared property parses with warning', () => {
-      const { ontology, warnings } = parseTurtleWithWarnings(restrictionsTurtle);
+      const { ontology } = parseTurtleWithWarnings(restrictionsTurtle);
       const contractor = ontology.classes.get(`${EX}Contractor`) as OntologyClass;
       expect(contractor.restrictions).toBeDefined();
-      expect(contractor.restrictions!.length).toBe(1);
-      expect(contractor.restrictions![0].onProperty).toBe(`${EX}undeclaredProp`);
+      expect(contractor.restrictions?.length).toBe(1);
+      expect(contractor.restrictions?.[0].onProperty).toBe(`${EX}undeclaredProp`);
     });
 
     it('restriction without onProperty emits warning and is skipped', () => {


### PR DESCRIPTION
## Summary

Implements UX Designer's visual spec for owl:Restriction rendering (builds on parser work from PR #52):

- **Inline restrictions on class nodes** using Manchester OWL syntax (`worksFor some Organization`, `hasEmail [1..*]`), toggled by `showRestrictions` filter
- **Dashed purple RestrictionEdge** for `someValuesFrom`/`allValuesFrom` restrictions that reference other classes — visually distinct from object property and subclass edges
- **Restrictions section in ClassDetail** panel with clickable target class links
- **`showRestrictions` toggle** in GraphControlsPanel
- **GraphLegend** updated with restriction edge entry
- **`--graph-edge-restriction` CSS variable** for light/dark themes

## Test plan

- [ ] Load `restrictions.ttl` fixture — verify restriction constraints appear inline on class nodes
- [ ] Toggle `showRestrictions` off — restrictions disappear from nodes and restriction edges hidden
- [ ] Click a restriction target class in ClassDetail — should focus/navigate to that class
- [ ] Verify dashed purple edges appear between classes with someValuesFrom/allValuesFrom restrictions
- [ ] Verify legend shows restriction edge entry
- [ ] Run `bun run lint` — 0 errors
- [ ] Run `bun test tests/model/` — all 122 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)