### PR TITLE
feat(emit): Convex schema emitter (IR → apps/web/convex/schema.ts)

### DIFF
--- a/apps/desktop/src/renderer/src/model/emit-convex.ts
+++ b/apps/desktop/src/renderer/src/model/emit-convex.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure IR → Convex schema source emitter.
+ *
+ * Turns the IR into the contents of `apps/web/convex/schema.ts`:
+ * table-flagged `ObjectTypeDef`s become `defineTable(...)` entries on
+ * `defineSchema`; indexes chain on via `.index("name", [fields])`.
+ * Non-table object types that are referenced via `ref` are inlined as
+ * `v.object({...})`.
+ *
+ * Convex reserves names starting with `_` (including `_id` and
+ * `_creationTime`). The emitter is the final backstop for that rule —
+ * callers that bypass the UI (chat ops, raw JSON edits) still hit this
+ * check before a broken `schema.ts` lands on disk.
+ *
+ * The function is pure: same IR in, same string out, no I/O.
+ */
+import type { FieldDef, FieldType, Schema, TypeDef } from './ir';
+
+const BANNER = '// @contexture-generated — do not edit by hand. Regenerated on every IR save.';
+
+type ObjectType = Extract<TypeDef, { kind: 'object' }>;
+
+export function emitConvexSchema(schema: Schema): string {
+  validateReservedNames(schema);
+  const objectByName = new Map<string, ObjectType>();
+  for (const t of schema.types) {
+    if (t.kind === 'object') objectByName.set(t.name, t);
+  }
+
+  const tables = schema.types.filter(
+    (t): t is ObjectType => t.kind === 'object' && t.table === true,
+  );
+
+  const tableEntries = tables
+    .map((t) => `  ${t.name}: ${renderTable(t, objectByName)},`)
+    .join('\n');
+
+  const body =
+    tableEntries.length > 0
+      ? `export default defineSchema({\n${tableEntries}\n});\n`
+      : 'export default defineSchema({});\n';
+
+  return [
+    BANNER,
+    '',
+    `import { defineSchema, defineTable } from 'convex/server';`,
+    `import { v } from 'convex/values';`,
+    '',
+    body,
+  ].join('\n');
+}
+
+function renderTable(t: ObjectType, objects: Map<string, ObjectType>): string {
+  const fields = t.fields.map((f) => `    ${f.name}: ${renderFieldDef(f, objects)},`).join('\n');
+  const indexChain = (t.indexes ?? [])
+    .map((i) => `.index("${i.name}", [${i.fields.map((f) => `"${f}"`).join(', ')}])`)
+    .join('');
+  return `defineTable({\n${fields}\n  })${indexChain}`;
+}
+
+function renderFieldDef(f: FieldDef, objects: Map<string, ObjectType>): string {
+  let expr = renderType(f.type, objects);
+  if (f.nullable) expr = `v.union(${expr}, v.null())`;
+  if (f.optional) expr = `v.optional(${expr})`;
+  return expr;
+}
+
+function renderType(t: FieldType, objects: Map<string, ObjectType>): string {
+  switch (t.kind) {
+    case 'string':
+      return 'v.string()';
+    case 'number':
+      return 'v.number()';
+    case 'boolean':
+      return 'v.boolean()';
+    case 'date':
+      // Convex has no native date validator; epoch ms is the conventional
+      // encoding.
+      return 'v.number()';
+    case 'literal':
+      return `v.literal(${JSON.stringify(t.value)})`;
+    case 'ref': {
+      const target = objects.get(t.typeName);
+      if (!target) {
+        // Unknown / qualified ref — fall back to `v.any()` rather than
+        // throwing; semantic validation lives elsewhere.
+        return 'v.any()';
+      }
+      if (target.table === true) {
+        return `v.id("${target.name}")`;
+      }
+      return renderInlineObject(target, objects);
+    }
+    case 'array':
+      return `v.array(${renderType(t.element, objects)})`;
+  }
+}
+
+function renderInlineObject(t: ObjectType, objects: Map<string, ObjectType>): string {
+  const fields = t.fields.map((f) => `${f.name}: ${renderFieldDef(f, objects)}`).join(', ');
+  return `v.object({ ${fields} })`;
+}
+
+function validateReservedNames(schema: Schema): void {
+  for (const t of schema.types) {
+    if (t.kind !== 'object') continue;
+    if (t.table !== true) continue;
+    if (t.name.startsWith('_')) {
+      throw new Error(
+        `emitConvexSchema: table name "${t.name}" is invalid — Convex reserves names starting with "_"`,
+      );
+    }
+    for (const f of t.fields) {
+      if (f.name.startsWith('_')) {
+        throw new Error(
+          `emitConvexSchema: field "${t.name}.${f.name}" is invalid — Convex reserves names starting with "_" (including _id, _creationTime)`,
+        );
+      }
+    }
+  }
+}

--- a/apps/desktop/tests/model/emit-convex.test.ts
+++ b/apps/desktop/tests/model/emit-convex.test.ts
@@ -1,0 +1,191 @@
+import { emitConvexSchema } from '@renderer/model/emit-convex';
+import type { Schema } from '@renderer/model/ir';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+function parses(source: string): boolean {
+  const sf = ts.createSourceFile('schema.ts', source, ts.ScriptTarget.Latest, false);
+  return (sf as unknown as { parseDiagnostics: ts.Diagnostic[] }).parseDiagnostics.length === 0;
+}
+
+describe('emitConvexSchema', () => {
+  it('emits the @contexture-generated banner and a defineSchema call for an empty IR', () => {
+    const ir: Schema = { version: '1', types: [] };
+    const out = emitConvexSchema(ir);
+    expect(out).toContain('@contexture-generated');
+    expect(out).toMatch(/defineSchema\s*\(/);
+    expect(parses(out)).toBe(true);
+  });
+
+  it('emits a single table with v.* field validators', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [
+            { name: 'title', type: { kind: 'string' } },
+            { name: 'views', type: { kind: 'number' } },
+            { name: 'published', type: { kind: 'boolean' } },
+            { name: 'createdAt', type: { kind: 'date' } },
+            { name: 'kind', type: { kind: 'literal', value: 'post' } },
+          ],
+        },
+      ],
+    };
+    const out = emitConvexSchema(ir);
+    expect(out).toMatch(/Post:\s*defineTable\(\{/);
+    expect(out).toContain('title: v.string()');
+    expect(out).toContain('views: v.number()');
+    expect(out).toContain('published: v.boolean()');
+    expect(out).toContain('createdAt: v.number()');
+    expect(out).toContain('kind: v.literal("post")');
+    expect(parses(out)).toBe(true);
+  });
+
+  it('emits v.optional / v.union(..., v.null()) wrappers for optional and nullable fields', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [
+            { name: 'subtitle', type: { kind: 'string' }, optional: true },
+            { name: 'summary', type: { kind: 'string' }, nullable: true },
+            { name: 'both', type: { kind: 'string' }, optional: true, nullable: true },
+          ],
+        },
+      ],
+    };
+    const out = emitConvexSchema(ir);
+    expect(out).toContain('subtitle: v.optional(v.string())');
+    expect(out).toContain('summary: v.union(v.string(), v.null())');
+    expect(out).toContain('both: v.optional(v.union(v.string(), v.null()))');
+  });
+
+  it('emits v.array(...) for array fields', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'tags', type: { kind: 'array', element: { kind: 'string' } } }],
+        },
+      ],
+    };
+    const out = emitConvexSchema(ir);
+    expect(out).toContain('tags: v.array(v.string())');
+  });
+
+  it('emits v.id("Target") for refs to other table-flagged types', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Author', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'author', type: { kind: 'ref', typeName: 'Author' } }],
+        },
+      ],
+    };
+    const out = emitConvexSchema(ir);
+    expect(out).toContain('author: v.id("Author")');
+    expect(parses(out)).toBe(true);
+  });
+
+  it('inlines non-table object types referenced from tables as v.object(...)', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Address',
+          fields: [
+            { name: 'city', type: { kind: 'string' } },
+            { name: 'zip', type: { kind: 'string' } },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'User',
+          table: true,
+          fields: [{ name: 'home', type: { kind: 'ref', typeName: 'Address' } }],
+        },
+      ],
+    };
+    const out = emitConvexSchema(ir);
+    expect(out).toMatch(
+      /home:\s*v\.object\(\{\s*city:\s*v\.string\(\),\s*zip:\s*v\.string\(\)\s*\}\)/,
+    );
+    // Only User should be a defineTable entry.
+    expect(out).not.toMatch(/Address:\s*defineTable/);
+    expect(parses(out)).toBe(true);
+  });
+
+  it('emits .index("name", [...]) chained on defineTable', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [
+            { name: 'author', type: { kind: 'string' } },
+            { name: 'publishedAt', type: { kind: 'date' } },
+          ],
+          indexes: [
+            { name: 'by_author', fields: ['author'] },
+            { name: 'by_author_and_date', fields: ['author', 'publishedAt'] },
+          ],
+        },
+      ],
+    };
+    const out = emitConvexSchema(ir);
+    expect(out).toContain('.index("by_author", ["author"])');
+    expect(out).toContain('.index("by_author_and_date", ["author", "publishedAt"])');
+    expect(parses(out)).toBe(true);
+  });
+
+  it('throws when a table name starts with "_"', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [{ kind: 'object', name: '_Post', table: true, fields: [] }],
+    };
+    expect(() => emitConvexSchema(ir)).toThrow(/_Post.*reserves/);
+  });
+
+  it('throws when a field name starts with "_"', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: '_id', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    expect(() => emitConvexSchema(ir)).toThrow(/_id.*reserves/);
+  });
+
+  it('does not flag `_`-prefix on non-table object types', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: '_Internal', fields: [{ name: '_x', type: { kind: 'string' } }] },
+      ],
+    };
+    // No table-flagged types — emitter should succeed.
+    expect(() => emitConvexSchema(ir)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Pure IR → string emitter at `apps/desktop/src/renderer/src/model/emit-convex.ts` producing the contents of `apps/web/convex/schema.ts` from the Contexture IR.
- Table-flagged `ObjectTypeDef`s become `defineTable({...})` entries on `defineSchema`; `indexes` chain on via `.index("name", [fields])`.
- Field types map to Convex validators: `string/number/boolean/literal → v.*`, `date → v.number()` (epoch ms), `array → v.array(...)`, `ref → v.id("Target")` for table refs or inlined `v.object({...})` for non-table refs. Unknown refs fall back to `v.any()`.
- `optional` wraps with `v.optional(...)`, `nullable` wraps with `v.union(..., v.null())`; both compose.
- Final backstop for Convex's "_"-prefix rule on table + field names — throws with a clear message so chat ops / raw JSON edits can't land a broken `schema.ts`. Non-table object types are exempt.
- Includes a `@contexture-generated` banner so the file is obviously machine-generated.

Stacked on #128 ([feat/convex-detail-panel](https://github.com/applification/contexture/tree/feat/convex-detail-panel)). Closes #118.

## Test plan
- [x] `vitest` suite green (568/568 incl. 10 new emitter tests)
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [ ] Manual: regenerate a schema.ts from a sample IR and tsc-compile it in `apps/web/convex`