### PR TITLE
feat(desktop): JSON-LD UX — open/save dialogs, status badge, empty-state copy (ONT-138)

### DIFF
--- a/apps/desktop/src/main/ipc/file.ts
+++ b/apps/desktop/src/main/ipc/file.ts
@@ -37,9 +37,10 @@ export function registerFileIPC(): void {
 
     const result = await dialog.showOpenDialog(win, {
       filters: [
-        { name: 'All Ontology Files', extensions: ['ttl', 'rdf', 'owl'] },
+        { name: 'All Ontology Files', extensions: ['ttl', 'rdf', 'owl', 'jsonld'] },
         { name: 'Turtle', extensions: ['ttl'] },
         { name: 'RDF/XML', extensions: ['rdf', 'owl'] },
+        { name: 'JSON-LD', extensions: ['jsonld'] },
         { name: 'All Files', extensions: ['*'] },
       ],
       properties: ['openFile'],
@@ -75,6 +76,7 @@ export function registerFileIPC(): void {
       filters: [
         { name: 'Turtle', extensions: ['ttl'] },
         { name: 'RDF/XML', extensions: ['rdf', 'owl'] },
+        { name: 'JSON-LD', extensions: ['jsonld'] },
         { name: 'All Files', extensions: ['*'] },
       ],
       defaultPath: 'ontology.ttl',
@@ -95,6 +97,7 @@ export function registerFileIPC(): void {
       filters: [
         { name: 'Turtle', extensions: ['ttl'] },
         { name: 'RDF/XML', extensions: ['rdf', 'owl'] },
+        { name: 'JSON-LD', extensions: ['jsonld'] },
         { name: 'All Files', extensions: ['*'] },
       ],
       defaultPath: 'ontology.ttl',

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -270,7 +270,8 @@ function App(): React.JSX.Element {
                     Where knowledge takes shape
                   </p>
                   <p className="text-sm mb-4">
-                    Open an ontology (.ttl, .rdf, .owl) or start chatting with Claude to create one
+                    Open an ontology (.ttl, .rdf, .owl, .jsonld) or start chatting with Claude to
+                    create one
                   </p>
                   <Button onClick={() => loadFromTurtle(peopleTtl, 'Sample: people.ttl')}>
                     Load sample ontology

--- a/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -33,6 +33,7 @@ export function StatusBar(): React.JSX.Element {
     if (!adapter) return null;
     if (adapter.mimeType.includes('turtle')) return 'Turtle';
     if (adapter.mimeType.includes('rdf+xml')) return 'RDF/XML';
+    if (adapter.mimeType.includes('ld+json')) return 'JSON-LD';
     return null;
   }, [filePath]);
 

--- a/apps/desktop/src/renderer/src/model/formats/index.ts
+++ b/apps/desktop/src/renderer/src/model/formats/index.ts
@@ -1,5 +1,6 @@
 import type { ParseWarning } from '../quads';
 import type { Ontology } from '../types';
+import { jsonLdAdapter } from './jsonld';
 import { rdfXmlAdapter } from './rdfxml';
 import { turtleAdapter } from './turtle';
 
@@ -15,7 +16,7 @@ export interface FormatAdapter {
   serialize?(ontology: Ontology): string;
 }
 
-const adapters: FormatAdapter[] = [turtleAdapter, rdfXmlAdapter];
+const adapters: FormatAdapter[] = [turtleAdapter, rdfXmlAdapter, jsonLdAdapter];
 
 export function getAdapterForExtension(ext: string): FormatAdapter | undefined {
   const normalized = ext.toLowerCase().startsWith('.')
@@ -44,7 +45,9 @@ export function getOpenDialogFilters(): { name: string; extensions: string[] }[]
       ? 'Turtle'
       : adapter.mimeType.includes('rdf+xml')
         ? 'RDF/XML'
-        : adapter.mimeType;
+        : adapter.mimeType.includes('ld+json')
+          ? 'JSON-LD'
+          : adapter.mimeType;
     filters.push({ name, extensions: exts });
   }
 

--- a/apps/desktop/src/renderer/src/model/formats/jsonld.ts
+++ b/apps/desktop/src/renderer/src/model/formats/jsonld.ts
@@ -1,0 +1,18 @@
+import { createEmptyOntology } from '../types';
+import type { FormatAdapter, ParseResult } from './index';
+
+export const jsonLdAdapter: FormatAdapter = {
+  extensions: ['.jsonld'],
+  mimeType: 'application/ld+json',
+  parse(_content: string): ParseResult {
+    return {
+      ontology: createEmptyOntology(),
+      warnings: [
+        {
+          severity: 'error',
+          message: 'JSON-LD parsing is not yet implemented',
+        },
+      ],
+    };
+  },
+};


### PR DESCRIPTION
## Summary

- Register a `jsonLdAdapter` (mimeType `application/ld+json`, extension `.jsonld`) in the format registry so adapter lookup resolves `.jsonld` files
- Status bar: map `ld+json` mimeType to `JSON-LD` badge alongside existing Turtle / RDF/XML mappings
- Open dialog: add `.jsonld` to the "All Ontology Files" catch-all filter and a dedicated `JSON-LD` filter entry
- Both save-as dialogs: add `JSON-LD / .jsonld` filter option
- Empty-state hint text updated to include `.jsonld`

The adapter stub currently returns an empty ontology with an error warning — full parse/serialize implementation is tracked as a follow-on CTO task.

Closes ONT-138 · Parent: ONT-130

## Test plan

- [ ] `bun run lint` + `bun run format:check` pass (verified locally)
- [ ] All 379 unit tests pass (verified locally)
- [ ] Open dialog shows "All Ontology Files" including `.jsonld`, plus a discrete "JSON-LD" filter
- [ ] Save As dialog shows a "JSON-LD" format option
- [ ] Loading a `.jsonld` file shows `JSON-LD` badge in the status bar
- [ ] Empty-state copy shows `(.ttl, .rdf, .owl, .jsonld)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)