### PR TITLE
feat: per-table CRUD seed emitter + seed-once semantics

### DIFF
--- a/apps/desktop/src/main/documents/document-store.ts
+++ b/apps/desktop/src/main/documents/document-store.ts
@@ -22,6 +22,7 @@ import { emit as defaultEmitClaudeMd } from '@renderer/model/emit-claude-md';
 import { emitConvexSchema as defaultEmitConvex } from '@renderer/model/emit-convex';
 import { emit as defaultEmitJsonSchema } from '@renderer/model/emit-json-schema';
 import { emit as defaultEmitSchemaIndex } from '@renderer/model/emit-schema-index';
+import { emitTableCrud as defaultEmitTableCrud } from '@renderer/model/emit-table-crud';
 import { emit as defaultEmitZod } from '@renderer/model/emit-zod';
 import type { Schema } from '@renderer/model/ir';
 import { type Layout, loadLayout, saveLayout } from '@renderer/model/layout';
@@ -103,6 +104,8 @@ export interface DocumentStoreDeps {
   emitClaudeMd?: (projectName: string) => string;
   /** Override for tests — defaults to the real Convex emitter. */
   emitConvex?: (schema: Schema) => string;
+  /** Override for tests — defaults to the real per-table CRUD emitter. */
+  emitTableCrud?: (schema: Schema, tableName: string) => string;
   /** Optional hook for main-process integration (e.g. `app.addRecentDocument`). */
   onRecentFileAdded?: (path: string) => void;
 }
@@ -201,6 +204,7 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
     emitSchemaIndex = defaultEmitSchemaIndex,
     emitClaudeMd = defaultEmitClaudeMd,
     emitConvex = defaultEmitConvex,
+    emitTableCrud = defaultEmitTableCrud,
     onRecentFileAdded,
   } = deps;
 
@@ -265,6 +269,16 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
         const claudePath = `${root}/CLAUDE.md`;
         if (!(await fs.fileExists(claudePath))) {
           await fs.writeFile(claudePath, emitClaudeMd(baseNameFor(irPath)));
+        }
+        // Seed one `apps/web/convex/<table>.ts` per table-flagged object.
+        // Written only if missing — these are `@contexture-seeded`, owned
+        // by the user/coding agent from first write on.
+        for (const type of schema.types) {
+          if (type.kind !== 'object' || type.table !== true) continue;
+          const crudPath = `${root}/apps/web/convex/${type.name}.ts`;
+          if (!(await fs.fileExists(crudPath))) {
+            await fs.writeFile(crudPath, emitTableCrud(schema, type.name));
+          }
         }
       }
     }

--- a/apps/desktop/src/main/documents/node-fs-adapter.ts
+++ b/apps/desktop/src/main/documents/node-fs-adapter.ts
@@ -4,6 +4,7 @@
  * `document-store.ts`; this file is just the Node-specific plumbing.
  */
 import { promises as fs } from 'node:fs';
+import { dirname } from 'node:path';
 import type { FsAdapter } from './document-store';
 
 export const nodeFsAdapter: FsAdapter = {
@@ -11,6 +12,10 @@ export const nodeFsAdapter: FsAdapter = {
     return fs.readFile(path, 'utf-8');
   },
   async writeFile(path, content) {
+    // Project-mode seeding may target paths like
+    // `apps/web/convex/<table>.ts` whose parent directories don't exist
+    // yet on first open. Mirror MemFsAdapter's implicit-parent semantics.
+    await fs.mkdir(dirname(path), { recursive: true });
     await fs.writeFile(path, content, 'utf-8');
   },
   async rename(from, to) {

--- a/apps/desktop/src/renderer/src/model/emit-table-crud.ts
+++ b/apps/desktop/src/renderer/src/model/emit-table-crud.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure emitter for `apps/web/convex/<table>.ts` — the starter CRUD file
+ * scaffolded for each table-flagged object. Unlike the other emitters
+ * in this folder, the output is `@contexture-seeded`: written once on
+ * first project-mode open and then left alone. Users and coding agents
+ * own this file from that point on, so the header specifically calls
+ * out that the file is editable and will not be regenerated.
+ *
+ * Pure function: same IR in, same string out, no I/O.
+ */
+import type { Schema, TypeDef } from './ir';
+
+const BANNER =
+  '// @contexture-seeded — Contexture created this on scaffold. Edit freely; not regenerated.';
+
+type ObjectType = Extract<TypeDef, { kind: 'object' }>;
+
+export function emitTableCrud(schema: Schema, tableName: string): string {
+  const type = schema.types.find((t) => t.name === tableName);
+  if (!type || type.kind !== 'object' || type.table !== true) {
+    throw new Error(`emitTableCrud: "${tableName}" is not a table-flagged object in the schema`);
+  }
+  return render(type);
+}
+
+function render(table: ObjectType): string {
+  const patchFields = table.fields
+    .filter((f) => f.name !== '_id' && f.name !== '_creationTime')
+    .map((f) => `    ${f.name}: v.optional(v.any()),`)
+    .join('\n');
+  const createFields = table.fields
+    .filter((f) => f.name !== '_id' && f.name !== '_creationTime')
+    .map((f) => `    ${f.name}: v.any(),`)
+    .join('\n');
+
+  return `${BANNER}
+import { v } from 'convex/values';
+import { mutation, query } from './_generated/server';
+
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("${table.name}").collect();
+  },
+});
+
+export const get = query({
+  args: { id: v.id("${table.name}") },
+  handler: async (ctx, { id }) => {
+    return await ctx.db.get(id);
+  },
+});
+
+export const create = mutation({
+  args: {
+${createFields}
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("${table.name}", args);
+  },
+});
+
+export const update = mutation({
+  args: {
+    id: v.id("${table.name}"),
+${patchFields}
+  },
+  handler: async (ctx, { id, ...patch }) => {
+    await ctx.db.patch(id, patch);
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.id("${table.name}") },
+  handler: async (ctx, { id }) => {
+    await ctx.db.delete(id);
+  },
+});
+`;
+}

--- a/apps/desktop/tests/main/document-store.test.ts
+++ b/apps/desktop/tests/main/document-store.test.ts
@@ -254,6 +254,81 @@ describe('DocumentStore', () => {
     expect(claude).toBe('# user-owned notes\n');
   });
 
+  it('project-mode open seeds apps/web/convex/<table>.ts for each table-flagged type when missing', async () => {
+    const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
+    const tableSchema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+        {
+          // Non-table object should NOT get a CRUD file.
+          kind: 'object',
+          name: 'Inline',
+          fields: [{ name: 'x', type: { kind: 'number' } }],
+        },
+      ],
+    };
+    const { store, fs } = setup({
+      [monorepoIrPath]: JSON.stringify(tableSchema),
+      '/proj/packages/schema/.contexture/.keep': '',
+    });
+    await store.open(monorepoIrPath);
+    const postPath = '/proj/apps/web/convex/Post.ts';
+    expect(fs.exists(postPath)).toBe(true);
+    const contents = await fs.readFile(postPath);
+    expect(contents).toContain('@contexture-seeded');
+    expect(contents).toContain('ctx.db.query("Post")');
+    // Non-table types get no file.
+    expect(fs.exists('/proj/apps/web/convex/Inline.ts')).toBe(false);
+  });
+
+  it('project-mode open never overwrites an existing per-table CRUD file', async () => {
+    const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
+    const tableSchema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    const userOwned = '// user-modified CRUD, do not touch\nexport const list = null;\n';
+    const { store, fs } = setup({
+      [monorepoIrPath]: JSON.stringify(tableSchema),
+      '/proj/packages/schema/.contexture/.keep': '',
+      '/proj/apps/web/convex/Post.ts': userOwned,
+    });
+    await store.open(monorepoIrPath);
+    expect(await fs.readFile('/proj/apps/web/convex/Post.ts')).toBe(userOwned);
+  });
+
+  it('scratch-mode open does not seed per-table CRUD files', async () => {
+    const tableSchema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    const { store, fs } = setup({ [irPath]: JSON.stringify(tableSchema) });
+    await store.open(irPath);
+    // Scratch mode has no project root, so no convex tree can be seeded.
+    expect(fs.exists('/apps/web/convex/Post.ts')).toBe(false);
+    expect(fs.exists('/work/apps/web/convex/Post.ts')).toBe(false);
+  });
+
   it('scratch-mode open does not write CLAUDE.md', async () => {
     const { store, fs } = setup({ [irPath]: JSON.stringify(sampleIR) });
     await store.open(irPath);

--- a/apps/desktop/tests/main/document-store.test.ts
+++ b/apps/desktop/tests/main/document-store.test.ts
@@ -287,6 +287,41 @@ describe('DocumentStore', () => {
     expect(fs.exists('/proj/apps/web/convex/Inline.ts')).toBe(false);
   });
 
+  it('auto-save never clobbers a user-edited seeded CRUD file', async () => {
+    // Seeded CRUD files are @contexture-seeded, not @contexture-generated.
+    // Once seeded, they must survive every subsequent IR save — the user
+    // or coding agent owns them.
+    const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
+    const tableSchema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    const { store, fs } = setup({
+      [monorepoIrPath]: JSON.stringify(tableSchema),
+      '/proj/packages/schema/.contexture/.keep': '',
+    });
+    await store.open(monorepoIrPath);
+    const crudPath = '/proj/apps/web/convex/Post.ts';
+    // User edits the seeded file.
+    const userEdit = '// user took over\nexport const list = () => 42;\n';
+    await fs.writeFile(crudPath, userEdit);
+    // An IR save goes through.
+    await store.save({
+      irPath: monorepoIrPath,
+      schema: tableSchema,
+      layout: { version: '1', positions: {} },
+      chat: { version: '1', messages: [] },
+    });
+    expect(await fs.readFile(crudPath)).toBe(userEdit);
+  });
+
   it('project-mode open never overwrites an existing per-table CRUD file', async () => {
     const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
     const tableSchema: Schema = {
@@ -365,6 +400,39 @@ describe('DocumentStore', () => {
     for (const hash of Object.values(manifest.files)) {
       expect(hash).toMatch(/^[a-f0-9]{64}$/);
     }
+  });
+
+  it('emitted.json does not track seeded per-table CRUD files', async () => {
+    // Seeded files are not @contexture-generated, so they must not appear
+    // in the drift manifest. A drift check flags regen-on-mismatch;
+    // listing seeded files there would cause them to be regenerated.
+    const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
+    const tableSchema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    const { store, fs } = setup({
+      [monorepoIrPath]: JSON.stringify(tableSchema),
+      '/proj/packages/schema/.contexture/.keep': '',
+    });
+    await store.open(monorepoIrPath);
+    await store.save({
+      irPath: monorepoIrPath,
+      schema: tableSchema,
+      layout: { version: '1', positions: {} },
+      chat: { version: '1', messages: [] },
+    });
+    const manifest = JSON.parse(
+      await fs.readFile('/proj/packages/schema/.contexture/emitted.json'),
+    ) as { files: Record<string, string> };
+    expect(Object.keys(manifest.files)).not.toContain('/proj/apps/web/convex/Post.ts');
   });
 
   it('scratch-mode save does not write a schema index', async () => {

--- a/apps/desktop/tests/model/emit-table-crud.test.ts
+++ b/apps/desktop/tests/model/emit-table-crud.test.ts
@@ -1,0 +1,115 @@
+/**
+ * `emitTableCrud` — per-table CRUD seed emitter.
+ *
+ * Produces the contents of `apps/web/convex/<table>.ts`: a starter set
+ * of queries + mutations for a single table. Unlike the other emitters
+ * in this folder, this file is `@contexture-seeded` — written once at
+ * scaffold time, then never re-generated (users / coding agents are
+ * expected to edit it). The banner warns re-emitters off.
+ */
+import { emitTableCrud } from '@renderer/model/emit-table-crud';
+import type { Schema } from '@renderer/model/ir';
+import { describe, expect, it } from 'vitest';
+
+const singleTable: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Post',
+      table: true,
+      fields: [
+        { name: 'title', type: { kind: 'string' } },
+        { name: 'body', type: { kind: 'string' } },
+      ],
+    },
+  ],
+};
+
+describe('emitTableCrud', () => {
+  it('starts with the @contexture-seeded banner', () => {
+    const out = emitTableCrud(singleTable, 'Post');
+    const firstLine = out.split('\n', 1)[0];
+    expect(firstLine).toMatch(/@contexture-seeded/);
+    expect(firstLine).toMatch(/edit freely/i);
+    expect(firstLine).toMatch(/not regenerated/i);
+  });
+
+  it('imports the Convex query + mutation helpers', () => {
+    const out = emitTableCrud(singleTable, 'Post');
+    expect(out).toMatch(/from\s+["']\.\/_generated\/server["']/);
+    expect(out).toMatch(/query/);
+    expect(out).toMatch(/mutation/);
+  });
+
+  it('exports the baseline operations: list, get, create, update, remove', () => {
+    const out = emitTableCrud(singleTable, 'Post');
+    expect(out).toMatch(/export const list\s*=/);
+    expect(out).toMatch(/export const get\s*=/);
+    expect(out).toMatch(/export const create\s*=/);
+    expect(out).toMatch(/export const update\s*=/);
+    expect(out).toMatch(/export const remove\s*=/);
+  });
+
+  it('uses the table name when calling ctx.db methods', () => {
+    const out = emitTableCrud(singleTable, 'Post');
+    expect(out).toMatch(/ctx\.db\.query\("Post"\)/);
+    expect(out).toMatch(/ctx\.db\.insert\("Post"/);
+  });
+
+  it('emits one file per named table — multi-table schemas stay isolated', () => {
+    const multi: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+        {
+          kind: 'object',
+          name: 'Comment',
+          table: true,
+          fields: [{ name: 'body', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    const post = emitTableCrud(multi, 'Post');
+    const comment = emitTableCrud(multi, 'Comment');
+    expect(post).toContain('ctx.db.query("Post")');
+    expect(post).not.toContain('"Comment"');
+    expect(comment).toContain('ctx.db.query("Comment")');
+    expect(comment).not.toContain('"Post"');
+  });
+
+  it('emits CRUD for an indexed table identically to a non-indexed one', () => {
+    // Indexes live in schema.ts, not the per-table CRUD file, so CRUD
+    // output must be unaffected by their presence.
+    const indexed: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [
+            { name: 'title', type: { kind: 'string' } },
+            { name: 'body', type: { kind: 'string' } },
+          ],
+          indexes: [{ name: 'by_title', fields: ['title'] }],
+        },
+      ],
+    };
+    expect(emitTableCrud(indexed, 'Post')).toBe(emitTableCrud(singleTable, 'Post'));
+  });
+
+  it('throws when the named table does not exist or is not table-flagged', () => {
+    expect(() => emitTableCrud(singleTable, 'Nope')).toThrow(/Post|table/i);
+    const notATable: Schema = {
+      version: '1',
+      types: [{ kind: 'object', name: 'Inline', fields: [] }],
+    };
+    expect(() => emitTableCrud(notATable, 'Inline')).toThrow(/table/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Pure `emitTableCrud` produces `apps/web/convex/<table>.ts` with the `@contexture-seeded` banner — list/get/create/update/remove baseline, indexes ignored (they live in schema.ts).
- DocumentStore seeds one file per table-flagged object on first project-mode open; existing files are never overwritten. NodeFsAdapter.writeFile now mkdir -p's the parent dir.
- Regression tests: user-edited seeded file survives subsequent IR saves, and `.contexture/emitted.json` never tracks seeded files (so drift detection won't regenerate them).

Closes #120.

## Test plan
- [x] `emit-table-crud.test.ts` — 7 tests covering banner, imports, baseline ops, table-name substitution, multi-table isolation, indexed-table parity, error on non-table.
- [x] `document-store.test.ts` — adds 5 tests: seeds on project open, never overwrites existing, scratch does not seed, auto-save preserves user-edited seeded file, emitted.json excludes seeded files.
- [x] Full desktop suite: 618 pass.