### PR TITLE
feat(desktop): support owl:AnnotationProperty and ontology-level metadata

### DIFF
--- a/apps/desktop/resources/sample-ontologies/annotations.ttl
+++ b/apps/desktop/resources/sample-ontologies/annotations.ttl
@@ -1,0 +1,90 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ex: <http://example.org/ontology#> .
+
+## Ontology header — declares the ontology IRI, version, imports, and Dublin Core metadata
+
+<http://example.org/ontology> a owl:Ontology ;
+    owl:versionIRI <http://example.org/ontology/1.0> ;
+    owl:imports <http://purl.org/dc/elements/1.1/> ;
+    dc:title "Example Annotation Ontology" ;
+    dc:creator "QA Engineer" ;
+    dc:description "A test ontology exercising owl:AnnotationProperty and owl:Ontology metadata" ;
+    dcterms:created "2026-03-30"^^xsd:date ;
+    rdfs:comment "Top-level ontology comment" .
+
+## Annotation property declarations — custom beyond rdfs:label/comment
+
+ex:authorName a owl:AnnotationProperty ;
+    rdfs:label "author name" ;
+    rdfs:comment "The name of the author of this entity" .
+
+ex:reviewStatus a owl:AnnotationProperty ;
+    rdfs:label "review status" .
+
+ex:deprecated a owl:AnnotationProperty ;
+    rdfs:label "deprecated" ;
+    rdfs:comment "Indicates whether the annotated entity is deprecated" .
+
+ex:seeAlso a owl:AnnotationProperty ;
+    rdfs:label "see also" .
+
+ex:editorialNote a owl:AnnotationProperty ;
+    rdfs:label "editorial note" ;
+    rdfs:comment "Internal notes for ontology editors" .
+
+## Annotation property with rdfs:subPropertyOf (hierarchy)
+
+ex:technicalNote a owl:AnnotationProperty ;
+    rdfs:subPropertyOf ex:editorialNote ;
+    rdfs:label "technical note" .
+
+## Standard annotation properties re-declared (legal in OWL 2)
+
+rdfs:label a owl:AnnotationProperty .
+rdfs:comment a owl:AnnotationProperty .
+
+## Dublin Core terms used as annotation properties
+
+dc:creator a owl:AnnotationProperty .
+dc:title a owl:AnnotationProperty .
+
+## Classes using custom annotation properties
+
+ex:Person a owl:Class ;
+    rdfs:label "Person" ;
+    rdfs:comment "A human being" ;
+    ex:authorName "Jane Ontologist" ;
+    ex:reviewStatus "approved" .
+
+ex:Organisation a owl:Class ;
+    rdfs:label "Organisation" ;
+    rdfs:comment "A formal group of people" ;
+    ex:deprecated "false" ;
+    ex:editorialNote "Consider splitting into ForProfit and NonProfit subclasses" .
+
+ex:LegacyEntity a owl:Class ;
+    rdfs:label "Legacy Entity" ;
+    ex:deprecated "true" ;
+    ex:seeAlso "Use ex:Person or ex:Organisation instead" .
+
+## Object property with annotation
+
+ex:worksFor a owl:ObjectProperty ;
+    rdfs:label "works for" ;
+    rdfs:domain ex:Person ;
+    rdfs:range ex:Organisation ;
+    ex:reviewStatus "draft" .
+
+## Datatype property with annotation
+
+ex:name a owl:DatatypeProperty ;
+    rdfs:label "name" ;
+    rdfs:domain ex:Person ;
+    rdfs:range xsd:string ;
+    ex:authorName "Jane Ontologist" .

--- a/apps/desktop/src/renderer/src/model/parse.ts
+++ b/apps/desktop/src/renderer/src/model/parse.ts
@@ -1,10 +1,12 @@
 import { Parser, type Quad } from 'n3';
 import type {
+  AnnotationProperty,
   DatatypeProperty,
   Individual,
   ObjectProperty,
   Ontology,
   OntologyClass,
+  OntologyMetadata,
   Restriction,
   RestrictionType,
 } from './types';
@@ -72,6 +74,15 @@ function getOrCreateIndividual(ontology: Ontology, uri: string): Individual {
     ontology.individuals.set(uri, ind);
   }
   return ind;
+}
+
+function getOrCreateAnnotationProperty(ontology: Ontology, uri: string): AnnotationProperty {
+  let prop = ontology.annotationProperties.get(uri);
+  if (!prop) {
+    prop = { uri, subPropertyOf: [] };
+    ontology.annotationProperties.set(uri, prop);
+  }
+  return prop;
 }
 
 export interface ParseWarning {
@@ -144,6 +155,23 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
         } else {
           getOrCreateIndividual(ontology, s);
         }
+      } else if (o === `${OWL}AnnotationProperty`) {
+        if (quad.subject.termType === 'BlankNode') {
+          warnings.push({
+            severity: 'warning',
+            message: `Blank node annotation property ignored: ${s}`,
+          });
+        } else {
+          getOrCreateAnnotationProperty(ontology, s);
+        }
+      } else if (o === `${OWL}Ontology`) {
+        if (quad.subject.termType !== 'BlankNode') {
+          ontology.ontologyMetadata = {
+            iri: s,
+            imports: [],
+            annotations: [],
+          };
+        }
       }
     }
   }
@@ -207,12 +235,37 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
       continue;
     }
 
+    // owl:Ontology metadata — must come before rdfs:label/comment to capture ontology-level annotations
+    if (ontology.ontologyMetadata && s === ontology.ontologyMetadata.iri) {
+      if (p === `${OWL}versionIRI`) {
+        ontology.ontologyMetadata.versionIRI = o;
+        continue;
+      }
+      if (p === `${OWL}imports`) {
+        ontology.ontologyMetadata.imports.push(o);
+        continue;
+      }
+      // Collect other ontology-level annotations (not rdf:type)
+      if (p !== `${RDF}type`) {
+        const datatype = quad.object.termType === 'Literal'
+          ? (quad.object as { datatype?: { value: string } }).datatype?.value
+          : undefined;
+        ontology.ontologyMetadata.annotations.push({
+          property: p,
+          value: o,
+          datatype: datatype || undefined,
+        });
+        continue;
+      }
+    }
+
     if (p === `${RDFS}label`) {
       const literal = quad.object.termType === 'Literal' ? quad.object.value : o;
       const cls = ontology.classes.get(s);
       const objProp = ontology.objectProperties.get(s);
       const dtProp = ontology.datatypeProperties.get(s);
       const ind = ontology.individuals.get(s);
+      const annProp = ontology.annotationProperties.get(s);
       if (cls) {
         cls.label = literal;
       } else if (objProp) {
@@ -221,6 +274,8 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
         dtProp.label = literal;
       } else if (ind) {
         ind.label = literal;
+      } else if (annProp) {
+        annProp.label = literal;
       }
       continue;
     }
@@ -231,6 +286,7 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
       const objProp = ontology.objectProperties.get(s);
       const dtProp = ontology.datatypeProperties.get(s);
       const ind = ontology.individuals.get(s);
+      const annProp = ontology.annotationProperties.get(s);
       if (cls) {
         cls.comment = literal;
       } else if (objProp) {
@@ -239,6 +295,17 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
         dtProp.comment = literal;
       } else if (ind) {
         ind.comment = literal;
+      } else if (annProp) {
+        annProp.comment = literal;
+      }
+      continue;
+    }
+
+    // rdfs:subPropertyOf for annotation properties
+    if (p === `${RDFS}subPropertyOf`) {
+      const annProp = ontology.annotationProperties.get(s);
+      if (annProp && !annProp.subPropertyOf.includes(o)) {
+        annProp.subPropertyOf.push(o);
       }
       continue;
     }
@@ -335,7 +402,7 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
 
   // Detect unsupported OWL constructs
   const unsupported = new Set<string>();
-  const UNSUPPORTED_TYPES = [`${OWL}AllDifferent`, `${OWL}AnnotationProperty`, `${OWL}Ontology`];
+  const UNSUPPORTED_TYPES = [`${OWL}AllDifferent`];
   for (const quad of quads) {
     if (quad.predicate.value === `${RDF}type` && UNSUPPORTED_TYPES.includes(quad.object.value)) {
       const name = quad.object.value.split('#').pop() || quad.object.value;

--- a/apps/desktop/src/renderer/src/model/parse.ts
+++ b/apps/desktop/src/renderer/src/model/parse.ts
@@ -6,7 +6,6 @@ import type {
   ObjectProperty,
   Ontology,
   OntologyClass,
-  OntologyMetadata,
   Restriction,
   RestrictionType,
 } from './types';
@@ -247,9 +246,10 @@ export function parseTurtleWithWarnings(turtle: string): ParseResult {
       }
       // Collect other ontology-level annotations (not rdf:type)
       if (p !== `${RDF}type`) {
-        const datatype = quad.object.termType === 'Literal'
-          ? (quad.object as { datatype?: { value: string } }).datatype?.value
-          : undefined;
+        const datatype =
+          quad.object.termType === 'Literal'
+            ? (quad.object as { datatype?: { value: string } }).datatype?.value
+            : undefined;
         ontology.ontologyMetadata.annotations.push({
           property: p,
           value: o,

--- a/apps/desktop/src/renderer/src/model/serialize.ts
+++ b/apps/desktop/src/renderer/src/model/serialize.ts
@@ -76,6 +76,44 @@ export function serializeToTurtle(ontology: Ontology): string {
     writer.addQuad(subject, namedNode(`${RDFS}range`), namedNode(prop.range));
   }
 
+  // Write ontology metadata
+  if (ontology.ontologyMetadata) {
+    const subject = namedNode(ontology.ontologyMetadata.iri);
+    writer.addQuad(subject, namedNode(`${RDF}type`), namedNode(`${OWL}Ontology`));
+    if (ontology.ontologyMetadata.versionIRI) {
+      writer.addQuad(
+        subject,
+        namedNode(`${OWL}versionIRI`),
+        namedNode(ontology.ontologyMetadata.versionIRI),
+      );
+    }
+    for (const imp of ontology.ontologyMetadata.imports) {
+      writer.addQuad(subject, namedNode(`${OWL}imports`), namedNode(imp));
+    }
+    for (const ann of ontology.ontologyMetadata.annotations) {
+      if (ann.datatype) {
+        writer.addQuad(subject, namedNode(ann.property), literal(ann.value, namedNode(ann.datatype)));
+      } else {
+        writer.addQuad(subject, namedNode(ann.property), literal(ann.value));
+      }
+    }
+  }
+
+  // Write annotation properties
+  for (const prop of (ontology.annotationProperties ?? new Map()).values()) {
+    const subject = namedNode(prop.uri);
+    writer.addQuad(subject, namedNode(`${RDF}type`), namedNode(`${OWL}AnnotationProperty`));
+    if (prop.label) {
+      writer.addQuad(subject, namedNode(`${RDFS}label`), literal(prop.label));
+    }
+    if (prop.comment) {
+      writer.addQuad(subject, namedNode(`${RDFS}comment`), literal(prop.comment));
+    }
+    for (const parent of prop.subPropertyOf) {
+      writer.addQuad(subject, namedNode(`${RDFS}subPropertyOf`), namedNode(parent));
+    }
+  }
+
   // Write individuals
   for (const ind of ontology.individuals.values()) {
     const subject = namedNode(ind.uri);

--- a/apps/desktop/src/renderer/src/model/serialize.ts
+++ b/apps/desktop/src/renderer/src/model/serialize.ts
@@ -92,7 +92,11 @@ export function serializeToTurtle(ontology: Ontology): string {
     }
     for (const ann of ontology.ontologyMetadata.annotations) {
       if (ann.datatype) {
-        writer.addQuad(subject, namedNode(ann.property), literal(ann.value, namedNode(ann.datatype)));
+        writer.addQuad(
+          subject,
+          namedNode(ann.property),
+          literal(ann.value, namedNode(ann.datatype)),
+        );
       } else {
         writer.addQuad(subject, namedNode(ann.property), literal(ann.value));
       }

--- a/apps/desktop/src/renderer/src/model/types.ts
+++ b/apps/desktop/src/renderer/src/model/types.ts
@@ -1,9 +1,25 @@
+export interface AnnotationProperty {
+  uri: string;
+  label?: string;
+  comment?: string;
+  subPropertyOf: string[];
+}
+
+export interface OntologyMetadata {
+  iri: string;
+  versionIRI?: string;
+  imports: string[];
+  annotations: { property: string; value: string; datatype?: string }[];
+}
+
 export interface Ontology {
   prefixes: Map<string, string>;
   classes: Map<string, OntologyClass>;
   objectProperties: Map<string, ObjectProperty>;
   datatypeProperties: Map<string, DatatypeProperty>;
   individuals: Map<string, Individual>;
+  annotationProperties: Map<string, AnnotationProperty>;
+  ontologyMetadata?: OntologyMetadata;
 }
 
 export type RestrictionType =
@@ -71,5 +87,6 @@ export function createEmptyOntology(): Ontology {
     objectProperties: new Map(),
     datatypeProperties: new Map(),
     individuals: new Map(),
+    annotationProperties: new Map(),
   };
 }

--- a/apps/desktop/src/renderer/src/store/ontology.ts
+++ b/apps/desktop/src/renderer/src/store/ontology.ts
@@ -271,5 +271,18 @@ function cloneOntology(ontology: Ontology): Ontology {
         },
       ]),
     ),
+    annotationProperties: new Map(
+      Array.from(ontology.annotationProperties.entries()).map(([k, v]) => [
+        k,
+        { ...v, subPropertyOf: [...v.subPropertyOf] },
+      ]),
+    ),
+    ontologyMetadata: ontology.ontologyMetadata
+      ? {
+          ...ontology.ontologyMetadata,
+          imports: [...ontology.ontologyMetadata.imports],
+          annotations: ontology.ontologyMetadata.annotations.map((a) => ({ ...a })),
+        }
+      : undefined,
   };
 }

--- a/apps/desktop/tests/model/fixtures.test.ts
+++ b/apps/desktop/tests/model/fixtures.test.ts
@@ -226,8 +226,6 @@ describe('edge-cases.ttl', () => {
 
 // ---- Annotations fixture ----
 
-const ANNOT = 'http://example.org/ontology#';
-
 describe('annotations.ttl', () => {
   const turtle = loadFixture('annotations.ttl');
 

--- a/apps/desktop/tests/model/fixtures.test.ts
+++ b/apps/desktop/tests/model/fixtures.test.ts
@@ -51,6 +51,13 @@ describe('all fixtures: parse and round-trip', () => {
         const reparsed = parseTurtle(serialized);
         expect(reparsed.datatypeProperties.size).toBe(original.datatypeProperties.size);
       });
+
+      it('round-trips: annotation property count preserved', () => {
+        const original = parseTurtle(turtle);
+        const serialized = serializeToTurtle(original);
+        const reparsed = parseTurtle(serialized);
+        expect(reparsed.annotationProperties.size).toBe(original.annotationProperties.size);
+      });
     });
   }
 });
@@ -214,6 +221,51 @@ describe('edge-cases.ttl', () => {
     expect(o.datatypeProperties.get(`${EDGE}shortVal`)?.range).toBe(`${XSD}short`);
     expect(o.datatypeProperties.get(`${EDGE}longVal`)?.range).toBe(`${XSD}long`);
     expect(o.datatypeProperties.get(`${EDGE}durationVal`)?.range).toBe(`${XSD}time`);
+  });
+});
+
+// ---- Annotations fixture ----
+
+const ANNOT = 'http://example.org/ontology#';
+
+describe('annotations.ttl', () => {
+  const turtle = loadFixture('annotations.ttl');
+
+  it('parses 3 classes', () => {
+    const o = parseTurtle(turtle);
+    expect(o.classes.size).toBe(3);
+  });
+
+  it('parses at least 5 custom annotation properties', () => {
+    const o = parseTurtle(turtle);
+    expect(o.annotationProperties.size).toBeGreaterThanOrEqual(5);
+  });
+
+  it('parses ontology metadata with IRI and versionIRI', () => {
+    const o = parseTurtle(turtle);
+    expect(o.ontologyMetadata).toBeDefined();
+    expect(o.ontologyMetadata?.iri).toBe('http://example.org/ontology');
+    expect(o.ontologyMetadata?.versionIRI).toBe('http://example.org/ontology/1.0');
+  });
+
+  it('round-trips annotation property count', () => {
+    const original = parseTurtle(turtle);
+    const serialized = serializeToTurtle(original);
+    const reparsed = parseTurtle(serialized);
+    expect(reparsed.annotationProperties.size).toBe(original.annotationProperties.size);
+  });
+
+  it('round-trips ontology metadata IRI', () => {
+    const original = parseTurtle(turtle);
+    const serialized = serializeToTurtle(original);
+    const reparsed = parseTurtle(serialized);
+    expect(reparsed.ontologyMetadata?.iri).toBe(original.ontologyMetadata?.iri);
+  });
+
+  it('produces no unsupported warnings for AnnotationProperty or Ontology', () => {
+    const { warnings } = parseTurtleWithWarnings(turtle);
+    const unsupported = warnings.filter((w) => w.message.includes('Unsupported'));
+    expect(unsupported).toEqual([]);
   });
 });
 

--- a/apps/desktop/tests/model/parse.test.ts
+++ b/apps/desktop/tests/model/parse.test.ts
@@ -249,9 +249,7 @@ describe('parseTurtle — annotation properties', () => {
 
   it('parses subPropertyOf on annotation properties', () => {
     const ontology = parseTurtle(annotationsTurtle);
-    const techNote = ontology.annotationProperties.get(
-      `${EX}technicalNote`,
-    ) as AnnotationProperty;
+    const techNote = ontology.annotationProperties.get(`${EX}technicalNote`) as AnnotationProperty;
     expect(techNote).toBeDefined();
     expect(techNote.subPropertyOf).toContain(`${EX}editorialNote`);
   });
@@ -327,9 +325,7 @@ describe('parseTurtle — ontology metadata', () => {
 
   it('parses owl:imports', () => {
     const ontology = parseTurtle(annotationsTurtle);
-    expect(ontology.ontologyMetadata?.imports).toContain(
-      'http://purl.org/dc/elements/1.1/',
-    );
+    expect(ontology.ontologyMetadata?.imports).toContain('http://purl.org/dc/elements/1.1/');
   });
 
   it('parses Dublin Core metadata (dc:title, dc:creator, dc:description)', () => {

--- a/apps/desktop/tests/model/parse.test.ts
+++ b/apps/desktop/tests/model/parse.test.ts
@@ -2,10 +2,12 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parseTurtle, parseTurtleWithWarnings } from '@renderer/model/parse';
 import type {
+  AnnotationProperty,
   DatatypeProperty,
   Individual,
   ObjectProperty,
   OntologyClass,
+  OntologyMetadata,
 } from '@renderer/model/types';
 import { describe, expect, it } from 'vitest';
 
@@ -19,6 +21,11 @@ const peopleTurtle = readFileSync(
 
 const individualsTurtle = readFileSync(
   resolve(__dirname, '../../resources/sample-ontologies/individuals.ttl'),
+  'utf-8',
+);
+
+const annotationsTurtle = readFileSync(
+  resolve(__dirname, '../../resources/sample-ontologies/annotations.ttl'),
   'utf-8',
 );
 
@@ -208,5 +215,200 @@ describe('parseTurtle — individuals', () => {
     const ontology = parseTurtle(turtle);
     const thing = ontology.individuals.get('http://example.org/thing') as Individual;
     expect(thing.types).toContain('http://example.org/UndeclaredClass');
+  });
+});
+
+// ---- owl:AnnotationProperty ----
+
+describe('parseTurtle — annotation properties', () => {
+  it('parses annotation property declarations from fixture', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    expect(ontology.annotationProperties.size).toBeGreaterThanOrEqual(5);
+    expect(ontology.annotationProperties.has(`${EX}authorName`)).toBe(true);
+    expect(ontology.annotationProperties.has(`${EX}reviewStatus`)).toBe(true);
+    expect(ontology.annotationProperties.has(`${EX}deprecated`)).toBe(true);
+    expect(ontology.annotationProperties.has(`${EX}seeAlso`)).toBe(true);
+    expect(ontology.annotationProperties.has(`${EX}editorialNote`)).toBe(true);
+  });
+
+  it('parses annotation property labels and comments', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    const authorName = ontology.annotationProperties.get(`${EX}authorName`) as AnnotationProperty;
+    expect(authorName.label).toBe('author name');
+    expect(authorName.comment).toBe('The name of the author of this entity');
+  });
+
+  it('parses annotation property with no comment', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    const reviewStatus = ontology.annotationProperties.get(
+      `${EX}reviewStatus`,
+    ) as AnnotationProperty;
+    expect(reviewStatus.label).toBe('review status');
+    expect(reviewStatus.comment).toBeUndefined();
+  });
+
+  it('parses subPropertyOf on annotation properties', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    const techNote = ontology.annotationProperties.get(
+      `${EX}technicalNote`,
+    ) as AnnotationProperty;
+    expect(techNote).toBeDefined();
+    expect(techNote.subPropertyOf).toContain(`${EX}editorialNote`);
+  });
+
+  it('handles re-declared standard annotation properties (rdfs:label, rdfs:comment)', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    const RDFS = 'http://www.w3.org/2000/01/rdf-schema#';
+    expect(ontology.annotationProperties.has(`${RDFS}label`)).toBe(true);
+    expect(ontology.annotationProperties.has(`${RDFS}comment`)).toBe(true);
+  });
+
+  it('handles Dublin Core terms declared as annotation properties', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    const DC = 'http://purl.org/dc/elements/1.1/';
+    expect(ontology.annotationProperties.has(`${DC}creator`)).toBe(true);
+    expect(ontology.annotationProperties.has(`${DC}title`)).toBe(true);
+  });
+
+  it('does not add AnnotationProperty to unsupported warnings', () => {
+    const { warnings } = parseTurtleWithWarnings(annotationsTurtle);
+    const unsupportedWarning = warnings.find(
+      (w) => w.message.includes('Unsupported') && w.message.includes('AnnotationProperty'),
+    );
+    expect(unsupportedWarning).toBeUndefined();
+  });
+
+  it('still parses classes and properties alongside annotation properties', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    expect(ontology.classes.size).toBe(3);
+    expect(ontology.objectProperties.size).toBe(1);
+    expect(ontology.datatypeProperties.size).toBe(1);
+  });
+
+  it('handles minimal annotation property declaration', () => {
+    const turtle = `
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix ex: <http://example.org/> .
+      ex:myAnnotation a owl:AnnotationProperty .
+    `;
+    const ontology = parseTurtle(turtle);
+    expect(ontology.annotationProperties.size).toBe(1);
+    const prop = ontology.annotationProperties.get(
+      'http://example.org/myAnnotation',
+    ) as AnnotationProperty;
+    expect(prop.uri).toBe('http://example.org/myAnnotation');
+    expect(prop.label).toBeUndefined();
+  });
+
+  it('skips blank node annotation properties with warning', () => {
+    const turtle = `
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      _:b0 a owl:AnnotationProperty .
+    `;
+    const { ontology, warnings } = parseTurtleWithWarnings(turtle);
+    expect(ontology.annotationProperties.size).toBe(0);
+    expect(warnings.some((w) => w.message.includes('Blank node annotation property'))).toBe(true);
+  });
+});
+
+// ---- owl:Ontology metadata ----
+
+describe('parseTurtle — ontology metadata', () => {
+  it('parses ontology IRI', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    expect(ontology.ontologyMetadata).toBeDefined();
+    expect(ontology.ontologyMetadata?.iri).toBe('http://example.org/ontology');
+  });
+
+  it('parses versionIRI', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    expect(ontology.ontologyMetadata?.versionIRI).toBe('http://example.org/ontology/1.0');
+  });
+
+  it('parses owl:imports', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    expect(ontology.ontologyMetadata?.imports).toContain(
+      'http://purl.org/dc/elements/1.1/',
+    );
+  });
+
+  it('parses Dublin Core metadata (dc:title, dc:creator, dc:description)', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    const meta = ontology.ontologyMetadata as OntologyMetadata;
+    expect(meta.annotations).toBeDefined();
+
+    const DC = 'http://purl.org/dc/elements/1.1/';
+    const title = meta.annotations.find((a) => a.property === `${DC}title`);
+    expect(title?.value).toBe('Example Annotation Ontology');
+
+    const creator = meta.annotations.find((a) => a.property === `${DC}creator`);
+    expect(creator?.value).toBe('QA Engineer');
+
+    const description = meta.annotations.find((a) => a.property === `${DC}description`);
+    expect(description?.value).toBe(
+      'A test ontology exercising owl:AnnotationProperty and owl:Ontology metadata',
+    );
+  });
+
+  it('parses rdfs:comment on ontology', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    const meta = ontology.ontologyMetadata as OntologyMetadata;
+    const RDFS = 'http://www.w3.org/2000/01/rdf-schema#';
+    const comment = meta.annotations.find((a) => a.property === `${RDFS}comment`);
+    expect(comment?.value).toBe('Top-level ontology comment');
+  });
+
+  it('parses typed literal annotations (dcterms:created as xsd:date)', () => {
+    const ontology = parseTurtle(annotationsTurtle);
+    const meta = ontology.ontologyMetadata as OntologyMetadata;
+    const DCTERMS = 'http://purl.org/dc/terms/';
+    const created = meta.annotations.find((a) => a.property === `${DCTERMS}created`);
+    expect(created?.value).toBe('2026-03-30');
+    expect(created?.datatype).toBe(`${XSD}date`);
+  });
+
+  it('does not add Ontology to unsupported warnings', () => {
+    const { warnings } = parseTurtleWithWarnings(annotationsTurtle);
+    const unsupportedWarning = warnings.find(
+      (w) => w.message.includes('Unsupported') && w.message.includes('Ontology'),
+    );
+    expect(unsupportedWarning).toBeUndefined();
+  });
+
+  it('handles ontology with no metadata', () => {
+    const turtle = `
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix ex: <http://example.org/> .
+      ex:MyOntology a owl:Ontology .
+    `;
+    const ontology = parseTurtle(turtle);
+    expect(ontology.ontologyMetadata).toBeDefined();
+    expect(ontology.ontologyMetadata?.iri).toBe('http://example.org/MyOntology');
+    expect(ontology.ontologyMetadata?.versionIRI).toBeUndefined();
+    expect(ontology.ontologyMetadata?.imports).toEqual([]);
+    expect(ontology.ontologyMetadata?.annotations).toEqual([]);
+  });
+
+  it('handles multiple owl:imports', () => {
+    const turtle = `
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      <http://example.org/ont> a owl:Ontology ;
+          owl:imports <http://example.org/base> ;
+          owl:imports <http://example.org/ext> .
+    `;
+    const ontology = parseTurtle(turtle);
+    expect(ontology.ontologyMetadata?.imports).toHaveLength(2);
+    expect(ontology.ontologyMetadata?.imports).toContain('http://example.org/base');
+    expect(ontology.ontologyMetadata?.imports).toContain('http://example.org/ext');
+  });
+
+  it('returns undefined ontologyMetadata when no owl:Ontology declaration exists', () => {
+    const turtle = `
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix ex: <http://example.org/> .
+      ex:Foo a owl:Class .
+    `;
+    const ontology = parseTurtle(turtle);
+    expect(ontology.ontologyMetadata).toBeUndefined();
   });
 });

--- a/apps/desktop/tests/model/serialize.test.ts
+++ b/apps/desktop/tests/model/serialize.test.ts
@@ -189,9 +189,7 @@ describe('serializeToTurtle — annotation properties', () => {
     const serialized = serializeToTurtle(original);
     const reparsed = parseTurtle(serialized);
 
-    const techNote = reparsed.annotationProperties.get(
-      `${EX}technicalNote`,
-    ) as AnnotationProperty;
+    const techNote = reparsed.annotationProperties.get(`${EX}technicalNote`) as AnnotationProperty;
     expect(techNote.subPropertyOf).toContain(`${EX}editorialNote`);
   });
 

--- a/apps/desktop/tests/model/serialize.test.ts
+++ b/apps/desktop/tests/model/serialize.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { parseTurtle } from '@renderer/model/parse';
 import { serializeToTurtle } from '@renderer/model/serialize';
 import type {
+  AnnotationProperty,
   DatatypeProperty,
   Individual,
   ObjectProperty,
@@ -21,6 +22,11 @@ const peopleTurtle = readFileSync(
 
 const individualsTurtle = readFileSync(
   resolve(__dirname, '../../resources/sample-ontologies/individuals.ttl'),
+  'utf-8',
+);
+
+const annotationsTurtle = readFileSync(
+  resolve(__dirname, '../../resources/sample-ontologies/annotations.ttl'),
   'utf-8',
 );
 
@@ -160,5 +166,55 @@ describe('serializeToTurtle — individuals', () => {
     const serialized = serializeToTurtle(ont);
     const reparsed = parseTurtle(serialized);
     expect(reparsed.individuals.has('http://ex/empty')).toBe(true);
+  });
+});
+
+describe('serializeToTurtle — annotation properties', () => {
+  it('round-trips: preserves annotation properties', () => {
+    const original = parseTurtle(annotationsTurtle);
+    const serialized = serializeToTurtle(original);
+    const reparsed = parseTurtle(serialized);
+
+    expect(reparsed.annotationProperties.size).toBe(original.annotationProperties.size);
+    for (const [uri, prop] of original.annotationProperties) {
+      const reparsedProp = reparsed.annotationProperties.get(uri) as AnnotationProperty;
+      expect(reparsedProp).toBeDefined();
+      expect(reparsedProp.label).toBe(prop.label);
+      expect(reparsedProp.comment).toBe(prop.comment);
+    }
+  });
+
+  it('round-trips: preserves annotation property subPropertyOf', () => {
+    const original = parseTurtle(annotationsTurtle);
+    const serialized = serializeToTurtle(original);
+    const reparsed = parseTurtle(serialized);
+
+    const techNote = reparsed.annotationProperties.get(
+      `${EX}technicalNote`,
+    ) as AnnotationProperty;
+    expect(techNote.subPropertyOf).toContain(`${EX}editorialNote`);
+  });
+
+  it('round-trips: preserves ontology metadata', () => {
+    const original = parseTurtle(annotationsTurtle);
+    const serialized = serializeToTurtle(original);
+    const reparsed = parseTurtle(serialized);
+
+    expect(reparsed.ontologyMetadata?.iri).toBe(original.ontologyMetadata?.iri);
+    expect(reparsed.ontologyMetadata?.versionIRI).toBe(original.ontologyMetadata?.versionIRI);
+    expect(reparsed.ontologyMetadata?.imports?.sort()).toEqual(
+      original.ontologyMetadata?.imports?.sort(),
+    );
+  });
+
+  it('serializes annotation property with no metadata', () => {
+    const ont = createEmptyOntology();
+    ont.annotationProperties.set('http://ex/note', {
+      uri: 'http://ex/note',
+      subPropertyOf: [],
+    });
+    const serialized = serializeToTurtle(ont);
+    const reparsed = parseTurtle(serialized);
+    expect(reparsed.annotationProperties.has('http://ex/note')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add `AnnotationProperty` and `OntologyMetadata` interfaces to the ontology type system
- Parse `owl:AnnotationProperty` declarations (labels, comments, `rdfs:subPropertyOf` hierarchy) and `owl:Ontology` headers (IRI, versionIRI, `owl:imports`, Dublin Core metadata, typed literals)
- Serialize annotation properties and ontology metadata in Turtle round-trips
- Remove `AnnotationProperty` and `Ontology` from unsupported OWL construct warnings

## Test plan

- [x] All 323 existing + new tests pass (`bun run test`)
- [ ] QA to verify annotation property parsing against `annotations.ttl` fixture
- [ ] QA to verify ontology metadata round-trip fidelity
- [ ] QA to verify no regressions in existing fixtures (healthcare, ecommerce, edge-cases, etc.)

Closes ONT-81

🤖 Generated with [Claude Code](https://claude.com/claude-code)