### PR TITLE
feat(desktop): deterministic Turtle serialization for git-friendly diffs

### DIFF
--- a/apps/desktop/src/renderer/src/model/serialize.ts
+++ b/apps/desktop/src/renderer/src/model/serialize.ts
@@ -16,7 +16,7 @@ export function serializeToTurtle(ontology: Ontology): string {
   // Sort prefixes alphabetically by prefix name
   const prefixes: Record<string, string> = {};
   for (const key of [...ontology.prefixes.keys()].sort()) {
-    prefixes[key] = ontology.prefixes.get(key)!;
+    prefixes[key] = ontology.prefixes.get(key) ?? '';
   }
 
   const writer = new Writer({ prefixes });

--- a/apps/desktop/src/renderer/src/model/serialize.ts
+++ b/apps/desktop/src/renderer/src/model/serialize.ts
@@ -35,8 +35,8 @@ export function serializeToTurtle(ontology: Ontology): string {
     for (const imp of [...ontology.ontologyMetadata.imports].sort()) {
       writer.addQuad(subject, namedNode(`${OWL}imports`), namedNode(imp));
     }
-    for (const ann of [...ontology.ontologyMetadata.annotations].sort((a, b) =>
-      a.property.localeCompare(b.property) || a.value.localeCompare(b.value),
+    for (const ann of [...ontology.ontologyMetadata.annotations].sort(
+      (a, b) => a.property.localeCompare(b.property) || a.value.localeCompare(b.value),
     )) {
       if (ann.datatype) {
         writer.addQuad(
@@ -141,13 +141,13 @@ export function serializeToTurtle(ontology: Ontology): string {
     if (ind.comment) {
       writer.addQuad(subject, namedNode(`${RDFS}comment`), literal(ind.comment));
     }
-    for (const assertion of [...ind.objectPropertyAssertions].sort((a, b) =>
-      a.property.localeCompare(b.property) || a.target.localeCompare(b.target),
+    for (const assertion of [...ind.objectPropertyAssertions].sort(
+      (a, b) => a.property.localeCompare(b.property) || a.target.localeCompare(b.target),
     )) {
       writer.addQuad(subject, namedNode(assertion.property), namedNode(assertion.target));
     }
-    for (const assertion of [...ind.dataPropertyAssertions].sort((a, b) =>
-      a.property.localeCompare(b.property) || a.value.localeCompare(b.value),
+    for (const assertion of [...ind.dataPropertyAssertions].sort(
+      (a, b) => a.property.localeCompare(b.property) || a.value.localeCompare(b.value),
     )) {
       if (assertion.datatype) {
         writer.addQuad(

--- a/apps/desktop/src/renderer/src/model/serialize.ts
+++ b/apps/desktop/src/renderer/src/model/serialize.ts
@@ -7,16 +7,22 @@ const OWL = 'http://www.w3.org/2002/07/owl#';
 const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
 const RDFS = 'http://www.w3.org/2000/01/rdf-schema#';
 
+/** Sort map values by URI for deterministic output. */
+function sortedByUri<T extends { uri: string }>(map: Map<string, T>): T[] {
+  return [...map.values()].sort((a, b) => a.uri.localeCompare(b.uri));
+}
+
 export function serializeToTurtle(ontology: Ontology): string {
+  // Sort prefixes alphabetically by prefix name
   const prefixes: Record<string, string> = {};
-  for (const [prefix, iri] of ontology.prefixes) {
-    prefixes[prefix] = iri;
+  for (const key of [...ontology.prefixes.keys()].sort()) {
+    prefixes[key] = ontology.prefixes.get(key)!;
   }
 
   const writer = new Writer({ prefixes });
 
-  // Write classes
-  for (const cls of ontology.classes.values()) {
+  // Write classes (sorted by URI)
+  for (const cls of sortedByUri(ontology.classes)) {
     const subject = namedNode(cls.uri);
 
     writer.addQuad(subject, namedNode(`${RDF}type`), namedNode(`${OWL}Class`));
@@ -27,16 +33,16 @@ export function serializeToTurtle(ontology: Ontology): string {
     if (cls.comment) {
       writer.addQuad(subject, namedNode(`${RDFS}comment`), literal(cls.comment));
     }
-    for (const parent of cls.subClassOf) {
+    for (const parent of [...cls.subClassOf].sort()) {
       writer.addQuad(subject, namedNode(`${RDFS}subClassOf`), namedNode(parent));
     }
-    for (const disjoint of cls.disjointWith) {
+    for (const disjoint of [...cls.disjointWith].sort()) {
       writer.addQuad(subject, namedNode(`${OWL}disjointWith`), namedNode(disjoint));
     }
   }
 
-  // Write object properties
-  for (const prop of ontology.objectProperties.values()) {
+  // Write object properties (sorted by URI)
+  for (const prop of sortedByUri(ontology.objectProperties)) {
     const subject = namedNode(prop.uri);
 
     writer.addQuad(subject, namedNode(`${RDF}type`), namedNode(`${OWL}ObjectProperty`));
@@ -47,10 +53,10 @@ export function serializeToTurtle(ontology: Ontology): string {
     if (prop.comment) {
       writer.addQuad(subject, namedNode(`${RDFS}comment`), literal(prop.comment));
     }
-    for (const d of prop.domain) {
+    for (const d of [...prop.domain].sort()) {
       writer.addQuad(subject, namedNode(`${RDFS}domain`), namedNode(d));
     }
-    for (const r of prop.range) {
+    for (const r of [...prop.range].sort()) {
       writer.addQuad(subject, namedNode(`${RDFS}range`), namedNode(r));
     }
     if (prop.inverseOf) {
@@ -58,8 +64,8 @@ export function serializeToTurtle(ontology: Ontology): string {
     }
   }
 
-  // Write datatype properties
-  for (const prop of ontology.datatypeProperties.values()) {
+  // Write datatype properties (sorted by URI)
+  for (const prop of sortedByUri(ontology.datatypeProperties)) {
     const subject = namedNode(prop.uri);
 
     writer.addQuad(subject, namedNode(`${RDF}type`), namedNode(`${OWL}DatatypeProperty`));
@@ -70,19 +76,19 @@ export function serializeToTurtle(ontology: Ontology): string {
     if (prop.comment) {
       writer.addQuad(subject, namedNode(`${RDFS}comment`), literal(prop.comment));
     }
-    for (const d of prop.domain) {
+    for (const d of [...prop.domain].sort()) {
       writer.addQuad(subject, namedNode(`${RDFS}domain`), namedNode(d));
     }
     writer.addQuad(subject, namedNode(`${RDFS}range`), namedNode(prop.range));
   }
 
-  // Write individuals
-  for (const ind of ontology.individuals.values()) {
+  // Write individuals (sorted by URI)
+  for (const ind of sortedByUri(ontology.individuals)) {
     const subject = namedNode(ind.uri);
 
     writer.addQuad(subject, namedNode(`${RDF}type`), namedNode(`${OWL}NamedIndividual`));
 
-    for (const typeUri of ind.types) {
+    for (const typeUri of [...ind.types].sort()) {
       writer.addQuad(subject, namedNode(`${RDF}type`), namedNode(typeUri));
     }
     if (ind.label) {
@@ -91,10 +97,14 @@ export function serializeToTurtle(ontology: Ontology): string {
     if (ind.comment) {
       writer.addQuad(subject, namedNode(`${RDFS}comment`), literal(ind.comment));
     }
-    for (const assertion of ind.objectPropertyAssertions) {
+    for (const assertion of [...ind.objectPropertyAssertions].sort((a, b) =>
+      a.property.localeCompare(b.property) || a.target.localeCompare(b.target),
+    )) {
       writer.addQuad(subject, namedNode(assertion.property), namedNode(assertion.target));
     }
-    for (const assertion of ind.dataPropertyAssertions) {
+    for (const assertion of [...ind.dataPropertyAssertions].sort((a, b) =>
+      a.property.localeCompare(b.property) || a.value.localeCompare(b.value),
+    )) {
       if (assertion.datatype) {
         writer.addQuad(
           subject,

--- a/apps/desktop/tests/model/serialize.test.ts
+++ b/apps/desktop/tests/model/serialize.test.ts
@@ -110,7 +110,11 @@ describe('serializeToTurtle — determinism', () => {
     // Insert classes in opposite order
     const classA = { uri: `${EX}Alpha`, subClassOf: [], disjointWith: [] };
     const classB = { uri: `${EX}Beta`, label: 'Beta', subClassOf: [], disjointWith: [] };
-    const classC = { uri: `${EX}Charlie`, subClassOf: [`${EX}Alpha`, `${EX}Beta`], disjointWith: [] };
+    const classC = {
+      uri: `${EX}Charlie`,
+      subClassOf: [`${EX}Alpha`, `${EX}Beta`],
+      disjointWith: [],
+    };
 
     ont1.classes.set(classA.uri, classA);
     ont1.classes.set(classB.uri, classB);

--- a/apps/desktop/tests/model/serialize.test.ts
+++ b/apps/desktop/tests/model/serialize.test.ts
@@ -89,6 +89,63 @@ describe('serializeToTurtle', () => {
   });
 });
 
+describe('serializeToTurtle — determinism', () => {
+  it('produces identical output on repeated serialization', () => {
+    const ont = parseTurtle(peopleTurtle);
+    const first = serializeToTurtle(ont);
+    const second = serializeToTurtle(ont);
+    expect(first).toBe(second);
+  });
+
+  it('produces identical output regardless of insertion order', () => {
+    const ont1 = createEmptyOntology();
+    const ont2 = createEmptyOntology();
+
+    // Insert classes in opposite order
+    const classA = { uri: `${EX}Alpha`, subClassOf: [], disjointWith: [] };
+    const classB = { uri: `${EX}Beta`, label: 'Beta', subClassOf: [], disjointWith: [] };
+    const classC = { uri: `${EX}Charlie`, subClassOf: [`${EX}Alpha`, `${EX}Beta`], disjointWith: [] };
+
+    ont1.classes.set(classA.uri, classA);
+    ont1.classes.set(classB.uri, classB);
+    ont1.classes.set(classC.uri, classC);
+
+    ont2.classes.set(classC.uri, classC);
+    ont2.classes.set(classA.uri, classA);
+    ont2.classes.set(classB.uri, classB);
+
+    expect(serializeToTurtle(ont1)).toBe(serializeToTurtle(ont2));
+  });
+
+  it('sorts prefixes alphabetically', () => {
+    const ont = createEmptyOntology();
+    ont.prefixes.set('z', 'http://z.example.org/');
+    ont.prefixes.set('a', 'http://a.example.org/');
+
+    const output = serializeToTurtle(ont);
+    const prefixLines = output.split('\n').filter((l) => l.startsWith('@prefix'));
+    const prefixNames = prefixLines.map((l) => l.match(/@prefix (\S+):/)?.[1]).filter(Boolean);
+    const sorted = [...prefixNames].sort();
+    expect(prefixNames).toEqual(sorted);
+  });
+
+  it('produces identical output for individuals regardless of insertion order', () => {
+    const ont1 = parseTurtle(individualsTurtle);
+    const ont2 = createEmptyOntology();
+
+    // Copy everything but reverse individual insertion order
+    for (const [k, v] of ont1.prefixes) ont2.prefixes.set(k, v);
+    for (const [k, v] of ont1.classes) ont2.classes.set(k, v);
+    for (const [k, v] of ont1.objectProperties) ont2.objectProperties.set(k, v);
+    for (const [k, v] of ont1.datatypeProperties) ont2.datatypeProperties.set(k, v);
+
+    const indEntries = [...ont1.individuals.entries()].reverse();
+    for (const [k, v] of indEntries) ont2.individuals.set(k, v);
+
+    expect(serializeToTurtle(ont1)).toBe(serializeToTurtle(ont2));
+  });
+});
+
 describe('serializeToTurtle — individuals', () => {
   it('round-trips: preserves individuals', () => {
     const original = parseTurtle(individualsTurtle);


### PR DESCRIPTION
## Summary

- Sort prefixes alphabetically, entities by URI, and array properties (subClassOf, domain, range, types, assertions) before writing to n3 Writer
- Ensures identical ontology state always produces identical `.ttl` output — saving is now a pure function with zero side-effect variation
- Adds 4 determinism-specific tests (repeated serialization, insertion order independence, prefix sorting, individual order independence)

## Test plan

- [x] All 285 existing tests pass
- [x] New determinism tests verify identical output regardless of Map insertion order
- [x] Round-trip tests continue to pass
- [ ] QA: manual verification that saving the same ontology twice produces byte-identical `.ttl` files

Closes ONT-98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>