### PR TITLE
feat(ir): add table/indexes on ObjectTypeDef + 4 new ops

### DIFF
--- a/apps/desktop/src/main/ops/index.ts
+++ b/apps/desktop/src/main/ops/index.ts
@@ -227,6 +227,47 @@ export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
       ({ alias }) => ({ kind: 'remove_import', alias }),
       forward,
     ),
+    strictTool(
+      'set_table_flag',
+      'Flag or unflag an object type as a Convex table.',
+      { typeName: z.string().min(1), table: z.boolean() },
+      ({ typeName, table }) => ({ kind: 'set_table_flag', typeName, table }),
+      forward,
+    ),
+    strictTool(
+      'add_index',
+      'Add a named index to a table-flagged object type.',
+      {
+        typeName: z.string().min(1),
+        index: z.object({
+          name: z.string().min(1),
+          fields: z.array(z.string().min(1)).min(1),
+        }),
+      },
+      ({ typeName, index }) => ({ kind: 'add_index', typeName, index }),
+      forward,
+    ),
+    strictTool(
+      'remove_index',
+      'Remove an index from an object type by index name.',
+      { typeName: z.string().min(1), name: z.string().min(1) },
+      ({ typeName, name }) => ({ kind: 'remove_index', typeName, name }),
+      forward,
+    ),
+    strictTool(
+      'update_index',
+      'Update an index name and/or fields on an object type.',
+      {
+        typeName: z.string().min(1),
+        name: z.string().min(1),
+        patch: z.object({
+          name: z.string().min(1).optional(),
+          fields: z.array(z.string().min(1)).min(1).optional(),
+        }),
+      },
+      ({ typeName, name, patch }) => ({ kind: 'update_index', typeName, name, patch }),
+      forward,
+    ),
     // --- Type-level (lenient with meta-schema validation) ---
     lenientTool(
       'add_type',

--- a/apps/desktop/src/renderer/src/model/ir.ts
+++ b/apps/desktop/src/renderer/src/model/ir.ts
@@ -88,11 +88,20 @@ export const FieldDefSchema = z.object({
 
 export type FieldDef = z.infer<typeof FieldDefSchema>;
 
+export const IndexDefSchema = z.object({
+  name: z.string().min(1),
+  fields: z.array(z.string().min(1)).min(1),
+});
+
+export type IndexDef = z.infer<typeof IndexDefSchema>;
+
 const ObjectTypeDefSchema = z.object({
   kind: z.literal('object'),
   name: z.string().min(1),
   description: z.string().optional(),
   fields: z.array(FieldDefSchema),
+  table: z.boolean().optional(),
+  indexes: z.array(IndexDefSchema).optional(),
 });
 
 const EnumTypeDefSchema = z.object({

--- a/apps/desktop/src/renderer/src/store/ops.ts
+++ b/apps/desktop/src/renderer/src/store/ops.ts
@@ -19,7 +19,7 @@
  *     field-level paths after the replacement lands.
  */
 
-import type { FieldDef, FieldType, ImportDecl, Schema, TypeDef } from '../model/ir';
+import type { FieldDef, FieldType, ImportDecl, IndexDef, Schema, TypeDef } from '../model/ir';
 import { IRSchema } from '../model/ir';
 
 export type Op =
@@ -35,6 +35,10 @@ export type Op =
   | { kind: 'set_discriminator'; typeName: string; discriminator: string }
   | { kind: 'add_import'; import: ImportDecl }
   | { kind: 'remove_import'; alias: string }
+  | { kind: 'set_table_flag'; typeName: string; table: boolean }
+  | { kind: 'add_index'; typeName: string; index: IndexDef }
+  | { kind: 'remove_index'; typeName: string; name: string }
+  | { kind: 'update_index'; typeName: string; name: string; patch: Partial<IndexDef> }
   | { kind: 'replace_schema'; schema: unknown };
 
 export type ApplyResult = { schema: Schema } | { error: string };
@@ -65,6 +69,14 @@ export function apply(schema: Schema, op: Op): ApplyResult {
       return addImport(schema, op.import);
     case 'remove_import':
       return removeImport(schema, op.alias);
+    case 'set_table_flag':
+      return setTableFlag(schema, op.typeName, op.table);
+    case 'add_index':
+      return addIndex(schema, op.typeName, op.index);
+    case 'remove_index':
+      return removeIndex(schema, op.typeName, op.name);
+    case 'update_index':
+      return updateIndex(schema, op.typeName, op.name, op.patch);
     case 'replace_schema':
       return replaceSchema(op.schema);
     default:
@@ -210,6 +222,71 @@ function reorderFields(schema: Schema, typeName: string, order: string[]): Apply
       next.push(f);
     }
     return { ...t, fields: next };
+  });
+}
+
+// ── tables + indexes ─────────────────────────────────────────────────────
+
+function setTableFlag(schema: Schema, typeName: string, table: boolean): ApplyResult {
+  return withObject(schema, typeName, (t) => ({ ...t, table }));
+}
+
+function addIndex(schema: Schema, typeName: string, index: IndexDef): ApplyResult {
+  return withObject(schema, typeName, (t) => {
+    if (index.fields.length === 0) {
+      return { error: `add_index: index "${index.name}" must have at least one field` };
+    }
+    const existing = t.indexes ?? [];
+    if (existing.some((i) => i.name === index.name)) {
+      return { error: `index "${index.name}" already exists on "${typeName}"` };
+    }
+    const fieldNames = new Set(t.fields.map((f) => f.name));
+    for (const f of index.fields) {
+      if (!fieldNames.has(f)) {
+        return { error: `add_index: unknown field "${f}" on "${typeName}"` };
+      }
+    }
+    return { ...t, indexes: [...existing, index] };
+  });
+}
+
+function removeIndex(schema: Schema, typeName: string, name: string): ApplyResult {
+  return withObject(schema, typeName, (t) => {
+    const existing = t.indexes ?? [];
+    if (!existing.some((i) => i.name === name)) {
+      return { error: `index "${name}" not found on "${typeName}"` };
+    }
+    return { ...t, indexes: existing.filter((i) => i.name !== name) };
+  });
+}
+
+function updateIndex(
+  schema: Schema,
+  typeName: string,
+  name: string,
+  patch: Partial<IndexDef>,
+): ApplyResult {
+  return withObject(schema, typeName, (t) => {
+    const existing = t.indexes ?? [];
+    const idx = existing.findIndex((i) => i.name === name);
+    if (idx === -1) return { error: `index "${name}" not found on "${typeName}"` };
+    const nextName = patch.name ?? existing[idx].name;
+    const nextFields = patch.fields ?? existing[idx].fields;
+    if (nextFields.length === 0) {
+      return { error: `update_index: index "${name}" must have at least one field` };
+    }
+    if (patch.name && patch.name !== name && existing.some((i) => i.name === patch.name)) {
+      return { error: `index "${patch.name}" already exists on "${typeName}"` };
+    }
+    const fieldNames = new Set(t.fields.map((f) => f.name));
+    for (const f of nextFields) {
+      if (!fieldNames.has(f)) {
+        return { error: `update_index: unknown field "${f}" on "${typeName}"` };
+      }
+    }
+    const indexes = [...existing];
+    indexes[idx] = { name: nextName, fields: nextFields };
+    return { ...t, indexes };
   });
 }
 

--- a/apps/desktop/tests/main/op-tools.test.ts
+++ b/apps/desktop/tests/main/op-tools.test.ts
@@ -15,26 +15,105 @@ function toolNamed(tools: OpToolDescriptor[], name: string): OpToolDescriptor {
 }
 
 describe('createOpTools', () => {
-  it('registers one SDK tool per op (13 total)', () => {
+  it('registers one SDK tool per op (17 total)', () => {
     const { tools } = makeTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual(
       [
         'add_field',
         'add_import',
+        'add_index',
         'add_type',
         'add_variant',
         'delete_field',
         'delete_type',
         'remove_import',
+        'remove_index',
         'rename_type',
         'reorder_fields',
         'replace_schema',
         'set_discriminator',
+        'set_table_flag',
         'update_field',
+        'update_index',
         'update_type',
       ].sort(),
     );
+  });
+
+  it('set_table_flag forwards a strict Op', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const tool = toolNamed(tools, 'set_table_flag');
+    await tool.handler({ typeName: 'Post', table: true });
+    expect(forwardSpy.mock.calls[0][0]).toEqual({
+      kind: 'set_table_flag',
+      typeName: 'Post',
+      table: true,
+    });
+  });
+
+  it('set_table_flag rejects malformed input', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const tool = toolNamed(tools, 'set_table_flag');
+    await expect(tool.handler({ typeName: '', table: true })).rejects.toThrow();
+    await expect(tool.handler({ typeName: 'Post', table: 'yes' })).rejects.toThrow();
+    expect(forwardSpy).not.toHaveBeenCalled();
+  });
+
+  it('add_index forwards a strict Op with index payload', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const tool = toolNamed(tools, 'add_index');
+    await tool.handler({
+      typeName: 'Post',
+      index: { name: 'by_author', fields: ['author'] },
+    });
+    expect(forwardSpy.mock.calls[0][0]).toEqual({
+      kind: 'add_index',
+      typeName: 'Post',
+      index: { name: 'by_author', fields: ['author'] },
+    });
+  });
+
+  it('add_index rejects an empty fields array at the tool boundary', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const tool = toolNamed(tools, 'add_index');
+    await expect(
+      tool.handler({ typeName: 'Post', index: { name: 'x', fields: [] } }),
+    ).rejects.toThrow();
+    expect(forwardSpy).not.toHaveBeenCalled();
+  });
+
+  it('remove_index forwards a strict Op', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const tool = toolNamed(tools, 'remove_index');
+    await tool.handler({ typeName: 'Post', name: 'by_author' });
+    expect(forwardSpy.mock.calls[0][0]).toEqual({
+      kind: 'remove_index',
+      typeName: 'Post',
+      name: 'by_author',
+    });
+  });
+
+  it('update_index forwards a strict Op with partial patch', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const tool = toolNamed(tools, 'update_index');
+    await tool.handler({
+      typeName: 'Post',
+      name: 'by_author',
+      patch: { fields: ['author', 'title'] },
+    });
+    expect(forwardSpy.mock.calls[0][0]).toEqual({
+      kind: 'update_index',
+      typeName: 'Post',
+      name: 'by_author',
+      patch: { fields: ['author', 'title'] },
+    });
   });
 
   it('add_field forwards a strict, well-typed Op to the renderer', async () => {

--- a/apps/desktop/tests/model/ir.test.ts
+++ b/apps/desktop/tests/model/ir.test.ts
@@ -271,6 +271,52 @@ describe('IRSchema', () => {
     expect(path).toContain('types.0.fields.0.type');
   });
 
+  it('accepts an object TypeDef with table:true and indexes', () => {
+    const input = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          indexes: [
+            { name: 'by_author', fields: ['author'] },
+            { name: 'by_author_and_date', fields: ['author', 'publishedAt'] },
+          ],
+          fields: [
+            { name: 'author', type: { kind: 'string' } },
+            { name: 'publishedAt', type: { kind: 'date' } },
+          ],
+        },
+      ],
+    };
+    const parsed = IRSchema.parse(input);
+    const td = parsed.types[0];
+    if (td.kind !== 'object') throw new Error('expected object');
+    expect(td.table).toBe(true);
+    expect(td.indexes).toEqual([
+      { name: 'by_author', fields: ['author'] },
+      { name: 'by_author_and_date', fields: ['author', 'publishedAt'] },
+    ]);
+  });
+
+  it('rejects an index with an empty fields array', () => {
+    const input = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          indexes: [{ name: 'bad', fields: [] }],
+          fields: [{ name: 'author', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    const res = IRSchema.safeParse(input);
+    expect(res.success).toBe(false);
+  });
+
   it('accepts an object TypeDef with a string field', () => {
     const input = {
       version: '1',

--- a/apps/desktop/tests/store/ops.test.ts
+++ b/apps/desktop/tests/store/ops.test.ts
@@ -305,6 +305,175 @@ describe('apply', () => {
     ]);
   });
 
+  // set_table_flag
+  it('set_table_flag: toggles the table flag on an object type', () => {
+    const base: Schema = {
+      version: '1',
+      types: [{ kind: 'object', name: 'Post', fields: [] }],
+    };
+    const s1 = ok(apply(base, { kind: 'set_table_flag', typeName: 'Post', table: true }));
+    const t = s1.types[0] as Extract<(typeof s1.types)[number], { kind: 'object' }>;
+    expect(t.table).toBe(true);
+
+    const s2 = ok(apply(s1, { kind: 'set_table_flag', typeName: 'Post', table: false }));
+    const t2 = s2.types[0] as Extract<(typeof s2.types)[number], { kind: 'object' }>;
+    expect(t2.table).toBe(false);
+
+    const missing = apply(base, { kind: 'set_table_flag', typeName: 'Nope', table: true });
+    expect('error' in missing).toBe(true);
+  });
+
+  it('set_table_flag: errors on non-object types', () => {
+    const base: Schema = {
+      version: '1',
+      types: [{ kind: 'enum', name: 'Role', values: [{ value: 'admin' }] }],
+    };
+    const res = apply(base, { kind: 'set_table_flag', typeName: 'Role', table: true });
+    expect('error' in res).toBe(true);
+  });
+
+  // add_index
+  it('add_index: appends, rejects duplicate name, unknown field, empty fields', () => {
+    const base: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [
+            { name: 'author', type: { kind: 'string' } },
+            { name: 'title', type: { kind: 'string' } },
+          ],
+        },
+      ],
+    };
+    const s1 = ok(
+      apply(base, {
+        kind: 'add_index',
+        typeName: 'Post',
+        index: { name: 'by_author', fields: ['author'] },
+      }),
+    );
+    const t = s1.types[0] as Extract<(typeof s1.types)[number], { kind: 'object' }>;
+    expect(t.indexes).toEqual([{ name: 'by_author', fields: ['author'] }]);
+
+    const dup = apply(s1, {
+      kind: 'add_index',
+      typeName: 'Post',
+      index: { name: 'by_author', fields: ['title'] },
+    });
+    expect('error' in dup).toBe(true);
+
+    const unknown = apply(base, {
+      kind: 'add_index',
+      typeName: 'Post',
+      index: { name: 'by_x', fields: ['nope'] },
+    });
+    expect('error' in unknown).toBe(true);
+
+    const empty = apply(base, {
+      kind: 'add_index',
+      typeName: 'Post',
+      index: { name: 'empty', fields: [] },
+    });
+    expect('error' in empty).toBe(true);
+  });
+
+  // remove_index
+  it('remove_index: drops by name, errors if missing', () => {
+    const base: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          fields: [{ name: 'author', type: { kind: 'string' } }],
+          indexes: [
+            { name: 'by_author', fields: ['author'] },
+            { name: 'by_author2', fields: ['author'] },
+          ],
+        },
+      ],
+    };
+    const s1 = ok(apply(base, { kind: 'remove_index', typeName: 'Post', name: 'by_author' }));
+    const t = s1.types[0] as Extract<(typeof s1.types)[number], { kind: 'object' }>;
+    expect(t.indexes).toEqual([{ name: 'by_author2', fields: ['author'] }]);
+
+    const missing = apply(base, { kind: 'remove_index', typeName: 'Post', name: 'nope' });
+    expect('error' in missing).toBe(true);
+  });
+
+  // update_index
+  it('update_index: patches name and/or fields, rejects conflicts', () => {
+    const base: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          fields: [
+            { name: 'author', type: { kind: 'string' } },
+            { name: 'title', type: { kind: 'string' } },
+          ],
+          indexes: [
+            { name: 'by_author', fields: ['author'] },
+            { name: 'by_title', fields: ['title'] },
+          ],
+        },
+      ],
+    };
+
+    const renamed = ok(
+      apply(base, {
+        kind: 'update_index',
+        typeName: 'Post',
+        name: 'by_author',
+        patch: { name: 'by_user' },
+      }),
+    );
+    const t = renamed.types[0] as Extract<(typeof renamed.types)[number], { kind: 'object' }>;
+    expect(t.indexes?.[0]).toEqual({ name: 'by_user', fields: ['author'] });
+
+    const fieldsPatched = ok(
+      apply(base, {
+        kind: 'update_index',
+        typeName: 'Post',
+        name: 'by_author',
+        patch: { fields: ['author', 'title'] },
+      }),
+    );
+    const t2 = fieldsPatched.types[0] as Extract<
+      (typeof fieldsPatched.types)[number],
+      { kind: 'object' }
+    >;
+    expect(t2.indexes?.[0]).toEqual({ name: 'by_author', fields: ['author', 'title'] });
+
+    const conflict = apply(base, {
+      kind: 'update_index',
+      typeName: 'Post',
+      name: 'by_author',
+      patch: { name: 'by_title' },
+    });
+    expect('error' in conflict).toBe(true);
+
+    const unknown = apply(base, {
+      kind: 'update_index',
+      typeName: 'Post',
+      name: 'by_author',
+      patch: { fields: ['nope'] },
+    });
+    expect('error' in unknown).toBe(true);
+
+    const missing = apply(base, {
+      kind: 'update_index',
+      typeName: 'Post',
+      name: 'nope',
+      patch: { fields: ['author'] },
+    });
+    expect('error' in missing).toBe(true);
+  });
+
   // 13. replace_schema — structural pre-flight
   it('replace_schema: installs a valid IR and rejects a structurally-bad one', () => {
     const next: Schema = {


### PR DESCRIPTION
## Summary
- Extends `ObjectTypeDef` with optional `table: boolean` and `indexes: IndexDef[]` fields in the IR meta-schema. Backwards-compatible — existing fixtures parse unchanged.
- Adds four ops — `set_table_flag`, `add_index`, `remove_index`, `update_index` — with applier handlers and SDK tool registration (strict schemas, `fields: min(1)`, duplicate-name / unknown-field rejection).
- Convex-specific validation (the `_`-prefix rule) stays in the emitter, not the IR — scratch-mode users can flag `table: true` with no downstream effect.

Closes #116

## Test plan
- [x] `bunx vitest run` — 543 tests pass
- [x] `bun run typecheck`
- [x] `bun run lint` / `format:check`
- [x] New tests: IR accepts table/indexes and rejects empty `fields`; applier covers happy + rejection paths for all 4 ops; op-tools register 17 tools and reject malformed input at the SDK boundary