### PR TITLE
feat(desktop): RDF/XML export with custom serializer

### DIFF
--- a/apps/desktop/src/main/ipc/file.ts
+++ b/apps/desktop/src/main/ipc/file.ts
@@ -74,6 +74,7 @@ export function registerFileIPC(): void {
     const result = await dialog.showSaveDialog(win, {
       filters: [
         { name: 'Turtle', extensions: ['ttl'] },
+        { name: 'RDF/XML', extensions: ['rdf', 'owl'] },
         { name: 'All Files', extensions: ['*'] },
       ],
       defaultPath: 'ontology.ttl',
@@ -84,6 +85,22 @@ export function registerFileIPC(): void {
     await writeFile(result.filePath, content, 'utf-8');
     addRecentFile(result.filePath);
     return result.filePath;
+  });
+
+  ipcMain.handle('file:save-as-dialog', async () => {
+    const win = BrowserWindow.getFocusedWindow();
+    if (!win) return null;
+
+    const result = await dialog.showSaveDialog(win, {
+      filters: [
+        { name: 'Turtle', extensions: ['ttl'] },
+        { name: 'RDF/XML', extensions: ['rdf', 'owl'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+      defaultPath: 'ontology.ttl',
+    });
+
+    return result.canceled || !result.filePath ? null : result.filePath;
   });
 
   ipcMain.handle('file:recent-files', () => {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -15,6 +15,7 @@ declare global {
       openFile: () => Promise<{ filePath: string; content: string } | null>;
       saveFile: (filePath: string, content: string) => Promise<boolean>;
       saveFileAs: (content: string) => Promise<string | null>;
+      saveFileAsDialog: () => Promise<string | null>;
       readFileSilent: (filePath: string) => Promise<string | null>;
       getRecentFiles: () => Promise<string[]>;
       openRecentFile: (filePath: string) => Promise<{ filePath: string; content: string } | null>;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -24,6 +24,7 @@ const api = {
     ipcRenderer.invoke('file:save', filePath, content),
   saveFileAs: (content: string): Promise<string | null> =>
     ipcRenderer.invoke('file:save-as', content),
+  saveFileAsDialog: (): Promise<string | null> => ipcRenderer.invoke('file:save-as-dialog'),
   readFileSilent: (filePath: string): Promise<string | null> =>
     ipcRenderer.invoke('file:read-silent', filePath),
   getRecentFiles: (): Promise<string[]> => ipcRenderer.invoke('file:recent-files'),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -49,7 +49,7 @@ function App(): React.JSX.Element {
   const ontology = useOntologyStore((s) => s.ontology);
   const loadFromFile = useOntologyStore((s) => s.loadFromFile);
   const loadFromTurtle = useOntologyStore((s) => s.loadFromTurtle);
-  const exportToTurtle = useOntologyStore((s) => s.exportToTurtle);
+  const serializeForFilePath = useOntologyStore((s) => s.serializeForFilePath);
   const setFilePath = useOntologyStore((s) => s.setFilePath);
   const markClean = useOntologyStore((s) => s.markClean);
   const isDirty = useOntologyStore((s) => s.isDirty);
@@ -78,28 +78,31 @@ function App(): React.JSX.Element {
   }, [loadFromFile]);
 
   const doSave = useCallback(async () => {
-    const turtle = exportToTurtle();
     const currentPath = useOntologyStore.getState().filePath;
     if (currentPath && !currentPath.startsWith('sample://') && !currentPath.startsWith('Sample:')) {
-      await window.api.saveFile(currentPath, turtle);
+      const content = serializeForFilePath(currentPath);
+      await window.api.saveFile(currentPath, content);
       markClean();
     } else {
-      const newPath = await window.api.saveFileAs(turtle);
+      const newPath = await window.api.saveFileAsDialog();
       if (newPath) {
+        const content = serializeForFilePath(newPath);
+        await window.api.saveFile(newPath, content);
         setFilePath(newPath);
         markClean();
       }
     }
-  }, [exportToTurtle, setFilePath, markClean]);
+  }, [serializeForFilePath, setFilePath, markClean]);
 
   const doSaveAs = useCallback(async () => {
-    const turtle = exportToTurtle();
-    const newPath = await window.api.saveFileAs(turtle);
+    const newPath = await window.api.saveFileAsDialog();
     if (newPath) {
+      const content = serializeForFilePath(newPath);
+      await window.api.saveFile(newPath, content);
       setFilePath(newPath);
       markClean();
     }
-  }, [exportToTurtle, setFilePath, markClean]);
+  }, [serializeForFilePath, setFilePath, markClean]);
 
   const handleSave = useCallback(async () => {
     const errors = validateOntology(useOntologyStore.getState().ontology);

--- a/apps/desktop/src/renderer/src/model/formats/rdfxml.ts
+++ b/apps/desktop/src/renderer/src/model/formats/rdfxml.ts
@@ -1,6 +1,7 @@
 import type { Quad } from 'n3';
 import { RdfXmlParser } from 'rdfxml-streaming-parser';
 import { type ParseWarning, walkQuads } from '../quads';
+import type { Ontology } from '../types';
 import { createEmptyOntology } from '../types';
 import type { FormatAdapter, ParseResult } from './index';
 
@@ -55,8 +56,182 @@ export function parseRdfXmlWithWarnings(content: string): ParseResult {
   return walkResult;
 }
 
+function escAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escText(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function toQName(uri: string, prefixes: Record<string, string>): string | null {
+  // Longest-namespace-first for correct matching
+  const sorted = Object.entries(prefixes).sort(([, a], [, b]) => b.length - a.length);
+  for (const [prefix, ns] of sorted) {
+    if (uri.startsWith(ns)) {
+      const local = uri.slice(ns.length);
+      // XML NCName: starts with letter or underscore, rest are word chars, dots, or hyphens
+      if (local && /^[a-zA-Z_][\w.-]*$/.test(local)) {
+        return `${prefix}:${local}`;
+      }
+    }
+  }
+  return null;
+}
+
+export function serializeToRdfXml(ontology: Ontology): string {
+  // Merge core prefixes with ontology-defined prefixes (core take priority for rdf/rdfs/owl/xsd)
+  const prefixes: Record<string, string> = {
+    owl: 'http://www.w3.org/2002/07/owl#',
+    rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+    rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
+    xsd: 'http://www.w3.org/2001/XMLSchema#',
+  };
+  for (const [prefix, iri] of ontology.prefixes) {
+    if (!prefixes[prefix]) prefixes[prefix] = iri;
+  }
+
+  const nsAttrs = Object.keys(prefixes)
+    .sort()
+    .map((p) => `  xmlns:${p}="${escAttr(prefixes[p])}"`)
+    .join('\n');
+
+  const lines: string[] = ['<?xml version="1.0" encoding="UTF-8"?>', `<rdf:RDF\n${nsAttrs}\n>`, ''];
+
+  // Ontology metadata
+  if (ontology.ontologyMetadata) {
+    const meta = ontology.ontologyMetadata;
+    lines.push(`  <owl:Ontology rdf:about="${escAttr(meta.iri)}">`);
+    if (meta.versionIRI) {
+      lines.push(`    <owl:versionIRI rdf:resource="${escAttr(meta.versionIRI)}"/>`);
+    }
+    for (const imp of [...meta.imports].sort()) {
+      lines.push(`    <owl:imports rdf:resource="${escAttr(imp)}"/>`);
+    }
+    for (const ann of [...meta.annotations].sort(
+      (a, b) => a.property.localeCompare(b.property) || a.value.localeCompare(b.value),
+    )) {
+      const qname = toQName(ann.property, prefixes);
+      if (!qname) continue;
+      if (ann.datatype) {
+        lines.push(
+          `    <${qname} rdf:datatype="${escAttr(ann.datatype)}">${escText(ann.value)}</${qname}>`,
+        );
+      } else {
+        lines.push(`    <${qname}>${escText(ann.value)}</${qname}>`);
+      }
+    }
+    lines.push(`  </owl:Ontology>`);
+    lines.push('');
+  }
+
+  // Classes
+  for (const cls of [...ontology.classes.values()].sort((a, b) => a.uri.localeCompare(b.uri))) {
+    lines.push(`  <owl:Class rdf:about="${escAttr(cls.uri)}">`);
+    if (cls.label) lines.push(`    <rdfs:label>${escText(cls.label)}</rdfs:label>`);
+    if (cls.comment) lines.push(`    <rdfs:comment>${escText(cls.comment)}</rdfs:comment>`);
+    for (const parent of [...cls.subClassOf].sort()) {
+      lines.push(`    <rdfs:subClassOf rdf:resource="${escAttr(parent)}"/>`);
+    }
+    for (const disjoint of [...cls.disjointWith].sort()) {
+      lines.push(`    <owl:disjointWith rdf:resource="${escAttr(disjoint)}"/>`);
+    }
+    lines.push(`  </owl:Class>`);
+    lines.push('');
+  }
+
+  // Object properties
+  for (const prop of [...ontology.objectProperties.values()].sort((a, b) =>
+    a.uri.localeCompare(b.uri),
+  )) {
+    lines.push(`  <owl:ObjectProperty rdf:about="${escAttr(prop.uri)}">`);
+    if (prop.label) lines.push(`    <rdfs:label>${escText(prop.label)}</rdfs:label>`);
+    if (prop.comment) lines.push(`    <rdfs:comment>${escText(prop.comment)}</rdfs:comment>`);
+    for (const d of [...prop.domain].sort()) {
+      lines.push(`    <rdfs:domain rdf:resource="${escAttr(d)}"/>`);
+    }
+    for (const r of [...prop.range].sort()) {
+      lines.push(`    <rdfs:range rdf:resource="${escAttr(r)}"/>`);
+    }
+    if (prop.inverseOf) {
+      lines.push(`    <owl:inverseOf rdf:resource="${escAttr(prop.inverseOf)}"/>`);
+    }
+    lines.push(`  </owl:ObjectProperty>`);
+    lines.push('');
+  }
+
+  // Datatype properties
+  for (const prop of [...ontology.datatypeProperties.values()].sort((a, b) =>
+    a.uri.localeCompare(b.uri),
+  )) {
+    lines.push(`  <owl:DatatypeProperty rdf:about="${escAttr(prop.uri)}">`);
+    if (prop.label) lines.push(`    <rdfs:label>${escText(prop.label)}</rdfs:label>`);
+    if (prop.comment) lines.push(`    <rdfs:comment>${escText(prop.comment)}</rdfs:comment>`);
+    for (const d of [...prop.domain].sort()) {
+      lines.push(`    <rdfs:domain rdf:resource="${escAttr(d)}"/>`);
+    }
+    lines.push(`    <rdfs:range rdf:resource="${escAttr(prop.range)}"/>`);
+    lines.push(`  </owl:DatatypeProperty>`);
+    lines.push('');
+  }
+
+  // Annotation properties
+  for (const prop of [...ontology.annotationProperties.values()].sort((a, b) =>
+    a.uri.localeCompare(b.uri),
+  )) {
+    lines.push(`  <owl:AnnotationProperty rdf:about="${escAttr(prop.uri)}">`);
+    if (prop.label) lines.push(`    <rdfs:label>${escText(prop.label)}</rdfs:label>`);
+    if (prop.comment) lines.push(`    <rdfs:comment>${escText(prop.comment)}</rdfs:comment>`);
+    for (const parent of [...prop.subPropertyOf].sort()) {
+      lines.push(`    <rdfs:subPropertyOf rdf:resource="${escAttr(parent)}"/>`);
+    }
+    lines.push(`  </owl:AnnotationProperty>`);
+    lines.push('');
+  }
+
+  // Individuals
+  for (const ind of [...ontology.individuals.values()].sort((a, b) => a.uri.localeCompare(b.uri))) {
+    lines.push(`  <owl:NamedIndividual rdf:about="${escAttr(ind.uri)}">`);
+    for (const typeUri of [...ind.types].sort()) {
+      lines.push(`    <rdf:type rdf:resource="${escAttr(typeUri)}"/>`);
+    }
+    if (ind.label) lines.push(`    <rdfs:label>${escText(ind.label)}</rdfs:label>`);
+    if (ind.comment) lines.push(`    <rdfs:comment>${escText(ind.comment)}</rdfs:comment>`);
+    for (const assertion of [...ind.objectPropertyAssertions].sort(
+      (a, b) => a.property.localeCompare(b.property) || a.target.localeCompare(b.target),
+    )) {
+      const qname = toQName(assertion.property, prefixes);
+      if (!qname) continue;
+      lines.push(`    <${qname} rdf:resource="${escAttr(assertion.target)}"/>`);
+    }
+    for (const assertion of [...ind.dataPropertyAssertions].sort(
+      (a, b) => a.property.localeCompare(b.property) || a.value.localeCompare(b.value),
+    )) {
+      const qname = toQName(assertion.property, prefixes);
+      if (!qname) continue;
+      if (assertion.datatype) {
+        lines.push(
+          `    <${qname} rdf:datatype="${escAttr(assertion.datatype)}">${escText(assertion.value)}</${qname}>`,
+        );
+      } else {
+        lines.push(`    <${qname}>${escText(assertion.value)}</${qname}>`);
+      }
+    }
+    lines.push(`  </owl:NamedIndividual>`);
+    lines.push('');
+  }
+
+  lines.push('</rdf:RDF>');
+  return lines.join('\n');
+}
+
 export const rdfXmlAdapter: FormatAdapter = {
   extensions: ['.rdf', '.owl'],
   mimeType: 'application/rdf+xml',
   parse: (content) => parseRdfXmlWithWarnings(content),
+  serialize: (ontology) => serializeToRdfXml(ontology),
 };

--- a/apps/desktop/src/renderer/src/store/ontology.ts
+++ b/apps/desktop/src/renderer/src/store/ontology.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { track } from '../lib/analytics';
 import { getAdapterForFilePath } from '../model/formats';
+import { serializeToRdfXml } from '../model/formats/rdfxml';
 import { type ParseWarning, parseTurtleWithWarnings } from '../model/parse';
 import { serializeToTurtle } from '../model/serialize';
 import type {
@@ -23,6 +24,7 @@ interface OntologyState {
   loadFromTurtle: (turtle: string, filePath?: string) => void;
   clearImportWarnings: () => void;
   exportToTurtle: () => string;
+  serializeForFilePath: (filePath: string) => string;
   reset: () => void;
   setFilePath: (path: string | null) => void;
   markClean: () => void;
@@ -86,6 +88,15 @@ export const useOntologyStore = create<OntologyState>((set, get) => ({
   exportToTurtle: () => {
     track('ontology_exported', { classCount: get().ontology.classes.size });
     return serializeToTurtle(get().ontology);
+  },
+
+  serializeForFilePath: (filePath) => {
+    const ontology = get().ontology;
+    const ext = filePath.substring(filePath.lastIndexOf('.')).toLowerCase();
+    const isRdfXml = ext === '.rdf' || ext === '.owl';
+    const format = isRdfXml ? 'rdf+xml' : 'turtle';
+    track('ontology_exported', { classCount: ontology.classes.size, format });
+    return isRdfXml ? serializeToRdfXml(ontology) : serializeToTurtle(ontology);
   },
 
   reset: () => {

--- a/apps/desktop/tests/model/rdfxml.test.ts
+++ b/apps/desktop/tests/model/rdfxml.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { parseRdfXmlWithWarnings } from '@renderer/model/formats/rdfxml';
+import { parseRdfXmlWithWarnings, serializeToRdfXml } from '@renderer/model/formats/rdfxml';
 import { parseTurtleWithWarnings } from '@renderer/model/parse';
 import type { DatatypeProperty, ObjectProperty, OntologyClass } from '@renderer/model/types';
+import { createEmptyOntology } from '@renderer/model/types';
 import { describe, expect, it } from 'vitest';
 
 const EX = 'http://example.org/ontology#';
@@ -100,5 +101,97 @@ describe('parseRdfXml', () => {
     expect([...rdfOnt.datatypeProperties.keys()].sort()).toEqual(
       [...ttlOnt.datatypeProperties.keys()].sort(),
     );
+  });
+});
+
+const individualsRdf = readFileSync(
+  resolve(__dirname, '../../resources/sample-ontologies/individuals.ttl'),
+  'utf-8',
+);
+
+describe('serializeToRdfXml', () => {
+  it('round-trips: parse RDF/XML → serialize → reparse preserves classes', () => {
+    const { ontology: original } = parseRdfXmlWithWarnings(peopleRdf);
+    const serialized = serializeToRdfXml(original);
+    const { ontology: reparsed } = parseRdfXmlWithWarnings(serialized);
+
+    expect(reparsed.classes.size).toBe(original.classes.size);
+    for (const [uri, cls] of original.classes) {
+      const reparsedCls = reparsed.classes.get(uri) as OntologyClass;
+      expect(reparsedCls).toBeDefined();
+      expect(reparsedCls.label).toBe(cls.label);
+      expect(reparsedCls.comment).toBe(cls.comment);
+      expect(reparsedCls.subClassOf.sort()).toEqual(cls.subClassOf.sort());
+    }
+  });
+
+  it('round-trips: preserves object properties', () => {
+    const { ontology: original } = parseRdfXmlWithWarnings(peopleRdf);
+    const serialized = serializeToRdfXml(original);
+    const { ontology: reparsed } = parseRdfXmlWithWarnings(serialized);
+
+    expect(reparsed.objectProperties.size).toBe(original.objectProperties.size);
+    for (const [uri, prop] of original.objectProperties) {
+      const reparsedProp = reparsed.objectProperties.get(uri) as ObjectProperty;
+      expect(reparsedProp).toBeDefined();
+      expect(reparsedProp.label).toBe(prop.label);
+      expect(reparsedProp.domain.sort()).toEqual(prop.domain.sort());
+      expect(reparsedProp.range.sort()).toEqual(prop.range.sort());
+      expect(reparsedProp.inverseOf).toBe(prop.inverseOf);
+    }
+  });
+
+  it('round-trips: preserves datatype properties', () => {
+    const { ontology: original } = parseRdfXmlWithWarnings(peopleRdf);
+    const serialized = serializeToRdfXml(original);
+    const { ontology: reparsed } = parseRdfXmlWithWarnings(serialized);
+
+    expect(reparsed.datatypeProperties.size).toBe(original.datatypeProperties.size);
+    for (const [uri, prop] of original.datatypeProperties) {
+      const reparsedProp = reparsed.datatypeProperties.get(uri) as DatatypeProperty;
+      expect(reparsedProp).toBeDefined();
+      expect(reparsedProp.label).toBe(prop.label);
+      expect(reparsedProp.domain.sort()).toEqual(prop.domain.sort());
+      expect(reparsedProp.range).toBe(prop.range);
+    }
+  });
+
+  it('produces valid XML with rdf:RDF root', () => {
+    const { ontology } = parseRdfXmlWithWarnings(peopleRdf);
+    const serialized = serializeToRdfXml(ontology);
+    expect(serialized).toMatch(/^<\?xml version="1\.0"/);
+    expect(serialized).toContain('<rdf:RDF');
+    expect(serialized).toContain('</rdf:RDF>');
+  });
+
+  it('produces no errors when reparsing serialized output', () => {
+    const { ontology } = parseRdfXmlWithWarnings(peopleRdf);
+    const serialized = serializeToRdfXml(ontology);
+    const { warnings } = parseRdfXmlWithWarnings(serialized);
+    expect(warnings.filter((w) => w.severity === 'error')).toHaveLength(0);
+  });
+
+  it('serializes empty ontology without errors', () => {
+    const empty = createEmptyOntology();
+    const serialized = serializeToRdfXml(empty);
+    const { warnings } = parseRdfXmlWithWarnings(serialized);
+    expect(warnings.filter((w) => w.severity === 'error')).toHaveLength(0);
+  });
+
+  it('is deterministic', () => {
+    const { ontology } = parseRdfXmlWithWarnings(peopleRdf);
+    expect(serializeToRdfXml(ontology)).toBe(serializeToRdfXml(ontology));
+  });
+
+  it('round-trips Turtle→RDF/XML: parse Turtle, serialize as RDF/XML, reparse', () => {
+    const { ontology: ttlOnt } = parseTurtleWithWarnings(individualsRdf);
+    const serialized = serializeToRdfXml(ttlOnt);
+    const { ontology: reparsed, warnings } = parseRdfXmlWithWarnings(serialized);
+
+    expect(warnings.filter((w) => w.severity === 'error')).toHaveLength(0);
+    expect(reparsed.classes.size).toBe(ttlOnt.classes.size);
+    expect(reparsed.individuals.size).toBe(ttlOnt.individuals.size);
+    expect(reparsed.objectProperties.size).toBe(ttlOnt.objectProperties.size);
+    expect(reparsed.datatypeProperties.size).toBe(ttlOnt.datatypeProperties.size);
   });
 });


### PR DESCRIPTION
## Summary

- Implements `serializeToRdfXml()` — a custom, deterministic RDF/XML serializer covering classes, object/datatype/annotation properties, individuals, and ontology metadata
- Wires serialization into `rdfXmlAdapter` (`.rdf`/`.owl`) completing the format adapter contract
- Adds `serializeForFilePath()` to the ontology store — picks the right serializer by file extension, enabling format-aware save
- Introduces `file:save-as-dialog` IPC that shows a Turtle + RDF/XML format picker and returns the chosen path (without writing), so the renderer can serialize correctly before writing
- Updates `doSave` and `doSaveAs` in `App.tsx` to use the new format-aware flow
- Adds 8 round-trip serialization tests to `rdfxml.test.ts`

Closes [ONT-129](/ONT/issues/ONT-129). Completes the export half of the import work done in [ONT-84](/ONT/issues/ONT-84).

## Test plan

- [ ] All 374 existing tests pass (no regressions)
- [ ] 8 new `serializeToRdfXml` round-trip tests pass
- [ ] Open `people.rdf` → Save As → pick `.rdf` → reopen → same structure
- [ ] Open `people.rdf` → Save As → pick `.ttl` → file is valid Turtle
- [ ] Open `people.ttl` → Cmd+S with existing path → saves as Turtle (unchanged)
- [ ] Open `people.rdf` → Cmd+S with existing path → saves as RDF/XML (not Turtle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)