### PR TITLE
feat(desktop): natural language querying of the loaded ontology (ONT-124)

### DIFF
--- a/apps/desktop/src/main/ipc/claude.ts
+++ b/apps/desktop/src/main/ipc/claude.ts
@@ -153,6 +153,64 @@ const removeElement = tool(
   },
 );
 
+const queryOntology = tool(
+  'query_ontology',
+  'Query the loaded ontology graph for information. Use this to answer questions like "Show me all subclasses of Vehicle", "What properties does Person have?", "List all classes", "Find all instances of Animal". This is a read-only operation — use it for exploration and answering questions, not for making changes.',
+  {
+    type: z
+      .enum([
+        'subclasses',
+        'superclasses',
+        'class_properties',
+        'class_info',
+        'instances',
+        'all_classes',
+        'all_properties',
+        'search',
+      ])
+      .describe(
+        'Query type: subclasses (find all subclasses of a class), superclasses (find parent classes), class_properties (get object and datatype properties for a class), class_info (full details about a class), instances (get individuals of a class), all_classes (list every class), all_properties (list every property), search (text search across labels/URIs)',
+      ),
+    classUri: z
+      .string()
+      .optional()
+      .describe(
+        'URI of the class to query. Required for: subclasses, superclasses, class_properties, class_info, instances',
+      ),
+    transitive: z
+      .boolean()
+      .optional()
+      .describe(
+        'If true, traverse the full hierarchy (not just direct relationships). Defaults to true. Applies to subclasses and superclasses queries.',
+      ),
+    query: z.string().optional().describe('Search term for the search query type'),
+  },
+  async (args) => {
+    return new Promise((resolve) => {
+      const win = getMainWindow();
+      if (!win) {
+        resolve({
+          content: [{ type: 'text' as const, text: 'No window available' }],
+          isError: true,
+        });
+        return;
+      }
+      ipcMain.handleOnce(
+        'claude:graph-query-response',
+        (_event, result: Record<string, unknown>) => {
+          resolve({ content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] });
+        },
+      );
+      win.webContents.send('claude:graph-query', {
+        type: args.type,
+        classUri: args.classUri,
+        transitive: args.transitive !== false,
+        query: args.query,
+      });
+    });
+  },
+);
+
 const validateOntology = tool(
   'validate_ontology',
   'Run validation on the current ontology and return any errors or warnings',
@@ -180,6 +238,7 @@ const ontographServer = createSdkMcpServer({
   version: '0.1.0',
   tools: [
     getCurrentOntology,
+    queryOntology,
     generateOntology,
     addClass,
     addObjectProperty,
@@ -190,7 +249,7 @@ const ontographServer = createSdkMcpServer({
   ],
 });
 
-const SYSTEM_PROMPT = `You are an ontology engineering assistant integrated into Ontograph, a visual OWL ontology editor. You help users create, modify, and refine OWL ontologies.
+const SYSTEM_PROMPT = `You are an ontology engineering assistant integrated into Ontograph, a visual OWL ontology editor. You help users create, modify, and query OWL ontologies.
 
 Key guidelines:
 - When creating ontologies, use a consistent namespace prefix (e.g. http://example.org/ontology#)
@@ -200,6 +259,26 @@ Key guidelines:
 - Create meaningful object properties to connect classes
 - Consider subclass hierarchies to organize classes
 - Keep ontologies focused and practical for knowledge graph extraction
+
+## Answering questions about the ontology (read-only queries)
+
+When the user asks questions about the loaded ontology — e.g. "Show me all subclasses of Vehicle", "What properties does Person have?", "List all classes", "Find all instances of Animal" — use the query_ontology tool. Do NOT fetch the full Turtle for simple questions.
+
+Query type guidance:
+- "subclasses of X" → type: subclasses, classUri: <URI of X>
+- "superclasses / parents of X" → type: superclasses, classUri: <URI of X>
+- "properties of X" / "attributes of X" → type: class_properties, classUri: <URI of X>
+- "details about X" / "tell me about X" → type: class_info, classUri: <URI of X>
+- "instances of X" / "individuals of X" → type: instances, classUri: <URI of X>
+- "list all classes" / "what classes exist?" → type: all_classes
+- "list all properties" → type: all_properties
+- "find / search for X" → type: search, query: "X"
+
+When URIs are not known, first use type: search or type: all_classes to find the correct URI, then run the intended query.
+
+Present query results in a clear, human-readable format — use bullet lists, tables, or prose depending on what fits best.
+
+## Modifying the ontology
 
 When the user asks you to create an ontology:
 1. First call get_current_ontology to see what exists
@@ -214,6 +293,7 @@ Always include necessary prefix declarations in generated Turtle:
 
 const ALL_TOOLS = [
   'mcp__ontograph__get_current_ontology',
+  'mcp__ontograph__query_ontology',
   'mcp__ontograph__generate_ontology',
   'mcp__ontograph__add_class',
   'mcp__ontograph__add_object_property',

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -70,6 +70,7 @@ declare global {
       ) => () => void;
       onClaudeRemoveElement: (callback: (uri: string, type: string) => void) => () => void;
       onClaudeValidate: (callback: () => void) => () => void;
+      onClaudeGraphQuery: (callback: (query: Record<string, unknown>) => void) => () => void;
 
       // Eval operations
       runEval: (payload: {
@@ -88,6 +89,7 @@ declare global {
       // Respond to main process
       respondOntology: (turtle: string) => void;
       respondValidation: (errors: string) => void;
+      respondGraphQuery: (result: Record<string, unknown>) => void;
 
       // Update operations
       checkForUpdate: () => Promise<void>;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -76,6 +76,8 @@ const api = {
   onClaudeRemoveElement: (callback: Callback<[string, string]>) =>
     onChannel('claude:remove-element', callback),
   onClaudeValidate: (callback: () => void) => onChannel('claude:validate', callback),
+  onClaudeGraphQuery: (callback: Callback<[Record<string, unknown>]>) =>
+    onChannel('claude:graph-query', callback),
 
   // Eval operations
   runEval: (payload: {
@@ -97,6 +99,9 @@ const api = {
   },
   respondValidation: (errors: string): void => {
     ipcRenderer.invoke('claude:validation-response', errors);
+  },
+  respondGraphQuery: (result: Record<string, unknown>): void => {
+    ipcRenderer.invoke('claude:graph-query-response', result);
   },
 
   // Update operations

--- a/apps/desktop/src/renderer/src/components/chat/useClaude.ts
+++ b/apps/desktop/src/renderer/src/components/chat/useClaude.ts
@@ -175,7 +175,7 @@ export function useClaude(): UseClaudeReturn {
 
       // Graph query
       window.api.onClaudeGraphQuery((query: Record<string, unknown>) => {
-        const result = executeGraphQuery(store.getState().ontology, query as GraphQuery);
+        const result = executeGraphQuery(store.getState().ontology, query as unknown as GraphQuery);
         window.api.respondGraphQuery(result);
       }),
 

--- a/apps/desktop/src/renderer/src/components/chat/useClaude.ts
+++ b/apps/desktop/src/renderer/src/components/chat/useClaude.ts
@@ -1,4 +1,5 @@
 import { track } from '@renderer/lib/analytics';
+import { executeGraphQuery, type GraphQuery } from '@renderer/model/graphQuery';
 import { serializeToTurtle } from '@renderer/model/serialize';
 import type { OntologyClass } from '@renderer/model/types';
 import { validateOntology } from '@renderer/services/validation';
@@ -170,6 +171,12 @@ export function useClaude(): UseClaudeReturn {
       window.api.onClaudeValidate(() => {
         const errors = validateOntology(store.getState().ontology);
         window.api.respondValidation(JSON.stringify(errors, null, 2));
+      }),
+
+      // Graph query
+      window.api.onClaudeGraphQuery((query: Record<string, unknown>) => {
+        const result = executeGraphQuery(store.getState().ontology, query as GraphQuery);
+        window.api.respondGraphQuery(result);
       }),
 
       // Assistant responses

--- a/apps/desktop/src/renderer/src/model/graphQuery.ts
+++ b/apps/desktop/src/renderer/src/model/graphQuery.ts
@@ -1,4 +1,4 @@
-import type { Ontology } from './types';
+import type { Ontology, OWLCharacteristic } from './types';
 
 export type GraphQueryType =
   | 'subclasses'
@@ -87,7 +87,13 @@ export function executeGraphQuery(ontology: Ontology, query: GraphQuery): GraphQ
     case 'class_properties': {
       const classUri = query.classUri;
       if (!classUri) return { error: 'classUri is required for class_properties query' };
-      const objectProps = [];
+      const objectProps: {
+        uri: string;
+        label: string;
+        comment: string | undefined;
+        range: { uri: string; label: string }[];
+        characteristics: OWLCharacteristic[];
+      }[] = [];
       for (const prop of ontology.objectProperties.values()) {
         if (prop.domain.includes(classUri)) {
           objectProps.push({
@@ -99,7 +105,12 @@ export function executeGraphQuery(ontology: Ontology, query: GraphQuery): GraphQ
           });
         }
       }
-      const datatypeProps = [];
+      const datatypeProps: {
+        uri: string;
+        label: string;
+        comment: string | undefined;
+        range: string;
+      }[] = [];
       for (const prop of ontology.datatypeProperties.values()) {
         if (prop.domain.includes(classUri)) {
           datatypeProps.push({
@@ -138,7 +149,13 @@ export function executeGraphQuery(ontology: Ontology, query: GraphQuery): GraphQ
     case 'instances': {
       const classUri = query.classUri;
       if (!classUri) return { error: 'classUri is required for instances query' };
-      const results = [];
+      const results: {
+        uri: string;
+        label: string;
+        comment: string | undefined;
+        objectAssertions: { property: string; target: string }[];
+        dataAssertions: { property: string; value: string; datatype?: string }[];
+      }[] = [];
       for (const ind of ontology.individuals.values()) {
         if (ind.types.includes(classUri)) {
           results.push({

--- a/apps/desktop/src/renderer/src/model/graphQuery.ts
+++ b/apps/desktop/src/renderer/src/model/graphQuery.ts
@@ -1,0 +1,246 @@
+import type { Ontology } from './types';
+
+export type GraphQueryType =
+  | 'subclasses'
+  | 'superclasses'
+  | 'class_properties'
+  | 'class_info'
+  | 'instances'
+  | 'all_classes'
+  | 'all_properties'
+  | 'search';
+
+export interface GraphQuery {
+  type: GraphQueryType;
+  classUri?: string;
+  transitive?: boolean;
+  query?: string;
+}
+
+export type GraphQueryResult = Record<string, unknown>;
+
+function labelOf(uri: string, ontology: Ontology): string {
+  return (
+    ontology.classes.get(uri)?.label ||
+    ontology.objectProperties.get(uri)?.label ||
+    ontology.datatypeProperties.get(uri)?.label ||
+    uri
+  );
+}
+
+export function executeGraphQuery(ontology: Ontology, query: GraphQuery): GraphQueryResult {
+  switch (query.type) {
+    case 'subclasses': {
+      const classUri = query.classUri;
+      if (!classUri) return { error: 'classUri is required for subclasses query' };
+      const results: { uri: string; label: string; comment?: string; direct: boolean }[] = [];
+      const visited = new Set<string>();
+      const queue: Array<{ uri: string; isDirect: boolean }> = [{ uri: classUri, isDirect: true }];
+      while (queue.length > 0) {
+        // biome-ignore lint/style/noNonNullAssertion: queue.length > 0 guarantees shift() is defined
+        const { uri: current, isDirect } = queue.shift()!;
+        for (const [uri, cls] of ontology.classes) {
+          if (cls.subClassOf.includes(current) && !visited.has(uri)) {
+            visited.add(uri);
+            results.push({
+              uri,
+              label: cls.label || uri,
+              comment: cls.comment,
+              direct: isDirect,
+            });
+            if (query.transitive !== false) {
+              queue.push({ uri, isDirect: false });
+            }
+          }
+        }
+      }
+      return { classUri, subclasses: results, count: results.length };
+    }
+
+    case 'superclasses': {
+      const classUri = query.classUri;
+      if (!classUri) return { error: 'classUri is required for superclasses query' };
+      const cls0 = ontology.classes.get(classUri);
+      if (!cls0) return { error: `Class not found: ${classUri}` };
+      const results: { uri: string; label: string; comment?: string }[] = [];
+      const visited = new Set<string>();
+      const recurse = (uri: string): void => {
+        const cls = ontology.classes.get(uri);
+        if (!cls) return;
+        for (const parentUri of cls.subClassOf) {
+          if (!visited.has(parentUri)) {
+            visited.add(parentUri);
+            const parent = ontology.classes.get(parentUri);
+            results.push({
+              uri: parentUri,
+              label: parent?.label || parentUri,
+              comment: parent?.comment,
+            });
+            if (query.transitive !== false) recurse(parentUri);
+          }
+        }
+      };
+      recurse(classUri);
+      return { classUri, superclasses: results, count: results.length };
+    }
+
+    case 'class_properties': {
+      const classUri = query.classUri;
+      if (!classUri) return { error: 'classUri is required for class_properties query' };
+      const objectProps = [];
+      for (const prop of ontology.objectProperties.values()) {
+        if (prop.domain.includes(classUri)) {
+          objectProps.push({
+            uri: prop.uri,
+            label: prop.label || prop.uri,
+            comment: prop.comment,
+            range: prop.range.map((r) => ({ uri: r, label: labelOf(r, ontology) })),
+            characteristics: prop.characteristics,
+          });
+        }
+      }
+      const datatypeProps = [];
+      for (const prop of ontology.datatypeProperties.values()) {
+        if (prop.domain.includes(classUri)) {
+          datatypeProps.push({
+            uri: prop.uri,
+            label: prop.label || prop.uri,
+            comment: prop.comment,
+            range: prop.range,
+          });
+        }
+      }
+      return { classUri, objectProperties: objectProps, datatypeProperties: datatypeProps };
+    }
+
+    case 'class_info': {
+      const classUri = query.classUri;
+      if (!classUri) return { error: 'classUri is required for class_info query' };
+      const cls = ontology.classes.get(classUri);
+      if (!cls) return { error: `Class not found: ${classUri}` };
+      return {
+        uri: cls.uri,
+        label: cls.label,
+        comment: cls.comment,
+        superclasses: cls.subClassOf.map((uri) => ({
+          uri,
+          label: ontology.classes.get(uri)?.label || uri,
+        })),
+        disjointWith: cls.disjointWith.map((uri) => ({
+          uri,
+          label: ontology.classes.get(uri)?.label || uri,
+        })),
+        restrictions: cls.restrictions || [],
+        classExpressions: cls.classExpressions || [],
+      };
+    }
+
+    case 'instances': {
+      const classUri = query.classUri;
+      if (!classUri) return { error: 'classUri is required for instances query' };
+      const results = [];
+      for (const ind of ontology.individuals.values()) {
+        if (ind.types.includes(classUri)) {
+          results.push({
+            uri: ind.uri,
+            label: ind.label || ind.uri,
+            comment: ind.comment,
+            objectAssertions: ind.objectPropertyAssertions,
+            dataAssertions: ind.dataPropertyAssertions,
+          });
+        }
+      }
+      return { classUri, individuals: results, count: results.length };
+    }
+
+    case 'all_classes': {
+      const classes = Array.from(ontology.classes.values()).map((cls) => ({
+        uri: cls.uri,
+        label: cls.label || cls.uri,
+        comment: cls.comment,
+        superclasses: cls.subClassOf,
+      }));
+      return { classes, count: classes.length };
+    }
+
+    case 'all_properties': {
+      const objectProps = Array.from(ontology.objectProperties.values()).map((p) => ({
+        uri: p.uri,
+        label: p.label || p.uri,
+        comment: p.comment,
+        domain: p.domain,
+        range: p.range,
+        characteristics: p.characteristics,
+        type: 'object' as const,
+      }));
+      const datatypeProps = Array.from(ontology.datatypeProperties.values()).map((p) => ({
+        uri: p.uri,
+        label: p.label || p.uri,
+        comment: p.comment,
+        domain: p.domain,
+        range: p.range,
+        type: 'datatype' as const,
+      }));
+      const properties = [...objectProps, ...datatypeProps];
+      return { properties, count: properties.length };
+    }
+
+    case 'search': {
+      const q = (query.query || '').toLowerCase();
+      if (!q) return { error: 'query is required for search' };
+      const results: { uri: string; label: string; comment?: string; elementType: string }[] = [];
+      for (const cls of ontology.classes.values()) {
+        const label = cls.label || '';
+        if (
+          label.toLowerCase().includes(q) ||
+          cls.uri.toLowerCase().includes(q) ||
+          (cls.comment || '').toLowerCase().includes(q)
+        ) {
+          results.push({
+            uri: cls.uri,
+            label: label || cls.uri,
+            comment: cls.comment,
+            elementType: 'class',
+          });
+        }
+      }
+      for (const prop of ontology.objectProperties.values()) {
+        const label = prop.label || '';
+        if (label.toLowerCase().includes(q) || prop.uri.toLowerCase().includes(q)) {
+          results.push({
+            uri: prop.uri,
+            label: label || prop.uri,
+            comment: prop.comment,
+            elementType: 'objectProperty',
+          });
+        }
+      }
+      for (const prop of ontology.datatypeProperties.values()) {
+        const label = prop.label || '';
+        if (label.toLowerCase().includes(q) || prop.uri.toLowerCase().includes(q)) {
+          results.push({
+            uri: prop.uri,
+            label: label || prop.uri,
+            comment: prop.comment,
+            elementType: 'datatypeProperty',
+          });
+        }
+      }
+      for (const ind of ontology.individuals.values()) {
+        const label = ind.label || '';
+        if (label.toLowerCase().includes(q) || ind.uri.toLowerCase().includes(q)) {
+          results.push({
+            uri: ind.uri,
+            label: label || ind.uri,
+            comment: ind.comment,
+            elementType: 'individual',
+          });
+        }
+      }
+      return { query: query.query, results, count: results.length };
+    }
+
+    default:
+      return { error: `Unknown query type: ${(query as GraphQuery).type}` };
+  }
+}

--- a/apps/desktop/tests/setup.ts
+++ b/apps/desktop/tests/setup.ts
@@ -42,9 +42,11 @@ Object.defineProperty(window, 'api', {
     onClaudeModifyClass: vi.fn(noop),
     onClaudeRemoveElement: vi.fn(noop),
     onClaudeValidate: vi.fn(noop),
+    onClaudeGraphQuery: vi.fn(noop),
 
     respondOntology: vi.fn(),
     respondValidation: vi.fn(),
+    respondGraphQuery: vi.fn(),
 
     runEval: vi.fn(),
     abortEval: vi.fn(),


### PR DESCRIPTION
## Summary

- Adds a `query_ontology` MCP tool enabling Claude to answer natural language questions about the loaded ontology graph
- Supports 8 query types: `subclasses`, `superclasses`, `class_properties`, `class_info`, `instances`, `all_classes`, `all_properties`, `search`
- Query logic (`graphQuery.ts`) runs directly against the Zustand store — no full Turtle fetch needed for read queries
- New IPC channel pair (`claude:graph-query` / `claude:graph-query-response`) follows the same request-response pattern as existing ontology tools
- System prompt updated to guide Claude to use `query_ontology` for exploration vs `get_current_ontology` for modifications

## Test plan

- [ ] Load an ontology with a class hierarchy (e.g. Vehicle → Car, Truck)
- [ ] Ask "Show me all subclasses of Vehicle" — verify Claude calls `query_ontology` with `type: subclasses`
- [ ] Ask "What properties does Person have?" — verify object and datatype properties are listed
- [ ] Ask "List all classes" — verify full class list is returned
- [ ] Ask "Find all instances of Animal" — verify individuals are returned
- [ ] Ask Claude to create a new class — verify it still uses modification tools, not `query_ontology`
- [ ] Confirm 489 tests pass (`bun run test`)

Closes ONT-124