### PR TITLE
feat(desktop): content sniffing fallback + export conversion warnings

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -39,6 +39,7 @@ import {
 } from './components/ui/empty';
 import { Popover, PopoverContent, PopoverTrigger } from './components/ui/popover';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './components/ui/resizable';
+import { getAdapterForFilePath } from './model/formats';
 import peopleTtl from './samples/people.ttl?raw';
 import { validateOntology } from './services/validation';
 import { useHistoryStore } from './store/history';
@@ -69,40 +70,76 @@ function App(): React.JSX.Element {
   const pendingSaveRef = useRef<'save' | 'saveAs' | null>(null);
   const [showGraphControls, setShowGraphControls] = useState(false);
   const [recentFiles, setRecentFiles] = useState<string[]>([]);
+  const [showFormatUnknown, setShowFormatUnknown] = useState(false);
+  const [showConversionWarning, setShowConversionWarning] = useState(false);
+  const pendingConversionActionRef = useRef<(() => Promise<void>) | null>(null);
 
   const handleOpen = useCallback(async () => {
     const result = await window.api.openFile();
     if (result) {
-      await loadFromFile(result.content, result.filePath);
+      try {
+        await loadFromFile(result.content, result.filePath);
+      } catch (e) {
+        if (e instanceof Error && e.message === 'FORMAT_UNKNOWN') {
+          setShowFormatUnknown(true);
+        } else {
+          throw e;
+        }
+      }
     }
   }, [loadFromFile]);
+
+  const checkConversionWarning = useCallback(
+    (targetPath: string, actualSave: () => Promise<void>): boolean => {
+      const { importWarnings: warnings, sourceFormat: srcFmt } = useOntologyStore.getState();
+      if (warnings.length > 0 && srcFmt) {
+        const targetAdapter = getAdapterForFilePath(targetPath);
+        if (targetAdapter && targetAdapter.mimeType !== srcFmt) {
+          pendingConversionActionRef.current = actualSave;
+          setShowConversionWarning(true);
+          return true;
+        }
+      }
+      return false;
+    },
+    [],
+  );
 
   const doSave = useCallback(async () => {
     const currentPath = useOntologyStore.getState().filePath;
     if (currentPath && !currentPath.startsWith('sample://') && !currentPath.startsWith('Sample:')) {
-      const content = await serializeForFilePath(currentPath);
-      await window.api.saveFile(currentPath, content);
-      markClean();
+      const actualSave = async (): Promise<void> => {
+        const content = await serializeForFilePath(currentPath);
+        await window.api.saveFile(currentPath, content);
+        markClean();
+      };
+      if (!checkConversionWarning(currentPath, actualSave)) await actualSave();
     } else {
       const newPath = await window.api.saveFileAsDialog();
       if (newPath) {
-        const content = await serializeForFilePath(newPath);
-        await window.api.saveFile(newPath, content);
-        setFilePath(newPath);
-        markClean();
+        const actualSave = async (): Promise<void> => {
+          const content = await serializeForFilePath(newPath);
+          await window.api.saveFile(newPath, content);
+          setFilePath(newPath);
+          markClean();
+        };
+        if (!checkConversionWarning(newPath, actualSave)) await actualSave();
       }
     }
-  }, [serializeForFilePath, setFilePath, markClean]);
+  }, [serializeForFilePath, setFilePath, markClean, checkConversionWarning]);
 
   const doSaveAs = useCallback(async () => {
     const newPath = await window.api.saveFileAsDialog();
     if (newPath) {
-      const content = await serializeForFilePath(newPath);
-      await window.api.saveFile(newPath, content);
-      setFilePath(newPath);
-      markClean();
+      const actualSave = async (): Promise<void> => {
+        const content = await serializeForFilePath(newPath);
+        await window.api.saveFile(newPath, content);
+        setFilePath(newPath);
+        markClean();
+      };
+      if (!checkConversionWarning(newPath, actualSave)) await actualSave();
     }
-  }, [serializeForFilePath, setFilePath, markClean]);
+  }, [serializeForFilePath, setFilePath, markClean, checkConversionWarning]);
 
   const handleSave = useCallback(async () => {
     const errors = validateOntology(useOntologyStore.getState().ontology);
@@ -209,7 +246,15 @@ function App(): React.JSX.Element {
     async (filePath: string) => {
       const result = await window.api.openRecentFile(filePath);
       if (result) {
-        await loadFromFile(result.content, result.filePath);
+        try {
+          await loadFromFile(result.content, result.filePath);
+        } catch (e) {
+          if (e instanceof Error && e.message === 'FORMAT_UNKNOWN') {
+            setShowFormatUnknown(true);
+          } else {
+            throw e;
+          }
+        }
       }
     },
     [loadFromFile],
@@ -409,6 +454,63 @@ function App(): React.JSX.Element {
               Cancel
             </Button>
             <Button variant="destructive" onClick={handleForceSave}>
+              Save anyway
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showFormatUnknown} onOpenChange={setShowFormatUnknown}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Cannot determine format</DialogTitle>
+            <DialogDescription>
+              The file format could not be detected from its extension or content. Please ensure the
+              file is a valid Turtle, RDF/XML, or JSON-LD ontology.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button onClick={() => setShowFormatUnknown(false)}>OK</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showConversionWarning} onOpenChange={setShowConversionWarning}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Format conversion warning</DialogTitle>
+            <DialogDescription>
+              The following constructs could not be fully represented when the file was parsed and
+              will not be preserved in the exported file:
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 max-h-48 overflow-y-auto text-sm">
+            {importWarnings.map((w) => (
+              <div key={w.message} className="flex items-start gap-2">
+                <TriangleAlert className="size-4 shrink-0 mt-0.5 text-warning" />
+                <span>{w.message}</span>
+              </div>
+            ))}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowConversionWarning(false);
+                pendingConversionActionRef.current = null;
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={async () => {
+                setShowConversionWarning(false);
+                if (pendingConversionActionRef.current) {
+                  await pendingConversionActionRef.current();
+                  pendingConversionActionRef.current = null;
+                }
+              }}
+            >
               Save anyway
             </Button>
           </DialogFooter>

--- a/apps/desktop/src/renderer/src/model/formats/index.ts
+++ b/apps/desktop/src/renderer/src/model/formats/index.ts
@@ -28,8 +28,18 @@ export function getAdapterForExtension(ext: string): FormatAdapter | undefined {
 }
 
 export function getAdapterForFilePath(filePath: string): FormatAdapter | undefined {
-  const ext = filePath.substring(filePath.lastIndexOf('.')).toLowerCase();
+  const dotIndex = filePath.lastIndexOf('.');
+  if (dotIndex === -1) return undefined;
+  const ext = filePath.substring(dotIndex).toLowerCase();
   return getAdapterForExtension(ext);
+}
+
+export function sniffAdapterFromContent(content: string): FormatAdapter | null {
+  const head = content.slice(0, 200);
+  if (head.includes('@prefix') || head.includes('@base')) return turtleAdapter;
+  if (head.includes('<?xml') || head.includes('<rdf:RDF')) return rdfXmlAdapter;
+  if (/"@context"/.test(head) && head.trimStart().startsWith('{')) return jsonLdAdapter;
+  return null;
 }
 
 export function getAllSupportedExtensions(): string[] {

--- a/apps/desktop/src/renderer/src/store/ontology.ts
+++ b/apps/desktop/src/renderer/src/store/ontology.ts
@@ -114,7 +114,7 @@ export const useOntologyStore = create<OntologyState>((set, get) => ({
   },
 
   reset: () => {
-    set({ ontology: createEmptyOntology(), filePath: null, isDirty: false });
+    set({ ontology: createEmptyOntology(), filePath: null, isDirty: false, sourceFormat: null });
   },
 
   setFilePath: (path) => set({ filePath: path }),

--- a/apps/desktop/src/renderer/src/store/ontology.ts
+++ b/apps/desktop/src/renderer/src/store/ontology.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { track } from '../lib/analytics';
-import { getAdapterForFilePath } from '../model/formats';
+import { getAdapterForFilePath, sniffAdapterFromContent } from '../model/formats';
 import { serializeToRdfXml } from '../model/formats/rdfxml';
 import { type ParseWarning, parseTurtleWithWarnings } from '../model/parse';
 import { serializeToTurtle } from '../model/serialize';
@@ -18,6 +18,7 @@ interface OntologyState {
   filePath: string | null;
   isDirty: boolean;
   importWarnings: ParseWarning[];
+  sourceFormat: string | null;
 
   // Actions
   loadFromFile: (content: string, filePath: string) => Promise<void>;
@@ -58,21 +59,29 @@ export const useOntologyStore = create<OntologyState>((set, get) => ({
   filePath: null,
   isDirty: false,
   importWarnings: [],
+  sourceFormat: null,
 
   loadFromFile: async (content, filePath) => {
-    const adapter = getAdapterForFilePath(filePath);
-    const result = adapter?.parseAsync
-      ? await adapter.parseAsync(content)
-      : adapter
-        ? adapter.parse(content)
-        : parseTurtleWithWarnings(content);
+    let adapter = getAdapterForFilePath(filePath);
+    if (!adapter) {
+      const sniffed = sniffAdapterFromContent(content);
+      if (!sniffed) throw new Error('FORMAT_UNKNOWN');
+      adapter = sniffed;
+    }
+    const result = adapter.parseAsync ? await adapter.parseAsync(content) : adapter.parse(content);
     const { ontology, warnings } = result;
-    set({ ontology, filePath, isDirty: false, importWarnings: warnings });
+    set({
+      ontology,
+      filePath,
+      isDirty: false,
+      importWarnings: warnings,
+      sourceFormat: adapter.mimeType,
+    });
     track('ontology_loaded', {
       classCount: ontology.classes.size,
       individualCount: ontology.individuals.size,
       source: 'file',
-      format: filePath.substring(filePath.lastIndexOf('.')).toLowerCase(),
+      format: adapter.mimeType,
     });
   },
 

--- a/apps/desktop/tests/model/formats.test.ts
+++ b/apps/desktop/tests/model/formats.test.ts
@@ -1,4 +1,8 @@
-import { getAdapterForExtension, getAdapterForFilePath } from '@renderer/model/formats';
+import {
+  getAdapterForExtension,
+  getAdapterForFilePath,
+  sniffAdapterFromContent,
+} from '@renderer/model/formats';
 import { describe, expect, it } from 'vitest';
 
 describe('format registry', () => {
@@ -28,5 +32,50 @@ describe('format registry', () => {
   it('returns undefined for unknown extension', () => {
     const adapter = getAdapterForExtension('.csv');
     expect(adapter).toBeUndefined();
+  });
+
+  it('returns undefined for file with no extension', () => {
+    expect(getAdapterForFilePath('/some/path/ontology')).toBeUndefined();
+  });
+});
+
+describe('sniffAdapterFromContent', () => {
+  it('detects Turtle via @prefix', () => {
+    const adapter = sniffAdapterFromContent('@prefix owl: <http://www.w3.org/2002/07/owl#> .\n');
+    expect(adapter?.mimeType).toBe('text/turtle');
+  });
+
+  it('detects Turtle via @base', () => {
+    const adapter = sniffAdapterFromContent('@base <http://example.org/> .\n');
+    expect(adapter?.mimeType).toBe('text/turtle');
+  });
+
+  it('detects RDF/XML via <?xml header', () => {
+    const adapter = sniffAdapterFromContent(
+      '<?xml version="1.0"?>\n<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">',
+    );
+    expect(adapter?.mimeType).toBe('application/rdf+xml');
+  });
+
+  it('detects RDF/XML via <rdf:RDF tag without xml declaration', () => {
+    const adapter = sniffAdapterFromContent(
+      '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">',
+    );
+    expect(adapter?.mimeType).toBe('application/rdf+xml');
+  });
+
+  it('detects JSON-LD via @context in JSON object', () => {
+    const adapter = sniffAdapterFromContent('{\n  "@context": "http://schema.org/",\n');
+    expect(adapter?.mimeType).toBe('application/ld+json');
+  });
+
+  it('returns null for unrecognised content', () => {
+    const adapter = sniffAdapterFromContent('just some random text\nwith no format markers');
+    expect(adapter).toBeNull();
+  });
+
+  it('returns null for JSON without @context', () => {
+    const adapter = sniffAdapterFromContent('{ "name": "test", "value": 42 }');
+    expect(adapter).toBeNull();
   });
 });

--- a/apps/desktop/tests/store/ontology.test.ts
+++ b/apps/desktop/tests/store/ontology.test.ts
@@ -298,4 +298,31 @@ describe('useOntologyStore', () => {
       expect(exported).toContain('NamedIndividual');
     });
   });
+
+  describe('loadFromFile — content sniffing', () => {
+    it('loads a .ttl file by extension and sets sourceFormat', async () => {
+      await useOntologyStore.getState().loadFromFile(SAMPLE_TURTLE, '/test.ttl');
+      const { sourceFormat, ontology } = useOntologyStore.getState();
+      expect(sourceFormat).toBe('text/turtle');
+      expect(ontology.classes.size).toBeGreaterThanOrEqual(3);
+    });
+
+    it('sniffs Turtle from content when extension is missing', async () => {
+      await useOntologyStore.getState().loadFromFile(SAMPLE_TURTLE, '/unknown-file');
+      const { sourceFormat } = useOntologyStore.getState();
+      expect(sourceFormat).toBe('text/turtle');
+    });
+
+    it('throws FORMAT_UNKNOWN when content and extension are unrecognised', async () => {
+      await expect(
+        useOntologyStore.getState().loadFromFile('just random text', '/mystery.dat'),
+      ).rejects.toThrow('FORMAT_UNKNOWN');
+    });
+
+    it('clears sourceFormat on reset', async () => {
+      await useOntologyStore.getState().loadFromFile(SAMPLE_TURTLE, '/test.ttl');
+      useOntologyStore.getState().reset();
+      expect(useOntologyStore.getState().sourceFormat).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Content sniffing fallback** (`formats/index.ts`): adds `sniffAdapterFromContent()` which inspects the first 200 bytes when no file extension is recognised. Detects Turtle (`@prefix`/`@base`), RDF/XML (`<?xml`/`<rdf:RDF`), and JSON-LD (`{"@context"`). Falls back to an error dialog ("Cannot determine format") when content is ambiguous.
- **Format-aware `loadFromFile`** (`store/ontology.ts`): uses sniffing as a fallback; stores `sourceFormat` (adapter `mimeType`) so save-time can detect cross-format conversions. Throws `FORMAT_UNKNOWN` for the ambiguous case.
- **Export conversion warning** (`App.tsx`): if `importWarnings` is non-empty and the user saves to a different format than the file was opened in, a warning dialog lists the unpreserved constructs; user can cancel or proceed.

Closes [ONT-141](/ONT/issues/ONT-141).

## Test plan
- [ ] Open file with no extension containing `<?xml version="1.0"?>\n<rdf:RDF` → opens as RDF/XML
- [ ] Open file with no extension containing `{"@context":` → opens as JSON-LD
- [ ] Open file with no extension containing `@prefix owl:` → opens as Turtle
- [ ] Open file with completely ambiguous content → "Cannot determine format" dialog
- [ ] Load ontology that has parse warnings, attempt cross-format save → conversion warning dialog appears
- [ ] Dismiss warning → file not saved; confirm → file saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)