### PR TITLE
feat(scaffold): ten-stage project scaffolder (#121)

### DIFF
--- a/apps/desktop/src/main/documents/document-store.ts
+++ b/apps/desktop/src/main/documents/document-store.ts
@@ -188,10 +188,10 @@ export function bundlePathsFor(irPath: string): {
     // Workspace re-export: consumers `import { … } from '@<project>/schema'`
     // and resolve to this barrel rather than a specific `.schema` module.
     schemaIndex: `${dir}/index.ts`,
-    // Convex schema is the headline emitted artefact — `schema.ts`
-    // sits next to the IR so `apps/*` re-export it via
-    // `packages/schema/schema.ts`.
-    convex: `${dir}/schema.ts`,
+    // Convex demands a `convex/` subdir sibling of its callers; the
+    // schema package hosts it so `apps/web` imports the workspace
+    // package rather than owning its own convex folder.
+    convex: `${dir}/convex/schema.ts`,
   };
 }
 
@@ -270,12 +270,13 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
         if (!(await fs.fileExists(claudePath))) {
           await fs.writeFile(claudePath, emitClaudeMd(baseNameFor(irPath)));
         }
-        // Seed one `apps/web/convex/<table>.ts` per table-flagged object.
-        // Written only if missing — these are `@contexture-seeded`, owned
-        // by the user/coding agent from first write on.
+        // Seed one `packages/schema/convex/<table>.ts` per table-flagged
+        // object. Written only if missing — these are `@contexture-seeded`,
+        // owned by the user/coding agent from first write on.
+        const schemaDir = contextureDirFor(irPath).slice(0, -'/.contexture'.length);
         for (const type of schema.types) {
           if (type.kind !== 'object' || type.table !== true) continue;
-          const crudPath = `${root}/apps/web/convex/${type.name}.ts`;
+          const crudPath = `${schemaDir}/convex/${type.name}.ts`;
           if (!(await fs.fileExists(crudPath))) {
             await fs.writeFile(crudPath, emitTableCrud(schema, type.name));
           }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { electronApp, is, optimizer } from '@electron-toolkit/utils';
 import { registerClaudeIpc } from './ipc/claude';
 import { registerFileIpc } from './ipc/file';
+import { registerScaffoldIpc } from './ipc/scaffold';
 import { registerUpdateIpc } from './ipc/update';
 import { createMenu } from './menu';
 
@@ -71,6 +72,7 @@ app.whenReady().then(() => {
   Menu.setApplicationMenu(createMenu(mainWindow));
   registerUpdateIpc(mainWindow);
   registerFileIpc(mainWindow);
+  registerScaffoldIpc(mainWindow);
   registerClaudeIpc(mainWindow);
 
   app.on('activate', () => {

--- a/apps/desktop/src/main/ipc/scaffold.ts
+++ b/apps/desktop/src/main/ipc/scaffold.ts
@@ -13,7 +13,9 @@ import { ipcMain } from 'electron';
 import type { FsAdapter } from '../documents/document-store';
 import { nodeFsAdapter } from '../documents/node-fs-adapter';
 import { createCompositeStageRunner } from '../scaffold/composite-runner';
-import type { PreflightError, PreflightResult } from '../scaffold/preflight';
+import { nodePreflightDeps } from '../scaffold/node-preflight-deps';
+import { nodeSpawner } from '../scaffold/node-spawner';
+import { type PreflightError, type PreflightResult, runPreflight } from '../scaffold/preflight';
 import {
   type ScaffoldConfig,
   type StageEvent,
@@ -57,13 +59,9 @@ export function registerScaffoldIpc(mainWindow: BrowserWindow): void {
   ipcMain.handle('scaffold:start', async (_evt, config: ScaffoldConfig) => {
     await handleScaffoldStart(config, {
       fs: nodeFsAdapter,
-      spawner: productionSpawner,
-      preflight: async () => ({ ok: true }),
+      spawner: nodeSpawner,
+      preflight: (c) => runPreflight({ targetDir: c.targetDir }, nodePreflightDeps),
       emit: (ev) => mainWindow.webContents.send('scaffold:event', ev),
     });
   });
 }
-
-const productionSpawner: Spawner = () => {
-  throw new Error('productionSpawner not yet wired — slice 10 wires child_process.spawn');
-};

--- a/apps/desktop/src/main/ipc/scaffold.ts
+++ b/apps/desktop/src/main/ipc/scaffold.ts
@@ -1,0 +1,69 @@
+/**
+ * `handleScaffoldStart` — the pure side of the scaffold IPC. Runs
+ * preflight, then drives `scaffoldProject` through the composite
+ * runner, forwarding every `StageEvent` (and a preflight-failed
+ * event when applicable) via the supplied `emit` callback.
+ *
+ * Kept callback-shaped so tests can drive it without Electron;
+ * `registerScaffoldIpc` binds it to `webContents.send`.
+ */
+import type { BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
+
+import type { FsAdapter } from '../documents/document-store';
+import { nodeFsAdapter } from '../documents/node-fs-adapter';
+import { createCompositeStageRunner } from '../scaffold/composite-runner';
+import type { PreflightError, PreflightResult } from '../scaffold/preflight';
+import {
+  type ScaffoldConfig,
+  type StageEvent,
+  scaffoldProject,
+} from '../scaffold/scaffold-project';
+import type { Spawner } from '../scaffold/spawn-runner';
+
+export type ScaffoldEvent = StageEvent | { kind: 'preflight-failed'; error: PreflightError };
+
+export interface ScaffoldHandlerDeps {
+  fs: FsAdapter;
+  spawner: Spawner;
+  preflight: (config: ScaffoldConfig) => Promise<PreflightResult>;
+  emit: (event: ScaffoldEvent) => void;
+  /** Test-only hook — production writes the log through fs. */
+  writeLog?: (path: string, content: string) => Promise<void>;
+}
+
+export async function handleScaffoldStart(
+  config: ScaffoldConfig,
+  deps: ScaffoldHandlerDeps,
+): Promise<void> {
+  const { fs, spawner, preflight, emit, writeLog } = deps;
+
+  const preflightResult = await preflight(config);
+  if (!preflightResult.ok) {
+    emit({ kind: 'preflight-failed', error: preflightResult.error });
+    return;
+  }
+
+  const runner = createCompositeStageRunner({ fs, spawner });
+  const logWriter =
+    writeLog ?? (async (path: string, content: string) => fs.writeFile(path, content));
+
+  for await (const ev of scaffoldProject(config, { runner, writeLog: logWriter })) {
+    emit(ev);
+  }
+}
+
+export function registerScaffoldIpc(mainWindow: BrowserWindow): void {
+  ipcMain.handle('scaffold:start', async (_evt, config: ScaffoldConfig) => {
+    await handleScaffoldStart(config, {
+      fs: nodeFsAdapter,
+      spawner: productionSpawner,
+      preflight: async () => ({ ok: true }),
+      emit: (ev) => mainWindow.webContents.send('scaffold:event', ev),
+    });
+  });
+}
+
+const productionSpawner: Spawner = () => {
+  throw new Error('productionSpawner not yet wired — slice 10 wires child_process.spawn');
+};

--- a/apps/desktop/src/main/scaffold/composite-runner.ts
+++ b/apps/desktop/src/main/scaffold/composite-runner.ts
@@ -24,13 +24,13 @@ export interface CompositeRunnerDeps {
   spawner: Spawner;
 }
 
-const SHELL_STAGES: ReadonlySet<StageNumber> = new Set([1, 2, 3, 4, 5, 9]);
+const PURE_SHELL_STAGES: ReadonlySet<StageNumber> = new Set([1, 2, 3, 4, 9]);
 
 export function createCompositeStageRunner(deps: CompositeRunnerDeps): StageRunner {
   const { fs, spawner } = deps;
   return {
     run(stage: StageNumber, config: ScaffoldConfig): AsyncIterable<StageChunk> {
-      if (SHELL_STAGES.has(stage)) {
+      if (PURE_SHELL_STAGES.has(stage)) {
         return spawner(shellStageSpecFor(stage, config));
       }
       return runInProcess(stage, config);
@@ -42,6 +42,35 @@ export function createCompositeStageRunner(deps: CompositeRunnerDeps): StageRunn
     config: ScaffoldConfig,
   ): AsyncIterable<StageChunk> {
     switch (stage) {
+      case 5: {
+        // Convex CLI needs (a) a package.json in cwd, (b) `convex` listed as
+        // a dep to reach the push step, and (c) `convex/server` resolvable
+        // on disk or its config bundler fails. So we write a bare anchor,
+        // install only convex locally, then run `convex dev --once`. Stage 6
+        // rewrites this file with the real schema-package shape later.
+        const schemaDir = `${config.targetDir}/packages/schema`;
+        await fs.writeFile(
+          `${schemaDir}/package.json`,
+          `${JSON.stringify(
+            {
+              name: `@${config.projectName}/schema`,
+              private: true,
+              dependencies: { convex: 'latest' },
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        for await (const chunk of spawner({
+          cmd: 'bun',
+          args: ['install'],
+          cwd: schemaDir,
+        })) {
+          yield chunk;
+        }
+        for await (const chunk of spawner(shellStageSpecFor(5, config))) yield chunk;
+        return;
+      }
       case 6:
         await scaffoldSchemaPackage(config, { fs });
         return;

--- a/apps/desktop/src/main/scaffold/composite-runner.ts
+++ b/apps/desktop/src/main/scaffold/composite-runner.ts
@@ -1,0 +1,64 @@
+/**
+ * `createCompositeStageRunner` — the production `StageRunner`: one
+ * object that knows how to run every stage 1-10. Shell-backed stages
+ * (1-5, 9) go through the injected `Spawner`; in-process stages
+ * (6 schema package, 7 Convex emit, 8 workspace stitch + git trio)
+ * run directly against the injected `FsAdapter`. Stage 10 is a
+ * no-op in v1 (LLM seeding lives in a separate issue).
+ *
+ * Splitting dispatch from implementation keeps the orchestrator
+ * ignorant of how any given stage does its work — it just drains
+ * the chunk stream and watches for throws.
+ */
+import type { FsAdapter } from '@main/documents/document-store';
+import { scaffoldConvexEmit } from './convex-emit';
+import { gitInitStageSpec } from './git-init';
+import type { ScaffoldConfig, StageChunk, StageNumber, StageRunner } from './scaffold-project';
+import { scaffoldSchemaPackage } from './schema-package';
+import type { Spawner } from './spawn-runner';
+import { shellStageSpecFor } from './stages';
+import { scaffoldWorkspaceStitch } from './workspace-stitch';
+
+export interface CompositeRunnerDeps {
+  fs: FsAdapter;
+  spawner: Spawner;
+}
+
+const SHELL_STAGES: ReadonlySet<StageNumber> = new Set([1, 2, 3, 4, 5, 9]);
+
+export function createCompositeStageRunner(deps: CompositeRunnerDeps): StageRunner {
+  const { fs, spawner } = deps;
+  return {
+    run(stage: StageNumber, config: ScaffoldConfig): AsyncIterable<StageChunk> {
+      if (SHELL_STAGES.has(stage)) {
+        return spawner(shellStageSpecFor(stage, config));
+      }
+      return runInProcess(stage, config);
+    },
+  };
+
+  async function* runInProcess(
+    stage: StageNumber,
+    config: ScaffoldConfig,
+  ): AsyncIterable<StageChunk> {
+    switch (stage) {
+      case 6:
+        await scaffoldSchemaPackage(config, { fs });
+        return;
+      case 7:
+        await scaffoldConvexEmit(config, { fs });
+        return;
+      case 8: {
+        await scaffoldWorkspaceStitch(config, { fs });
+        for (const spec of gitInitStageSpec(config)) {
+          for await (const chunk of spawner(spec)) yield chunk;
+        }
+        return;
+      }
+      case 10:
+        return;
+      default:
+        throw new Error(`composite runner: unexpected in-process stage ${stage}`);
+    }
+  }
+}

--- a/apps/desktop/src/main/scaffold/convex-emit.ts
+++ b/apps/desktop/src/main/scaffold/convex-emit.ts
@@ -1,0 +1,33 @@
+/**
+ * `scaffoldConvexEmit` (stage 7) — reads the IR that stage 6 just
+ * wrote and emits the Convex schema at
+ * `packages/schema/convex/schema.ts`. At scaffold time the IR is
+ * empty, so the emitted file is a degenerate `defineSchema({})` — but
+ * Convex requires the file to exist before `bun run dev` can start,
+ * so this stage always runs.
+ *
+ * Per-table CRUD seeds aren't written here: the initial IR has no
+ * `table: true` objects. Stage 10 (optional LLM seed) may populate
+ * tables; the subsequent save then seeds CRUD via the DocumentStore's
+ * open-time seed loop.
+ */
+import type { FsAdapter } from '@main/documents/document-store';
+import { emitConvexSchema } from '@renderer/model/emit-convex';
+import type { Schema } from '@renderer/model/ir';
+
+import type { ScaffoldConfig } from './scaffold-project';
+
+export interface ConvexEmitDeps {
+  fs: FsAdapter;
+}
+
+export async function scaffoldConvexEmit(
+  config: ScaffoldConfig,
+  deps: ConvexEmitDeps,
+): Promise<void> {
+  const { fs } = deps;
+  const schemaDir = `${config.targetDir}/packages/schema`;
+  const irPath = `${schemaDir}/${config.projectName}.contexture.json`;
+  const ir = JSON.parse(await fs.readFile(irPath)) as Schema;
+  await fs.writeFile(`${schemaDir}/convex/schema.ts`, emitConvexSchema(ir));
+}

--- a/apps/desktop/src/main/scaffold/git-init.ts
+++ b/apps/desktop/src/main/scaffold/git-init.ts
@@ -1,0 +1,21 @@
+/**
+ * `gitInitStageSpec` — the trio of `git init` / `git add -A` /
+ * `git commit` commands that run after the scaffold's file work is
+ * done. Held as a spec list (same shape as `ShellStageSpec`) so the
+ * orchestrator runs them through the injected Spawner like any other
+ * shell stage — no special-case git plumbing in the main path.
+ */
+import type { ScaffoldConfig } from './scaffold-project';
+import type { ShellStageSpec } from './stages';
+
+export function gitInitStageSpec(config: ScaffoldConfig): ShellStageSpec[] {
+  return [
+    { cmd: 'git', args: ['init'], cwd: config.targetDir },
+    { cmd: 'git', args: ['add', '-A'], cwd: config.targetDir },
+    {
+      cmd: 'git',
+      args: ['commit', '-m', 'initial scaffold by Contexture'],
+      cwd: config.targetDir,
+    },
+  ];
+}

--- a/apps/desktop/src/main/scaffold/node-preflight-deps.ts
+++ b/apps/desktop/src/main/scaffold/node-preflight-deps.ts
@@ -1,0 +1,62 @@
+/**
+ * Production `PreflightDeps` — the real-world implementations that
+ * bind the pure `runPreflight` to `node:child_process`, `node:fs`,
+ * `node:fs/promises` and `fetch`. Split out from `runPreflight` so the
+ * unit tests can drive the logic with fakes and this file owns the
+ * small amount of actual I/O.
+ */
+import { exec } from 'node:child_process';
+import { promises as fsp, statSync } from 'node:fs';
+import { promisify } from 'node:util';
+
+import type { PreflightDeps } from './preflight';
+
+const execAsync = promisify(exec);
+
+export const nodePreflightDeps: PreflightDeps = {
+  async runCommand(cmd) {
+    try {
+      const { stdout } = await execAsync(cmd, { timeout: 5000 });
+      return { stdout, code: 0 };
+    } catch (err) {
+      const e = err as { code?: number; stdout?: string };
+      return { stdout: e.stdout ?? '', code: e.code ?? 1 };
+    }
+  },
+  async headOk(url) {
+    try {
+      const res = await fetch(url, { method: 'HEAD' });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  },
+  async parentDirWritable(path) {
+    try {
+      await fsp.access(path, fsp.constants.W_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  async targetDirExists(path) {
+    try {
+      return statSync(path).isDirectory();
+    } catch {
+      return false;
+    }
+  },
+  async freeBytes(_path) {
+    // `node:fs.statfs` only lands in Node 18.15+; Electron bundles that,
+    // but bun test may not. Fall back to a very large number if the API
+    // is missing — preflight is advisory, not a hard gate.
+    try {
+      const statfs = (await import('node:fs/promises')).statfs;
+      if (typeof statfs !== 'function') return Number.MAX_SAFE_INTEGER;
+      const stat = await statfs(_path);
+      return Number(stat.bavail) * Number(stat.bsize);
+    } catch {
+      return Number.MAX_SAFE_INTEGER;
+    }
+  },
+};

--- a/apps/desktop/src/main/scaffold/node-spawner.ts
+++ b/apps/desktop/src/main/scaffold/node-spawner.ts
@@ -1,0 +1,44 @@
+/**
+ * `nodeSpawner` — the production `Spawner` for the scaffold runner.
+ * Wraps `child_process.spawn` so stdout / stderr chunks arrive as
+ * `StageChunk` events and a non-zero exit throws. Kept minimal: no
+ * buffering, no timeout, no kill-on-cancel — the orchestrator owns
+ * lifecycle via the async-iteration protocol.
+ */
+import { spawn } from 'node:child_process';
+
+import type { StageChunk } from './scaffold-project';
+import type { ShellStageSpec } from './stages';
+
+export async function* nodeSpawner(spec: ShellStageSpec): AsyncIterable<StageChunk> {
+  const child = spawn(spec.cmd, spec.args, { cwd: spec.cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+
+  const queue: Array<StageChunk | { kind: 'exit'; code: number | null }> = [];
+  let notify: (() => void) | null = null;
+  const push = (item: (typeof queue)[number]) => {
+    queue.push(item);
+    notify?.();
+  };
+
+  child.stdout.on('data', (buf: Buffer) => push({ kind: 'stdout-chunk', chunk: buf.toString() }));
+  child.stderr.on('data', (buf: Buffer) => push({ kind: 'stderr-chunk', chunk: buf.toString() }));
+  child.on('error', (err) => push({ kind: 'stderr-chunk', chunk: String(err) }));
+  child.on('close', (code) => push({ kind: 'exit', code }));
+
+  while (true) {
+    if (queue.length === 0) {
+      await new Promise<void>((resolve) => {
+        notify = resolve;
+      });
+      notify = null;
+      continue;
+    }
+    const item = queue.shift();
+    if (!item) continue;
+    if (item.kind === 'exit') {
+      if (item.code !== 0) throw new Error(`${spec.cmd} exited with code ${item.code}`);
+      return;
+    }
+    yield item;
+  }
+}

--- a/apps/desktop/src/main/scaffold/preflight.ts
+++ b/apps/desktop/src/main/scaffold/preflight.ts
@@ -1,0 +1,65 @@
+/**
+ * Scaffolder pre-flight checks (stage 0). Runs before any shell
+ * command; each check returns a specific, tagged error so the UI can
+ * render a directly actionable message ("install Bun", "pick another
+ * folder", "no network"). Deps are injected so the checks are
+ * unit-testable without shelling out or hitting the network.
+ */
+
+const REGISTRY_URL = 'https://registry.npmjs.org';
+const MIN_FREE_BYTES = 500 * 1024 * 1024;
+
+export interface PreflightConfig {
+  targetDir: string;
+}
+
+export interface PreflightDeps {
+  /** Run a short command and return stdout + exit code. */
+  runCommand: (cmd: string) => Promise<{ stdout: string; code: number }>;
+  headOk: (url: string) => Promise<boolean>;
+  parentDirWritable: (path: string) => Promise<boolean>;
+  targetDirExists: (path: string) => Promise<boolean>;
+  freeBytes: (path: string) => Promise<number>;
+}
+
+export type PreflightError =
+  | { kind: 'missing-bun' }
+  | { kind: 'missing-git' }
+  | { kind: 'missing-node' }
+  | { kind: 'no-network' }
+  | { kind: 'parent-not-writable'; path: string }
+  | { kind: 'target-exists'; path: string }
+  | { kind: 'insufficient-space'; bytesFree: number };
+
+export type PreflightResult = { ok: true } | { ok: false; error: PreflightError };
+
+function parentDirOf(path: string): string {
+  const slash = path.lastIndexOf('/');
+  if (slash <= 0) return '/';
+  return path.slice(0, slash);
+}
+
+export async function runPreflight(
+  config: PreflightConfig,
+  deps: PreflightDeps,
+): Promise<PreflightResult> {
+  if ((await deps.runCommand('bun --version')).code !== 0)
+    return { ok: false, error: { kind: 'missing-bun' } };
+  if ((await deps.runCommand('git --version')).code !== 0)
+    return { ok: false, error: { kind: 'missing-git' } };
+  if ((await deps.runCommand('node --version')).code !== 0)
+    return { ok: false, error: { kind: 'missing-node' } };
+  if (!(await deps.headOk(REGISTRY_URL))) return { ok: false, error: { kind: 'no-network' } };
+
+  const parent = parentDirOf(config.targetDir);
+  if (!(await deps.parentDirWritable(parent)))
+    return { ok: false, error: { kind: 'parent-not-writable', path: parent } };
+  if (await deps.targetDirExists(config.targetDir))
+    return { ok: false, error: { kind: 'target-exists', path: config.targetDir } };
+
+  const bytes = await deps.freeBytes(parent);
+  if (bytes < MIN_FREE_BYTES)
+    return { ok: false, error: { kind: 'insufficient-space', bytesFree: bytes } };
+
+  return { ok: true };
+}

--- a/apps/desktop/src/main/scaffold/scaffold-project.ts
+++ b/apps/desktop/src/main/scaffold/scaffold-project.ts
@@ -1,0 +1,116 @@
+/**
+ * `scaffoldProject` — the ten-stage project scaffolder. Streams
+ * `StageEvent`s per stage so the renderer can show live progress, and
+ * writes `.contexture/scaffold.log` on both success and failure paths.
+ *
+ * Stage implementations are injected via `StageRunner` so the
+ * orchestrator is unit-testable without shelling out; real runners
+ * wire `child_process.spawn` + the project emitters in later slices.
+ *
+ * Failure policy: any stage throwing aborts the chain. Stages 1-4
+ * (turbo/rm/next/shadcn) are "start over only" — a failed run should
+ * be wiped and retried fresh. Stages 5+ (`convex dev`, scaffold
+ * emitters, git init, `bun install`) are retry-safe against the same
+ * directory.
+ */
+
+export type StageNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+export const STAGE_NUMBERS: readonly StageNumber[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+/** First stage that is safe to retry against the same target dir. */
+const FIRST_RETRY_SAFE_STAGE: StageNumber = 5;
+
+export interface ScaffoldConfig {
+  targetDir: string;
+  projectName: string;
+}
+
+export type StageEvent =
+  | { kind: 'stage-start'; stage: StageNumber }
+  | { kind: 'stdout-chunk'; stage: StageNumber; chunk: string }
+  | { kind: 'stderr-chunk'; stage: StageNumber; chunk: string }
+  | { kind: 'stage-done'; stage: StageNumber }
+  | { kind: 'stage-failed'; stage: StageNumber; stderr: string; retrySafe: boolean };
+
+/** Yielded by a stage runner during its run — stage number is stamped on by the orchestrator. */
+export type StageChunk =
+  | { kind: 'stdout-chunk'; chunk: string }
+  | { kind: 'stderr-chunk'; chunk: string };
+
+export interface StageRunner {
+  run(stage: StageNumber, config: ScaffoldConfig): AsyncIterable<StageChunk>;
+}
+
+export interface ScaffoldDeps {
+  runner: StageRunner;
+  /** Writes the scaffold log — called once at end of run regardless of outcome. */
+  writeLog: (path: string, content: string) => Promise<void>;
+}
+
+export async function* scaffoldProject(
+  config: ScaffoldConfig,
+  deps: ScaffoldDeps,
+): AsyncIterable<StageEvent> {
+  const buffered: StageEvent[] = [];
+  let failedStderr = '';
+
+  for (const stage of STAGE_NUMBERS) {
+    const startEvent: StageEvent = { kind: 'stage-start', stage };
+    buffered.push(startEvent);
+    yield startEvent;
+
+    try {
+      for await (const chunk of deps.runner.run(stage, config)) {
+        const ev: StageEvent = { ...chunk, stage };
+        buffered.push(ev);
+        if (chunk.kind === 'stderr-chunk') failedStderr += chunk.chunk;
+        yield ev;
+      }
+      const done: StageEvent = { kind: 'stage-done', stage };
+      buffered.push(done);
+      yield done;
+      failedStderr = '';
+    } catch {
+      const retrySafe = stage >= FIRST_RETRY_SAFE_STAGE;
+      const failed: StageEvent = {
+        kind: 'stage-failed',
+        stage,
+        stderr: failedStderr,
+        retrySafe,
+      };
+      buffered.push(failed);
+      yield failed;
+      await deps
+        .writeLog(`${config.targetDir}/.contexture/scaffold.log`, formatLog(buffered))
+        .catch(() => undefined);
+      return;
+    }
+  }
+
+  await deps
+    .writeLog(`${config.targetDir}/.contexture/scaffold.log`, formatLog(buffered))
+    .catch(() => undefined);
+}
+
+function formatLog(events: ReadonlyArray<StageEvent>): string {
+  const lines: string[] = [];
+  for (const ev of events) {
+    switch (ev.kind) {
+      case 'stage-start':
+        lines.push(`[stage ${ev.stage}] start`);
+        break;
+      case 'stage-done':
+        lines.push(`[stage ${ev.stage}] done`);
+        break;
+      case 'stdout-chunk':
+        lines.push(`[stage ${ev.stage}] stdout: ${ev.chunk}`);
+        break;
+      case 'stderr-chunk':
+        lines.push(`[stage ${ev.stage}] stderr: ${ev.chunk}`);
+        break;
+      case 'stage-failed':
+        lines.push(`[stage ${ev.stage}] FAILED (retry-safe=${ev.retrySafe}): ${ev.stderr.trim()}`);
+        break;
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/apps/desktop/src/main/scaffold/schema-package.ts
+++ b/apps/desktop/src/main/scaffold/schema-package.ts
@@ -30,6 +30,7 @@ function makePackageJson(projectName: string): string {
       type: 'module',
       main: './index.ts',
       types: './index.ts',
+      dependencies: { convex: 'latest' },
     },
     null,
     2,

--- a/apps/desktop/src/main/scaffold/schema-package.ts
+++ b/apps/desktop/src/main/scaffold/schema-package.ts
@@ -1,0 +1,73 @@
+/**
+ * `scaffoldSchemaPackage` (stage 6) — lays down the `packages/schema/`
+ * tree: initial IR, Zod bundle + JSON mirror + barrel, workspace
+ * package.json, .gitignore, and the .contexture/ marker with empty
+ * layout/chat/emitted sidecars. Pure file generation against an
+ * injected FsAdapter; reuses the existing emitters for the Zod + JSON
+ * mirrors + barrel so the scaffolded tree matches what a subsequent
+ * save would produce.
+ */
+import type { FsAdapter } from '@main/documents/document-store';
+import { emit as emitJsonSchema } from '@renderer/model/emit-json-schema';
+import { emit as emitSchemaIndex } from '@renderer/model/emit-schema-index';
+import { emit as emitZod } from '@renderer/model/emit-zod';
+import type { Schema } from '@renderer/model/ir';
+
+import type { ScaffoldConfig } from './scaffold-project';
+
+export interface SchemaPackageDeps {
+  fs: FsAdapter;
+}
+
+const EMPTY_SCHEMA: Schema = { version: '1', types: [] };
+
+function makePackageJson(projectName: string): string {
+  return `${JSON.stringify(
+    {
+      name: `@${projectName}/schema`,
+      version: '0.0.0',
+      private: true,
+      type: 'module',
+      main: './index.ts',
+      types: './index.ts',
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+const GITIGNORE = ['node_modules', 'dist', ''].join('\n');
+
+export async function scaffoldSchemaPackage(
+  config: ScaffoldConfig,
+  deps: SchemaPackageDeps,
+): Promise<void> {
+  const { fs } = deps;
+  const schemaDir = `${config.targetDir}/packages/schema`;
+  const irPath = `${schemaDir}/${config.projectName}.contexture.json`;
+  const schemaTsPath = `${schemaDir}/${config.projectName}.schema.ts`;
+  const schemaJsonPath = `${schemaDir}/${config.projectName}.schema.json`;
+  const indexPath = `${schemaDir}/index.ts`;
+  const pkgPath = `${schemaDir}/package.json`;
+  const gitignorePath = `${schemaDir}/.gitignore`;
+  const ctxDir = `${schemaDir}/.contexture`;
+
+  await fs.writeFile(irPath, `${JSON.stringify(EMPTY_SCHEMA, null, 2)}\n`);
+  await fs.writeFile(schemaTsPath, emitZod(EMPTY_SCHEMA, irPath));
+  await fs.writeFile(schemaJsonPath, `${JSON.stringify(emitJsonSchema(EMPTY_SCHEMA), null, 2)}\n`);
+  await fs.writeFile(indexPath, emitSchemaIndex(config.projectName));
+  await fs.writeFile(pkgPath, makePackageJson(config.projectName));
+  await fs.writeFile(gitignorePath, GITIGNORE);
+  await fs.writeFile(
+    `${ctxDir}/layout.json`,
+    `${JSON.stringify({ version: '1', positions: {} }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    `${ctxDir}/chat.json`,
+    `${JSON.stringify({ version: '1', messages: [] }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    `${ctxDir}/emitted.json`,
+    `${JSON.stringify({ version: '1', files: {} }, null, 2)}\n`,
+  );
+}

--- a/apps/desktop/src/main/scaffold/spawn-runner.ts
+++ b/apps/desktop/src/main/scaffold/spawn-runner.ts
@@ -1,0 +1,29 @@
+/**
+ * `createSpawnStageRunner` — the default StageRunner for shell-backed
+ * stages (1-5). Delegates to an injected `Spawner` so the real
+ * `child_process.spawn` plumbing can be swapped for a fake in tests.
+ * The spawner is responsible for turning a spec into a stream of
+ * stdout/stderr chunks and throwing on non-zero exit; this runner
+ * just looks up the spec for the stage and forwards.
+ *
+ * Stages 6+ are in-process and use their own runner wiring; this
+ * runner throws if asked to run them.
+ */
+import type { ScaffoldConfig, StageChunk, StageNumber, StageRunner } from './scaffold-project';
+import type { ShellStageSpec } from './stages';
+import { shellStageSpecFor } from './stages';
+
+export type Spawner = (spec: ShellStageSpec) => AsyncIterable<StageChunk>;
+
+const SHELL_STAGES: ReadonlySet<StageNumber> = new Set([1, 2, 3, 4, 5]);
+
+export function createSpawnStageRunner(spawner: Spawner): StageRunner {
+  return {
+    run(stage: StageNumber, config: ScaffoldConfig) {
+      if (!SHELL_STAGES.has(stage)) {
+        throw new Error(`spawnStageRunner: stage ${stage} is not a shell-backed stage`);
+      }
+      return spawner(shellStageSpecFor(stage, config));
+    },
+  };
+}

--- a/apps/desktop/src/main/scaffold/spawn-runner.ts
+++ b/apps/desktop/src/main/scaffold/spawn-runner.ts
@@ -1,13 +1,13 @@
 /**
  * `createSpawnStageRunner` — the default StageRunner for shell-backed
- * stages (1-5). Delegates to an injected `Spawner` so the real
+ * stages (1-5, 9). Delegates to an injected `Spawner` so the real
  * `child_process.spawn` plumbing can be swapped for a fake in tests.
  * The spawner is responsible for turning a spec into a stream of
  * stdout/stderr chunks and throwing on non-zero exit; this runner
  * just looks up the spec for the stage and forwards.
  *
- * Stages 6+ are in-process and use their own runner wiring; this
- * runner throws if asked to run them.
+ * Stages 6-8, 10 are in-process and use their own runner wiring;
+ * this runner throws if asked to run them.
  */
 import type { ScaffoldConfig, StageChunk, StageNumber, StageRunner } from './scaffold-project';
 import type { ShellStageSpec } from './stages';
@@ -15,7 +15,7 @@ import { shellStageSpecFor } from './stages';
 
 export type Spawner = (spec: ShellStageSpec) => AsyncIterable<StageChunk>;
 
-const SHELL_STAGES: ReadonlySet<StageNumber> = new Set([1, 2, 3, 4, 5]);
+const SHELL_STAGES: ReadonlySet<StageNumber> = new Set([1, 2, 3, 4, 5, 9]);
 
 export function createSpawnStageRunner(spawner: Spawner): StageRunner {
   return {

--- a/apps/desktop/src/main/scaffold/stages.ts
+++ b/apps/desktop/src/main/scaffold/stages.ts
@@ -1,0 +1,69 @@
+/**
+ * Stage command table — pure derivation of what shell command each
+ * external-tool stage runs, against what cwd. Keeping this separate
+ * from the spawn/IO layer lets tests assert "stage 3 calls
+ * create-next-app with these exact flags" without shelling out.
+ *
+ * Only shell-backed stages (1-5) have a spec; stages 6-10 are
+ * in-process work (emitters, git, bun install wired separately).
+ */
+import type { ScaffoldConfig, StageNumber } from './scaffold-project';
+
+export interface ShellStageSpec {
+  cmd: string;
+  args: string[];
+  cwd: string;
+}
+
+function parentDirOf(path: string): string {
+  const slash = path.lastIndexOf('/');
+  if (slash <= 0) return '/';
+  return path.slice(0, slash);
+}
+
+export function shellStageSpecFor(stage: StageNumber, config: ScaffoldConfig): ShellStageSpec {
+  const parent = parentDirOf(config.targetDir);
+  const target = config.targetDir;
+  const webDir = `${target}/apps/web`;
+  switch (stage) {
+    case 1:
+      return {
+        cmd: 'bunx',
+        args: [
+          'create-turbo@latest',
+          config.projectName,
+          '--package-manager',
+          'bun',
+          '--skip-install',
+        ],
+        cwd: parent,
+      };
+    case 2:
+      return { cmd: 'rm', args: ['-rf', 'apps/web'], cwd: target };
+    case 3:
+      return {
+        cmd: 'bunx',
+        args: [
+          'create-next-app@latest',
+          'apps/web',
+          '--ts',
+          '--app',
+          '--tailwind',
+          '--eslint',
+          '--use-bun',
+          '--yes',
+        ],
+        cwd: target,
+      };
+    case 4:
+      return { cmd: 'bunx', args: ['shadcn@latest', 'init', '--yes'], cwd: webDir };
+    case 5:
+      return {
+        cmd: 'bunx',
+        args: ['convex@latest', 'dev', '--once', '--configure=new', '--local'],
+        cwd: webDir,
+      };
+    default:
+      throw new Error(`shellStageSpecFor: stage ${stage} is not a shell-backed stage`);
+  }
+}

--- a/apps/desktop/src/main/scaffold/stages.ts
+++ b/apps/desktop/src/main/scaffold/stages.ts
@@ -4,8 +4,9 @@
  * from the spawn/IO layer lets tests assert "stage 3 calls
  * create-next-app with these exact flags" without shelling out.
  *
- * Only shell-backed stages (1-5) have a spec; stages 6-10 are
- * in-process work (emitters, git, bun install wired separately).
+ * Only shell-backed stages (1-5, 9) have a spec; stages 6-8 and 10
+ * are in-process work (emitters; git init runs through its own spec
+ * trio from `git-init.ts`).
  */
 import type { ScaffoldConfig, StageNumber } from './scaffold-project';
 
@@ -63,6 +64,8 @@ export function shellStageSpecFor(stage: StageNumber, config: ScaffoldConfig): S
         args: ['convex@latest', 'dev', '--once', '--configure=new', '--local'],
         cwd: webDir,
       };
+    case 9:
+      return { cmd: 'bun', args: ['install'], cwd: target };
     default:
       throw new Error(`shellStageSpecFor: stage ${stage} is not a shell-backed stage`);
   }

--- a/apps/desktop/src/main/scaffold/stages.ts
+++ b/apps/desktop/src/main/scaffold/stages.ts
@@ -26,6 +26,7 @@ export function shellStageSpecFor(stage: StageNumber, config: ScaffoldConfig): S
   const parent = parentDirOf(config.targetDir);
   const target = config.targetDir;
   const webDir = `${target}/apps/web`;
+  const schemaDir = `${target}/packages/schema`;
   switch (stage) {
     case 1:
       return {
@@ -61,8 +62,16 @@ export function shellStageSpecFor(stage: StageNumber, config: ScaffoldConfig): S
     case 5:
       return {
         cmd: 'bunx',
-        args: ['convex@latest', 'dev', '--once', '--configure=new', '--local'],
-        cwd: webDir,
+        args: [
+          'convex@latest',
+          'dev',
+          '--once',
+          '--configure=new',
+          '--local',
+          '--project',
+          config.projectName,
+        ],
+        cwd: schemaDir,
       };
     case 9:
       return { cmd: 'bun', args: ['install'], cwd: target };

--- a/apps/desktop/src/main/scaffold/workspace-stitch.ts
+++ b/apps/desktop/src/main/scaffold/workspace-stitch.ts
@@ -1,0 +1,59 @@
+/**
+ * `scaffoldWorkspaceStitch` (stage 8) — finishes the file side of the
+ * scaffold: adds `@<project>/schema: workspace:*` to
+ * `apps/web/package.json` so Next.js resolves the schema package,
+ * writes the root `CLAUDE.md` from the template, writes the workspace
+ * `biome.json`, and writes a root `.gitignore`. Pure file work; the
+ * subsequent `git init` / `bun install` stages are handled elsewhere.
+ *
+ * Idempotent by construction: the dep is only added if missing, and
+ * the file writes overwrite with the same content on re-run.
+ */
+import type { FsAdapter } from '@main/documents/document-store';
+import { emit as emitClaudeMd } from '@renderer/model/emit-claude-md';
+
+import type { ScaffoldConfig } from './scaffold-project';
+
+export interface WorkspaceStitchDeps {
+  fs: FsAdapter;
+}
+
+const BIOME_CONFIG = {
+  $schema: 'https://biomejs.dev/schemas/2.0.0/schema.json',
+  vcs: { enabled: true, clientKind: 'git', useIgnoreFile: true },
+  files: { ignoreUnknown: true },
+  formatter: { enabled: true, indentStyle: 'space', indentWidth: 2, lineWidth: 100 },
+  linter: { enabled: true, rules: { recommended: true } },
+  javascript: { formatter: { quoteStyle: 'single', semicolons: 'always' } },
+};
+
+const ROOT_GITIGNORE = [
+  'node_modules',
+  '.next',
+  'dist',
+  '.turbo',
+  '.convex',
+  '.DS_Store',
+  '*.log',
+  '',
+].join('\n');
+
+export async function scaffoldWorkspaceStitch(
+  config: ScaffoldConfig,
+  deps: WorkspaceStitchDeps,
+): Promise<void> {
+  const { fs } = deps;
+  const webPkgPath = `${config.targetDir}/apps/web/package.json`;
+  const raw = await fs.readFile(webPkgPath);
+  const pkg = JSON.parse(raw) as { dependencies?: Record<string, string>; [k: string]: unknown };
+  pkg.dependencies ??= {};
+  pkg.dependencies[`@${config.projectName}/schema`] = 'workspace:*';
+  await fs.writeFile(webPkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+  await fs.writeFile(`${config.targetDir}/CLAUDE.md`, emitClaudeMd(config.projectName));
+  await fs.writeFile(
+    `${config.targetDir}/biome.json`,
+    `${JSON.stringify(BIOME_CONFIG, null, 2)}\n`,
+  );
+  await fs.writeFile(`${config.targetDir}/.gitignore`, ROOT_GITIGNORE);
+}

--- a/apps/desktop/src/renderer/src/model/emit-claude-md.ts
+++ b/apps/desktop/src/renderer/src/model/emit-claude-md.ts
@@ -13,28 +13,31 @@ const TEMPLATE = `# {{PROJECT_NAME}}
 
 A Convex + Next.js monorepo scaffolded by Contexture. The schema is the
 source of truth at \`packages/schema/{{PROJECT_NAME}}.contexture.json\` and
-is re-emitted automatically to \`apps/web/convex/schema.ts\` on every edit.
+is re-emitted automatically to \`packages/schema/convex/schema.ts\` on every
+edit. \`apps/web\` imports the workspace package \`@{{PROJECT_NAME}}/schema\`
+rather than owning its own \`convex/\` folder.
 
 ## Layout
 
 \`\`\`
 {{PROJECT_NAME}}/
   apps/web/             Next.js app (App Router, Tailwind, shadcn)
-    convex/
-      schema.ts         @contexture-generated — regenerated from the IR
-      <table>.ts        @contexture-seeded — edit freely
-  packages/schema/      Shared schema package (Zod + JSON-schema mirrors)
+                        imports @{{PROJECT_NAME}}/schema
+  packages/schema/      Shared schema package (Zod + JSON + Convex)
     {{PROJECT_NAME}}.contexture.json   source of truth
     {{PROJECT_NAME}}.schema.ts          @contexture-generated (Zod)
     {{PROJECT_NAME}}.schema.json        @contexture-generated (JSON Schema)
     index.ts            @contexture-generated barrel
+    convex/
+      schema.ts         @contexture-generated — regenerated from the IR
+      <table>.ts        @contexture-seeded — edit freely
     .contexture/        Contexture internal state (off-limits)
 \`\`\`
 
 ## Source of truth
 
-Do NOT edit \`apps/web/convex/schema.ts\` directly — it is regenerated on
-every IR save. To change the schema, edit
+Do NOT edit \`packages/schema/convex/schema.ts\` directly — it is regenerated
+on every IR save. To change the schema, edit
 \`packages/schema/{{PROJECT_NAME}}.contexture.json\` (or ask the user to
 use Contexture's editor).
 
@@ -44,7 +47,7 @@ into the IR. Your work is never silently clobbered.
 
 ## CRUD files are yours
 
-\`apps/web/convex/<table>.ts\` files are seeded once by the scaffolder and
+\`packages/schema/convex/<table>.ts\` files are seeded once by the scaffolder and
 are \`@contexture-seeded\`, not \`@contexture-generated\`. Add queries,
 mutations, and indexes as the app requires — Contexture does not
 regenerate them.
@@ -61,7 +64,7 @@ const parsed = Post.parse(input);
 type Post = z.infer<typeof Post>;
 \`\`\`
 
-The Convex validators in \`apps/web/convex/schema.ts\` are derived from
+The Convex validators in \`packages/schema/convex/schema.ts\` are derived from
 the same source, so field shape is guaranteed to match.
 
 ## Conventions
@@ -77,8 +80,8 @@ the same source, so field shape is guaranteed to match.
 1. Open the IR (\`packages/schema/{{PROJECT_NAME}}.contexture.json\`) or
    Contexture.
 2. Add the object type, set \`"table": true\`.
-3. Save. Contexture re-emits \`apps/web/convex/schema.ts\`.
-4. Add CRUD handlers in \`apps/web/convex/<table>.ts\` as needed.
+3. Save. Contexture re-emits \`packages/schema/convex/schema.ts\`.
+4. Add CRUD handlers in \`packages/schema/convex/<table>.ts\` as needed.
 
 ## What NOT to touch
 

--- a/apps/desktop/tests/main/document-store.test.ts
+++ b/apps/desktop/tests/main/document-store.test.ts
@@ -207,7 +207,7 @@ describe('DocumentStore', () => {
       layout: sampleLayout,
       chat: sampleChat,
     });
-    const convexPath = '/work/schema.ts';
+    const convexPath = '/work/convex/schema.ts';
     expect(harness.fs.exists(convexPath)).toBe(true);
     const convex = await harness.fs.readFile(convexPath);
     expect(convex).toContain('@contexture-generated');
@@ -278,13 +278,13 @@ describe('DocumentStore', () => {
       '/proj/packages/schema/.contexture/.keep': '',
     });
     await store.open(monorepoIrPath);
-    const postPath = '/proj/apps/web/convex/Post.ts';
+    const postPath = '/proj/packages/schema/convex/Post.ts';
     expect(fs.exists(postPath)).toBe(true);
     const contents = await fs.readFile(postPath);
     expect(contents).toContain('@contexture-seeded');
     expect(contents).toContain('ctx.db.query("Post")');
     // Non-table types get no file.
-    expect(fs.exists('/proj/apps/web/convex/Inline.ts')).toBe(false);
+    expect(fs.exists('/proj/packages/schema/convex/Inline.ts')).toBe(false);
   });
 
   it('auto-save never clobbers a user-edited seeded CRUD file', async () => {
@@ -308,7 +308,7 @@ describe('DocumentStore', () => {
       '/proj/packages/schema/.contexture/.keep': '',
     });
     await store.open(monorepoIrPath);
-    const crudPath = '/proj/apps/web/convex/Post.ts';
+    const crudPath = '/proj/packages/schema/convex/Post.ts';
     // User edits the seeded file.
     const userEdit = '// user took over\nexport const list = () => 42;\n';
     await fs.writeFile(crudPath, userEdit);
@@ -339,10 +339,10 @@ describe('DocumentStore', () => {
     const { store, fs } = setup({
       [monorepoIrPath]: JSON.stringify(tableSchema),
       '/proj/packages/schema/.contexture/.keep': '',
-      '/proj/apps/web/convex/Post.ts': userOwned,
+      '/proj/packages/schema/convex/Post.ts': userOwned,
     });
     await store.open(monorepoIrPath);
-    expect(await fs.readFile('/proj/apps/web/convex/Post.ts')).toBe(userOwned);
+    expect(await fs.readFile('/proj/packages/schema/convex/Post.ts')).toBe(userOwned);
   });
 
   it('scratch-mode open does not seed per-table CRUD files', async () => {
@@ -360,8 +360,8 @@ describe('DocumentStore', () => {
     const { store, fs } = setup({ [irPath]: JSON.stringify(tableSchema) });
     await store.open(irPath);
     // Scratch mode has no project root, so no convex tree can be seeded.
-    expect(fs.exists('/apps/web/convex/Post.ts')).toBe(false);
-    expect(fs.exists('/work/apps/web/convex/Post.ts')).toBe(false);
+    expect(fs.exists('/packages/schema/convex/Post.ts')).toBe(false);
+    expect(fs.exists('/work/packages/schema/convex/Post.ts')).toBe(false);
   });
 
   it('scratch-mode open does not write CLAUDE.md', async () => {
@@ -394,7 +394,7 @@ describe('DocumentStore', () => {
         '/work/garden.schema.ts',
         '/work/garden.schema.json',
         '/work/index.ts',
-        '/work/schema.ts',
+        '/work/convex/schema.ts',
       ].sort(),
     );
     for (const hash of Object.values(manifest.files)) {
@@ -432,7 +432,7 @@ describe('DocumentStore', () => {
     const manifest = JSON.parse(
       await fs.readFile('/proj/packages/schema/.contexture/emitted.json'),
     ) as { files: Record<string, string> };
-    expect(Object.keys(manifest.files)).not.toContain('/proj/apps/web/convex/Post.ts');
+    expect(Object.keys(manifest.files)).not.toContain('/proj/packages/schema/convex/Post.ts');
   });
 
   it('scratch-mode save does not write a schema index', async () => {

--- a/apps/desktop/tests/main/scaffold-composite-runner.test.ts
+++ b/apps/desktop/tests/main/scaffold-composite-runner.test.ts
@@ -1,0 +1,112 @@
+/**
+ * `createCompositeStageRunner` — the production StageRunner: delegates
+ * shell-backed stages (1-5, 9) to the spawn runner, runs the in-process
+ * stages (6 scaffold, 7 convex emit, 8 workspace stitch + git init,
+ * 10 no-op) directly, and gives the orchestrator a single runner to
+ * drive. Testing through fakes for fs + spawner so we can assert
+ * dispatch without touching disk or shelling out.
+ */
+import type { FsAdapter } from '@main/documents/document-store';
+import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
+import { createCompositeStageRunner } from '@main/scaffold/composite-runner';
+import type { Spawner } from '@main/scaffold/spawn-runner';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+
+let fs: ReturnType<typeof createMemFsAdapter>;
+let spawnCalls: Array<{ cmd: string; args: string[]; cwd: string }>;
+
+function seedWebPackageJson(adapter: FsAdapter) {
+  return adapter.writeFile(
+    `${config.targetDir}/apps/web/package.json`,
+    `${JSON.stringify({ name: 'web' }, null, 2)}\n`,
+  );
+}
+
+beforeEach(() => {
+  fs = createMemFsAdapter();
+  spawnCalls = [];
+});
+
+function okSpawner(): Spawner {
+  return (spec) => {
+    spawnCalls.push({ cmd: spec.cmd, args: spec.args, cwd: spec.cwd });
+    return (async function* () {
+      yield* [];
+    })();
+  };
+}
+
+describe('createCompositeStageRunner', () => {
+  it('dispatches stage 1 to the spawner (bunx create-turbo)', async () => {
+    const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
+    for await (const _ of runner.run(1, config)) {
+      // drain
+    }
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].cmd).toBe('bunx');
+    expect(spawnCalls[0].args[0]).toBe('create-turbo@latest');
+  });
+
+  it('runs stage 6 in-process — writes the schema package tree', async () => {
+    const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
+    for await (const _ of runner.run(6, config)) {
+      // drain
+    }
+    expect(fs.exists('/work/my-proj/packages/schema/my-proj.contexture.json')).toBe(true);
+    expect(fs.exists('/work/my-proj/packages/schema/package.json')).toBe(true);
+    // Spawner must not have been touched for in-process stages.
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it('runs stage 7 in-process — writes the Convex schema', async () => {
+    // Stage 6 runs first in the real flow; emulate it.
+    await fs.writeFile(
+      `${config.targetDir}/packages/schema/my-proj.contexture.json`,
+      JSON.stringify({ version: '1', types: [] }),
+    );
+    const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
+    for await (const _ of runner.run(7, config)) {
+      // drain
+    }
+    expect(fs.exists('/work/my-proj/packages/schema/convex/schema.ts')).toBe(true);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it('runs stage 8 — stitch + git init trio via spawner', async () => {
+    await seedWebPackageJson(fs);
+    const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
+    for await (const _ of runner.run(8, config)) {
+      // drain
+    }
+    // Files written by stitch half.
+    expect(fs.exists('/work/my-proj/CLAUDE.md')).toBe(true);
+    expect(fs.exists('/work/my-proj/biome.json')).toBe(true);
+    expect(fs.exists('/work/my-proj/.gitignore')).toBe(true);
+    // Git trio dispatched to spawner.
+    expect(spawnCalls.map((c) => c.args[0])).toEqual(['init', 'add', 'commit']);
+    for (const c of spawnCalls) {
+      expect(c.cmd).toBe('git');
+      expect(c.cwd).toBe(config.targetDir);
+    }
+  });
+
+  it('dispatches stage 9 to the spawner (bun install)', async () => {
+    const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
+    for await (const _ of runner.run(9, config)) {
+      // drain
+    }
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].cmd).toBe('bun');
+    expect(spawnCalls[0].args).toEqual(['install']);
+  });
+
+  it('stage 10 is a no-op in v1 — no spawner, no file writes', async () => {
+    const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
+    for await (const _ of runner.run(10, config)) {
+      // drain
+    }
+    expect(spawnCalls).toHaveLength(0);
+  });
+});

--- a/apps/desktop/tests/main/scaffold-composite-runner.test.ts
+++ b/apps/desktop/tests/main/scaffold-composite-runner.test.ts
@@ -49,6 +49,24 @@ describe('createCompositeStageRunner', () => {
     expect(spawnCalls[0].args[0]).toBe('create-turbo@latest');
   });
 
+  it('stage 5: seeds packages/schema anchor + installs convex locally, then spawns convex dev there', async () => {
+    const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
+    for await (const _ of runner.run(5, config)) {
+      // drain
+    }
+    // Anchor written with convex as a dep.
+    const pkg = JSON.parse(await fs.readFile('/work/my-proj/packages/schema/package.json'));
+    expect(pkg.dependencies.convex).toBeDefined();
+    // Two spawns: `bun install` (so convex/server resolves), then convex dev.
+    expect(spawnCalls).toHaveLength(2);
+    expect(spawnCalls[0].cmd).toBe('bun');
+    expect(spawnCalls[0].args).toEqual(['install']);
+    expect(spawnCalls[0].cwd).toBe('/work/my-proj/packages/schema');
+    expect(spawnCalls[1].cmd).toBe('bunx');
+    expect(spawnCalls[1].args[0]).toBe('convex@latest');
+    expect(spawnCalls[1].cwd).toBe('/work/my-proj/packages/schema');
+  });
+
   it('runs stage 6 in-process — writes the schema package tree', async () => {
     const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
     for await (const _ of runner.run(6, config)) {

--- a/apps/desktop/tests/main/scaffold-convex-emit.test.ts
+++ b/apps/desktop/tests/main/scaffold-convex-emit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * `scaffoldConvexEmit` (stage 7) — emits the Convex schema (and
+ * per-table CRUD seeds, if the initial IR had any tables) at
+ * `packages/schema/convex/`. At scaffold time the IR is empty, so
+ * the convex schema is the degenerate `defineSchema({})`. The stage
+ * still needs to run so `bun run dev` finds a valid schema file.
+ */
+import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
+import { scaffoldConvexEmit } from '@main/scaffold/convex-emit';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+const schemaDir = '/work/my-proj/packages/schema';
+
+let fs: ReturnType<typeof createMemFsAdapter>;
+
+beforeEach(() => {
+  fs = createMemFsAdapter();
+});
+
+describe('scaffoldConvexEmit', () => {
+  it('writes packages/schema/convex/schema.ts with the contexture-generated banner', async () => {
+    // Stage 6 has already written the empty IR; we read it back.
+    const irPath = `${schemaDir}/my-proj.contexture.json`;
+    await fs.writeFile(irPath, JSON.stringify({ version: '1', types: [] }));
+
+    await scaffoldConvexEmit(config, { fs });
+
+    const convexPath = `${schemaDir}/convex/schema.ts`;
+    expect(fs.exists(convexPath)).toBe(true);
+    const source = await fs.readFile(convexPath);
+    expect(source).toContain('@contexture-generated');
+    expect(source).toMatch(/defineSchema\s*\(/);
+  });
+
+  it('does not emit per-table CRUD files when the IR has no tables', async () => {
+    const irPath = `${schemaDir}/my-proj.contexture.json`;
+    await fs.writeFile(irPath, JSON.stringify({ version: '1', types: [] }));
+
+    await scaffoldConvexEmit(config, { fs });
+
+    // Empty IR means no table-flagged objects, so no CRUD files.
+    // (The scaffolder only ever runs against an empty IR in v1 — stage 10
+    // seeds tables afterwards, and a subsequent save writes the CRUD.)
+    expect(fs.exists(`${schemaDir}/convex/Post.ts`)).toBe(false);
+  });
+});

--- a/apps/desktop/tests/main/scaffold-e2e.test.ts
+++ b/apps/desktop/tests/main/scaffold-e2e.test.ts
@@ -40,9 +40,16 @@ describeOrSkip('scaffold end-to-end (SCAFFOLD_E2E=1)', () => {
           },
         );
 
-        // No preflight failure, no stage failure.
+        // No preflight failure, no stage failure. On failure, surface which
+        // stage tripped and the captured stderr — this is a 15-minute test,
+        // so "expected true to be false" alone is useless.
         expect(events.some((e) => e.kind === 'preflight-failed')).toBe(false);
-        expect(events.some((e) => e.kind === 'stage-failed')).toBe(false);
+        const failed = events.find((e) => e.kind === 'stage-failed');
+        if (failed) {
+          throw new Error(
+            `stage ${failed.stage} failed (retrySafe=${failed.retrySafe}):\n${failed.stderr}`,
+          );
+        }
 
         // Every stage reached stage-done.
         const dones = events.filter((e) => e.kind === 'stage-done').map((e) => e.stage);

--- a/apps/desktop/tests/main/scaffold-e2e.test.ts
+++ b/apps/desktop/tests/main/scaffold-e2e.test.ts
@@ -1,0 +1,66 @@
+/**
+ * End-to-end scaffold test — gated behind `SCAFFOLD_E2E=1` because it
+ * takes minutes (create-turbo, create-next-app, shadcn init, bunx
+ * convex --once, bun install) and hits the real network. Treat it as
+ * the "does the whole thing actually work on this machine" smoke.
+ *
+ * Normal CI / TDD loops skip it. Run locally with:
+ *   SCAFFOLD_E2E=1 bunx vitest run tests/main/scaffold-e2e.test.ts
+ */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { nodeFsAdapter } from '@main/documents/node-fs-adapter';
+import { handleScaffoldStart, type ScaffoldEvent } from '@main/ipc/scaffold';
+import { nodePreflightDeps } from '@main/scaffold/node-preflight-deps';
+import { nodeSpawner } from '@main/scaffold/node-spawner';
+import { runPreflight } from '@main/scaffold/preflight';
+import { describe, expect, it } from 'vitest';
+
+const E2E = process.env.SCAFFOLD_E2E === '1';
+const describeOrSkip = E2E ? describe : describe.skip;
+
+describeOrSkip('scaffold end-to-end (SCAFFOLD_E2E=1)', () => {
+  it(
+    'scaffolds a complete project and leaves it buildable',
+    async () => {
+      const parent = mkdtempSync(join(tmpdir(), 'contexture-e2e-'));
+      const projectName = 'e2e-proj';
+      const targetDir = join(parent, projectName);
+      const events: ScaffoldEvent[] = [];
+      try {
+        await handleScaffoldStart(
+          { targetDir, projectName },
+          {
+            fs: nodeFsAdapter,
+            spawner: nodeSpawner,
+            preflight: (c) => runPreflight({ targetDir: c.targetDir }, nodePreflightDeps),
+            emit: (ev) => events.push(ev),
+          },
+        );
+
+        // No preflight failure, no stage failure.
+        expect(events.some((e) => e.kind === 'preflight-failed')).toBe(false);
+        expect(events.some((e) => e.kind === 'stage-failed')).toBe(false);
+
+        // Every stage reached stage-done.
+        const dones = events.filter((e) => e.kind === 'stage-done').map((e) => e.stage);
+        expect(dones).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        // Key artefacts on disk.
+        expect(existsSync(join(targetDir, 'apps/web/package.json'))).toBe(true);
+        expect(
+          existsSync(join(targetDir, 'packages/schema', `${projectName}.contexture.json`)),
+        ).toBe(true);
+        expect(existsSync(join(targetDir, 'packages/schema/convex/schema.ts'))).toBe(true);
+        expect(existsSync(join(targetDir, 'CLAUDE.md'))).toBe(true);
+        expect(existsSync(join(targetDir, 'biome.json'))).toBe(true);
+        expect(existsSync(join(targetDir, '.git'))).toBe(true);
+      } finally {
+        rmSync(parent, { recursive: true, force: true });
+      }
+    },
+    15 * 60 * 1000,
+  );
+});

--- a/apps/desktop/tests/main/scaffold-git-init.test.ts
+++ b/apps/desktop/tests/main/scaffold-git-init.test.ts
@@ -1,0 +1,32 @@
+/**
+ * `gitInitStageSpec` (stage 8, git half) — runs `git init` plus
+ * an initial commit at the project root. The command is held as a
+ * spec (same shape as the shell stages 1-5) so the orchestrator can
+ * run it through the injected Spawner without special-casing git.
+ */
+import { gitInitStageSpec } from '@main/scaffold/git-init';
+import { describe, expect, it } from 'vitest';
+
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+
+describe('gitInitStageSpec', () => {
+  it('runs `git init` then `git add -A` then `git commit` at the project root', () => {
+    const specs = gitInitStageSpec(config);
+    expect(specs.map((s) => [s.cmd, s.args[0]])).toEqual([
+      ['git', 'init'],
+      ['git', 'add'],
+      ['git', 'commit'],
+    ]);
+    for (const s of specs) {
+      expect(s.cwd).toBe(config.targetDir);
+    }
+  });
+
+  it('uses a descriptive initial commit message', () => {
+    const specs = gitInitStageSpec(config);
+    const commit = specs[2];
+    const messageIdx = commit.args.indexOf('-m');
+    expect(messageIdx).toBeGreaterThanOrEqual(0);
+    expect(commit.args[messageIdx + 1]).toMatch(/initial|scaffold/i);
+  });
+});

--- a/apps/desktop/tests/main/scaffold-ipc.test.ts
+++ b/apps/desktop/tests/main/scaffold-ipc.test.ts
@@ -1,0 +1,64 @@
+/**
+ * `handleScaffoldStart` — the pure IPC handler that runs the
+ * scaffolder: preflight → orchestrator → composite runner, streaming
+ * `StageEvent`s through the supplied emit callback. Bypasses Electron
+ * so the flow is testable with MemFsAdapter and a fake spawner.
+ */
+import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
+import { handleScaffoldStart } from '@main/ipc/scaffold';
+import type { Spawner } from '@main/scaffold/spawn-runner';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+
+let fs: ReturnType<typeof createMemFsAdapter>;
+
+function passThroughSpawner(): Spawner {
+  return async function* () {
+    // Shell stages succeed silently; the scaffolder only cares about throws.
+  };
+}
+
+function alwaysOkPreflight() {
+  return async () => ({ ok: true as const });
+}
+
+beforeEach(() => {
+  fs = createMemFsAdapter();
+  // Seed the files that shell stages 1-5 would have laid down — the
+  // in-process stages reach for `apps/web/package.json` and the IR.
+  fs.writeFile(`${config.targetDir}/apps/web/package.json`, `${JSON.stringify({ name: 'web' })}\n`);
+});
+
+describe('handleScaffoldStart', () => {
+  it('streams stage-start through stage-done for every stage on the happy path', async () => {
+    const events: Array<{ kind: string; stage?: number }> = [];
+    await handleScaffoldStart(config, {
+      fs,
+      spawner: passThroughSpawner(),
+      preflight: alwaysOkPreflight(),
+      emit: (ev) => {
+        events.push(ev);
+      },
+    });
+    const starts = events.filter((e) => e.kind === 'stage-start').map((e) => e.stage);
+    const dones = events.filter((e) => e.kind === 'stage-done').map((e) => e.stage);
+    expect(starts).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(dones).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it('emits a preflight-failed event and stops when preflight returns errors', async () => {
+    const events: Array<{ kind: string }> = [];
+    await handleScaffoldStart(config, {
+      fs,
+      spawner: passThroughSpawner(),
+      preflight: async () => ({ ok: false, error: { kind: 'missing-bun' } as const }),
+      emit: (ev) => {
+        events.push(ev);
+      },
+    });
+    expect(events[0].kind).toBe('preflight-failed');
+    // No stages should have run.
+    expect(events.some((e) => e.kind === 'stage-start')).toBe(false);
+  });
+});

--- a/apps/desktop/tests/main/scaffold-node-spawner.test.ts
+++ b/apps/desktop/tests/main/scaffold-node-spawner.test.ts
@@ -1,0 +1,27 @@
+/**
+ * `nodeSpawner` — the production `Spawner`: wraps `child_process.spawn`
+ * into the `AsyncIterable<StageChunk>` shape the orchestrator expects.
+ * Tested against real short commands (`echo`, `false`) so the spawn
+ * plumbing — stdout streaming, stderr streaming, non-zero-exit throws —
+ * is exercised end-to-end without needing a full scaffold run.
+ */
+import { nodeSpawner } from '@main/scaffold/node-spawner';
+import { describe, expect, it } from 'vitest';
+
+describe('nodeSpawner', () => {
+  it('streams stdout from a real command as stdout-chunk events', async () => {
+    const chunks: string[] = [];
+    for await (const ev of nodeSpawner({ cmd: 'echo', args: ['hello'], cwd: '/tmp' })) {
+      if (ev.kind === 'stdout-chunk') chunks.push(ev.chunk);
+    }
+    expect(chunks.join('')).toContain('hello');
+  });
+
+  it('throws on non-zero exit, surfacing the exit code in the message', async () => {
+    await expect(async () => {
+      for await (const _ of nodeSpawner({ cmd: 'false', args: [], cwd: '/tmp' })) {
+        // drain
+      }
+    }).rejects.toThrow(/exit|code/i);
+  });
+});

--- a/apps/desktop/tests/main/scaffold-orchestrator.test.ts
+++ b/apps/desktop/tests/main/scaffold-orchestrator.test.ts
@@ -1,0 +1,104 @@
+/**
+ * scaffoldProject — the ten-stage orchestrator that runs the preflight,
+ * each stage, and writes `.contexture/scaffold.log` regardless of
+ * outcome. This test drives it through an in-memory `StageRunner` and
+ * fake log writer so we can assert the event stream order + shape
+ * without actually shelling out. Real stage wiring comes in later
+ * slices.
+ */
+import {
+  type StageEvent,
+  type StageRunner,
+  scaffoldProject,
+} from '@main/scaffold/scaffold-project';
+import { describe, expect, it } from 'vitest';
+
+function collect(stream: AsyncIterable<StageEvent>): Promise<StageEvent[]> {
+  return (async () => {
+    const events: StageEvent[] = [];
+    for await (const ev of stream) events.push(ev);
+    return events;
+  })();
+}
+
+/** Makes a runner that succeeds for every stage. */
+function okRunner(): StageRunner {
+  return {
+    run: async function* () {
+      // Nothing to stream.
+    },
+  };
+}
+
+/** Makes a runner that succeeds on stage N, then fails on stage N+1. */
+function failAtRunner(failStage: number, stderr = 'boom'): StageRunner {
+  return {
+    run: async function* (stage) {
+      if (stage === failStage) {
+        yield { kind: 'stderr-chunk', chunk: stderr };
+        throw new Error(`stage ${stage} failed`);
+      }
+    },
+  };
+}
+
+describe('scaffoldProject', () => {
+  it('emits stage-start and stage-done for every stage on the happy path and writes the log', async () => {
+    const logWrites: Array<{ path: string; content: string }> = [];
+    const stream = scaffoldProject(
+      { targetDir: '/tmp/p', projectName: 'p' },
+      {
+        runner: okRunner(),
+        writeLog: async (path, content) => logWrites.push({ path, content }),
+      },
+    );
+    const events = await collect(stream);
+    const starts = events.filter((e) => e.kind === 'stage-start').map((e) => e.stage);
+    const dones = events.filter((e) => e.kind === 'stage-done').map((e) => e.stage);
+    expect(starts).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(dones).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(logWrites).toHaveLength(1);
+    expect(logWrites[0].path).toBe('/tmp/p/.contexture/scaffold.log');
+  });
+
+  it('stops at the first failing stage, emits stage-failed, and still writes the log', async () => {
+    const logWrites: Array<{ path: string; content: string }> = [];
+    const stream = scaffoldProject(
+      { targetDir: '/tmp/p', projectName: 'p' },
+      {
+        runner: failAtRunner(3, 'next-app exited 1'),
+        writeLog: async (path, content) => logWrites.push({ path, content }),
+      },
+    );
+    const events = await collect(stream);
+    const starts = events.filter((e) => e.kind === 'stage-start').map((e) => e.stage);
+    const failed = events.find((e) => e.kind === 'stage-failed');
+    // Stages 1 and 2 ran, stage 3 started + failed; nothing after stage 3.
+    expect(starts).toEqual([1, 2, 3]);
+    expect(failed?.kind).toBe('stage-failed');
+    if (failed?.kind === 'stage-failed') {
+      expect(failed.stage).toBe(3);
+      expect(failed.stderr).toContain('next-app exited 1');
+    }
+    expect(logWrites).toHaveLength(1);
+    expect(logWrites[0].content).toContain('next-app exited 1');
+  });
+
+  it('stage-failed carries the retry-safe flag (false for 1-4, true for 5+)', async () => {
+    async function firstFailedAt(stage: number) {
+      const events = await collect(
+        scaffoldProject(
+          { targetDir: '/tmp/p', projectName: 'p' },
+          { runner: failAtRunner(stage), writeLog: async () => undefined },
+        ),
+      );
+      const failed = events.find((e) => e.kind === 'stage-failed');
+      if (failed?.kind !== 'stage-failed') throw new Error('expected stage-failed');
+      return failed;
+    }
+    expect((await firstFailedAt(1)).retrySafe).toBe(false);
+    expect((await firstFailedAt(4)).retrySafe).toBe(false);
+    expect((await firstFailedAt(5)).retrySafe).toBe(true);
+    expect((await firstFailedAt(9)).retrySafe).toBe(true);
+  });
+});

--- a/apps/desktop/tests/main/scaffold-preflight.test.ts
+++ b/apps/desktop/tests/main/scaffold-preflight.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Scaffolder pre-flight (stage 0) — synchronous, sub-100ms checks run
+ * before any shell commands fire. Each failure must return a specific,
+ * user-actionable error so the UI can render the right "install X" /
+ * "pick another folder" message. Drives through injected runners so
+ * the tests don't actually shell out or hit the network.
+ */
+import { type PreflightDeps, type PreflightError, runPreflight } from '@main/scaffold/preflight';
+import { describe, expect, it } from 'vitest';
+
+function okDeps(overrides: Partial<PreflightDeps> = {}): PreflightDeps {
+  return {
+    runCommand: async () => ({ stdout: 'ok', code: 0 }),
+    headOk: async () => true,
+    parentDirWritable: async () => true,
+    targetDirExists: async () => false,
+    freeBytes: async () => 600 * 1024 * 1024,
+    ...overrides,
+  };
+}
+
+async function expectError(
+  deps: Partial<PreflightDeps>,
+  expected: PreflightError['kind'],
+): Promise<PreflightError> {
+  const result = await runPreflight({ targetDir: '/tmp/new-proj' }, okDeps(deps));
+  if (result.ok) throw new Error(`expected preflight to fail with ${expected}`);
+  expect(result.error.kind).toBe(expected);
+  return result.error;
+}
+
+describe('runPreflight', () => {
+  it('returns ok when every check passes', async () => {
+    const result = await runPreflight({ targetDir: '/tmp/new-proj' }, okDeps());
+    expect(result.ok).toBe(true);
+  });
+
+  it('flags missing bun with a bun-specific error', async () => {
+    await expectError(
+      {
+        runCommand: async (cmd) =>
+          cmd === 'bun --version' ? { stdout: '', code: 127 } : { stdout: 'ok', code: 0 },
+      },
+      'missing-bun',
+    );
+  });
+
+  it('flags missing git', async () => {
+    await expectError(
+      {
+        runCommand: async (cmd) =>
+          cmd === 'git --version' ? { stdout: '', code: 127 } : { stdout: 'ok', code: 0 },
+      },
+      'missing-git',
+    );
+  });
+
+  it('flags missing node', async () => {
+    await expectError(
+      {
+        runCommand: async (cmd) =>
+          cmd === 'node --version' ? { stdout: '', code: 127 } : { stdout: 'ok', code: 0 },
+      },
+      'missing-node',
+    );
+  });
+
+  it('flags no network when registry HEAD fails', async () => {
+    await expectError({ headOk: async () => false }, 'no-network');
+  });
+
+  it('flags parent-not-writable with the path', async () => {
+    const err = await expectError({ parentDirWritable: async () => false }, 'parent-not-writable');
+    if (err.kind === 'parent-not-writable') expect(err.path).toBe('/tmp');
+  });
+
+  it('flags target-exists with the target path', async () => {
+    const err = await expectError({ targetDirExists: async () => true }, 'target-exists');
+    if (err.kind === 'target-exists') expect(err.path).toBe('/tmp/new-proj');
+  });
+
+  it('flags insufficient-space when < 500MB free', async () => {
+    const err = await expectError(
+      { freeBytes: async () => 100 * 1024 * 1024 },
+      'insufficient-space',
+    );
+    if (err.kind === 'insufficient-space') expect(err.bytesFree).toBe(100 * 1024 * 1024);
+  });
+});

--- a/apps/desktop/tests/main/scaffold-schema-package.test.ts
+++ b/apps/desktop/tests/main/scaffold-schema-package.test.ts
@@ -1,0 +1,66 @@
+/**
+ * `scaffoldSchemaPackage` (stage 6) — lays down `packages/schema/`
+ * with the initial IR, empty sidecars, a workspace package.json, a
+ * `.gitignore`, and the `.contexture/` marker dir with empty
+ * layout/chat/emitted stubs. Drives through MemFsAdapter so the
+ * expected tree is easy to assert.
+ */
+import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
+import { scaffoldSchemaPackage } from '@main/scaffold/schema-package';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+const schemaDir = '/work/my-proj/packages/schema';
+
+let fs: ReturnType<typeof createMemFsAdapter>;
+
+beforeEach(() => {
+  fs = createMemFsAdapter();
+});
+
+describe('scaffoldSchemaPackage', () => {
+  it('writes the initial IR file (empty schema)', async () => {
+    await scaffoldSchemaPackage(config, { fs });
+    const irPath = `${schemaDir}/my-proj.contexture.json`;
+    expect(fs.exists(irPath)).toBe(true);
+    const ir = JSON.parse(await fs.readFile(irPath));
+    expect(ir).toEqual({ version: '1', types: [] });
+  });
+
+  it('writes the Zod bundle, JSON-schema mirror, and index barrel', async () => {
+    await scaffoldSchemaPackage(config, { fs });
+    expect(fs.exists(`${schemaDir}/my-proj.schema.ts`)).toBe(true);
+    expect(fs.exists(`${schemaDir}/my-proj.schema.json`)).toBe(true);
+    expect(fs.exists(`${schemaDir}/index.ts`)).toBe(true);
+    const index = await fs.readFile(`${schemaDir}/index.ts`);
+    expect(index).toContain(`export * from './my-proj.schema';`);
+  });
+
+  it('writes a workspace package.json with the @<project>/schema name', async () => {
+    await scaffoldSchemaPackage(config, { fs });
+    const pkg = JSON.parse(await fs.readFile(`${schemaDir}/package.json`));
+    expect(pkg.name).toBe('@my-proj/schema');
+    expect(pkg.private).toBe(true);
+  });
+
+  it('writes a .gitignore', async () => {
+    await scaffoldSchemaPackage(config, { fs });
+    expect(fs.exists(`${schemaDir}/.gitignore`)).toBe(true);
+  });
+
+  it('seeds an empty layout.json, chat.json, and emitted.json under .contexture/', async () => {
+    await scaffoldSchemaPackage(config, { fs });
+    expect(JSON.parse(await fs.readFile(`${schemaDir}/.contexture/layout.json`))).toEqual({
+      version: '1',
+      positions: {},
+    });
+    expect(JSON.parse(await fs.readFile(`${schemaDir}/.contexture/chat.json`))).toEqual({
+      version: '1',
+      messages: [],
+    });
+    expect(JSON.parse(await fs.readFile(`${schemaDir}/.contexture/emitted.json`))).toEqual({
+      version: '1',
+      files: {},
+    });
+  });
+});

--- a/apps/desktop/tests/main/scaffold-spawn-runner.test.ts
+++ b/apps/desktop/tests/main/scaffold-spawn-runner.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `spawnStageRunner` — a StageRunner backed by `shellStageSpecFor` +
+ * an injected spawner. This test drives a fake spawner so we exercise
+ * the runner's contract (correct cmd/args/cwd, stdout/stderr streamed
+ * as StageChunks, non-zero exit throws) without actually forking a
+ * process. Real spawn wiring is a one-liner in production.
+ */
+import { createSpawnStageRunner, type Spawner } from '@main/scaffold/spawn-runner';
+import { describe, expect, it } from 'vitest';
+
+const config = { targetDir: '/work/p', projectName: 'p' };
+
+function fakeSpawner(
+  fn: (args: Parameters<Spawner>[0]) => {
+    stdout?: string[];
+    stderr?: string[];
+    code: number;
+  },
+): Spawner {
+  return async function* (call) {
+    const result = fn(call);
+    for (const chunk of result.stdout ?? []) yield { kind: 'stdout-chunk', chunk };
+    for (const chunk of result.stderr ?? []) yield { kind: 'stderr-chunk', chunk };
+    if (result.code !== 0) throw new Error(`process exited with code ${result.code}`);
+  };
+}
+
+describe('spawnStageRunner', () => {
+  it('feeds the stage spec into the spawner and streams chunks through', async () => {
+    const calls: Array<{ cmd: string; args: string[]; cwd: string }> = [];
+    const spawner = fakeSpawner((call) => {
+      calls.push(call);
+      return { stdout: ['creating...\n', 'done.\n'], code: 0 };
+    });
+    const runner = createSpawnStageRunner(spawner);
+    const chunks: Array<string> = [];
+    for await (const ev of runner.run(1, config)) {
+      if (ev.kind === 'stdout-chunk') chunks.push(ev.chunk);
+    }
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe('bunx');
+    expect(calls[0].args[0]).toBe('create-turbo@latest');
+    expect(calls[0].cwd).toBe('/work');
+    expect(chunks).toEqual(['creating...\n', 'done.\n']);
+  });
+
+  it('propagates a non-zero exit as a thrown error', async () => {
+    const spawner = fakeSpawner(() => ({ stderr: ['next-app: EACCES\n'], code: 1 }));
+    const runner = createSpawnStageRunner(spawner);
+    let threw = false;
+    try {
+      for await (const _ of runner.run(3, config)) {
+        // drain
+      }
+    } catch (e) {
+      threw = true;
+      expect(String(e)).toMatch(/code 1/);
+    }
+    expect(threw).toBe(true);
+  });
+});

--- a/apps/desktop/tests/main/scaffold-stages.test.ts
+++ b/apps/desktop/tests/main/scaffold-stages.test.ts
@@ -60,4 +60,13 @@ describe('shellStageSpecFor', () => {
     expect(spec.args).toEqual(['convex@latest', 'dev', '--once', '--configure=new', '--local']);
     expect(spec.cwd).toBe(nextCwd);
   });
+
+  it('stage 9: bun install at the project root to resolve the new workspace dep', () => {
+    const spec = shellStageSpecFor(9, config);
+    expect(spec).toEqual({
+      cmd: 'bun',
+      args: ['install'],
+      cwd: '/work/my-proj',
+    });
+  });
 });

--- a/apps/desktop/tests/main/scaffold-stages.test.ts
+++ b/apps/desktop/tests/main/scaffold-stages.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Per-stage command/cwd/args derivation — separated from spawn/IO so
+ * we can assert exactly what commands the scaffolder would run for a
+ * given config. Stages 1-4 are fully external (Turbo, Next, shadcn);
+ * they share the same spawn shape so only this pure-data derivation
+ * is worth asserting here.
+ */
+import { shellStageSpecFor } from '@main/scaffold/stages';
+import { describe, expect, it } from 'vitest';
+
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+const parent = '/work';
+const nextCwd = '/work/my-proj/apps/web';
+
+describe('shellStageSpecFor', () => {
+  it('stage 1: bunx create-turbo in the parent dir, skip-install, bun package manager', () => {
+    const spec = shellStageSpecFor(1, config);
+    expect(spec).toEqual({
+      cmd: 'bunx',
+      args: ['create-turbo@latest', 'my-proj', '--package-manager', 'bun', '--skip-install'],
+      cwd: parent,
+    });
+  });
+
+  it('stage 2: removes apps/web that create-turbo just laid down', () => {
+    const spec = shellStageSpecFor(2, config);
+    expect(spec.cmd).toBe('rm');
+    expect(spec.args).toEqual(['-rf', 'apps/web']);
+    expect(spec.cwd).toBe('/work/my-proj');
+  });
+
+  it('stage 3: bunx create-next-app at apps/web with the non-interactive flag set', () => {
+    const spec = shellStageSpecFor(3, config);
+    expect(spec.cmd).toBe('bunx');
+    expect(spec.args).toEqual([
+      'create-next-app@latest',
+      'apps/web',
+      '--ts',
+      '--app',
+      '--tailwind',
+      '--eslint',
+      '--use-bun',
+      '--yes',
+    ]);
+    expect(spec.cwd).toBe('/work/my-proj');
+  });
+
+  it('stage 4: bunx shadcn init inside apps/web', () => {
+    const spec = shellStageSpecFor(4, config);
+    expect(spec).toEqual({
+      cmd: 'bunx',
+      args: ['shadcn@latest', 'init', '--yes'],
+      cwd: nextCwd,
+    });
+  });
+
+  it('stage 5: convex dev one-shot configure, local backend, inside apps/web', () => {
+    const spec = shellStageSpecFor(5, config);
+    expect(spec.cmd).toBe('bunx');
+    expect(spec.args).toEqual(['convex@latest', 'dev', '--once', '--configure=new', '--local']);
+    expect(spec.cwd).toBe(nextCwd);
+  });
+});

--- a/apps/desktop/tests/main/scaffold-stages.test.ts
+++ b/apps/desktop/tests/main/scaffold-stages.test.ts
@@ -54,11 +54,19 @@ describe('shellStageSpecFor', () => {
     });
   });
 
-  it('stage 5: convex dev one-shot configure, local backend, inside apps/web', () => {
+  it('stage 5: convex dev one-shot configure, local backend, inside packages/schema', () => {
     const spec = shellStageSpecFor(5, config);
     expect(spec.cmd).toBe('bunx');
-    expect(spec.args).toEqual(['convex@latest', 'dev', '--once', '--configure=new', '--local']);
-    expect(spec.cwd).toBe(nextCwd);
+    expect(spec.args).toEqual([
+      'convex@latest',
+      'dev',
+      '--once',
+      '--configure=new',
+      '--local',
+      '--project',
+      'my-proj',
+    ]);
+    expect(spec.cwd).toBe('/work/my-proj/packages/schema');
   });
 
   it('stage 9: bun install at the project root to resolve the new workspace dep', () => {

--- a/apps/desktop/tests/main/scaffold-workspace-stitch.test.ts
+++ b/apps/desktop/tests/main/scaffold-workspace-stitch.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `scaffoldWorkspaceStitch` (stage 8) — merges
+ * `@<project>/schema: workspace:*` into `apps/web/package.json`,
+ * writes the root `CLAUDE.md`, the workspace `biome.json`, and
+ * ensures the root `.gitignore` has the usual entries. Pure file
+ * manipulation against an injected FsAdapter; git init is handled
+ * by a separate step so this slice stays testable without a shell.
+ */
+import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
+import { scaffoldWorkspaceStitch } from '@main/scaffold/workspace-stitch';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+const webPkgPath = '/work/my-proj/apps/web/package.json';
+
+let fs: ReturnType<typeof createMemFsAdapter>;
+
+beforeEach(() => {
+  fs = createMemFsAdapter();
+});
+
+describe('scaffoldWorkspaceStitch', () => {
+  it('adds @<project>/schema: workspace:* to apps/web/package.json dependencies', async () => {
+    await fs.writeFile(
+      webPkgPath,
+      `${JSON.stringify({ name: 'web', dependencies: { next: '^15.0.0' } }, null, 2)}\n`,
+    );
+    await scaffoldWorkspaceStitch(config, { fs });
+    const pkg = JSON.parse(await fs.readFile(webPkgPath));
+    expect(pkg.dependencies['@my-proj/schema']).toBe('workspace:*');
+    // Existing deps preserved.
+    expect(pkg.dependencies.next).toBe('^15.0.0');
+    expect(pkg.name).toBe('web');
+  });
+
+  it('creates a dependencies object if apps/web/package.json lacked one', async () => {
+    await fs.writeFile(webPkgPath, `${JSON.stringify({ name: 'web' }, null, 2)}\n`);
+    await scaffoldWorkspaceStitch(config, { fs });
+    const pkg = JSON.parse(await fs.readFile(webPkgPath));
+    expect(pkg.dependencies['@my-proj/schema']).toBe('workspace:*');
+  });
+
+  it('writes the root CLAUDE.md with {{PROJECT_NAME}} substituted', async () => {
+    await fs.writeFile(webPkgPath, `${JSON.stringify({ name: 'web' }, null, 2)}\n`);
+    await scaffoldWorkspaceStitch(config, { fs });
+    const claude = await fs.readFile('/work/my-proj/CLAUDE.md');
+    expect(claude).toContain('my-proj');
+    expect(claude).not.toContain('{{PROJECT_NAME}}');
+  });
+
+  it('writes biome.json at the project root', async () => {
+    await fs.writeFile(webPkgPath, `${JSON.stringify({ name: 'web' }, null, 2)}\n`);
+    await scaffoldWorkspaceStitch(config, { fs });
+    expect(fs.exists('/work/my-proj/biome.json')).toBe(true);
+    const biome = JSON.parse(await fs.readFile('/work/my-proj/biome.json'));
+    // Minimal sanity: must be a valid biome config shape.
+    expect(biome.$schema).toMatch(/biomejs/);
+  });
+
+  it('writes a root .gitignore covering node_modules, .next, .convex, and .contexture internals', async () => {
+    await fs.writeFile(webPkgPath, `${JSON.stringify({ name: 'web' }, null, 2)}\n`);
+    await scaffoldWorkspaceStitch(config, { fs });
+    const gitignore = await fs.readFile('/work/my-proj/.gitignore');
+    expect(gitignore).toMatch(/node_modules/);
+    expect(gitignore).toMatch(/\.next/);
+    expect(gitignore).toMatch(/\.convex/);
+  });
+
+  it('is idempotent — running twice leaves the web package.json unchanged', async () => {
+    await fs.writeFile(
+      webPkgPath,
+      `${JSON.stringify({ name: 'web', dependencies: { next: '^15.0.0' } }, null, 2)}\n`,
+    );
+    await scaffoldWorkspaceStitch(config, { fs });
+    const first = await fs.readFile(webPkgPath);
+    await scaffoldWorkspaceStitch(config, { fs });
+    const second = await fs.readFile(webPkgPath);
+    expect(second).toBe(first);
+  });
+});

--- a/apps/desktop/tests/model/emit-claude-md.test.ts
+++ b/apps/desktop/tests/model/emit-claude-md.test.ts
@@ -16,7 +16,7 @@ describe('emit (CLAUDE.md)', () => {
 
   it('warns against editing the generated Convex schema directly', () => {
     const out = emit('my-blog');
-    expect(out).toMatch(/apps\/web\/convex\/schema\.ts/);
+    expect(out).toMatch(/packages\/schema\/convex\/schema\.ts/);
     expect(out).toMatch(/do not edit|regenerat/i);
   });
 


### PR DESCRIPTION
Closes #121.

## Summary
Lands the full main-process scaffolder — pre-flight through stage 10 — as an injectable, unit-testable pipeline, plus the IPC surface the New Project dialog (#122) will drive. UI is out of scope; this PR is all plumbing.

Slice-by-slice breakdown (each its own commit):
- Stage 0 pre-flight: tagged errors for bun/git/node/network/writable-parent/target-exists/free-space.
- Orchestrator + `StageEvent` stream; writes `.contexture/scaffold.log` on both success and failure paths; retry-safe flag flips at stage 5.
- Shell stages 1-5 + 9 as a pure command table; `createSpawnStageRunner` delegates to an injected `Spawner` (real one wraps `child_process.spawn`).
- In-process stages: 6 scaffolds `packages/schema/` (IR + Zod + JSON + barrel + package.json + `.contexture/` marker); 7 emits `packages/schema/convex/schema.ts`; 8 stitches `@<project>/schema: workspace:*` into `apps/web/package.json`, writes root CLAUDE.md / biome.json / .gitignore, then runs the git init / add / commit trio through the same spawner.
- `createCompositeStageRunner` dispatches every stage to the right implementation; `handleScaffoldStart` is the pure IPC handler that preflight-then-drives-the-orchestrator, emitting every event via a callback. `registerScaffoldIpc` binds it to `webContents.send`.
- Gated end-to-end test behind `SCAFFOLD_E2E=1` that drives the whole flow against a real temp dir.

Also includes a small refactor commit that moves Convex emit targets from `apps/web/convex/schema.ts` → `packages/schema/convex/schema.ts` (Convex needs a `convex/` subdir, and `apps/web` imports the workspace package instead of owning its own tree).

## Test plan
- [x] `bunx vitest run` passes (662 + 1 skipped; all new slices have unit coverage)
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [ ] `SCAFFOLD_E2E=1 bunx vitest run tests/main/scaffold-e2e.test.ts` — run locally before merge to confirm the real ten-stage flow still succeeds end-to-end