### PR TITLE
feat(desktop): OWL property characteristics (ONT-82)

### DIFF
--- a/apps/desktop/resources/sample-ontologies/owl-characteristics.ttl
+++ b/apps/desktop/resources/sample-ontologies/owl-characteristics.ttl
@@ -1,0 +1,77 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <http://example.org/characteristics#> .
+
+# Ontology declaration
+ex:CharacteristicsOntology rdf:type owl:Ontology .
+
+# Classes
+ex:Person rdf:type owl:Class ;
+  rdfs:label "Person" .
+
+ex:Animal rdf:type owl:Class ;
+  rdfs:label "Animal" .
+
+ex:Thing rdf:type owl:Class ;
+  rdfs:label "Thing" .
+
+# Transitive property: ancestor
+ex:hasAncestor rdf:type owl:ObjectProperty ;
+  rdf:type owl:TransitiveProperty ;
+  rdfs:label "has ancestor" ;
+  rdfs:domain ex:Person ;
+  rdfs:range ex:Person .
+
+# Symmetric property: sibling
+ex:hasSibling rdf:type owl:ObjectProperty ;
+  rdf:type owl:SymmetricProperty ;
+  rdfs:label "has sibling" ;
+  rdfs:domain ex:Person ;
+  rdfs:range ex:Person .
+
+# Reflexive property: knows
+ex:knows rdf:type owl:ObjectProperty ;
+  rdf:type owl:ReflexiveProperty ;
+  rdfs:label "knows" ;
+  rdfs:domain ex:Person ;
+  rdfs:range ex:Person .
+
+# Functional property: hasBiologicalMother
+ex:hasBiologicalMother rdf:type owl:ObjectProperty ;
+  rdf:type owl:FunctionalProperty ;
+  rdfs:label "has biological mother" ;
+  rdfs:domain ex:Person ;
+  rdfs:range ex:Person .
+
+# InverseFunctional property: hasSSN
+ex:hasSSN rdf:type owl:ObjectProperty ;
+  rdf:type owl:InverseFunctionalProperty ;
+  rdfs:label "has SSN" ;
+  rdfs:domain ex:Person ;
+  rdfs:range ex:Thing .
+
+# Multiple characteristics: transitiveAndFunctional
+ex:hasUniqueAncestor rdf:type owl:ObjectProperty ;
+  rdf:type owl:TransitiveProperty ;
+  rdf:type owl:FunctionalProperty ;
+  rdfs:label "has unique ancestor" ;
+  rdfs:domain ex:Person ;
+  rdfs:range ex:Person .
+
+# All five characteristics on a single property
+ex:hasAll rdf:type owl:ObjectProperty ;
+  rdf:type owl:TransitiveProperty ;
+  rdf:type owl:SymmetricProperty ;
+  rdf:type owl:ReflexiveProperty ;
+  rdf:type owl:FunctionalProperty ;
+  rdf:type owl:InverseFunctionalProperty ;
+  rdfs:label "has all" ;
+  rdfs:domain ex:Person ;
+  rdfs:range ex:Person .
+
+# Plain property (no characteristics) — for negative testing
+ex:worksFor rdf:type owl:ObjectProperty ;
+  rdfs:label "works for" ;
+  rdfs:domain ex:Person ;
+  rdfs:range ex:Thing .

--- a/apps/desktop/src/renderer/src/components/detail/CharacteristicBadge.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/CharacteristicBadge.tsx
@@ -1,0 +1,46 @@
+import type { OWLCharacteristic } from '@renderer/model/types';
+import { Badge } from '@/components/ui/badge';
+
+interface CharInfo {
+  label: string;
+  tooltip: string;
+}
+
+const CHAR_INFO: Record<OWLCharacteristic, CharInfo> = {
+  transitive: {
+    label: 'Transitive',
+    tooltip: 'If A→B and B→C, then A→C is entailed.',
+  },
+  symmetric: {
+    label: 'Symmetric',
+    tooltip: 'If A→B, then B→A is entailed.',
+  },
+  reflexive: {
+    label: 'Reflexive',
+    tooltip: 'Every individual is related to itself.',
+  },
+  functional: {
+    label: 'Functional',
+    tooltip: 'Each subject has at most one value.',
+  },
+  inverseFunctional: {
+    label: 'Inv. Functional',
+    tooltip: 'Each value has at most one subject.',
+  },
+};
+
+interface Props {
+  characteristic: OWLCharacteristic;
+}
+
+export function CharacteristicBadge({ characteristic }: Props): React.JSX.Element {
+  const { label, tooltip } = CHAR_INFO[characteristic];
+  return (
+    <span>
+      <Badge variant="secondary" className="px-2 py-0.5 text-xs">
+        {label}
+      </Badge>
+      <span className="sr-only">{tooltip}</span>
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/detail/EdgeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/EdgeDetail.tsx
@@ -3,6 +3,7 @@ import { useOntologyStore } from '@renderer/store/ontology';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { CharacteristicBadge } from './CharacteristicBadge';
 
 interface Props {
   property: ObjectProperty;
@@ -37,6 +38,17 @@ export function EdgeDetail({ property }: Props): React.JSX.Element {
           }}
         />
       </div>
+
+      {property.characteristics.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-xs text-muted-foreground">Characteristics</p>
+          <div className="flex flex-wrap gap-1.5">
+            {property.characteristics.map((c) => (
+              <CharacteristicBadge key={c} characteristic={c} />
+            ))}
+          </div>
+        </div>
+      )}
 
       {property.domain.length > 0 && (
         <div>

--- a/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
@@ -57,9 +57,9 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
     targetY: ty,
     targetPosition,
   });
-
   const isAdjacent = adjacentEdgeIds.includes(id);
   const isDimmed = selectedNodeId !== null && !isAdjacent;
+  const isSelfLoop = source === target;
   const color = 'var(--graph-edge-property)';
   const markerId = `objprop-arrow-${id}`;
   const rotation = autoRotation(sx, sy, tx, ty);
@@ -125,7 +125,7 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
               transform: `translate(-50%, -50%) translate(${badgeX}px, ${badgeY}px) rotate(${rotation}deg)`,
               display: 'flex',
               gap: 2,
-              opacity: isDimmed ? 0.15 : 1,
+              opacity: isSelfLoop && !selected ? 0 : isDimmed ? 0.15 : 1,
               transition: 'opacity 0.15s ease',
               pointerEvents: 'none',
             }}

--- a/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
@@ -138,6 +138,7 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
                   key={c}
                   title={title}
                   style={{
+                    pointerEvents: 'auto',
                     fontSize: 5,
                     fontFamily: 'monospace',
                     height: 10,

--- a/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
@@ -67,7 +67,7 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
 
   // Stagger badge rows when multiple edges share the same source→target pair,
   // so they don't overlap. Sort by id for a stable, deterministic order.
-  const peerEdges = allEdges
+  const peerEdges = (allEdges as ObjPropEdge[])
     .filter((e) => e.source === source && e.target === target && e.data?.characteristics?.length)
     .sort((a, b) => a.id.localeCompare(b.id));
   const badgeStagger = peerEdges.findIndex((e) => e.id === id);

--- a/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
@@ -7,6 +7,7 @@ import {
   EdgeLabelRenderer,
   type EdgeProps,
   getBezierPath,
+  useEdges,
   useInternalNode,
 } from '@xyflow/react';
 import { memo } from 'react';
@@ -39,6 +40,7 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
   const targetNode = useInternalNode(target);
   const selectedNodeId = useUIStore((s) => s.selectedNodeId);
   const adjacentEdgeIds = useUIStore((s) => s.adjacentEdgeIds);
+  const allEdges = useEdges();
 
   if (!sourceNode || !targetNode) return null;
 
@@ -62,6 +64,17 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
   const markerId = `objprop-arrow-${id}`;
   const rotation = autoRotation(sx, sy, tx, ty);
   const uniqueCharacteristics = [...new Set(data?.characteristics ?? [])];
+
+  // Stagger badge rows when multiple edges share the same source→target pair,
+  // so they don't overlap. Sort by id for a stable, deterministic order.
+  const peerEdges = allEdges
+    .filter((e) => e.source === source && e.target === target && e.data?.characteristics?.length)
+    .sort((a, b) => a.id.localeCompare(b.id));
+  const badgeStagger = peerEdges.findIndex((e) => e.id === id);
+  const staggerDist = badgeStagger * 14;
+  const rotRad = rotation * (Math.PI / 180);
+  const badgeX = labelX + (18 + staggerDist) * Math.sin(rotRad);
+  const badgeY = labelY + (18 + staggerDist) * Math.cos(rotRad);
 
   return (
     <>
@@ -109,7 +122,7 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
           <div
             style={{
               position: 'absolute',
-              transform: `translate(-50%, -50%) translate(${labelX + 18 * Math.sin(rotation * (Math.PI / 180))}px, ${labelY + 18 * Math.cos(rotation * (Math.PI / 180))}px) rotate(${rotation}deg)`,
+              transform: `translate(-50%, -50%) translate(${badgeX}px, ${badgeY}px) rotate(${rotation}deg)`,
               display: 'flex',
               gap: 2,
               opacity: isDimmed ? 0.15 : 1,

--- a/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
@@ -109,7 +109,7 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
           <div
             style={{
               position: 'absolute',
-              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY + 18}px) rotate(${rotation}deg)`,
+              transform: `translate(-50%, -50%) translate(${labelX + 18 * Math.sin(rotation * (Math.PI / 180))}px, ${labelY + 18 * Math.cos(rotation * (Math.PI / 180))}px) rotate(${rotation}deg)`,
               display: 'flex',
               gap: 2,
               opacity: isDimmed ? 0.15 : 1,

--- a/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
@@ -1,4 +1,5 @@
 import type { ObjPropEdgeData } from '@renderer/model/reactflow';
+import type { OWLCharacteristic } from '@renderer/model/types';
 import { useUIStore } from '@renderer/store/ui';
 import {
   BaseEdge,
@@ -12,6 +13,14 @@ import { memo } from 'react';
 import { getFloatingEdgeParams } from './floating-edge-utils';
 
 type ObjPropEdge = Edge<ObjPropEdgeData>;
+
+const CHAR_ABBREV: Record<OWLCharacteristic, { abbr: string; title: string }> = {
+  transitive: { abbr: 'T', title: 'Transitive' },
+  symmetric: { abbr: 'S', title: 'Symmetric' },
+  reflexive: { abbr: 'R', title: 'Reflexive' },
+  functional: { abbr: 'F', title: 'Functional' },
+  inverseFunctional: { abbr: 'IF', title: 'Inverse Functional' },
+};
 
 function autoRotation(sx: number, sy: number, tx: number, ty: number): number {
   let angle = Math.atan2(ty - sy, tx - sx) * (180 / Math.PI);
@@ -52,6 +61,7 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
   const color = 'var(--graph-edge-property)';
   const markerId = `objprop-arrow-${id}`;
   const rotation = autoRotation(sx, sy, tx, ty);
+  const uniqueCharacteristics = [...new Set(data?.characteristics ?? [])];
 
   return (
     <>
@@ -91,6 +101,46 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
             className="nodrag nopan"
           >
             {data.label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+      {uniqueCharacteristics.length > 0 && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY + 18}px) rotate(${rotation}deg)`,
+              display: 'flex',
+              gap: 2,
+              opacity: isDimmed ? 0.15 : 1,
+              transition: 'opacity 0.15s ease',
+              pointerEvents: 'none',
+            }}
+            className="nodrag nopan"
+          >
+            {uniqueCharacteristics.map((c) => {
+              const { abbr, title } = CHAR_ABBREV[c];
+              return (
+                <span
+                  key={c}
+                  title={title}
+                  style={{
+                    fontSize: 5,
+                    fontFamily: 'monospace',
+                    height: 10,
+                    background: 'var(--characteristic-badge-bg)',
+                    border: '1px solid var(--characteristic-badge-border)',
+                    color: 'var(--characteristic-badge-text)',
+                    padding: '0 2px',
+                    borderRadius: 2,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                  }}
+                >
+                  {abbr}
+                </span>
+              );
+            })}
           </div>
         </EdgeLabelRenderer>
       )}

--- a/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/ObjectPropertyEdge.tsx
@@ -125,7 +125,7 @@ export const ObjectPropertyEdge = memo(function ObjectPropertyEdge({
               transform: `translate(-50%, -50%) translate(${badgeX}px, ${badgeY}px) rotate(${rotation}deg)`,
               display: 'flex',
               gap: 2,
-              opacity: isSelfLoop && !selected ? 0 : isDimmed ? 0.15 : 1,
+              opacity: isSelfLoop && !selected && !isAdjacent ? 0 : isDimmed ? 0.15 : 1,
               transition: 'opacity 0.15s ease',
               pointerEvents: 'none',
             }}

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -54,6 +54,9 @@
   --graph-edge-disjoint: oklch(0.60 0.12 15);
   --graph-edge-subclass: oklch(0.50 0.02 270);
   --graph-edge-restriction: oklch(0.65 0.15 280);
+  --characteristic-badge-bg: oklch(0.65 0.12 280 / 0.15);
+  --characteristic-badge-border: oklch(0.65 0.12 280 / 0.50);
+  --characteristic-badge-text: oklch(0.45 0.12 280);
 }
 
 .dark {
@@ -103,6 +106,9 @@
   --graph-edge-disjoint: oklch(0.65 0.12 15);
   --graph-edge-subclass: oklch(0.65 0.015 270);
   --graph-edge-restriction: oklch(0.65 0.15 280);
+  --characteristic-badge-bg: oklch(0.65 0.12 280 / 0.15);
+  --characteristic-badge-border: oklch(0.65 0.12 280 / 0.50);
+  --characteristic-badge-text: oklch(0.75 0.12 280);
 }
 
 @theme inline {

--- a/apps/desktop/src/renderer/src/model/quads.ts
+++ b/apps/desktop/src/renderer/src/model/quads.ts
@@ -6,6 +6,7 @@ import type {
   ObjectProperty,
   Ontology,
   OntologyClass,
+  OWLCharacteristic,
   Restriction,
   RestrictionType,
 } from './types';
@@ -51,11 +52,19 @@ function getOrCreateClass(ontology: Ontology, uri: string): OntologyClass {
 function getOrCreateObjectProperty(ontology: Ontology, uri: string): ObjectProperty {
   let prop = ontology.objectProperties.get(uri);
   if (!prop) {
-    prop = { uri, domain: [], range: [] };
+    prop = { uri, domain: [], range: [], characteristics: [] };
     ontology.objectProperties.set(uri, prop);
   }
   return prop;
 }
+
+const OWL_CHARACTERISTIC_MAP: Record<string, OWLCharacteristic> = {
+  [`${OWL}TransitiveProperty`]: 'transitive',
+  [`${OWL}SymmetricProperty`]: 'symmetric',
+  [`${OWL}ReflexiveProperty`]: 'reflexive',
+  [`${OWL}FunctionalProperty`]: 'functional',
+  [`${OWL}InverseFunctionalProperty`]: 'inverseFunctional',
+};
 
 function getOrCreateDatatypeProperty(ontology: Ontology, uri: string): DatatypeProperty {
   let prop = ontology.datatypeProperties.get(uri);
@@ -107,6 +116,9 @@ export function walkQuads(quads: Quad[], prefixes?: Map<string, string>): WalkQu
   // Track declared types to distinguish ObjectProperty from DatatypeProperty
   const declaredTypes = new Map<string, Set<string>>();
 
+  // Collect OWL characteristic type tokens per URI (order-independent)
+  const pendingCharacteristics = new Map<string, OWLCharacteristic[]>();
+
   // First pass: collect type declarations
   for (const quad of quads) {
     const s = quad.subject.value;
@@ -116,6 +128,12 @@ export function walkQuads(quads: Quad[], prefixes?: Map<string, string>): WalkQu
     if (p === `${RDF}type`) {
       if (!declaredTypes.has(s)) declaredTypes.set(s, new Set());
       declaredTypes.get(s)?.add(o);
+
+      const charToken = OWL_CHARACTERISTIC_MAP[o];
+      if (charToken) {
+        if (!pendingCharacteristics.has(s)) pendingCharacteristics.set(s, []);
+        pendingCharacteristics.get(s)?.push(charToken);
+      }
 
       if (o === `${OWL}Class`) {
         getOrCreateClass(ontology, s);
@@ -150,6 +168,14 @@ export function walkQuads(quads: Quad[], prefixes?: Map<string, string>): WalkQu
           };
         }
       }
+    }
+  }
+
+  // Apply collected characteristics to ObjectProperties (handles order-independence)
+  for (const [uri, tokens] of pendingCharacteristics) {
+    const prop = ontology.objectProperties.get(uri);
+    if (prop) {
+      prop.characteristics = tokens;
     }
   }
 

--- a/apps/desktop/src/renderer/src/model/reactflow.ts
+++ b/apps/desktop/src/renderer/src/model/reactflow.ts
@@ -1,6 +1,6 @@
 import type { Edge, Node } from '@xyflow/react';
 import type { ValidationError } from '../services/validation';
-import type { Ontology, Restriction } from './types';
+import type { Ontology, OWLCharacteristic, Restriction } from './types';
 
 export interface ClassNodeData extends Record<string, unknown> {
   label: string;
@@ -34,6 +34,7 @@ export type OntographNode = ClassNode | IndividualNode | GroupNode;
 export interface ObjPropEdgeData extends Record<string, unknown> {
   label: string;
   uri: string;
+  characteristics?: OWLCharacteristic[];
 }
 
 export interface SubClassEdgeData extends Record<string, unknown> {
@@ -151,7 +152,7 @@ export function ontologyToReactFlowElements(
           source: domainUri,
           target: rangeUri,
           type: 'objectProperty',
-          data: { label, uri: prop.uri },
+          data: { label, uri: prop.uri, characteristics: prop.characteristics },
         });
       }
     }

--- a/apps/desktop/src/renderer/src/model/types.ts
+++ b/apps/desktop/src/renderer/src/model/types.ts
@@ -45,6 +45,13 @@ export interface OntologyClass {
   restrictions?: Restriction[];
 }
 
+export type OWLCharacteristic =
+  | 'transitive'
+  | 'symmetric'
+  | 'reflexive'
+  | 'functional'
+  | 'inverseFunctional';
+
 export interface ObjectProperty {
   uri: string;
   label?: string;
@@ -54,6 +61,7 @@ export interface ObjectProperty {
   minCardinality?: number;
   maxCardinality?: number;
   inverseOf?: string;
+  characteristics: OWLCharacteristic[];
 }
 
 export interface DatatypeProperty {

--- a/apps/desktop/src/renderer/src/store/ontology.ts
+++ b/apps/desktop/src/renderer/src/store/ontology.ts
@@ -184,6 +184,7 @@ export const useOntologyStore = create<OntologyState>((set, get) => ({
         uri,
         domain: [],
         range: [],
+        characteristics: [],
         ...partial,
       });
       track('object_property_added');

--- a/apps/desktop/tests/components/CharacteristicBadge.test.tsx
+++ b/apps/desktop/tests/components/CharacteristicBadge.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const { CharacteristicBadge } = await import('@renderer/components/detail/CharacteristicBadge');
+
+describe('CharacteristicBadge', () => {
+  afterEach(cleanup);
+
+  describe('label rendering', () => {
+    it('renders "Transitive" for transitive', () => {
+      render(<CharacteristicBadge characteristic="transitive" />);
+      expect(screen.getByText('Transitive')).toBeInTheDocument();
+    });
+
+    it('renders "Symmetric" for symmetric', () => {
+      render(<CharacteristicBadge characteristic="symmetric" />);
+      expect(screen.getByText('Symmetric')).toBeInTheDocument();
+    });
+
+    it('renders "Reflexive" for reflexive', () => {
+      render(<CharacteristicBadge characteristic="reflexive" />);
+      expect(screen.getByText('Reflexive')).toBeInTheDocument();
+    });
+
+    it('renders "Functional" for functional', () => {
+      render(<CharacteristicBadge characteristic="functional" />);
+      expect(screen.getByText('Functional')).toBeInTheDocument();
+    });
+
+    it('renders "Inv. Functional" for inverseFunctional', () => {
+      render(<CharacteristicBadge characteristic="inverseFunctional" />);
+      expect(screen.getByText('Inv. Functional')).toBeInTheDocument();
+    });
+  });
+
+  describe('tooltip help text', () => {
+    it('transitive badge has tooltip describing inference', () => {
+      render(<CharacteristicBadge characteristic="transitive" />);
+      // The tooltip trigger element should carry the help text as accessible title or aria-label
+      // shadcn Tooltip wraps — check that tooltip content is present in DOM
+      expect(screen.getByText(/A→B.*B→C.*A→C/i)).toBeInTheDocument();
+    });
+
+    it('symmetric badge has tooltip describing inference', () => {
+      render(<CharacteristicBadge characteristic="symmetric" />);
+      expect(screen.getByText(/A→B.*B→A/i)).toBeInTheDocument();
+    });
+
+    it('reflexive badge has tooltip describing self-relation', () => {
+      render(<CharacteristicBadge characteristic="reflexive" />);
+      expect(screen.getByText(/every individual.*itself/i)).toBeInTheDocument();
+    });
+
+    it('functional badge has tooltip describing single-value constraint', () => {
+      render(<CharacteristicBadge characteristic="functional" />);
+      expect(screen.getByText(/at most one value/i)).toBeInTheDocument();
+    });
+
+    it('inverseFunctional badge has tooltip describing single-subject constraint', () => {
+      render(<CharacteristicBadge characteristic="inverseFunctional" />);
+      expect(screen.getByText(/at most one subject/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('visual structure', () => {
+    it('renders a Badge element (secondary variant class)', () => {
+      const { container } = render(<CharacteristicBadge characteristic="transitive" />);
+      // shadcn Badge with variant="secondary" renders with secondary styling
+      const badge = container.querySelector('[class*="secondary"], [data-slot="badge"]');
+      expect(badge).not.toBeNull();
+    });
+
+    it('renders exactly one badge per characteristic', () => {
+      render(<CharacteristicBadge characteristic="functional" />);
+      expect(screen.getAllByText('Functional')).toHaveLength(1);
+    });
+  });
+});

--- a/apps/desktop/tests/components/EdgeDetail.test.tsx
+++ b/apps/desktop/tests/components/EdgeDetail.test.tsx
@@ -1,0 +1,148 @@
+import { useOntologyStore } from '@renderer/store/ontology';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const { EdgeDetail } = await import('@renderer/components/detail/EdgeDetail');
+
+const BASE_PROP = {
+  uri: 'http://ex/rel',
+  domain: [],
+  range: [],
+  characteristics: [] as import('@renderer/model/types').OWLCharacteristic[],
+};
+
+function resetStore() {
+  useOntologyStore.getState().reset();
+}
+
+describe('EdgeDetail — Characteristics section', () => {
+  beforeEach(resetStore);
+  afterEach(cleanup);
+
+  describe('no characteristics', () => {
+    it('does not render Characteristics section when array is empty', () => {
+      render(<EdgeDetail property={{ ...BASE_PROP, characteristics: [] }} type="objectProperty" />);
+      expect(screen.queryByText('Characteristics')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('single characteristic', () => {
+    it('renders Characteristics section heading when characteristics present', () => {
+      render(
+        <EdgeDetail
+          property={{ ...BASE_PROP, characteristics: ['transitive'] }}
+          type="objectProperty"
+        />,
+      );
+      expect(screen.getByText('Characteristics')).toBeInTheDocument();
+    });
+
+    it('shows Transitive badge', () => {
+      render(
+        <EdgeDetail
+          property={{ ...BASE_PROP, characteristics: ['transitive'] }}
+          type="objectProperty"
+        />,
+      );
+      expect(screen.getByText('Transitive')).toBeInTheDocument();
+    });
+
+    it('shows Symmetric badge', () => {
+      render(
+        <EdgeDetail
+          property={{ ...BASE_PROP, characteristics: ['symmetric'] }}
+          type="objectProperty"
+        />,
+      );
+      expect(screen.getByText('Symmetric')).toBeInTheDocument();
+    });
+
+    it('shows Reflexive badge', () => {
+      render(
+        <EdgeDetail
+          property={{ ...BASE_PROP, characteristics: ['reflexive'] }}
+          type="objectProperty"
+        />,
+      );
+      expect(screen.getByText('Reflexive')).toBeInTheDocument();
+    });
+
+    it('shows Functional badge', () => {
+      render(
+        <EdgeDetail
+          property={{ ...BASE_PROP, characteristics: ['functional'] }}
+          type="objectProperty"
+        />,
+      );
+      expect(screen.getByText('Functional')).toBeInTheDocument();
+    });
+
+    it('shows Inv. Functional badge', () => {
+      render(
+        <EdgeDetail
+          property={{ ...BASE_PROP, characteristics: ['inverseFunctional'] }}
+          type="objectProperty"
+        />,
+      );
+      expect(screen.getByText('Inv. Functional')).toBeInTheDocument();
+    });
+  });
+
+  describe('multiple characteristics', () => {
+    it('renders all provided characteristic badges', () => {
+      render(
+        <EdgeDetail
+          property={{
+            ...BASE_PROP,
+            characteristics: [
+              'transitive',
+              'symmetric',
+              'reflexive',
+              'functional',
+              'inverseFunctional',
+            ],
+          }}
+          type="objectProperty"
+        />,
+      );
+      expect(screen.getByText('Transitive')).toBeInTheDocument();
+      expect(screen.getByText('Symmetric')).toBeInTheDocument();
+      expect(screen.getByText('Reflexive')).toBeInTheDocument();
+      expect(screen.getByText('Functional')).toBeInTheDocument();
+      expect(screen.getByText('Inv. Functional')).toBeInTheDocument();
+    });
+
+    it('renders two characteristics without duplicates', () => {
+      render(
+        <EdgeDetail
+          property={{ ...BASE_PROP, characteristics: ['transitive', 'functional'] }}
+          type="objectProperty"
+        />,
+      );
+      expect(screen.getAllByText('Transitive')).toHaveLength(1);
+      expect(screen.getAllByText('Functional')).toHaveLength(1);
+    });
+  });
+
+  describe('section ordering', () => {
+    it('Characteristics section appears before Domain section', () => {
+      render(
+        <EdgeDetail
+          property={{
+            ...BASE_PROP,
+            characteristics: ['transitive'],
+            domain: ['http://ex/Person'],
+            range: [],
+          }}
+          type="objectProperty"
+        />,
+      );
+      const charHeading = screen.getByText('Characteristics');
+      const domainHeading = screen.getByText('Domain');
+      // compareDocumentPosition: 4 = DOCUMENT_POSITION_FOLLOWING (domain comes after characteristics)
+      expect(
+        charHeading.compareDocumentPosition(domainHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+  });
+});

--- a/apps/desktop/tests/components/ObjectPropertyEdge.test.tsx
+++ b/apps/desktop/tests/components/ObjectPropertyEdge.test.tsx
@@ -1,0 +1,222 @@
+import { useUIStore } from '@renderer/store/ui';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock @xyflow/react — component uses BaseEdge, EdgeLabelRenderer, getBezierPath, useInternalNode
+vi.mock('@xyflow/react', () => ({
+  BaseEdge: ({ id }: { id: string }) => <path data-testid={`base-edge-${id}`} />,
+  EdgeLabelRenderer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  getBezierPath: () => ['M0 0', 50, 50],
+  useInternalNode: vi.fn(() => ({
+    internals: {
+      positionAbsolute: { x: 0, y: 0 },
+      handleBounds: { source: [], target: [] },
+    },
+    measured: { width: 100, height: 40 },
+  })),
+  Position: { Left: 'left', Top: 'top', Right: 'right', Bottom: 'bottom' },
+}));
+
+const { ObjectPropertyEdge } = await import('@renderer/components/graph/edges/ObjectPropertyEdge');
+
+const EDGE_BASE = {
+  id: 'test-edge',
+  source: 'node-a',
+  target: 'node-b',
+  selected: false,
+  type: 'objectProperty',
+  sourceX: 0,
+  sourceY: 0,
+  targetX: 100,
+  targetY: 0,
+  sourcePosition: 'right' as const,
+  targetPosition: 'left' as const,
+};
+
+function resetStore() {
+  useUIStore.setState({ selectedNodeId: null, adjacentEdgeIds: [] });
+}
+
+describe('ObjectPropertyEdge — characteristic badge row', () => {
+  beforeEach(resetStore);
+  afterEach(cleanup);
+
+  describe('no characteristics', () => {
+    it('renders without badge row when characteristics is empty', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'knows', uri: 'http://ex/knows', characteristics: [] }}
+        />,
+      );
+      expect(screen.queryByText('T')).not.toBeInTheDocument();
+      expect(screen.queryByText('S')).not.toBeInTheDocument();
+      expect(screen.queryByText('R')).not.toBeInTheDocument();
+      expect(screen.queryByText('F')).not.toBeInTheDocument();
+      expect(screen.queryByText('IF')).not.toBeInTheDocument();
+    });
+
+    it('renders without badge row when characteristics is undefined (backwards compat)', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'knows', uri: 'http://ex/knows' } as never}
+        />,
+      );
+      expect(screen.queryByText('T')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('single characteristic abbreviations', () => {
+    it('renders T badge for transitive', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'p', uri: 'http://ex/p', characteristics: ['transitive'] }}
+        />,
+      );
+      expect(screen.getByText('T')).toBeInTheDocument();
+    });
+
+    it('renders S badge for symmetric', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'p', uri: 'http://ex/p', characteristics: ['symmetric'] }}
+        />,
+      );
+      expect(screen.getByText('S')).toBeInTheDocument();
+    });
+
+    it('renders R badge for reflexive', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'p', uri: 'http://ex/p', characteristics: ['reflexive'] }}
+        />,
+      );
+      expect(screen.getByText('R')).toBeInTheDocument();
+    });
+
+    it('renders F badge for functional', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'p', uri: 'http://ex/p', characteristics: ['functional'] }}
+        />,
+      );
+      expect(screen.getByText('F')).toBeInTheDocument();
+    });
+
+    it('renders IF badge for inverseFunctional', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'p', uri: 'http://ex/p', characteristics: ['inverseFunctional'] }}
+        />,
+      );
+      expect(screen.getByText('IF')).toBeInTheDocument();
+    });
+  });
+
+  describe('multiple characteristics', () => {
+    it('renders all five abbreviation badges', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{
+            label: 'p',
+            uri: 'http://ex/p',
+            characteristics: [
+              'transitive',
+              'symmetric',
+              'reflexive',
+              'functional',
+              'inverseFunctional',
+            ],
+          }}
+        />,
+      );
+      expect(screen.getByText('T')).toBeInTheDocument();
+      expect(screen.getByText('S')).toBeInTheDocument();
+      expect(screen.getByText('R')).toBeInTheDocument();
+      expect(screen.getByText('F')).toBeInTheDocument();
+      expect(screen.getByText('IF')).toBeInTheDocument();
+    });
+
+    it('renders exactly one badge per characteristic — no duplicates', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'p', uri: 'http://ex/p', characteristics: ['transitive', 'transitive'] }}
+        />,
+      );
+      // Should deduplicate or only render once per unique characteristic
+      expect(screen.getAllByText('T')).toHaveLength(1);
+    });
+  });
+
+  describe('tooltip on badges', () => {
+    it('T badge has title "Transitive"', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'p', uri: 'http://ex/p', characteristics: ['transitive'] }}
+        />,
+      );
+      const badge = screen.getByText('T');
+      expect(badge.closest('[title]')?.getAttribute('title')).toBe('Transitive');
+    });
+
+    it('IF badge has title "Inverse Functional"', () => {
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'p', uri: 'http://ex/p', characteristics: ['inverseFunctional'] }}
+        />,
+      );
+      const badge = screen.getByText('IF');
+      expect(badge.closest('[title]')?.getAttribute('title')).toBe('Inverse Functional');
+    });
+  });
+
+  describe('dimming behavior', () => {
+    it('badge row container has same opacity as edge when not dimmed', () => {
+      useUIStore.setState({ selectedNodeId: null, adjacentEdgeIds: [] });
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'p', uri: 'http://ex/p', characteristics: ['transitive'] }}
+        />,
+      );
+      const tBadge = screen.getByText('T');
+      // The badge row should not have opacity: 0.15 when not dimmed
+      const badgeRow = tBadge.closest('div');
+      const style = badgeRow?.style?.opacity;
+      expect(style).not.toBe('0.15');
+    });
+
+    it('badge row dims when a different node is selected', () => {
+      useUIStore.setState({ selectedNodeId: 'node-c', adjacentEdgeIds: [] });
+      render(
+        <ObjectPropertyEdge
+          {...EDGE_BASE}
+          data={{ label: 'p', uri: 'http://ex/p', characteristics: ['transitive'] }}
+        />,
+      );
+      // The wrapping container for the whole edge group should carry opacity 0.15
+      const tBadge = screen.getByText('T');
+      // Walk up until we find an element with opacity style
+      let el: HTMLElement | null = tBadge;
+      let foundDimmed = false;
+      while (el) {
+        if (el.style?.opacity === '0.15') {
+          foundDimmed = true;
+          break;
+        }
+        el = el.parentElement;
+      }
+      expect(foundDimmed).toBe(true);
+    });
+  });
+});

--- a/apps/desktop/tests/components/ObjectPropertyEdge.test.tsx
+++ b/apps/desktop/tests/components/ObjectPropertyEdge.test.tsx
@@ -2,7 +2,7 @@ import { useUIStore } from '@renderer/store/ui';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock @xyflow/react — component uses BaseEdge, EdgeLabelRenderer, getBezierPath, useInternalNode
+// Mock @xyflow/react — component uses BaseEdge, EdgeLabelRenderer, getBezierPath, useInternalNode, useEdges
 vi.mock('@xyflow/react', () => ({
   BaseEdge: ({ id }: { id: string }) => <path data-testid={`base-edge-${id}`} />,
   EdgeLabelRenderer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -14,6 +14,7 @@ vi.mock('@xyflow/react', () => ({
     },
     measured: { width: 100, height: 40 },
   })),
+  useEdges: vi.fn(() => []),
   Position: { Left: 'left', Top: 'top', Right: 'right', Bottom: 'bottom' },
 }));
 

--- a/apps/desktop/tests/model/owl-characteristics.test.ts
+++ b/apps/desktop/tests/model/owl-characteristics.test.ts
@@ -1,0 +1,170 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseTurtle, parseTurtleWithWarnings } from '@renderer/model/parse';
+import type { ObjectProperty } from '@renderer/model/types';
+import { describe, expect, it } from 'vitest';
+
+const EX = 'http://example.org/characteristics#';
+
+const characteristicsTurtle = readFileSync(
+  resolve(__dirname, '../../resources/sample-ontologies/owl-characteristics.ttl'),
+  'utf-8',
+);
+
+describe('OWL property characteristics parsing', () => {
+  it('parses without errors', () => {
+    const { warnings } = parseTurtleWithWarnings(characteristicsTurtle);
+    const errors = warnings.filter((w) => w.severity === 'error');
+    expect(errors).toEqual([]);
+  });
+
+  describe('single characteristics', () => {
+    it('detects owl:TransitiveProperty', () => {
+      const ontology = parseTurtle(characteristicsTurtle);
+      const prop = ontology.objectProperties.get(`${EX}hasAncestor`) as ObjectProperty;
+      expect(prop).toBeDefined();
+      expect(prop.characteristics).toContain('transitive');
+      expect(prop.characteristics).toHaveLength(1);
+    });
+
+    it('detects owl:SymmetricProperty', () => {
+      const ontology = parseTurtle(characteristicsTurtle);
+      const prop = ontology.objectProperties.get(`${EX}hasSibling`) as ObjectProperty;
+      expect(prop).toBeDefined();
+      expect(prop.characteristics).toContain('symmetric');
+      expect(prop.characteristics).toHaveLength(1);
+    });
+
+    it('detects owl:ReflexiveProperty', () => {
+      const ontology = parseTurtle(characteristicsTurtle);
+      const prop = ontology.objectProperties.get(`${EX}knows`) as ObjectProperty;
+      expect(prop).toBeDefined();
+      expect(prop.characteristics).toContain('reflexive');
+      expect(prop.characteristics).toHaveLength(1);
+    });
+
+    it('detects owl:FunctionalProperty', () => {
+      const ontology = parseTurtle(characteristicsTurtle);
+      const prop = ontology.objectProperties.get(`${EX}hasBiologicalMother`) as ObjectProperty;
+      expect(prop).toBeDefined();
+      expect(prop.characteristics).toContain('functional');
+      expect(prop.characteristics).toHaveLength(1);
+    });
+
+    it('detects owl:InverseFunctionalProperty', () => {
+      const ontology = parseTurtle(characteristicsTurtle);
+      const prop = ontology.objectProperties.get(`${EX}hasSSN`) as ObjectProperty;
+      expect(prop).toBeDefined();
+      expect(prop.characteristics).toContain('inverseFunctional');
+      expect(prop.characteristics).toHaveLength(1);
+    });
+  });
+
+  describe('multiple characteristics', () => {
+    it('detects two characteristics on one property', () => {
+      const ontology = parseTurtle(characteristicsTurtle);
+      const prop = ontology.objectProperties.get(`${EX}hasUniqueAncestor`) as ObjectProperty;
+      expect(prop).toBeDefined();
+      expect(prop.characteristics).toHaveLength(2);
+      expect(prop.characteristics).toContain('transitive');
+      expect(prop.characteristics).toContain('functional');
+    });
+
+    it('detects all five characteristics on one property', () => {
+      const ontology = parseTurtle(characteristicsTurtle);
+      const prop = ontology.objectProperties.get(`${EX}hasAll`) as ObjectProperty;
+      expect(prop).toBeDefined();
+      expect(prop.characteristics).toHaveLength(5);
+      expect(prop.characteristics).toContain('transitive');
+      expect(prop.characteristics).toContain('symmetric');
+      expect(prop.characteristics).toContain('reflexive');
+      expect(prop.characteristics).toContain('functional');
+      expect(prop.characteristics).toContain('inverseFunctional');
+    });
+  });
+
+  describe('no characteristics', () => {
+    it('returns empty characteristics array for plain property', () => {
+      const ontology = parseTurtle(characteristicsTurtle);
+      const prop = ontology.objectProperties.get(`${EX}worksFor`) as ObjectProperty;
+      expect(prop).toBeDefined();
+      expect(prop.characteristics).toEqual([]);
+    });
+  });
+
+  describe('existing ontology compatibility', () => {
+    it('properties parsed from people.ttl have empty characteristics array', () => {
+      const peopleTurtle = readFileSync(
+        resolve(__dirname, '../../resources/sample-ontologies/people.ttl'),
+        'utf-8',
+      );
+      const ontology = parseTurtle(peopleTurtle);
+      for (const prop of ontology.objectProperties.values()) {
+        expect(prop.characteristics).toBeDefined();
+        expect(Array.isArray(prop.characteristics)).toBe(true);
+        expect(prop.characteristics).toEqual([]);
+      }
+    });
+  });
+
+  describe('inline TTL snippets', () => {
+    it('handles property declared as ObjectProperty and characteristic in separate triples', () => {
+      const ttl = `
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex: <http://ex.org/> .
+        ex:p rdf:type owl:ObjectProperty .
+        ex:p rdf:type owl:SymmetricProperty .
+      `;
+      const ontology = parseTurtle(ttl);
+      const prop = ontology.objectProperties.get('http://ex.org/p') as ObjectProperty;
+      expect(prop).toBeDefined();
+      expect(prop.characteristics).toContain('symmetric');
+    });
+
+    it('handles characteristic declared before ObjectProperty type triple', () => {
+      const ttl = `
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex: <http://ex.org/> .
+        ex:p rdf:type owl:TransitiveProperty .
+        ex:p rdf:type owl:ObjectProperty .
+      `;
+      const ontology = parseTurtle(ttl);
+      const prop = ontology.objectProperties.get('http://ex.org/p') as ObjectProperty;
+      expect(prop).toBeDefined();
+      expect(prop.characteristics).toContain('transitive');
+    });
+
+    it('does not add characteristic tokens to non-object-properties', () => {
+      const ttl = `
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+        @prefix ex: <http://ex.org/> .
+        ex:dp rdf:type owl:DatatypeProperty ;
+          rdfs:range xsd:string .
+      `;
+      const ontology = parseTurtle(ttl);
+      // Should not appear as an object property
+      expect(ontology.objectProperties.has('http://ex.org/dp')).toBe(false);
+    });
+
+    it('does not emit unsupported warning for characteristic type triples', () => {
+      const ttl = `
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex: <http://ex.org/> .
+        ex:p rdf:type owl:ObjectProperty ;
+          rdf:type owl:TransitiveProperty ;
+          rdf:type owl:SymmetricProperty .
+      `;
+      const { warnings } = parseTurtleWithWarnings(ttl);
+      const unsupportedForP = warnings.filter(
+        (w) => w.message.includes('ex.org/p') && w.message.toLowerCase().includes('unsupported'),
+      );
+      expect(unsupportedForP).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `OWLCharacteristic` type and `characteristics[]` to `ObjectProperty` — parses `owl:TransitiveProperty`, `owl:SymmetricProperty`, `owl:ReflexiveProperty`, `owl:FunctionalProperty`, `owl:InverseFunctionalProperty` via `rdf:type` triples (order-independent)
- Graph edges show compact `T`/`S`/`R`/`F`/`IF` badge row below property label, with `title` tooltip and `isDimmed` opacity support
- `EdgeDetail` panel shows full characteristic labels (`Transitive`, `Symmetric`, etc.) with accessible tooltip text, between the label block and Domain section
- New `CharacteristicBadge` component (shadcn `Badge` + sr-only tooltip text)
- CSS tokens for light/dark theme badge styling

## Test plan

- [ ] 14 parse tests (`owl-characteristics.test.ts`) — all 5 chars, multi-char, order-independence, backwards compat
- [ ] 12 `CharacteristicBadge` tests — label rendering, tooltip text in DOM, visual structure
- [ ] 10 `EdgeDetail` tests — section shown/hidden, all labels, DOM ordering
- [ ] 13 `ObjectPropertyEdge` tests — abbreviations, dedup, title attrs, dimming behaviour
- [ ] All 465 tests pass

Closes ONT-82

🤖 Generated with [Claude Code](https://claude.com/claude-code)