### PR TITLE
feat(detail): Convex section + graph node table indicator

### DIFF
--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -12,11 +12,18 @@
  * direct edits interleave cleanly with chat-driven ops. Edits fire on
  * `blur` (not `change`) to avoid a history entry per keystroke.
  */
-import type { TypeDef } from '../../model/ir';
+import type { IndexDef, TypeDef } from '../../model/ir';
 import type { Op } from '../../store/ops';
+import { Checkbox } from '../ui/checkbox';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Textarea } from '../ui/textarea';
+
+const CONVEX_RESERVED_PREFIX_MSG = "Convex reserves names starting with '_'";
+
+function isConvexReservedName(name: string): boolean {
+  return name.startsWith('_');
+}
 
 export interface TypeDetailProps {
   type: TypeDef;
@@ -25,6 +32,9 @@ export interface TypeDetailProps {
 }
 
 export function TypeDetail({ type, dispatch }: TypeDetailProps) {
+  const isTable = type.kind === 'object' && type.table === true;
+  const nameReserved = isTable && isConvexReservedName(type.name);
+
   return (
     <div className="space-y-4 p-3">
       <div className="flex items-center justify-between">
@@ -32,10 +42,11 @@ export function TypeDetail({ type, dispatch }: TypeDetailProps) {
         <span className="text-xs text-muted-foreground">{type.kind}</span>
       </div>
 
-      <NameField type={type} dispatch={dispatch} />
+      <NameField type={type} dispatch={dispatch} reserved={nameReserved} />
       <DescriptionField type={type} dispatch={dispatch} />
 
       {type.kind === 'object' && <ObjectBody type={type} dispatch={dispatch} />}
+      {type.kind === 'object' && <ConvexSection type={type} dispatch={dispatch} />}
       {type.kind === 'enum' && <EnumBody type={type} dispatch={dispatch} />}
       {type.kind === 'discriminatedUnion' && (
         <DiscriminatedUnionBody type={type} dispatch={dispatch} />
@@ -45,13 +56,15 @@ export function TypeDetail({ type, dispatch }: TypeDetailProps) {
   );
 }
 
-function NameField({ type, dispatch }: TypeDetailProps) {
+function NameField({ type, dispatch, reserved }: TypeDetailProps & { reserved: boolean }) {
   return (
     <div className="space-y-1">
       <Label htmlFor="type-name">Name</Label>
       <Input
         id="type-name"
         defaultValue={type.name}
+        aria-invalid={reserved || undefined}
+        title={reserved ? CONVEX_RESERVED_PREFIX_MSG : undefined}
         onBlur={(ev) => {
           const next = ev.target.value.trim();
           if (next && next !== type.name)
@@ -96,22 +109,183 @@ function ObjectBody({
       <p className="text-xs text-muted-foreground">No fields. Use the canvas or chat to add one.</p>
     );
   }
+  const isTable = type.table === true;
   return (
     <div className="space-y-1">
       <Label>Fields</Label>
       <ul className="text-xs space-y-1">
-        {type.fields.map((f) => (
-          <li key={f.name} data-testid="object-field-summary" className="flex justify-between">
-            <span>
-              {f.name}
-              {f.optional ? '?' : ''}
-            </span>
-            <span className="text-muted-foreground">{summariseKind(f.type.kind)}</span>
-          </li>
-        ))}
+        {type.fields.map((f) => {
+          const reserved = isTable && isConvexReservedName(f.name);
+          return (
+            <li
+              key={f.name}
+              data-testid="object-field-summary"
+              data-reserved={reserved || undefined}
+              title={reserved ? CONVEX_RESERVED_PREFIX_MSG : undefined}
+              className={`flex justify-between ${reserved ? 'text-destructive' : ''}`}
+            >
+              <span>
+                {f.name}
+                {f.optional ? '?' : ''}
+              </span>
+              <span className="text-muted-foreground">{summariseKind(f.type.kind)}</span>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );
+}
+
+// ConvexSection is rendered in project mode only. TODO(#119): gate on project
+// mode via a DocumentStore-derived context — always-on for now.
+function ConvexSection({
+  type,
+  dispatch,
+}: {
+  type: Extract<TypeDef, { kind: 'object' }>;
+  dispatch: (op: Op) => void;
+}) {
+  const isTable = type.table === true;
+  const indexes = type.indexes ?? [];
+  const fieldNames = type.fields.map((f) => f.name);
+
+  const toggleTable = () => {
+    dispatch({ kind: 'set_table_flag', typeName: type.name, table: !isTable });
+  };
+
+  const addIndex = () => {
+    const name = nextIndexName(indexes);
+    // Must have at least one field — seed with the first field if available.
+    const seed = fieldNames[0];
+    if (!seed) return;
+    dispatch({
+      kind: 'add_index',
+      typeName: type.name,
+      index: { name, fields: [seed] },
+    });
+  };
+
+  return (
+    <div className="space-y-2 border-t pt-3">
+      <Label htmlFor="convex-table" className="flex items-center gap-2">
+        <Checkbox id="convex-table" checked={isTable} onCheckedChange={toggleTable} />
+        Use as Convex table
+      </Label>
+
+      {isTable && (
+        <div className="space-y-2 pt-1">
+          <div className="flex items-center justify-between">
+            <Label>Indexes</Label>
+            <button
+              type="button"
+              onClick={addIndex}
+              disabled={fieldNames.length === 0}
+              className="text-xs underline disabled:opacity-40 disabled:no-underline"
+            >
+              Add index
+            </button>
+          </div>
+          {indexes.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No indexes.</p>
+          ) : (
+            <ul className="space-y-2">
+              {indexes.map((idx) => (
+                <IndexRow
+                  key={idx.name}
+                  typeName={type.name}
+                  index={idx}
+                  fieldNames={fieldNames}
+                  dispatch={dispatch}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IndexRow({
+  typeName,
+  index,
+  fieldNames,
+  dispatch,
+}: {
+  typeName: string;
+  index: IndexDef;
+  fieldNames: string[];
+  dispatch: (op: Op) => void;
+}) {
+  return (
+    <li className="space-y-1 rounded border p-2" data-testid="convex-index-row">
+      <div className="flex items-center gap-2">
+        <Input
+          aria-label={`Index name for ${index.name}`}
+          defaultValue={index.name}
+          onBlur={(ev) => {
+            const next = ev.target.value.trim();
+            if (next && next !== index.name) {
+              dispatch({
+                kind: 'update_index',
+                typeName,
+                name: index.name,
+                patch: { name: next },
+              });
+            }
+          }}
+        />
+        <button
+          type="button"
+          aria-label={`Delete index ${index.name}`}
+          onClick={() => dispatch({ kind: 'remove_index', typeName, name: index.name })}
+          className="text-xs text-destructive underline"
+        >
+          Delete
+        </button>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {fieldNames.map((fname) => {
+          const checked = index.fields.includes(fname);
+          return (
+            <Label
+              key={fname}
+              htmlFor={`idx-${index.name}-${fname}`}
+              className="flex items-center gap-1 text-xs"
+            >
+              <Checkbox
+                id={`idx-${index.name}-${fname}`}
+                aria-label={`${index.name}: ${fname}`}
+                checked={checked}
+                onCheckedChange={(v) => {
+                  const want = v === true;
+                  const nextFields = want
+                    ? [...index.fields, fname]
+                    : index.fields.filter((f) => f !== fname);
+                  if (nextFields.length === 0) return;
+                  dispatch({
+                    kind: 'update_index',
+                    typeName,
+                    name: index.name,
+                    patch: { fields: nextFields },
+                  });
+                }}
+              />
+              {fname}
+            </Label>
+          );
+        })}
+      </div>
+    </li>
+  );
+}
+
+function nextIndexName(existing: IndexDef[]): string {
+  const taken = new Set(existing.map((i) => i.name));
+  let n = existing.length + 1;
+  while (taken.has(`index${n}`)) n += 1;
+  return `index${n}`;
 }
 
 function EnumBody({

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -86,6 +86,7 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
       data-imported={data.imported ? 'true' : 'false'}
       data-selected={isSelected ? 'true' : 'false'}
       data-adjacent={isAdjacent ? 'true' : 'false'}
+      {...(data.table ? { 'data-table': 'true' } : {})}
       className="contexture-type-node"
       style={{
         minWidth: 180,
@@ -139,17 +140,37 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         >
           {data.typeName}
         </span>
-        <span
-          style={{
-            fontSize: 9,
-            fontWeight: 500,
-            textTransform: 'uppercase',
-            letterSpacing: '0.08em',
-            opacity: 0.75,
-          }}
-        >
-          {data.kind === 'discriminatedUnion' ? 'union' : data.kind}
-        </span>
+        {data.table ? (
+          <span
+            data-testid="type-node-table-badge"
+            title="Convex table"
+            style={{
+              fontSize: 9,
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              padding: '1px 5px',
+              borderRadius: 3,
+              background: 'var(--graph-edge-property)',
+              color: 'var(--graph-node-header-text)',
+              opacity: 0.9,
+            }}
+          >
+            table
+          </span>
+        ) : (
+          <span
+            style={{
+              fontSize: 9,
+              fontWeight: 500,
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              opacity: 0.75,
+            }}
+          >
+            {data.kind === 'discriminatedUnion' ? 'union' : data.kind}
+          </span>
+        )}
       </div>
 
       {data.fields.length > 0 && (

--- a/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
+++ b/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
@@ -31,6 +31,8 @@ export interface TypeNodeData extends Record<string, unknown> {
   description?: string;
   fields: ReadonlyArray<FieldRow>;
   imported: boolean;
+  /** True when the source `ObjectTypeDef` carries `table: true`. */
+  table?: boolean;
 }
 
 export interface FieldRow {
@@ -118,6 +120,7 @@ function localNodeFor(type: TypeDef, position: { x: number; y: number }): Node<T
       description: type.description,
       fields: type.kind === 'object' ? type.fields.map(fieldRow) : [],
       imported: false,
+      table: type.kind === 'object' && type.table === true ? true : undefined,
     },
   };
 }

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -61,6 +61,153 @@ describe('TypeDetail', () => {
     });
   });
 
+  describe('Convex section (object kind)', () => {
+    const base: TypeDef = {
+      kind: 'object',
+      name: 'Post',
+      fields: [
+        { name: 'author', type: { kind: 'string' } },
+        { name: 'title', type: { kind: 'string' } },
+      ],
+    };
+
+    it('renders the "Use as Convex table" checkbox', () => {
+      setup(base);
+      expect(screen.getByLabelText('Use as Convex table')).toBeInTheDocument();
+    });
+
+    it('dispatches set_table_flag when the checkbox toggles on', () => {
+      const { dispatch } = setup(base);
+      fireEvent.click(screen.getByLabelText('Use as Convex table'));
+      expect(dispatch).toHaveBeenCalledWith({
+        kind: 'set_table_flag',
+        typeName: 'Post',
+        table: true,
+      });
+    });
+
+    it('dispatches set_table_flag:false when toggled off', () => {
+      const { dispatch } = setup({ ...base, table: true });
+      fireEvent.click(screen.getByLabelText('Use as Convex table'));
+      expect(dispatch).toHaveBeenCalledWith({
+        kind: 'set_table_flag',
+        typeName: 'Post',
+        table: false,
+      });
+    });
+
+    it('does not show the indexes editor when the type is not a table', () => {
+      setup(base);
+      expect(screen.queryByText('Indexes')).not.toBeInTheDocument();
+    });
+
+    it('shows the indexes editor and add-index button when table:true', () => {
+      setup({ ...base, table: true });
+      expect(screen.getByText('Indexes')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /add index/i })).toBeInTheDocument();
+    });
+
+    it('does not render the Convex section for non-object kinds', () => {
+      setup({
+        kind: 'enum',
+        name: 'Role',
+        values: [{ value: 'admin' }],
+      });
+      expect(screen.queryByLabelText('Use as Convex table')).not.toBeInTheDocument();
+    });
+
+    it('dispatches add_index with a placeholder name when "Add index" is clicked', () => {
+      const { dispatch } = setup({ ...base, table: true });
+      fireEvent.click(screen.getByRole('button', { name: /add index/i }));
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'add_index',
+          typeName: 'Post',
+          index: expect.objectContaining({ fields: [expect.any(String)] }),
+        }),
+      );
+    });
+
+    it('dispatches remove_index when the delete button is clicked', () => {
+      const typeWithIndex: TypeDef = {
+        ...base,
+        table: true,
+        indexes: [{ name: 'by_author', fields: ['author'] }],
+      };
+      const { dispatch } = setup(typeWithIndex);
+      fireEvent.click(screen.getByRole('button', { name: /delete index by_author/i }));
+      expect(dispatch).toHaveBeenCalledWith({
+        kind: 'remove_index',
+        typeName: 'Post',
+        name: 'by_author',
+      });
+    });
+
+    it('dispatches update_index when the name input blurs with a new value', () => {
+      const typeWithIndex: TypeDef = {
+        ...base,
+        table: true,
+        indexes: [{ name: 'by_author', fields: ['author'] }],
+      };
+      const { dispatch } = setup(typeWithIndex);
+      const input = screen.getByDisplayValue('by_author') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'by_writer' } });
+      fireEvent.blur(input);
+      expect(dispatch).toHaveBeenCalledWith({
+        kind: 'update_index',
+        typeName: 'Post',
+        name: 'by_author',
+        patch: { name: 'by_writer' },
+      });
+    });
+
+    it('dispatches update_index when a field checkbox toggles', () => {
+      const typeWithIndex: TypeDef = {
+        ...base,
+        table: true,
+        indexes: [{ name: 'by_author', fields: ['author'] }],
+      };
+      const { dispatch } = setup(typeWithIndex);
+      // The "title" field is not in the index — toggling it on should patch fields.
+      const titleCheckbox = screen.getByLabelText('by_author: title');
+      fireEvent.click(titleCheckbox);
+      expect(dispatch).toHaveBeenCalledWith({
+        kind: 'update_index',
+        typeName: 'Post',
+        name: 'by_author',
+        patch: { fields: ['author', 'title'] },
+      });
+    });
+
+    it('flags type name starting with "_" as reserved when table:true', () => {
+      setup({ ...base, name: '_Post', table: true });
+      const nameInput = screen.getByLabelText('Name') as HTMLInputElement;
+      expect(nameInput.getAttribute('aria-invalid')).toBe('true');
+      expect(nameInput.title).toMatch(/reserves/i);
+    });
+
+    it('does not flag type name starting with "_" when table:false', () => {
+      setup({ ...base, name: '_Post' });
+      const nameInput = screen.getByLabelText('Name') as HTMLInputElement;
+      expect(nameInput.getAttribute('aria-invalid')).not.toBe('true');
+    });
+
+    it('flags field names starting with "_" in the field summary when table:true', () => {
+      const typeWithReserved: TypeDef = {
+        ...base,
+        table: true,
+        fields: [
+          { name: '_id', type: { kind: 'string' } },
+          { name: 'author', type: { kind: 'string' } },
+        ],
+      };
+      setup(typeWithReserved);
+      const rows = screen.getAllByTestId('object-field-summary');
+      expect(rows[0].getAttribute('data-reserved')).toBe('true');
+      expect(rows[1].getAttribute('data-reserved')).not.toBe('true');
+    });
+  });
+
   describe('enum kind', () => {
     const type: TypeDef = {
       kind: 'enum',

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -96,6 +96,31 @@ describe('TypeNode', () => {
     expect(event.detail).toEqual({ typeName: 'Plot', fieldName: 'name' });
   });
 
+  it('marks table-flagged nodes with data-table="true"', () => {
+    const data: TypeNodeData = {
+      typeName: 'Post',
+      kind: 'object',
+      imported: false,
+      table: true,
+      fields: [],
+    };
+    const { container } = render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+    const node = container.querySelector('[data-testid="type-node"]') as HTMLElement;
+    expect(node.dataset.table).toBe('true');
+  });
+
+  it('does not mark non-table nodes with data-table', () => {
+    const data: TypeNodeData = {
+      typeName: 'Post',
+      kind: 'object',
+      imported: false,
+      fields: [],
+    };
+    const { container } = render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+    const node = container.querySelector('[data-testid="type-node"]') as HTMLElement;
+    expect(node.dataset.table).toBeUndefined();
+  });
+
   it('does not render a field list when there are no fields', () => {
     const data: TypeNodeData = {
       typeName: 'Empty',


### PR DESCRIPTION
## Summary
- `TypeDetail` gains a "Convex" section for object kinds: table checkbox + indexes editor (add / rename / delete / toggle fields).
- `TypeNode` marks `table: true` nodes with `data-table` + a "table" header badge for at-a-glance recognition.
- Live `_`-prefix validation (via `aria-invalid` + tooltip) on the type name and field summary rows when the type is table-flagged.

**Stacked on #127** (base: `feat/ir-table-indexes-ops`). The Convex section is always-on for now; scratch-mode gating is tracked in #119.

Closes #117

## Test plan
- [x] `bunx vitest run` — 558 pass (10 new in TypeDetail, 2 new in TypeNode)
- [x] `bun run typecheck` / `lint` / `format:check`
- [x] Manual sanity on selectors — checkbox toggles, "Add index" seeds with the first field, deletes propagate correct op, reserved-prefix warning shows only when `table: true`