### PR TITLE
feat(desktop): OWL consistency checking — detect logical contradictions (ONT-131)

### DIFF
--- a/apps/desktop/resources/sample-ontologies/owl-consistency-errors.ttl
+++ b/apps/desktop/resources/sample-ontologies/owl-consistency-errors.ttl
@@ -1,0 +1,116 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://example.org/consistency-errors#> .
+
+# OWL Consistency Error Demo Ontology
+# Loads into the Ontograph desktop app to visually test consistency-error
+# reporting. Each section deliberately introduces a semantic contradiction
+# that the validator should flag as an error.
+
+ex:ConsistencyErrorsOntology rdf:type owl:Ontology ;
+  rdfs:comment "Sample ontology containing intentional OWL contradictions for UI testing." .
+
+# ────────────────────────────────────────────────────────────────────────────
+# ERROR 1: Self-disjoint class
+# A class declared disjoint with itself can never have any instances.
+# Expected error: "Class is declared disjoint with itself (unsatisfiable)"
+# ────────────────────────────────────────────────────────────────────────────
+
+ex:ImpossibleThing rdf:type owl:Class ;
+  rdfs:label "ImpossibleThing" ;
+  rdfs:comment "Self-disjoint: declared disjoint with itself." ;
+  owl:disjointWith ex:ImpossibleThing .
+
+# ────────────────────────────────────────────────────────────────────────────
+# ERROR 2: Subclass-disjoint conflict
+# Elephant is declared a subclass of Animal, but also disjoint with Animal.
+# A subclass must share all instances of its parent, so disjointness is a
+# direct contradiction.
+# Expected error: "Class is both a subclass and disjoint with Animal (unsatisfiable)"
+# ────────────────────────────────────────────────────────────────────────────
+
+ex:Animal rdf:type owl:Class ;
+  rdfs:label "Animal" .
+
+ex:Elephant rdf:type owl:Class ;
+  rdfs:label "Elephant" ;
+  rdfs:comment "Subclass-disjoint conflict: subclass of Animal yet disjoint with it." ;
+  rdfs:subClassOf ex:Animal ;
+  owl:disjointWith ex:Animal .
+
+# ────────────────────────────────────────────────────────────────────────────
+# ERROR 3: Multiple inheritance from mutually disjoint ancestors
+# Platypus inherits from both Mammal and Bird. Mammal and Bird are declared
+# disjoint, so no class can be a member of both. Platypus is therefore
+# unsatisfiable.
+# Expected error: "Class inherits from mutually disjoint classes Mammal and Bird"
+# ────────────────────────────────────────────────────────────────────────────
+
+ex:Mammal rdf:type owl:Class ;
+  rdfs:label "Mammal" ;
+  rdfs:subClassOf ex:Animal ;
+  owl:disjointWith ex:Bird .
+
+ex:Bird rdf:type owl:Class ;
+  rdfs:label "Bird" ;
+  rdfs:subClassOf ex:Animal ;
+  owl:disjointWith ex:Mammal .
+
+ex:Platypus rdf:type owl:Class ;
+  rdfs:label "Platypus" ;
+  rdfs:comment "Inherits from both Mammal and Bird, which are mutually disjoint." ;
+  rdfs:subClassOf ex:Mammal ;
+  rdfs:subClassOf ex:Bird .
+
+# ────────────────────────────────────────────────────────────────────────────
+# ERROR 4: Functional property with minCardinality > 1
+# A functional property can link a subject to at most one value. Requiring a
+# minimum of 2 values contradicts that constraint directly.
+# Expected error: "Functional property has minCardinality 2, contradicting
+# the max-1 functional restriction"
+# ────────────────────────────────────────────────────────────────────────────
+
+ex:Person rdf:type owl:Class ;
+  rdfs:label "Person" .
+
+ex:hasMother rdf:type owl:ObjectProperty ;
+  rdf:type owl:FunctionalProperty ;
+  rdfs:label "has mother" ;
+  rdfs:domain ex:Person ;
+  rdfs:range ex:Person ;
+  rdfs:comment "Functional (max 1 value) but minCardinality 2 — direct contradiction." .
+
+ex:Person rdfs:subClassOf [
+  rdf:type owl:Restriction ;
+  owl:onProperty ex:hasMother ;
+  owl:minCardinality "2"^^xsd:nonNegativeInteger
+] .
+
+# ────────────────────────────────────────────────────────────────────────────
+# VALID classes (no errors expected)
+# These demonstrate correct modelling alongside the erroneous declarations so
+# the graph still renders with some valid structure.
+# ────────────────────────────────────────────────────────────────────────────
+
+ex:Plant rdf:type owl:Class ;
+  rdfs:label "Plant" ;
+  owl:disjointWith ex:Animal .
+
+ex:Tree rdf:type owl:Class ;
+  rdfs:label "Tree" ;
+  rdfs:subClassOf ex:Plant .
+
+ex:Dog rdf:type owl:Class ;
+  rdfs:label "Dog" ;
+  rdfs:subClassOf ex:Mammal .
+
+ex:Eagle rdf:type owl:Class ;
+  rdfs:label "Eagle" ;
+  rdfs:subClassOf ex:Bird .
+
+ex:hasParent rdf:type owl:ObjectProperty ;
+  rdfs:label "has parent" ;
+  rdfs:domain ex:Animal ;
+  rdfs:range ex:Animal .

--- a/apps/desktop/src/renderer/src/services/validation.ts
+++ b/apps/desktop/src/renderer/src/services/validation.ts
@@ -170,6 +170,106 @@ export function validateOntology(ontology: Ontology): ValidationError[] {
     }
   }
 
+  // OWL consistency checks (semantic contradictions)
+  errors.push(...checkOWLConsistency(ontology));
+
+  return errors;
+}
+
+/**
+ * Detects semantic contradictions that make classes logically unsatisfiable:
+ * 1. Self-disjoint: A disjointWith A
+ * 2. Subclass-disjoint conflict: A subClassOf B AND A disjointWith B
+ * 3. Multiple inheritance from mutually disjoint ancestors: A subClassOf B, A subClassOf C, B disjointWith C
+ * 4. Functional property with minCardinality > 1
+ */
+function checkOWLConsistency(ontology: Ontology): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  // Build a symmetric index of disjoint pairs for O(1) lookup
+  const disjointPairs = new Set<string>();
+  for (const cls of ontology.classes.values()) {
+    for (const djUri of cls.disjointWith) {
+      disjointPairs.add([cls.uri, djUri].sort().join('\0'));
+    }
+  }
+  const isDisjoint = (a: string, b: string): boolean => disjointPairs.has([a, b].sort().join('\0'));
+
+  // Collect all transitive ancestors for a class (BFS, cycle-safe)
+  const getAncestors = (uri: string): string[] => {
+    const visited = new Set<string>();
+    const queue = [...(ontology.classes.get(uri)?.subClassOf ?? [])];
+    while (queue.length > 0) {
+      const cur = queue.shift();
+      if (cur === undefined || visited.has(cur)) continue;
+      visited.add(cur);
+      const curCls = ontology.classes.get(cur);
+      if (curCls) {
+        for (const parent of curCls.subClassOf) {
+          if (!visited.has(parent)) queue.push(parent);
+        }
+      }
+    }
+    return [...visited];
+  };
+
+  for (const cls of ontology.classes.values()) {
+    // Check 1: self-disjoint
+    if (cls.disjointWith.includes(cls.uri)) {
+      errors.push({
+        severity: 'error',
+        message: 'Class is declared disjoint with itself (unsatisfiable)',
+        elementUri: cls.uri,
+        elementType: 'class',
+      });
+    }
+
+    // Check 2: subclass of a class it is also disjoint with
+    for (const parentUri of cls.subClassOf) {
+      if (isDisjoint(cls.uri, parentUri)) {
+        errors.push({
+          severity: 'error',
+          message: `Class is both a subclass and disjoint with "${localName(parentUri)}" (unsatisfiable)`,
+          elementUri: cls.uri,
+          elementType: 'class',
+        });
+      }
+    }
+
+    // Check 3: inherits from two mutually disjoint ancestors
+    const ancestors = getAncestors(cls.uri);
+    let foundAncestorConflict = false;
+    for (let i = 0; i < ancestors.length && !foundAncestorConflict; i++) {
+      for (let j = i + 1; j < ancestors.length && !foundAncestorConflict; j++) {
+        if (isDisjoint(ancestors[i], ancestors[j])) {
+          errors.push({
+            severity: 'error',
+            message: `Class inherits from mutually disjoint classes "${localName(ancestors[i])}" and "${localName(ancestors[j])}" (unsatisfiable)`,
+            elementUri: cls.uri,
+            elementType: 'class',
+          });
+          foundAncestorConflict = true;
+        }
+      }
+    }
+  }
+
+  // Check 4: functional property with minCardinality > 1
+  for (const prop of ontology.objectProperties.values()) {
+    if (
+      prop.characteristics?.includes('functional') &&
+      prop.minCardinality !== undefined &&
+      prop.minCardinality > 1
+    ) {
+      errors.push({
+        severity: 'error',
+        message: `Functional property has minCardinality ${prop.minCardinality}, contradicting the max-1 functional restriction`,
+        elementUri: prop.uri,
+        elementType: 'objectProperty',
+      });
+    }
+  }
+
   return errors;
 }
 

--- a/apps/desktop/tests/services/validation.test.ts
+++ b/apps/desktop/tests/services/validation.test.ts
@@ -259,3 +259,232 @@ describe('validateOntology — individuals', () => {
     ).toBe(true);
   });
 });
+
+describe('validateOntology — OWL consistency checks', () => {
+  it('detects self-disjoint class', () => {
+    const o = makeOntology((o) => {
+      o.classes.set(`${EX}Paradox`, {
+        uri: `${EX}Paradox`,
+        label: 'Paradox',
+        subClassOf: [],
+        disjointWith: [`${EX}Paradox`],
+      });
+    });
+    const errors = validateOntology(o);
+    expect(
+      errors.some((e) => e.severity === 'error' && e.message.includes('disjoint with itself')),
+    ).toBe(true);
+  });
+
+  it('detects subclass-disjoint conflict (A subClassOf B AND A disjointWith B)', () => {
+    const o = makeOntology((o) => {
+      o.classes.set(`${EX}Animal`, {
+        uri: `${EX}Animal`,
+        label: 'Animal',
+        subClassOf: [],
+        disjointWith: [],
+      });
+      o.classes.set(`${EX}Plant`, {
+        uri: `${EX}Plant`,
+        label: 'Plant',
+        subClassOf: [`${EX}Animal`],
+        disjointWith: [`${EX}Animal`],
+      });
+    });
+    const errors = validateOntology(o);
+    expect(
+      errors.some(
+        (e) =>
+          e.elementUri === `${EX}Plant` &&
+          e.severity === 'error' &&
+          e.message.includes('subclass and disjoint'),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects subclass-disjoint conflict when disjointness is stated on the parent', () => {
+    const o = makeOntology((o) => {
+      // Animal disjointWith Plant, but Plant subClassOf Animal — conflict detected via symmetry
+      o.classes.set(`${EX}Animal`, {
+        uri: `${EX}Animal`,
+        label: 'Animal',
+        subClassOf: [],
+        disjointWith: [`${EX}Plant`],
+      });
+      o.classes.set(`${EX}Plant`, {
+        uri: `${EX}Plant`,
+        label: 'Plant',
+        subClassOf: [`${EX}Animal`],
+        disjointWith: [],
+      });
+    });
+    const errors = validateOntology(o);
+    expect(
+      errors.some(
+        (e) =>
+          e.elementUri === `${EX}Plant` &&
+          e.severity === 'error' &&
+          e.message.includes('subclass and disjoint'),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects class inheriting from mutually disjoint ancestors', () => {
+    const o = makeOntology((o) => {
+      o.classes.set(`${EX}Cat`, {
+        uri: `${EX}Cat`,
+        label: 'Cat',
+        subClassOf: [],
+        disjointWith: [`${EX}Dog`],
+      });
+      o.classes.set(`${EX}Dog`, {
+        uri: `${EX}Dog`,
+        label: 'Dog',
+        subClassOf: [],
+        disjointWith: [],
+      });
+      // CatDog inherits from both Cat and Dog which are disjoint → unsatisfiable
+      o.classes.set(`${EX}CatDog`, {
+        uri: `${EX}CatDog`,
+        label: 'CatDog',
+        subClassOf: [`${EX}Cat`, `${EX}Dog`],
+        disjointWith: [],
+      });
+    });
+    const errors = validateOntology(o);
+    expect(
+      errors.some(
+        (e) =>
+          e.elementUri === `${EX}CatDog` &&
+          e.severity === 'error' &&
+          e.message.includes('mutually disjoint'),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects unsatisfiable class via transitive ancestor disjointness', () => {
+    const o = makeOntology((o) => {
+      // A disjointWith B
+      // C subClassOf A
+      // D subClassOf B
+      // E subClassOf C AND D  →  E inherits from disjoint ancestors A and B
+      o.classes.set(`${EX}A`, {
+        uri: `${EX}A`,
+        label: 'A',
+        subClassOf: [],
+        disjointWith: [`${EX}B`],
+      });
+      o.classes.set(`${EX}B`, {
+        uri: `${EX}B`,
+        label: 'B',
+        subClassOf: [],
+        disjointWith: [],
+      });
+      o.classes.set(`${EX}C`, {
+        uri: `${EX}C`,
+        label: 'C',
+        subClassOf: [`${EX}A`],
+        disjointWith: [],
+      });
+      o.classes.set(`${EX}D`, {
+        uri: `${EX}D`,
+        label: 'D',
+        subClassOf: [`${EX}B`],
+        disjointWith: [],
+      });
+      o.classes.set(`${EX}E`, {
+        uri: `${EX}E`,
+        label: 'E',
+        subClassOf: [`${EX}C`, `${EX}D`],
+        disjointWith: [],
+      });
+    });
+    const errors = validateOntology(o);
+    expect(
+      errors.some(
+        (e) =>
+          e.elementUri === `${EX}E` &&
+          e.severity === 'error' &&
+          e.message.includes('mutually disjoint'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not flag valid multiple inheritance without disjointness', () => {
+    const o = makeOntology((o) => {
+      o.classes.set(`${EX}Living`, {
+        uri: `${EX}Living`,
+        label: 'Living',
+        subClassOf: [],
+        disjointWith: [],
+      });
+      o.classes.set(`${EX}Aquatic`, {
+        uri: `${EX}Aquatic`,
+        label: 'Aquatic',
+        subClassOf: [],
+        disjointWith: [],
+      });
+      o.classes.set(`${EX}Fish`, {
+        uri: `${EX}Fish`,
+        label: 'Fish',
+        subClassOf: [`${EX}Living`, `${EX}Aquatic`],
+        disjointWith: [],
+      });
+    });
+    const errors = validateOntology(o).filter(
+      (e) => e.severity === 'error' && e.elementUri === `${EX}Fish`,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('detects functional property with minCardinality > 1', () => {
+    const o = makeOntology((o) => {
+      o.classes.set(`${EX}Person`, {
+        uri: `${EX}Person`,
+        label: 'Person',
+        subClassOf: [],
+        disjointWith: [],
+      });
+      o.objectProperties.set(`${EX}hasMother`, {
+        uri: `${EX}hasMother`,
+        label: 'has mother',
+        domain: [`${EX}Person`],
+        range: [`${EX}Person`],
+        characteristics: ['functional'],
+        minCardinality: 2,
+      });
+    });
+    const errors = validateOntology(o);
+    expect(
+      errors.some(
+        (e) =>
+          e.elementUri === `${EX}hasMother` &&
+          e.severity === 'error' &&
+          e.message.includes('Functional property'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not flag functional property with minCardinality of 1', () => {
+    const o = makeOntology((o) => {
+      o.classes.set(`${EX}Person`, {
+        uri: `${EX}Person`,
+        label: 'Person',
+        subClassOf: [],
+        disjointWith: [],
+      });
+      o.objectProperties.set(`${EX}hasMother`, {
+        uri: `${EX}hasMother`,
+        label: 'has mother',
+        domain: [`${EX}Person`],
+        range: [`${EX}Person`],
+        characteristics: ['functional'],
+        minCardinality: 1,
+      });
+    });
+    const errors = validateOntology(o).filter(
+      (e) => e.severity === 'error' && e.elementUri === `${EX}hasMother`,
+    );
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `checkOWLConsistency()` to `validation.ts` detecting four categories of semantic contradiction that make OWL classes unsatisfiable
- Surfaces all findings as `severity: 'error'` in the existing `ValidationPanel` (no UI changes needed)

### Checks added

| # | Contradiction | Example |
|---|---|---|
| 1 | **Self-disjoint** | `A disjointWith A` |
| 2 | **Subclass-disjoint conflict** | `A subClassOf B` AND `A disjointWith B` (symmetry-aware) |
| 3 | **Mutually disjoint ancestors** | `A subClassOf B`, `A subClassOf C`, `B disjointWith C` (transitive BFS) |
| 4 | **Functional property cardinality conflict** | `owl:FunctionalProperty` with `minCardinality > 1` |

## Test plan

- [x] 8 new unit tests in `tests/services/validation.test.ts` — positive and negative cases for all 4 checks
- [x] All 484 existing tests pass
- [x] `bun run lint` and `bun run format:check` pass clean