### PR TITLE
feat: add husky pre-commit hook for biome checks and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@ playwright-report/
 .env.local
 .env.*.local
 
+# Paperclip agent worktrees and local state
+.paperclip/
+
 # Sensitive docs migrated to Paperclip issue documents (ONT-49)
 Marketing/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+bun run check
+bun run test

--- a/bun.lock
+++ b/bun.lock
@@ -6,12 +6,13 @@
       "name": "ontograph",
       "devDependencies": {
         "@biomejs/biome": "^2.4.9",
+        "husky": "^9.1.7",
         "turbo": "^2.5.4",
       },
     },
     "apps/desktop": {
       "name": "@ontograph/desktop",
-      "version": "0.8.0",
+      "version": "0.10.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.83",
         "@electron-toolkit/preload": "^3.0.1",
@@ -1743,6 +1744,8 @@
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "iconv-corefoundation": ["iconv-corefoundation@1.1.7", "", { "dependencies": { "cli-truncate": "^2.1.0", "node-addon-api": "^1.6.3" }, "os": "darwin" }, "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ=="],
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "lint": "biome lint .",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "check": "biome check ."
+    "check": "biome check .",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
+    "husky": "^9.1.7",
     "turbo": "^2.5.4"
   }
 }


### PR DESCRIPTION
## Summary

- Adds [Husky](https://typicode.github.io/husky/) pre-commit hook that runs `bun run check` (biome format + lint) and `bun run test` before every commit
- Catches formatting and lint issues locally before they reach CI
- Adds `.paperclip/` to `.gitignore` so agent worktrees don't interfere with biome scanning

## Test plan

- [x] `bun run check` passes (163 files, no issues)
- [x] `bun run test` passes (373 tests across desktop + web)
- [x] Pre-commit hook verified working — ran automatically during the commit itself
- [ ] QA: verify hook fires on a fresh clone after `bun install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)