### PR TITLE
New Project dialog + progress modal + success panel

### DIFF
--- a/apps/desktop/e2e/new-project.spec.ts
+++ b/apps/desktop/e2e/new-project.spec.ts
@@ -1,9 +1,9 @@
 /**
  * New Project dialog — end-to-end check that the menu entry opens the
- * dialog and the form renders. The heavy 10-stage scaffold is covered
- * by vitest (`scaffold-orchestrator.test.ts` etc.) + a skipped real-fs
- * suite (`scaffold-e2e.test.ts`); here we just prove the menu → IPC →
- * renderer chain wires up and the form is reachable.
+ * dialog and the form renders. The heavy scaffold is covered by vitest
+ * (`scaffold-orchestrator.test.ts` etc.) + a skipped real-fs suite
+ * (`scaffold-e2e.test.ts`); here we prove the menu → IPC → renderer
+ * chain wires up and the form is reachable.
  */
 import { expect, test } from '@playwright/test';
 import { launchElectron } from './electron-launch';
@@ -22,23 +22,40 @@ test.describe('New Project dialog', () => {
     await electronApp?.close();
   });
 
-  test('menu entry opens the dialog with the form visible', async () => {
+  async function openDialog(): Promise<void> {
     await electronApp.evaluate(({ BrowserWindow }) => {
       const [win] = BrowserWindow.getAllWindows();
       win?.webContents.send('menu:file-new-project');
     });
-
     await expect(page.getByRole('heading', { name: /New Project/i })).toBeVisible({
       timeout: 10_000,
     });
+  }
+
+  test('menu entry opens the dialog with the form visible', async () => {
+    await openDialog();
     await expect(page.getByLabel(/Project name/i)).toBeVisible();
     await expect(page.getByRole('button', { name: /Choose folder/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /^Create$/i })).toBeDisabled();
   });
 
   test('typing an invalid project name surfaces the validation error', async () => {
-    // Dialog is already open from the previous test.
+    await openDialog();
     await page.getByLabel(/Project name/i).fill('Bad Name With Spaces');
     await expect(page.getByText(/lowercase letters/i)).toBeVisible();
+  });
+
+  test('app picker shows Web pre-checked and Mobile, Desktop unchecked', async () => {
+    await openDialog();
+    await expect(page.getByRole('checkbox', { name: /Web/i })).toBeChecked();
+    await expect(page.getByRole('checkbox', { name: /Mobile/i })).not.toBeChecked();
+    await expect(page.getByRole('checkbox', { name: /Desktop/i })).not.toBeChecked();
+  });
+
+  test('unchecking all apps disables Create and surfaces validation message', async () => {
+    await openDialog();
+    await page.getByRole('checkbox', { name: /Web/i }).uncheck();
+    await expect(page.getByText(/at least one app/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Create$/i })).toBeDisabled();
   });
 });

--- a/apps/desktop/e2e/new-project.spec.ts
+++ b/apps/desktop/e2e/new-project.spec.ts
@@ -23,6 +23,10 @@ test.describe('New Project dialog', () => {
   });
 
   async function openDialog(): Promise<void> {
+    // Close any previously open dialog so each test starts from a clean state.
+    const closeBtn = page.getByRole('button', { name: /^Cancel$/i });
+    if (await closeBtn.isVisible()) await closeBtn.click();
+
     await electronApp.evaluate(({ BrowserWindow }) => {
       const [win] = BrowserWindow.getAllWindows();
       win?.webContents.send('menu:file-new-project');
@@ -42,7 +46,7 @@ test.describe('New Project dialog', () => {
   test('typing an invalid project name surfaces the validation error', async () => {
     await openDialog();
     await page.getByLabel(/Project name/i).fill('Bad Name With Spaces');
-    await expect(page.getByText(/lowercase letters/i)).toBeVisible();
+    await expect(page.getByText('Name must be lowercase.')).toBeVisible();
   });
 
   test('app picker shows Web pre-checked and Mobile, Desktop unchecked', async () => {
@@ -55,7 +59,7 @@ test.describe('New Project dialog', () => {
   test('unchecking all apps disables Create and surfaces validation message', async () => {
     await openDialog();
     await page.getByRole('checkbox', { name: /Web/i }).uncheck();
-    await expect(page.getByText(/at least one app/i)).toBeVisible();
+    await expect(page.getByText('Select at least one app.')).toBeVisible();
     await expect(page.getByRole('button', { name: /^Create$/i })).toBeDisabled();
   });
 });

--- a/apps/desktop/e2e/new-project.spec.ts
+++ b/apps/desktop/e2e/new-project.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * New Project dialog — end-to-end check that the menu entry opens the
+ * dialog and the form renders. The heavy 10-stage scaffold is covered
+ * by vitest (`scaffold-orchestrator.test.ts` etc.) + a skipped real-fs
+ * suite (`scaffold-e2e.test.ts`); here we just prove the menu → IPC →
+ * renderer chain wires up and the form is reachable.
+ */
+import { expect, test } from '@playwright/test';
+import { launchElectron } from './electron-launch';
+
+test.describe('New Project dialog', () => {
+  let electronApp: Awaited<ReturnType<typeof launchElectron>>;
+  let page: Awaited<ReturnType<typeof electronApp.firstWindow>>;
+
+  test.beforeAll(async () => {
+    electronApp = await launchElectron();
+    page = await electronApp.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test.afterAll(async () => {
+    await electronApp?.close();
+  });
+
+  test('menu entry opens the dialog with the form visible', async () => {
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      const [win] = BrowserWindow.getAllWindows();
+      win?.webContents.send('menu:file-new-project');
+    });
+
+    await expect(page.getByRole('heading', { name: /New Project/i })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByLabel(/Project name/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /Choose folder/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Create$/i })).toBeDisabled();
+  });
+
+  test('typing an invalid project name surfaces the validation error', async () => {
+    // Dialog is already open from the previous test.
+    await page.getByLabel(/Project name/i).fill('Bad Name With Spaces');
+    await expect(page.getByText(/lowercase letters/i)).toBeVisible();
+  });
+});

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { electronApp, is, optimizer } from '@electron-toolkit/utils';
 import { registerClaudeIpc } from './ipc/claude';
 import { registerFileIpc } from './ipc/file';
+import { registerProjectIpc } from './ipc/project';
 import { registerScaffoldIpc } from './ipc/scaffold';
 import { registerShellIpc } from './ipc/shell';
 import { registerUpdateIpc } from './ipc/update';
@@ -75,6 +76,7 @@ app.whenReady().then(() => {
   registerFileIpc(mainWindow);
   registerScaffoldIpc(mainWindow);
   registerShellIpc();
+  registerProjectIpc();
   registerClaudeIpc(mainWindow);
 
   app.on('activate', () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,6 +12,7 @@ import { electronApp, is, optimizer } from '@electron-toolkit/utils';
 import { registerClaudeIpc } from './ipc/claude';
 import { registerFileIpc } from './ipc/file';
 import { registerScaffoldIpc } from './ipc/scaffold';
+import { registerShellIpc } from './ipc/shell';
 import { registerUpdateIpc } from './ipc/update';
 import { createMenu } from './menu';
 
@@ -73,6 +74,7 @@ app.whenReady().then(() => {
   registerUpdateIpc(mainWindow);
   registerFileIpc(mainWindow);
   registerScaffoldIpc(mainWindow);
+  registerShellIpc();
   registerClaudeIpc(mainWindow);
 
   app.on('activate', () => {

--- a/apps/desktop/src/main/ipc/file.ts
+++ b/apps/desktop/src/main/ipc/file.ts
@@ -124,6 +124,15 @@ export function registerFileIpc(mainWindow: BrowserWindow): void {
     return handleOpen(result.filePaths[0]);
   });
 
+  ipcMain.handle('file:pick-directory', async () => {
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: 'Choose Parent Folder',
+      properties: ['openDirectory', 'createDirectory'],
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return result.filePaths[0];
+  });
+
   ipcMain.handle('file:save-as-dialog', async () => {
     const result = await dialog.showSaveDialog(mainWindow, {
       title: 'Save Contexture File As',

--- a/apps/desktop/src/main/ipc/project.ts
+++ b/apps/desktop/src/main/ipc/project.ts
@@ -1,0 +1,18 @@
+/**
+ * `registerProjectIpc` — project-lifecycle IPC that doesn't belong in the
+ * file/open bundle flow. Currently just a recursive directory delete used
+ * by the New Project dialog's "delete and start over" action.
+ *
+ * The handler trusts the renderer to have confirmed with the user before
+ * calling — main is deliberately dumb here. Delete is `force: true` so a
+ * partial scaffold (unwritable child files, etc.) still cleans up.
+ */
+import { rm } from 'node:fs/promises';
+import { ipcMain } from 'electron';
+
+export function registerProjectIpc(): void {
+  ipcMain.handle('project:delete-directory', async (_evt, path: string) => {
+    if (typeof path !== 'string' || path === '' || path === '/') return;
+    await rm(path, { recursive: true, force: true });
+  });
+}

--- a/apps/desktop/src/main/ipc/shell.ts
+++ b/apps/desktop/src/main/ipc/shell.ts
@@ -10,4 +10,7 @@ export function registerShellIpc(): void {
   ipcMain.handle('shell:reveal', (_evt, path: string) => {
     shell.showItemInFolder(path);
   });
+  ipcMain.handle('shell:open-in-editor', async (_evt, path: string) => {
+    await shell.openExternal(`vscode://file${path}`);
+  });
 }

--- a/apps/desktop/src/main/ipc/shell.ts
+++ b/apps/desktop/src/main/ipc/shell.ts
@@ -1,0 +1,13 @@
+/**
+ * `registerShellIpc` — tiny wrapper around Electron's `shell.showItemInFolder`
+ * so the renderer can reveal a scaffolded project (or its log file) in the
+ * OS file manager. Kept separate so the success / failure views can reach
+ * the same IPC channel.
+ */
+import { ipcMain, shell } from 'electron';
+
+export function registerShellIpc(): void {
+  ipcMain.handle('shell:reveal', (_evt, path: string) => {
+    shell.showItemInFolder(path);
+  });
+}

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -38,6 +38,13 @@ export function createMenuTemplate(mainWindow: BrowserWindow): MenuItemConstruct
           },
         },
         {
+          label: 'New Project…',
+          accelerator: 'CmdOrCtrl+Shift+N',
+          click: (): void => {
+            mainWindow.webContents.send('menu:file-new-project');
+          },
+        },
+        {
           label: 'Open Contexture File…',
           accelerator: 'CmdOrCtrl+O',
           click: (): void => {

--- a/apps/desktop/src/main/scaffold/composite-runner.ts
+++ b/apps/desktop/src/main/scaffold/composite-runner.ts
@@ -1,22 +1,19 @@
 /**
  * `createCompositeStageRunner` — the production `StageRunner`: one
- * object that knows how to run every stage 1-10. Shell-backed stages
- * (1-5, 9) go through the injected `Spawner`; in-process stages
- * (6 schema package, 7 Convex emit, 8 workspace stitch + git trio)
- * run directly against the injected `FsAdapter`. Stage 10 is a
- * no-op in v1 (LLM seeding lives in a separate issue).
- *
- * Splitting dispatch from implementation keeps the orchestrator
- * ignorant of how any given stage does its work — it just drains
- * the chunk stream and watches for throws.
+ * object that knows how to run every stage. Shell-backed stages
+ * (2-5, 10) go through the injected `Spawner`; in-process stages
+ * (1 skeleton, 6 Convex init, 7 schema package, 8 Convex emit,
+ * 9 workspace stitch + git trio, 11 LLM seed no-op) run directly.
  */
 import type { FsAdapter } from '@main/documents/document-store';
 import { scaffoldConvexEmit } from './convex-emit';
 import { gitInitStageSpec } from './git-init';
 import type { ScaffoldConfig, StageChunk, StageNumber, StageRunner } from './scaffold-project';
+import { STAGE } from './scaffold-project';
 import { scaffoldSchemaPackage } from './schema-package';
 import type { Spawner } from './spawn-runner';
 import { shellStageSpecFor } from './stages';
+import { scaffoldTurboSkeleton } from './turbo-skeleton';
 import { scaffoldWorkspaceStitch } from './workspace-stitch';
 
 export interface CompositeRunnerDeps {
@@ -24,7 +21,13 @@ export interface CompositeRunnerDeps {
   spawner: Spawner;
 }
 
-const PURE_SHELL_STAGES: ReadonlySet<StageNumber> = new Set([1, 2, 3, 4, 9]);
+const PURE_SHELL_STAGES: ReadonlySet<StageNumber> = new Set([
+  STAGE.WEB_NEXT,
+  STAGE.WEB_SHADCN,
+  STAGE.MOBILE_EXPO,
+  STAGE.DESKTOP_ELECTRON,
+  STAGE.BUN_INSTALL,
+]);
 
 export function createCompositeStageRunner(deps: CompositeRunnerDeps): StageRunner {
   const { fs, spawner } = deps;
@@ -42,11 +45,14 @@ export function createCompositeStageRunner(deps: CompositeRunnerDeps): StageRunn
     config: ScaffoldConfig,
   ): AsyncIterable<StageChunk> {
     switch (stage) {
-      case 5: {
+      case STAGE.TURBO_SKELETON:
+        await scaffoldTurboSkeleton(config, { fs });
+        return;
+      case STAGE.CONVEX_INIT: {
         // Convex CLI needs (a) a package.json in cwd, (b) `convex` listed as
         // a dep to reach the push step, and (c) `convex/server` resolvable
         // on disk or its config bundler fails. So we write a bare anchor,
-        // install only convex locally, then run `convex dev --once`. Stage 6
+        // install only convex locally, then run `convex dev --once`. Stage 7
         // rewrites this file with the real schema-package shape later.
         const schemaDir = `${config.targetDir}/packages/schema`;
         await fs.writeFile(
@@ -68,23 +74,24 @@ export function createCompositeStageRunner(deps: CompositeRunnerDeps): StageRunn
         })) {
           yield chunk;
         }
-        for await (const chunk of spawner(shellStageSpecFor(5, config))) yield chunk;
+        for await (const chunk of spawner(shellStageSpecFor(STAGE.CONVEX_INIT, config)))
+          yield chunk;
         return;
       }
-      case 6:
+      case STAGE.SCHEMA_PACKAGE:
         await scaffoldSchemaPackage(config, { fs });
         return;
-      case 7:
+      case STAGE.CONVEX_EMIT:
         await scaffoldConvexEmit(config, { fs });
         return;
-      case 8: {
+      case STAGE.WORKSPACE_STITCH: {
         await scaffoldWorkspaceStitch(config, { fs });
         for (const spec of gitInitStageSpec(config)) {
           for await (const chunk of spawner(spec)) yield chunk;
         }
         return;
       }
-      case 10:
+      case STAGE.LLM_SEED:
         return;
       default:
         throw new Error(`composite runner: unexpected in-process stage ${stage}`);

--- a/apps/desktop/src/main/scaffold/scaffold-project.ts
+++ b/apps/desktop/src/main/scaffold/scaffold-project.ts
@@ -1,27 +1,71 @@
 /**
- * `scaffoldProject` — the ten-stage project scaffolder. Streams
+ * `scaffoldProject` — the composable project scaffolder. Derives a
+ * dynamic stage list from the selected app kinds, then streams
  * `StageEvent`s per stage so the renderer can show live progress, and
  * writes `.contexture/scaffold.log` on both success and failure paths.
  *
  * Stage implementations are injected via `StageRunner` so the
- * orchestrator is unit-testable without shelling out; real runners
- * wire `child_process.spawn` + the project emitters in later slices.
+ * orchestrator is unit-testable without shelling out.
  *
- * Failure policy: any stage throwing aborts the chain. Stages 1-4
- * (turbo/rm/next/shadcn) are "start over only" — a failed run should
- * be wiped and retried fresh. Stages 5+ (`convex dev`, scaffold
- * emitters, git init, `bun install`) are retry-safe against the same
- * directory.
+ * Failure policy: any stage throwing aborts the chain. The TurboRepo
+ * skeleton stage (1) is "start over only". Stages 2+ are retry-safe
+ * against the same directory.
  */
 
-export type StageNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
-export const STAGE_NUMBERS: readonly StageNumber[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-/** First stage that is safe to retry against the same target dir. */
-const FIRST_RETRY_SAFE_STAGE: StageNumber = 5;
+export type AppKind = 'web' | 'mobile' | 'desktop';
 
 export interface ScaffoldConfig {
   targetDir: string;
   projectName: string;
+  apps: AppKind[];
+  /** Initial user prompt seeded into chat.json when the project is created. */
+  description?: string;
+}
+
+/**
+ * Fixed stage numbers. Optional app stages (WEB_*, MOBILE, DESKTOP)
+ * are included only when the corresponding app kind is selected.
+ */
+export const STAGE = {
+  TURBO_SKELETON: 1,
+  WEB_NEXT: 2,
+  WEB_SHADCN: 3,
+  MOBILE_EXPO: 4,
+  DESKTOP_ELECTRON: 5,
+  CONVEX_INIT: 6,
+  SCHEMA_PACKAGE: 7,
+  CONVEX_EMIT: 8,
+  WORKSPACE_STITCH: 9,
+  BUN_INSTALL: 10,
+  LLM_SEED: 11,
+} as const;
+
+export type StageNumber = (typeof STAGE)[keyof typeof STAGE];
+
+/** First stage that is safe to retry against the same target dir. */
+const FIRST_RETRY_SAFE_STAGE: StageNumber = STAGE.WEB_NEXT;
+
+/** Derive the ordered stage list for a given app selection. */
+export function deriveStages(apps: AppKind[]): StageNumber[] {
+  const stages: StageNumber[] = [STAGE.TURBO_SKELETON];
+  if (apps.includes('web')) {
+    stages.push(STAGE.WEB_NEXT, STAGE.WEB_SHADCN);
+  }
+  if (apps.includes('mobile')) {
+    stages.push(STAGE.MOBILE_EXPO);
+  }
+  if (apps.includes('desktop')) {
+    stages.push(STAGE.DESKTOP_ELECTRON);
+  }
+  stages.push(
+    STAGE.CONVEX_INIT,
+    STAGE.SCHEMA_PACKAGE,
+    STAGE.CONVEX_EMIT,
+    STAGE.WORKSPACE_STITCH,
+    STAGE.BUN_INSTALL,
+    STAGE.LLM_SEED,
+  );
+  return stages;
 }
 
 export type StageEvent =
@@ -51,10 +95,11 @@ export async function* scaffoldProject(
   config: ScaffoldConfig,
   deps: ScaffoldDeps,
 ): AsyncIterable<StageEvent> {
+  const stages = deriveStages(config.apps);
   const buffered: StageEvent[] = [];
   let failedStderr = '';
 
-  for (const stage of STAGE_NUMBERS) {
+  for (const stage of stages) {
     const startEvent: StageEvent = { kind: 'stage-start', stage };
     buffered.push(startEvent);
     yield startEvent;

--- a/apps/desktop/src/main/scaffold/scaffold-project.ts
+++ b/apps/desktop/src/main/scaffold/scaffold-project.ts
@@ -29,7 +29,8 @@ export type StageEvent =
   | { kind: 'stdout-chunk'; stage: StageNumber; chunk: string }
   | { kind: 'stderr-chunk'; stage: StageNumber; chunk: string }
   | { kind: 'stage-done'; stage: StageNumber }
-  | { kind: 'stage-failed'; stage: StageNumber; stderr: string; retrySafe: boolean };
+  | { kind: 'stage-failed'; stage: StageNumber; stderr: string; retrySafe: boolean }
+  | { kind: 'scaffold-done' };
 
 /** Yielded by a stage runner during its run — stage number is stamped on by the orchestrator. */
 export type StageChunk =
@@ -89,6 +90,7 @@ export async function* scaffoldProject(
   await deps
     .writeLog(`${config.targetDir}/.contexture/scaffold.log`, formatLog(buffered))
     .catch(() => undefined);
+  yield { kind: 'scaffold-done' };
 }
 
 function formatLog(events: ReadonlyArray<StageEvent>): string {

--- a/apps/desktop/src/main/scaffold/schema-package.ts
+++ b/apps/desktop/src/main/scaffold/schema-package.ts
@@ -21,6 +21,20 @@ export interface SchemaPackageDeps {
 
 const EMPTY_SCHEMA: Schema = { version: '1', types: [] };
 
+function makeChatHistory(description?: string): string {
+  const messages = description?.trim()
+    ? [
+        {
+          id: crypto.randomUUID(),
+          role: 'user',
+          content: description.trim(),
+          createdAt: Date.now(),
+        },
+      ]
+    : [];
+  return `${JSON.stringify({ version: '1', messages }, null, 2)}\n`;
+}
+
 function makePackageJson(projectName: string): string {
   return `${JSON.stringify(
     {
@@ -63,10 +77,7 @@ export async function scaffoldSchemaPackage(
     `${ctxDir}/layout.json`,
     `${JSON.stringify({ version: '1', positions: {} }, null, 2)}\n`,
   );
-  await fs.writeFile(
-    `${ctxDir}/chat.json`,
-    `${JSON.stringify({ version: '1', messages: [] }, null, 2)}\n`,
-  );
+  await fs.writeFile(`${ctxDir}/chat.json`, makeChatHistory(config.description));
   await fs.writeFile(
     `${ctxDir}/emitted.json`,
     `${JSON.stringify({ version: '1', files: {} }, null, 2)}\n`,

--- a/apps/desktop/src/main/scaffold/stages.ts
+++ b/apps/desktop/src/main/scaffold/stages.ts
@@ -1,14 +1,12 @@
 /**
  * Stage command table — pure derivation of what shell command each
- * external-tool stage runs, against what cwd. Keeping this separate
- * from the spawn/IO layer lets tests assert "stage 3 calls
- * create-next-app with these exact flags" without shelling out.
- *
- * Only shell-backed stages (1-5, 9) have a spec; stages 6-8 and 10
- * are in-process work (emitters; git init runs through its own spec
- * trio from `git-init.ts`).
+ * external-tool stage runs, against what cwd. Only shell-backed stages
+ * have a spec; the TurboRepo skeleton (stage 1), Convex init (stage 6),
+ * schema/emit stages (7-9), and LLM seed (11) are in-process.
  */
-import type { ScaffoldConfig, StageNumber } from './scaffold-project';
+
+import type { ScaffoldConfig } from './scaffold-project';
+import { STAGE } from './scaffold-project';
 
 export interface ShellStageSpec {
   cmd: string;
@@ -16,33 +14,12 @@ export interface ShellStageSpec {
   cwd: string;
 }
 
-function parentDirOf(path: string): string {
-  const slash = path.lastIndexOf('/');
-  if (slash <= 0) return '/';
-  return path.slice(0, slash);
-}
-
-export function shellStageSpecFor(stage: StageNumber, config: ScaffoldConfig): ShellStageSpec {
-  const parent = parentDirOf(config.targetDir);
+export function shellStageSpecFor(stage: number, config: ScaffoldConfig): ShellStageSpec {
   const target = config.targetDir;
   const webDir = `${target}/apps/web`;
   const schemaDir = `${target}/packages/schema`;
   switch (stage) {
-    case 1:
-      return {
-        cmd: 'bunx',
-        args: [
-          'create-turbo@latest',
-          config.projectName,
-          '--package-manager',
-          'bun',
-          '--skip-install',
-        ],
-        cwd: parent,
-      };
-    case 2:
-      return { cmd: 'rm', args: ['-rf', 'apps/web'], cwd: target };
-    case 3:
+    case STAGE.WEB_NEXT:
       return {
         cmd: 'bunx',
         args: [
@@ -57,9 +34,27 @@ export function shellStageSpecFor(stage: StageNumber, config: ScaffoldConfig): S
         ],
         cwd: target,
       };
-    case 4:
+    case STAGE.WEB_SHADCN:
       return { cmd: 'bunx', args: ['shadcn@latest', 'init', '--yes'], cwd: webDir };
-    case 5:
+    case STAGE.MOBILE_EXPO:
+      return {
+        cmd: 'bunx',
+        args: [
+          'create-expo-app@latest',
+          'apps/mobile',
+          '--template=default',
+          '--yes',
+          '--no-install',
+        ],
+        cwd: target,
+      };
+    case STAGE.DESKTOP_ELECTRON:
+      return {
+        cmd: 'bunx',
+        args: ['create-electron-app@latest', 'apps/desktop', '--template=vite-typescript'],
+        cwd: target,
+      };
+    case STAGE.CONVEX_INIT:
       return {
         cmd: 'bunx',
         args: [
@@ -73,7 +68,7 @@ export function shellStageSpecFor(stage: StageNumber, config: ScaffoldConfig): S
         ],
         cwd: schemaDir,
       };
-    case 9:
+    case STAGE.BUN_INSTALL:
       return { cmd: 'bun', args: ['install'], cwd: target };
     default:
       throw new Error(`shellStageSpecFor: stage ${stage} is not a shell-backed stage`);

--- a/apps/desktop/src/main/scaffold/turbo-skeleton.ts
+++ b/apps/desktop/src/main/scaffold/turbo-skeleton.ts
@@ -1,0 +1,69 @@
+/**
+ * `scaffoldTurboSkeleton` (stage 1) — writes the minimal TurboRepo
+ * monorepo skeleton without invoking the create-turbo CLI (which
+ * always adds an apps/web stub we don't want). Creates:
+ *   - package.json (workspace root)
+ *   - turbo.json
+ *   - .gitignore
+ *   - apps/ and packages/ directories (via placeholder files)
+ */
+import type { FsAdapter } from '@main/documents/document-store';
+import type { ScaffoldConfig } from './scaffold-project';
+
+export interface TurboSkeletonDeps {
+  fs: FsAdapter;
+}
+
+const TURBO_CONFIG = {
+  $schema: 'https://turbo.build/schema.json',
+  tasks: {
+    build: { dependsOn: ['^build'], outputs: ['.next/**', '!.next/cache/**', 'dist/**'] },
+    dev: { cache: false, persistent: true },
+    lint: { dependsOn: ['^lint'] },
+    typecheck: { dependsOn: ['^typecheck'] },
+  },
+};
+
+const ROOT_GITIGNORE = [
+  'node_modules',
+  '.next',
+  'dist',
+  'out',
+  '.turbo',
+  '.convex',
+  '.DS_Store',
+  '*.log',
+  '.env.local',
+  '',
+].join('\n');
+
+export async function scaffoldTurboSkeleton(
+  config: ScaffoldConfig,
+  deps: TurboSkeletonDeps,
+): Promise<void> {
+  const { fs } = deps;
+  const { targetDir, projectName } = config;
+
+  const rootPkg = {
+    name: projectName,
+    private: true,
+    packageManager: 'bun',
+    workspaces: ['apps/*', 'packages/*'],
+    scripts: {
+      build: 'turbo build',
+      dev: 'turbo dev',
+      lint: 'turbo lint',
+      typecheck: 'turbo typecheck',
+    },
+    devDependencies: {
+      turbo: 'latest',
+    },
+  };
+
+  await fs.writeFile(`${targetDir}/package.json`, `${JSON.stringify(rootPkg, null, 2)}\n`);
+  await fs.writeFile(`${targetDir}/turbo.json`, `${JSON.stringify(TURBO_CONFIG, null, 2)}\n`);
+  await fs.writeFile(`${targetDir}/.gitignore`, ROOT_GITIGNORE);
+  // Create empty directory markers so downstream stages can cd into them.
+  await fs.writeFile(`${targetDir}/apps/.gitkeep`, '');
+  await fs.writeFile(`${targetDir}/packages/.gitkeep`, '');
+}

--- a/apps/desktop/src/main/scaffold/workspace-stitch.ts
+++ b/apps/desktop/src/main/scaffold/workspace-stitch.ts
@@ -1,13 +1,13 @@
 /**
- * `scaffoldWorkspaceStitch` (stage 8) — finishes the file side of the
- * scaffold: adds `@<project>/schema: workspace:*` to
- * `apps/web/package.json` so Next.js resolves the schema package,
- * writes the root `CLAUDE.md` from the template, writes the workspace
- * `biome.json`, and writes a root `.gitignore`. Pure file work; the
- * subsequent `git init` / `bun install` stages are handled elsewhere.
+ * `scaffoldWorkspaceStitch` (stage 9) — finishes the file side of the
+ * scaffold: if a web app was created, adds `@<project>/schema: workspace:*`
+ * to `apps/web/package.json`; writes the root `CLAUDE.md`, `biome.json`,
+ * and root `.gitignore` (overwriting the skeleton's version with the
+ * richer one). Pure file work; the subsequent git + bun install stages
+ * are handled elsewhere.
  *
  * Idempotent by construction: the dep is only added if missing, and
- * the file writes overwrite with the same content on re-run.
+ * file writes overwrite with the same content on re-run.
  */
 import type { FsAdapter } from '@main/documents/document-store';
 import { emit as emitClaudeMd } from '@renderer/model/emit-claude-md';
@@ -31,10 +31,12 @@ const ROOT_GITIGNORE = [
   'node_modules',
   '.next',
   'dist',
+  'out',
   '.turbo',
   '.convex',
   '.DS_Store',
   '*.log',
+  '.env.local',
   '',
 ].join('\n');
 
@@ -43,12 +45,15 @@ export async function scaffoldWorkspaceStitch(
   deps: WorkspaceStitchDeps,
 ): Promise<void> {
   const { fs } = deps;
-  const webPkgPath = `${config.targetDir}/apps/web/package.json`;
-  const raw = await fs.readFile(webPkgPath);
-  const pkg = JSON.parse(raw) as { dependencies?: Record<string, string>; [k: string]: unknown };
-  pkg.dependencies ??= {};
-  pkg.dependencies[`@${config.projectName}/schema`] = 'workspace:*';
-  await fs.writeFile(webPkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+  if (config.apps.includes('web')) {
+    const webPkgPath = `${config.targetDir}/apps/web/package.json`;
+    const raw = await fs.readFile(webPkgPath);
+    const pkg = JSON.parse(raw) as { dependencies?: Record<string, string>; [k: string]: unknown };
+    pkg.dependencies ??= {};
+    pkg.dependencies[`@${config.projectName}/schema`] = 'workspace:*';
+    await fs.writeFile(webPkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+  }
 
   await fs.writeFile(`${config.targetDir}/CLAUDE.md`, emitClaudeMd(config.projectName));
   await fs.writeFile(

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -119,9 +119,32 @@ export interface ContextureFileAPI {
   onMenuSaveAs: (listener: () => void) => Unsubscribe;
 }
 
+export type ScaffoldPreflightError =
+  | { kind: 'missing-bun' }
+  | { kind: 'missing-git' }
+  | { kind: 'missing-node' }
+  | { kind: 'no-network' }
+  | { kind: 'parent-not-writable'; path: string }
+  | { kind: 'target-exists'; path: string }
+  | { kind: 'insufficient-space'; bytesFree: number };
+
+export type ScaffoldEvent =
+  | { kind: 'preflight-failed'; error: ScaffoldPreflightError }
+  | { kind: 'stage-start'; stage: number }
+  | { kind: 'stdout-chunk'; stage: number; chunk: string }
+  | { kind: 'stderr-chunk'; stage: number; chunk: string }
+  | { kind: 'stage-done'; stage: number }
+  | { kind: 'stage-failed'; stage: number; stderr: string; retrySafe: boolean };
+
+export interface ContextureScaffoldAPI {
+  start: (config: { targetDir: string; projectName: string }) => Promise<void>;
+  onEvent: (listener: (event: ScaffoldEvent) => void) => Unsubscribe;
+}
+
 export interface ContextureAPI {
   chat: ContextureChatAPI;
   file: ContextureFileAPI;
+  scaffold: ContextureScaffoldAPI;
 }
 
 declare global {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -112,6 +112,7 @@ export interface ContextureFileAPI {
   getRecentFiles: () => Promise<string[]>;
   openRecent: (filePath: string) => Promise<OpenedDocument | null>;
   onMenuNew: (listener: () => void) => Unsubscribe;
+  onMenuNewProject: (listener: () => void) => Unsubscribe;
   onMenuOpen: (listener: () => void) => Unsubscribe;
   onMenuSave: (listener: () => void) => Unsubscribe;
   onMenuSaveAs: (listener: () => void) => Unsubscribe;

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -137,8 +137,15 @@ export type ScaffoldEvent =
   | { kind: 'stage-failed'; stage: number; stderr: string; retrySafe: boolean }
   | { kind: 'scaffold-done' };
 
+export type AppKind = 'web' | 'mobile' | 'desktop';
+
 export interface ContextureScaffoldAPI {
-  start: (config: { targetDir: string; projectName: string }) => Promise<void>;
+  start: (config: {
+    targetDir: string;
+    projectName: string;
+    apps: AppKind[];
+    description?: string;
+  }) => Promise<void>;
   onEvent: (listener: (event: ScaffoldEvent) => void) => Unsubscribe;
 }
 

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -134,7 +134,8 @@ export type ScaffoldEvent =
   | { kind: 'stdout-chunk'; stage: number; chunk: string }
   | { kind: 'stderr-chunk'; stage: number; chunk: string }
   | { kind: 'stage-done'; stage: number }
-  | { kind: 'stage-failed'; stage: number; stderr: string; retrySafe: boolean };
+  | { kind: 'stage-failed'; stage: number; stderr: string; retrySafe: boolean }
+  | { kind: 'scaffold-done' };
 
 export interface ContextureScaffoldAPI {
   start: (config: { targetDir: string; projectName: string }) => Promise<void>;

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -147,11 +147,17 @@ export interface ContextureShellAPI {
   reveal: (path: string) => Promise<void>;
 }
 
+export interface ContextureProjectAPI {
+  /** Recursively delete a directory — used by the "delete and start over" flow. */
+  deleteDirectory: (path: string) => Promise<void>;
+}
+
 export interface ContextureAPI {
   chat: ContextureChatAPI;
   file: ContextureFileAPI;
   scaffold: ContextureScaffoldAPI;
   shell: ContextureShellAPI;
+  project: ContextureProjectAPI;
 }
 
 declare global {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -142,10 +142,16 @@ export interface ContextureScaffoldAPI {
   onEvent: (listener: (event: ScaffoldEvent) => void) => Unsubscribe;
 }
 
+export interface ContextureShellAPI {
+  /** Reveal the given path in the OS file manager (Finder / Explorer). */
+  reveal: (path: string) => Promise<void>;
+}
+
 export interface ContextureAPI {
   chat: ContextureChatAPI;
   file: ContextureFileAPI;
   scaffold: ContextureScaffoldAPI;
+  shell: ContextureShellAPI;
 }
 
 declare global {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -145,6 +145,8 @@ export interface ContextureScaffoldAPI {
 export interface ContextureShellAPI {
   /** Reveal the given path in the OS file manager (Finder / Explorer). */
   reveal: (path: string) => Promise<void>;
+  /** Open a folder or file in VS Code via the `vscode://` URL scheme. */
+  openInEditor: (path: string) => Promise<void>;
 }
 
 export interface ContextureProjectAPI {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -102,6 +102,7 @@ export interface OpenedDocument {
 export interface ContextureFileAPI {
   openDialog: () => Promise<OpenedDocument | null>;
   saveAsDialog: () => Promise<string | null>;
+  pickDirectory: () => Promise<string | null>;
   save: (payload: {
     irPath: string;
     schema: unknown;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -112,6 +112,8 @@ const file = {
   /** Menu-bar -> renderer subscriptions. */
   onMenuNew: (listener: () => void) =>
     subscribe('menu:file-new', (() => listener()) as (p: unknown) => void),
+  onMenuNewProject: (listener: () => void) =>
+    subscribe('menu:file-new-project', (() => listener()) as (p: unknown) => void),
   onMenuOpen: (listener: () => void) =>
     subscribe('menu:file-open', (() => listener()) as (p: unknown) => void),
   onMenuSave: (listener: () => void) =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -133,7 +133,13 @@ const scaffold = {
     subscribe('scaffold:event', listener as (p: unknown) => void),
 };
 
-const contexture = { chat, file, scaffold };
+const shell = {
+  /** Reveal a file or folder in the OS file manager (Finder / Explorer). */
+  reveal: (path: string): Promise<void> =>
+    ipcRenderer.invoke('shell:reveal', path) as Promise<void>,
+};
+
+const contexture = { chat, file, scaffold, shell };
 
 /**
  * Legacy surface. Sidecar reads/writes use the preload process's

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -96,6 +96,8 @@ const file = {
   openDialog: () => ipcRenderer.invoke('file:open-dialog'),
   /** Show the OS save-as dialog and return the chosen path. */
   saveAsDialog: () => ipcRenderer.invoke('file:save-as-dialog') as Promise<string | null>,
+  /** Show a directory picker; returns the selected folder or null if cancelled. */
+  pickDirectory: () => ipcRenderer.invoke('file:pick-directory') as Promise<string | null>,
   /** Write the five-file bundle atomically under `irPath`. */
   save: (payload: {
     irPath: string;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -139,7 +139,13 @@ const shell = {
     ipcRenderer.invoke('shell:reveal', path) as Promise<void>,
 };
 
-const contexture = { chat, file, scaffold, shell };
+const project = {
+  /** Recursively delete a directory (used by the New Project "delete and start over" flow). */
+  deleteDirectory: (path: string): Promise<void> =>
+    ipcRenderer.invoke('project:delete-directory', path) as Promise<void>,
+};
+
+const contexture = { chat, file, scaffold, shell, project };
 
 /**
  * Legacy surface. Sidecar reads/writes use the preload process's

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -125,9 +125,13 @@ const file = {
 };
 
 const scaffold = {
-  /** Kick off the 10-stage scaffolder; events arrive on `onEvent`. */
-  start: (config: { targetDir: string; projectName: string }) =>
-    ipcRenderer.invoke('scaffold:start', config) as Promise<void>,
+  /** Kick off the composable scaffolder; events arrive on `onEvent`. */
+  start: (config: {
+    targetDir: string;
+    projectName: string;
+    apps: string[];
+    description?: string;
+  }) => ipcRenderer.invoke('scaffold:start', config) as Promise<void>,
   /** Subscribe to preflight + stage events streamed from main. */
   onEvent: (listener: (event: unknown) => void) =>
     subscribe('scaffold:event', listener as (p: unknown) => void),

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -124,7 +124,16 @@ const file = {
     subscribe('menu:file-save-as', (() => listener()) as (p: unknown) => void),
 };
 
-const contexture = { chat, file };
+const scaffold = {
+  /** Kick off the 10-stage scaffolder; events arrive on `onEvent`. */
+  start: (config: { targetDir: string; projectName: string }) =>
+    ipcRenderer.invoke('scaffold:start', config) as Promise<void>,
+  /** Subscribe to preflight + stage events streamed from main. */
+  onEvent: (listener: (event: unknown) => void) =>
+    subscribe('scaffold:event', listener as (p: unknown) => void),
+};
+
+const contexture = { chat, file, scaffold };
 
 /**
  * Legacy surface. Sidecar reads/writes use the preload process's

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -137,6 +137,9 @@ const shell = {
   /** Reveal a file or folder in the OS file manager (Finder / Explorer). */
   reveal: (path: string): Promise<void> =>
     ipcRenderer.invoke('shell:reveal', path) as Promise<void>,
+  /** Open a folder (or file) in VS Code via the `vscode://` URL scheme. */
+  openInEditor: (path: string): Promise<void> =>
+    ipcRenderer.invoke('shell:open-in-editor', path) as Promise<void>,
 };
 
 const project = {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -29,6 +29,7 @@ import { ActivityBar } from './components/activity-bar/ActivityBar';
 import { ChatPanel } from './components/chat/ChatPanel';
 import { DetailPanel } from './components/detail/DetailPanel';
 import { DocumentDialogs } from './components/dialogs/DocumentDialogs';
+import { NewProjectDialog } from './components/dialogs/NewProjectDialog';
 import { EvalPanel } from './components/eval/EvalPanel';
 import { GraphBackground } from './components/graph/GraphBackground';
 import { type CanvasPosition, GraphCanvas } from './components/graph/GraphCanvas';
@@ -48,6 +49,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from './components/ui/popover';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './components/ui/resizable';
 import { useFileMenu } from './hooks/useFileMenu';
+import { useNewProject } from './hooks/useNewProject';
 import { useProjectAutoSave } from './hooks/useProjectAutoSave';
 import { emit as emitJsonSchema } from './model/emit-json-schema';
 import { emit as emitZod } from './model/emit-zod';
@@ -143,6 +145,8 @@ export default function App(): React.JSX.Element {
   chatMessagesRef.current = chat.messages;
   const chatHydrateRef = useRef(chat.hydrate);
   chatHydrateRef.current = chat.hydrate;
+
+  useNewProject();
 
   const fileMenu = useFileMenu({
     getLayout: () => ({ version: '1', positions: positionsRef.current }),
@@ -331,6 +335,7 @@ export default function App(): React.JSX.Element {
 
       <StatusBar />
       <DocumentDialogs onForceSave={fileMenu.handleForceSave} />
+      <NewProjectDialog />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -335,7 +335,7 @@ export default function App(): React.JSX.Element {
 
       <StatusBar />
       <DocumentDialogs onForceSave={fileMenu.handleForceSave} />
-      <NewProjectDialog />
+      <NewProjectDialog onOpenProject={fileMenu.handleOpenPath} />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -145,6 +145,12 @@ export default function App(): React.JSX.Element {
   chatMessagesRef.current = chat.messages;
   const chatHydrateRef = useRef(chat.hydrate);
   chatHydrateRef.current = chat.hydrate;
+  const chatSendRef = useRef(chat.send);
+  chatSendRef.current = chat.send;
+
+  // Captures the first seeded user message from a newly scaffolded project
+  // so onOpenProject can auto-send it after the bundle loads.
+  const pendingAutoSendRef = useRef<string | null>(null);
 
   useNewProject();
 
@@ -158,6 +164,17 @@ export default function App(): React.JSX.Element {
         void window.contexture?.chat.setSessionId(loadedChat.sessionId);
       } else {
         void window.contexture?.chat.clearSession();
+      }
+      // Capture a seeded first message for auto-send (set by onOpenProject).
+      const first = loadedChat.messages[0];
+      if (
+        pendingAutoSendRef.current &&
+        first?.role === 'user' &&
+        loadedChat.messages.length === 1
+      ) {
+        pendingAutoSendRef.current = first.content;
+      } else {
+        pendingAutoSendRef.current = null;
       }
     },
     onNew: () => {
@@ -221,6 +238,7 @@ export default function App(): React.JSX.Element {
   // multi-op chat turn) surfaces as an in-panel error rather than
   // crashing the sidebar.
   const filePath = useDocumentStore((s) => s.filePath);
+  const documentMode = useDocumentStore((s) => s.mode);
   const zodEmission = useMemo((): { source: string; error: string | null } => {
     if (activeTab !== 'schema') return { source: '', error: null };
     try {
@@ -277,6 +295,8 @@ export default function App(): React.JSX.Element {
                 onLoadSample={loadSample}
                 recentFiles={recentFiles}
                 onOpenRecent={fileMenu.handleOpenPath}
+                isNewProject={documentMode === 'project'}
+                projectName={filePath?.split('/').at(-1)?.replace('.contexture.json', '') ?? null}
               />
             )}
           </div>
@@ -335,7 +355,22 @@ export default function App(): React.JSX.Element {
 
       <StatusBar />
       <DocumentDialogs onForceSave={fileMenu.handleForceSave} />
-      <NewProjectDialog onOpenProject={fileMenu.handleOpenPath} />
+      <NewProjectDialog
+        onOpenProject={async (irPath) => {
+          // Signal onBundleLoaded to capture a seeded first message.
+          pendingAutoSendRef.current = '__pending__';
+          await fileMenu.handleOpenPath(irPath);
+          // Switch to chat and ensure the sidebar is visible.
+          setActiveTab('chat');
+          useUIChromeStore.getState().setSidebarVisible(true);
+          // If onBundleLoaded captured a seeded first message, auto-send it.
+          const toSend = pendingAutoSendRef.current;
+          pendingAutoSendRef.current = null;
+          if (toSend && toSend !== '__pending__') {
+            await chatSendRef.current(toSend);
+          }
+        }}
+      />
     </div>
   );
 }
@@ -344,10 +379,14 @@ function EmptyState({
   onLoadSample,
   recentFiles,
   onOpenRecent,
+  isNewProject = false,
+  projectName = null,
 }: {
   onLoadSample: () => void;
   recentFiles: string[];
   onOpenRecent: (path: string) => void;
+  isNewProject?: boolean;
+  projectName?: string | null;
 }): React.JSX.Element {
   return (
     <div
@@ -355,40 +394,56 @@ function EmptyState({
       style={{ background: 'var(--graph-bg)' }}
     >
       <GraphBackground />
-      <div className="relative z-10 text-center text-muted-foreground max-w-sm">
-        <h1 className="text-2xl font-semibold mb-1 text-foreground tracking-tight">Contexture</h1>
-        <p className="text-xs text-muted-foreground/70 mb-3">Visual Zod schema editor</p>
-        <p className="text-sm mb-4">
-          Open a <code className="text-xs">.contexture.json</code> file or start chatting with
-          Claude to create one.
-        </p>
-        <Button onClick={onLoadSample}>Load allotment sample</Button>
+      {isNewProject ? (
+        <div className="relative z-10 text-center text-muted-foreground max-w-sm space-y-3">
+          <h1 className="text-2xl font-semibold text-foreground tracking-tight">
+            {projectName ?? 'New project'}
+          </h1>
+          <p className="text-sm">
+            Your project has been scaffolded. Claude is building your schema in the chat panel —
+            types will appear here as they're created.
+          </p>
+          <p className="text-xs text-muted-foreground/60">
+            You can iterate on the schema by continuing the conversation, or edit types directly
+            once they appear on the canvas.
+          </p>
+        </div>
+      ) : (
+        <div className="relative z-10 text-center text-muted-foreground max-w-sm">
+          <h1 className="text-2xl font-semibold mb-1 text-foreground tracking-tight">Contexture</h1>
+          <p className="text-xs text-muted-foreground/70 mb-3">Visual Zod schema editor</p>
+          <p className="text-sm mb-4">
+            Open a <code className="text-xs">.contexture.json</code> file or start chatting with
+            Claude to create one.
+          </p>
+          <Button onClick={onLoadSample}>Load allotment sample</Button>
 
-        {recentFiles.length > 0 && (
-          <div className="mt-6 text-left">
-            <div className="flex items-center gap-1.5 text-xs text-muted-foreground/70 mb-2">
-              <Clock className="size-3" />
-              <span>Recent files</span>
+          {recentFiles.length > 0 && (
+            <div className="mt-6 text-left">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground/70 mb-2">
+                <Clock className="size-3" />
+                <span>Recent files</span>
+              </div>
+              <div className="space-y-0.5">
+                {recentFiles.slice(0, 5).map((fp) => (
+                  <button
+                    type="button"
+                    key={fp}
+                    onClick={() => onOpenRecent(fp)}
+                    className="w-full text-left px-2 py-1.5 rounded text-xs hover:bg-secondary/60 transition-colors truncate"
+                    title={fp}
+                  >
+                    {fp.split('/').pop()}
+                    <span className="text-muted-foreground/50 ml-1.5">
+                      {fp.split('/').slice(0, -1).join('/')}
+                    </span>
+                  </button>
+                ))}
+              </div>
             </div>
-            <div className="space-y-0.5">
-              {recentFiles.slice(0, 5).map((fp) => (
-                <button
-                  type="button"
-                  key={fp}
-                  onClick={() => onOpenRecent(fp)}
-                  className="w-full text-left px-2 py-1.5 rounded text-xs hover:bg-secondary/60 transition-colors truncate"
-                  title={fp}
-                >
-                  {fp.split('/').pop()}
-                  <span className="text-muted-foreground/50 ml-1.5">
-                    {fp.split('/').slice(0, -1).join('/')}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -77,6 +77,9 @@ export function NewProjectDialog(): React.JSX.Element {
           setPhase('failed');
           appendLog(event.stderr);
           return;
+        case 'scaffold-done':
+          setPhase('done');
+          return;
         case 'stdout-chunk':
         case 'stderr-chunk':
           appendLog(event.chunk);

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -1,15 +1,20 @@
 /**
- * New Project dialog — form + preflight slice.
+ * New Project dialog — form, preflight, and live progress.
  *
- * Collects the name + parent directory, shows the computed target path,
- * and invokes the scaffolder pre-flight on Create. A failed preflight
- * renders inline error copy (mapped from the tagged `PreflightError`)
- * so the user can fix the problem without leaving the dialog. The live
- * progress UI lands in the next slice.
+ * Three views in one dialog, switched by `phase`:
+ *   - `form`    — name + parent-dir inputs; inline preflight error if
+ *                 the scaffolder's stage-0 checks fail.
+ *   - `running` — ten stage rows with running/done/pending status plus
+ *                 a streaming log tail from stdout/stderr chunks.
+ *   - `done` / `failed` — land in later slices.
+ *
+ * Event fan-out: a single `scaffold.onEvent` subscription mutates the
+ * store; components below re-render off those store slices.
  */
 import { type PreflightError, preflightErrorCopy } from '@renderer/model/preflight-error-copy';
+import { labelForStage } from '@renderer/model/scaffold-stage-labels';
 import { validateProjectName } from '@renderer/model/validate-project-name';
-import { useNewProjectStore } from '@renderer/store/new-project';
+import { type StageStatus, useNewProjectStore } from '@renderer/store/new-project';
 import { Folder } from 'lucide-react';
 import { useEffect } from 'react';
 import { Button } from '@/components/ui/button';
@@ -24,9 +29,12 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
+const STAGE_NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
+
 export function NewProjectDialog(): React.JSX.Element {
   const isOpen = useNewProjectStore((s) => s.isOpen);
   const close = useNewProjectStore((s) => s.close);
+  const phase = useNewProjectStore((s) => s.phase);
   const name = useNewProjectStore((s) => s.name);
   const parentDir = useNewProjectStore((s) => s.parentDir);
   const setName = useNewProjectStore((s) => s.setName);
@@ -35,6 +43,9 @@ export function NewProjectDialog(): React.JSX.Element {
   const setPreflightError = useNewProjectStore((s) => s.setPreflightError);
   const clearPreflightError = useNewProjectStore((s) => s.clearPreflightError);
   const setPhase = useNewProjectStore((s) => s.setPhase);
+  const markStage = useNewProjectStore((s) => s.markStage);
+  const appendLog = useNewProjectStore((s) => s.appendLog);
+  const resetProgress = useNewProjectStore((s) => s.resetProgress);
 
   const nameValidation = name === '' ? { ok: true as const } : validateProjectName(name);
   const canCreate = name !== '' && nameValidation.ok && parentDir !== '';
@@ -44,13 +55,29 @@ export function NewProjectDialog(): React.JSX.Element {
     const scaffold = window.contexture?.scaffold;
     if (!scaffold) return;
     return scaffold.onEvent((event) => {
-      if (event.kind === 'preflight-failed') {
-        setPreflightError(event.error as PreflightError);
-      } else if (event.kind === 'stage-start') {
-        setPhase('running');
+      switch (event.kind) {
+        case 'preflight-failed':
+          setPreflightError(event.error as PreflightError);
+          return;
+        case 'stage-start':
+          setPhase('running');
+          markStage(event.stage, 'running');
+          return;
+        case 'stage-done':
+          markStage(event.stage, 'done');
+          return;
+        case 'stage-failed':
+          markStage(event.stage, 'failed');
+          setPhase('failed');
+          appendLog(event.stderr);
+          return;
+        case 'stdout-chunk':
+        case 'stderr-chunk':
+          appendLog(event.chunk);
+          return;
       }
     });
-  }, [setPreflightError, setPhase]);
+  }, [setPreflightError, setPhase, markStage, appendLog]);
 
   async function handlePickFolder(): Promise<void> {
     const picked = await window.contexture?.file.pickDirectory();
@@ -60,8 +87,11 @@ export function NewProjectDialog(): React.JSX.Element {
   async function handleCreate(): Promise<void> {
     if (!targetPath) return;
     clearPreflightError();
+    resetProgress();
     await window.contexture?.scaffold.start({ targetDir: targetPath, projectName: name });
   }
+
+  const showProgress = phase === 'running' || phase === 'failed' || phase === 'done';
 
   return (
     <Dialog
@@ -74,63 +104,135 @@ export function NewProjectDialog(): React.JSX.Element {
         <DialogHeader>
           <DialogTitle>New Project</DialogTitle>
           <DialogDescription>
-            Scaffold a Contexture monorepo under a folder you choose.
+            {showProgress
+              ? 'Scaffolding your project — this usually takes a minute.'
+              : 'Scaffold a Contexture monorepo under a folder you choose.'}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="new-project-name">Project name</Label>
-            <Input
-              id="new-project-name"
-              autoFocus
-              placeholder="my-proj"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-            {!nameValidation.ok && (
-              <p className="text-xs text-destructive">{nameValidation.reason}</p>
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <Label>Parent folder</Label>
-            <div className="flex items-center gap-2">
-              <Button variant="outline" onClick={() => void handlePickFolder()}>
-                <Folder className="size-4" />
-                Choose folder…
-              </Button>
-              {parentDir && (
-                <span className="text-xs font-mono text-muted-foreground truncate">
-                  {parentDir}
-                </span>
+        {showProgress ? (
+          <ProgressView />
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="new-project-name">Project name</Label>
+              <Input
+                id="new-project-name"
+                autoFocus
+                placeholder="my-proj"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+              {!nameValidation.ok && (
+                <p className="text-xs text-destructive">{nameValidation.reason}</p>
               )}
             </div>
-          </div>
 
-          {targetPath && (
-            <div className="space-y-1">
-              <Label>Target path</Label>
-              <p className="text-xs font-mono text-muted-foreground break-all">{targetPath}</p>
+            <div className="space-y-2">
+              <Label>Parent folder</Label>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" onClick={() => void handlePickFolder()}>
+                  <Folder className="size-4" />
+                  Choose folder…
+                </Button>
+                {parentDir && (
+                  <span className="text-xs font-mono text-muted-foreground truncate">
+                    {parentDir}
+                  </span>
+                )}
+              </div>
             </div>
-          )}
 
-          {preflightError && (
-            <p className="text-sm text-destructive" role="alert">
-              {preflightErrorCopy(preflightError)}
-            </p>
-          )}
-        </div>
+            {targetPath && (
+              <div className="space-y-1">
+                <Label>Target path</Label>
+                <p className="text-xs font-mono text-muted-foreground break-all">{targetPath}</p>
+              </div>
+            )}
 
-        <DialogFooter>
-          <Button variant="outline" onClick={close}>
-            Cancel
-          </Button>
-          <Button disabled={!canCreate} onClick={() => void handleCreate()}>
-            Create
-          </Button>
-        </DialogFooter>
+            {preflightError && (
+              <p className="text-sm text-destructive" role="alert">
+                {preflightErrorCopy(preflightError)}
+              </p>
+            )}
+          </div>
+        )}
+
+        {!showProgress && (
+          <DialogFooter>
+            <Button variant="outline" onClick={close}>
+              Cancel
+            </Button>
+            <Button disabled={!canCreate} onClick={() => void handleCreate()}>
+              Create
+            </Button>
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   );
+}
+
+function ProgressView(): React.JSX.Element {
+  const stageStates = useNewProjectStore((s) => s.stageStates);
+  const log = useNewProjectStore((s) => s.log);
+
+  return (
+    <div className="space-y-3">
+      <ul className="space-y-1">
+        {STAGE_NUMBERS.map((n) => {
+          const status = stageStates[n] ?? 'pending';
+          return (
+            <li
+              key={n}
+              data-testid={`scaffold-stage-${n}`}
+              data-status={status}
+              className="flex items-center gap-2 text-sm"
+            >
+              <StatusGlyph status={status} />
+              <span className={status === 'pending' ? 'text-muted-foreground' : ''}>
+                {labelForStage(n)}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+
+      <pre
+        data-testid="scaffold-log"
+        className="text-xs font-mono bg-muted rounded p-2 max-h-40 overflow-auto whitespace-pre-wrap"
+      >
+        {log || ' '}
+      </pre>
+    </div>
+  );
+}
+
+function StatusGlyph({ status }: { status: StageStatus }): React.JSX.Element {
+  switch (status) {
+    case 'done':
+      return (
+        <span role="img" aria-label="done">
+          ✓
+        </span>
+      );
+    case 'running':
+      return (
+        <span role="img" aria-label="running">
+          …
+        </span>
+      );
+    case 'failed':
+      return (
+        <span role="img" aria-label="failed">
+          ✗
+        </span>
+      );
+    default:
+      return (
+        <span role="img" aria-label="pending">
+          ·
+        </span>
+      );
+  }
 }

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -278,6 +278,12 @@ function SuccessView({
         <Button variant="outline" onClick={() => void window.contexture?.shell.reveal(targetPath)}>
           Reveal
         </Button>
+        <Button
+          variant="outline"
+          onClick={() => void window.contexture?.shell.openInEditor(targetPath)}
+        >
+          Open in VS Code
+        </Button>
         <Button variant="outline" onClick={() => void navigator.clipboard.writeText(targetPath)}>
           Copy path
         </Button>

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -100,7 +100,9 @@ export function NewProjectDialog(): React.JSX.Element {
     await window.contexture?.scaffold.start({ targetDir: targetPath, projectName: name });
   }
 
-  const showProgress = phase === 'running' || phase === 'failed' || phase === 'done';
+  const showSuccess = phase === 'done';
+  const showProgress = phase === 'running' || phase === 'failed';
+  const showForm = !showProgress && !showSuccess;
 
   return (
     <Dialog
@@ -113,13 +115,17 @@ export function NewProjectDialog(): React.JSX.Element {
         <DialogHeader>
           <DialogTitle>New Project</DialogTitle>
           <DialogDescription>
-            {showProgress
-              ? 'Scaffolding your project — this usually takes a minute.'
-              : 'Scaffold a Contexture monorepo under a folder you choose.'}
+            {showSuccess
+              ? 'Your project is ready.'
+              : showProgress
+                ? 'Scaffolding your project — this usually takes a minute.'
+                : 'Scaffold a Contexture monorepo under a folder you choose.'}
           </DialogDescription>
         </DialogHeader>
 
-        {showProgress ? (
+        {showSuccess ? (
+          <SuccessView targetPath={targetPath} />
+        ) : showProgress ? (
           <ProgressView />
         ) : (
           <div className="space-y-4">
@@ -209,7 +215,7 @@ export function NewProjectDialog(): React.JSX.Element {
           </div>
         )}
 
-        {!showProgress && (
+        {showForm && (
           <DialogFooter>
             <Button variant="outline" onClick={close}>
               Cancel
@@ -221,6 +227,32 @@ export function NewProjectDialog(): React.JSX.Element {
         )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function SuccessView({ targetPath }: { targetPath: string }): React.JSX.Element {
+  const close = useNewProjectStore((s) => s.close);
+  return (
+    <div data-testid="scaffold-success" className="space-y-3">
+      <div className="flex items-center gap-2 text-sm">
+        <span role="img" aria-label="success">
+          ✓
+        </span>
+        <span>Project scaffolded successfully.</span>
+      </div>
+      <div className="space-y-1">
+        <Label>Location</Label>
+        <p className="text-xs font-mono text-muted-foreground break-all">{targetPath}</p>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={() => void navigator.clipboard.writeText(targetPath)}>
+          Copy path
+        </Button>
+        <Button data-testid="scaffold-success-close" onClick={close}>
+          Close
+        </Button>
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -32,7 +32,12 @@ import { Textarea } from '@/components/ui/textarea';
 
 const STAGE_NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
 
-export function NewProjectDialog(): React.JSX.Element {
+export interface NewProjectDialogProps {
+  /** Called with the scaffolded IR path when the user dismisses the success panel. */
+  onOpenProject?: (irPath: string) => void;
+}
+
+export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}): React.JSX.Element {
   const isOpen = useNewProjectStore((s) => s.isOpen);
   const close = useNewProjectStore((s) => s.close);
   const phase = useNewProjectStore((s) => s.phase);
@@ -128,7 +133,11 @@ export function NewProjectDialog(): React.JSX.Element {
         </DialogHeader>
 
         {showSuccess ? (
-          <SuccessView targetPath={targetPath} />
+          <SuccessView
+            targetPath={targetPath}
+            irPath={`${targetPath}/packages/schema/${name}.contexture.json`}
+            onOpenProject={onOpenProject}
+          />
         ) : showFailure ? (
           <FailureView onRetry={() => void handleCreate()} />
         ) : showProgress ? (
@@ -236,8 +245,20 @@ export function NewProjectDialog(): React.JSX.Element {
   );
 }
 
-function SuccessView({ targetPath }: { targetPath: string }): React.JSX.Element {
+function SuccessView({
+  targetPath,
+  irPath,
+  onOpenProject,
+}: {
+  targetPath: string;
+  irPath: string;
+  onOpenProject?: (irPath: string) => void;
+}): React.JSX.Element {
   const close = useNewProjectStore((s) => s.close);
+  function handleClose(): void {
+    onOpenProject?.(irPath);
+    close();
+  }
   return (
     <div data-testid="scaffold-success" className="space-y-3">
       <div className="flex items-center gap-2 text-sm">
@@ -254,7 +275,7 @@ function SuccessView({ targetPath }: { targetPath: string }): React.JSX.Element 
         <Button variant="outline" onClick={() => void navigator.clipboard.writeText(targetPath)}>
           Copy path
         </Button>
-        <Button data-testid="scaffold-success-close" onClick={close}>
+        <Button data-testid="scaffold-success-close" onClick={handleClose}>
           Close
         </Button>
       </div>

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -136,10 +136,11 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
           <SuccessView
             targetPath={targetPath}
             irPath={`${targetPath}/packages/schema/${name}.contexture.json`}
+            logPath={`${targetPath}/.contexture/scaffold.log`}
             onOpenProject={onOpenProject}
           />
         ) : showFailure ? (
-          <FailureView onRetry={() => void handleCreate()} />
+          <FailureView targetPath={targetPath} onRetry={() => void handleCreate()} />
         ) : showProgress ? (
           <ProgressView />
         ) : (
@@ -248,10 +249,12 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
 function SuccessView({
   targetPath,
   irPath,
+  logPath,
   onOpenProject,
 }: {
   targetPath: string;
   irPath: string;
+  logPath: string;
   onOpenProject?: (irPath: string) => void;
 }): React.JSX.Element {
   const close = useNewProjectStore((s) => s.close);
@@ -278,6 +281,9 @@ function SuccessView({
         <Button variant="outline" onClick={() => void navigator.clipboard.writeText(targetPath)}>
           Copy path
         </Button>
+        <Button variant="outline" onClick={() => void window.contexture?.shell.reveal(logPath)}>
+          View log
+        </Button>
         <Button data-testid="scaffold-success-close" onClick={handleClose}>
           Close
         </Button>
@@ -286,7 +292,13 @@ function SuccessView({
   );
 }
 
-function FailureView({ onRetry }: { onRetry: () => void }): React.JSX.Element {
+function FailureView({
+  targetPath,
+  onRetry,
+}: {
+  targetPath: string;
+  onRetry: () => void;
+}): React.JSX.Element {
   const failure = useNewProjectStore((s) => s.failure);
   const close = useNewProjectStore((s) => s.close);
   const stageLabel = failure ? labelForStage(failure.stage) : '';
@@ -308,7 +320,10 @@ function FailureView({ onRetry }: { onRetry: () => void }): React.JSX.Element {
           ? 'This stage is safe to retry against the same folder.'
           : 'Earlier stages touched the target folder. Delete it and start over to retry.'}
       </p>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        <Button variant="outline" onClick={() => void window.contexture?.shell.reveal(targetPath)}>
+          Open folder
+        </Button>
         <Button variant="outline" onClick={close}>
           Close
         </Button>

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -1,0 +1,48 @@
+/**
+ * New Project dialog — tracer shell.
+ *
+ * This slice proves the end-to-end wiring: menu click in main process
+ * → IPC → `useNewProjectStore.open()` → dialog renders. Subsequent
+ * slices replace the placeholder body with the real form (name, parent
+ * dir picker, starting point), the progress modal, and the success
+ * panel. The dialog is intentionally unstyled beyond a title + Cancel
+ * button so the tests assert behaviour rather than chrome.
+ */
+import { useNewProjectStore } from '@renderer/store/new-project';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+export function NewProjectDialog(): React.JSX.Element {
+  const isOpen = useNewProjectStore((s) => s.isOpen);
+  const close = useNewProjectStore((s) => s.close);
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New Project</DialogTitle>
+          <DialogDescription>
+            Scaffold a Contexture monorepo. The form lands in a later slice.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={close}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -48,6 +48,7 @@ export function NewProjectDialog(): React.JSX.Element {
   const setPreflightError = useNewProjectStore((s) => s.setPreflightError);
   const clearPreflightError = useNewProjectStore((s) => s.clearPreflightError);
   const setPhase = useNewProjectStore((s) => s.setPhase);
+  const setFailure = useNewProjectStore((s) => s.setFailure);
   const markStage = useNewProjectStore((s) => s.markStage);
   const appendLog = useNewProjectStore((s) => s.appendLog);
   const resetProgress = useNewProjectStore((s) => s.resetProgress);
@@ -74,7 +75,7 @@ export function NewProjectDialog(): React.JSX.Element {
           return;
         case 'stage-failed':
           markStage(event.stage, 'failed');
-          setPhase('failed');
+          setFailure({ stage: event.stage, stderr: event.stderr, retrySafe: event.retrySafe });
           appendLog(event.stderr);
           return;
         case 'scaffold-done':
@@ -86,7 +87,7 @@ export function NewProjectDialog(): React.JSX.Element {
           return;
       }
     });
-  }, [setPreflightError, setPhase, markStage, appendLog]);
+  }, [setPreflightError, setPhase, setFailure, markStage, appendLog]);
 
   async function handlePickFolder(): Promise<void> {
     const picked = await window.contexture?.file.pickDirectory();
@@ -101,8 +102,9 @@ export function NewProjectDialog(): React.JSX.Element {
   }
 
   const showSuccess = phase === 'done';
-  const showProgress = phase === 'running' || phase === 'failed';
-  const showForm = !showProgress && !showSuccess;
+  const showFailure = phase === 'failed';
+  const showProgress = phase === 'running';
+  const showForm = !showProgress && !showSuccess && !showFailure;
 
   return (
     <Dialog
@@ -117,14 +119,18 @@ export function NewProjectDialog(): React.JSX.Element {
           <DialogDescription>
             {showSuccess
               ? 'Your project is ready.'
-              : showProgress
-                ? 'Scaffolding your project — this usually takes a minute.'
-                : 'Scaffold a Contexture monorepo under a folder you choose.'}
+              : showFailure
+                ? 'Scaffolding hit a snag.'
+                : showProgress
+                  ? 'Scaffolding your project — this usually takes a minute.'
+                  : 'Scaffold a Contexture monorepo under a folder you choose.'}
           </DialogDescription>
         </DialogHeader>
 
         {showSuccess ? (
           <SuccessView targetPath={targetPath} />
+        ) : showFailure ? (
+          <FailureView onRetry={() => void handleCreate()} />
         ) : showProgress ? (
           <ProgressView />
         ) : (
@@ -250,6 +256,40 @@ function SuccessView({ targetPath }: { targetPath: string }): React.JSX.Element 
         </Button>
         <Button data-testid="scaffold-success-close" onClick={close}>
           Close
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function FailureView({ onRetry }: { onRetry: () => void }): React.JSX.Element {
+  const failure = useNewProjectStore((s) => s.failure);
+  const close = useNewProjectStore((s) => s.close);
+  const stageLabel = failure ? labelForStage(failure.stage) : '';
+  return (
+    <div data-testid="scaffold-failure" className="space-y-3">
+      <div className="flex items-center gap-2 text-sm text-destructive">
+        <span role="img" aria-label="failed">
+          ✗
+        </span>
+        <span>Failed at: {stageLabel}</span>
+      </div>
+      {failure?.stderr && (
+        <pre className="text-xs font-mono bg-muted rounded p-2 max-h-40 overflow-auto whitespace-pre-wrap">
+          {failure.stderr}
+        </pre>
+      )}
+      <p className="text-xs text-muted-foreground">
+        {failure?.retrySafe
+          ? 'This stage is safe to retry against the same folder.'
+          : 'Earlier stages touched the target folder. Delete it and start over to retry.'}
+      </p>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={close}>
+          Close
+        </Button>
+        <Button disabled={!failure?.retrySafe} onClick={onRetry}>
+          Try again
         </Button>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -1,18 +1,17 @@
 /**
- * New Project dialog — form slice.
+ * New Project dialog — form + preflight slice.
  *
- * Collects the name + parent directory and shows the computed target
- * path. Name input live-validates against `validateProjectName`; the
- * Create button unlocks when the name is valid and a parent has been
- * picked. Parent dir uses the OS folder picker through
- * `window.contexture.file.pickDirectory`.
- *
- * Create is intentionally a no-op here; the next slice wires it to the
- * scaffold pre-flight + progress modal.
+ * Collects the name + parent directory, shows the computed target path,
+ * and invokes the scaffolder pre-flight on Create. A failed preflight
+ * renders inline error copy (mapped from the tagged `PreflightError`)
+ * so the user can fix the problem without leaving the dialog. The live
+ * progress UI lands in the next slice.
  */
+import { type PreflightError, preflightErrorCopy } from '@renderer/model/preflight-error-copy';
 import { validateProjectName } from '@renderer/model/validate-project-name';
 import { useNewProjectStore } from '@renderer/store/new-project';
 import { Folder } from 'lucide-react';
+import { useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -32,14 +31,36 @@ export function NewProjectDialog(): React.JSX.Element {
   const parentDir = useNewProjectStore((s) => s.parentDir);
   const setName = useNewProjectStore((s) => s.setName);
   const setParentDir = useNewProjectStore((s) => s.setParentDir);
+  const preflightError = useNewProjectStore((s) => s.preflightError);
+  const setPreflightError = useNewProjectStore((s) => s.setPreflightError);
+  const clearPreflightError = useNewProjectStore((s) => s.clearPreflightError);
+  const setPhase = useNewProjectStore((s) => s.setPhase);
 
   const nameValidation = name === '' ? { ok: true as const } : validateProjectName(name);
   const canCreate = name !== '' && nameValidation.ok && parentDir !== '';
   const targetPath = parentDir && name ? `${parentDir}/${name}` : '';
 
+  useEffect(() => {
+    const scaffold = window.contexture?.scaffold;
+    if (!scaffold) return;
+    return scaffold.onEvent((event) => {
+      if (event.kind === 'preflight-failed') {
+        setPreflightError(event.error as PreflightError);
+      } else if (event.kind === 'stage-start') {
+        setPhase('running');
+      }
+    });
+  }, [setPreflightError, setPhase]);
+
   async function handlePickFolder(): Promise<void> {
     const picked = await window.contexture?.file.pickDirectory();
     if (picked) setParentDir(picked);
+  }
+
+  async function handleCreate(): Promise<void> {
+    if (!targetPath) return;
+    clearPreflightError();
+    await window.contexture?.scaffold.start({ targetDir: targetPath, projectName: name });
   }
 
   return (
@@ -93,13 +114,21 @@ export function NewProjectDialog(): React.JSX.Element {
               <p className="text-xs font-mono text-muted-foreground break-all">{targetPath}</p>
             </div>
           )}
+
+          {preflightError && (
+            <p className="text-sm text-destructive" role="alert">
+              {preflightErrorCopy(preflightError)}
+            </p>
+          )}
         </div>
 
         <DialogFooter>
           <Button variant="outline" onClick={close}>
             Cancel
           </Button>
-          <Button disabled={!canCreate}>Create</Button>
+          <Button disabled={!canCreate} onClick={() => void handleCreate()}>
+            Create
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -2,22 +2,24 @@
  * New Project dialog — form, preflight, and live progress.
  *
  * Three views in one dialog, switched by `phase`:
- *   - `form`    — name + parent-dir inputs; inline preflight error if
- *                 the scaffolder's stage-0 checks fail.
- *   - `running` — ten stage rows with running/done/pending status plus
- *                 a streaming log tail from stdout/stderr chunks.
- *   - `done` / `failed` — land in later slices.
+ *   - `form`    — name + parent-dir inputs + app picker; inline
+ *                 preflight error if the scaffolder's stage-0 checks fail.
+ *   - `running` — dynamic stage rows (based on selected apps) with
+ *                 running/done/pending status plus a streaming log tail.
+ *   - `done` / `failed` — success and failure panels.
  *
  * Event fan-out: a single `scaffold.onEvent` subscription mutates the
  * store; components below re-render off those store slices.
  */
+import { deriveStages } from '@main/scaffold/scaffold-project';
 import { type PreflightError, preflightErrorCopy } from '@renderer/model/preflight-error-copy';
 import { labelForStage } from '@renderer/model/scaffold-stage-labels';
 import { validateProjectName } from '@renderer/model/validate-project-name';
-import { type StageStatus, useNewProjectStore } from '@renderer/store/new-project';
+import { type AppKind, type StageStatus, useNewProjectStore } from '@renderer/store/new-project';
 import { Folder } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -30,7 +32,11 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 
-const STAGE_NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
+const APP_OPTIONS: { kind: AppKind; label: string; description: string }[] = [
+  { kind: 'web', label: 'Web', description: 'Next.js + shadcn/ui' },
+  { kind: 'mobile', label: 'Mobile', description: 'Expo (React Native)' },
+  { kind: 'desktop', label: 'Desktop', description: 'Electron Forge' },
+];
 
 export interface NewProjectDialogProps {
   /** Called with the scaffolded IR path when the user dismisses the success panel. */
@@ -43,11 +49,11 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
   const phase = useNewProjectStore((s) => s.phase);
   const name = useNewProjectStore((s) => s.name);
   const parentDir = useNewProjectStore((s) => s.parentDir);
+  const apps = useNewProjectStore((s) => s.apps);
+  const description = useNewProjectStore((s) => s.description);
   const setName = useNewProjectStore((s) => s.setName);
   const setParentDir = useNewProjectStore((s) => s.setParentDir);
-  const startingPoint = useNewProjectStore((s) => s.startingPoint);
-  const description = useNewProjectStore((s) => s.description);
-  const setStartingPoint = useNewProjectStore((s) => s.setStartingPoint);
+  const toggleApp = useNewProjectStore((s) => s.toggleApp);
   const setDescription = useNewProjectStore((s) => s.setDescription);
   const preflightError = useNewProjectStore((s) => s.preflightError);
   const setPreflightError = useNewProjectStore((s) => s.setPreflightError);
@@ -59,9 +65,15 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
   const resetProgress = useNewProjectStore((s) => s.resetProgress);
 
   const nameValidation = name === '' ? { ok: true as const } : validateProjectName(name);
-  const startingPointValid = startingPoint === 'describe' && description.trim() !== '';
-  const canCreate = name !== '' && nameValidation.ok && parentDir !== '' && startingPointValid;
+  const canCreate = name !== '' && nameValidation.ok && parentDir !== '' && apps.length >= 1;
   const targetPath = parentDir && name ? `${parentDir}/${name}` : '';
+
+  const onOpenProjectRef = useRef(onOpenProject);
+  onOpenProjectRef.current = onOpenProject;
+  const targetPathRef = useRef(targetPath);
+  targetPathRef.current = targetPath;
+  const nameRef = useRef(name);
+  nameRef.current = name;
 
   useEffect(() => {
     const scaffold = window.contexture?.scaffold;
@@ -83,16 +95,19 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
           setFailure({ stage: event.stage, stderr: event.stderr, retrySafe: event.retrySafe });
           appendLog(event.stderr);
           return;
-        case 'scaffold-done':
-          setPhase('done');
+        case 'scaffold-done': {
+          const irPath = `${targetPathRef.current}/packages/schema/${nameRef.current}.contexture.json`;
+          close();
+          void onOpenProjectRef.current?.(irPath);
           return;
+        }
         case 'stdout-chunk':
         case 'stderr-chunk':
           appendLog(event.chunk);
           return;
       }
     });
-  }, [setPreflightError, setPhase, setFailure, markStage, appendLog]);
+  }, [setPreflightError, setPhase, setFailure, markStage, appendLog, close]);
 
   async function handlePickFolder(): Promise<void> {
     const picked = await window.contexture?.file.pickDirectory();
@@ -103,13 +118,17 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
     if (!targetPath) return;
     clearPreflightError();
     resetProgress();
-    await window.contexture?.scaffold.start({ targetDir: targetPath, projectName: name });
+    await window.contexture?.scaffold.start({
+      targetDir: targetPath,
+      projectName: name,
+      apps,
+      description: description.trim() || undefined,
+    });
   }
 
-  const showSuccess = phase === 'done';
   const showFailure = phase === 'failed';
   const showProgress = phase === 'running';
-  const showForm = !showProgress && !showSuccess && !showFailure;
+  const showForm = !showProgress && !showFailure;
 
   return (
     <Dialog
@@ -122,27 +141,18 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
         <DialogHeader>
           <DialogTitle>New Project</DialogTitle>
           <DialogDescription>
-            {showSuccess
-              ? 'Your project is ready.'
-              : showFailure
-                ? 'Scaffolding hit a snag.'
-                : showProgress
-                  ? 'Scaffolding your project — this usually takes a minute.'
-                  : 'Scaffold a Contexture monorepo under a folder you choose.'}
+            {showFailure
+              ? 'Scaffolding hit a snag.'
+              : showProgress
+                ? 'Scaffolding your project — this usually takes a minute.'
+                : 'Scaffold a Contexture monorepo under a folder you choose.'}
           </DialogDescription>
         </DialogHeader>
 
-        {showSuccess ? (
-          <SuccessView
-            targetPath={targetPath}
-            irPath={`${targetPath}/packages/schema/${name}.contexture.json`}
-            logPath={`${targetPath}/.contexture/scaffold.log`}
-            onOpenProject={onOpenProject}
-          />
-        ) : showFailure ? (
+        {showFailure ? (
           <FailureView targetPath={targetPath} onRetry={() => void handleCreate()} />
         ) : showProgress ? (
-          <ProgressView />
+          <ProgressView apps={apps} />
         ) : (
           <div className="space-y-4">
             <div className="space-y-2">
@@ -182,45 +192,51 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
             )}
 
             <div className="space-y-2">
-              <Label>Starting point</Label>
+              <Label>Apps to include</Label>
+              <p className="text-xs text-muted-foreground">
+                Convex is always included. Select at least one app layer.
+              </p>
               <div className="space-y-2">
-                <label className="flex items-start gap-2 text-sm cursor-pointer">
-                  <input
-                    type="radio"
-                    name="starting-point"
-                    className="mt-1"
-                    checked={startingPoint === 'describe'}
-                    onChange={() => setStartingPoint('describe')}
-                    aria-label="Describe what you're building"
-                  />
-                  <span>Describe what you're building</span>
-                </label>
-                <label className="flex items-start gap-2 text-sm cursor-not-allowed text-muted-foreground">
-                  <input
-                    type="radio"
-                    name="starting-point"
-                    className="mt-1"
-                    disabled
-                    aria-label="Promote an existing scratch file"
-                  />
-                  <span>
-                    Promote an existing scratch file{' '}
-                    <span className="text-xs">(coming soon — #124)</span>
-                  </span>
-                </label>
+                {APP_OPTIONS.map(({ kind, label, description }) => (
+                  <label
+                    key={kind}
+                    htmlFor={`app-${kind}`}
+                    className="flex items-start gap-2 text-sm cursor-pointer"
+                  >
+                    <Checkbox
+                      id={`app-${kind}`}
+                      checked={apps.includes(kind)}
+                      onCheckedChange={() => toggleApp(kind)}
+                      aria-label={label}
+                      className="mt-0.5"
+                    />
+                    <span>
+                      {label} <span className="text-xs text-muted-foreground">({description})</span>
+                    </span>
+                  </label>
+                ))}
               </div>
-              {startingPoint === 'describe' && (
-                <div className="space-y-1">
-                  <Label htmlFor="new-project-description">Describe your project</Label>
-                  <Textarea
-                    id="new-project-description"
-                    rows={3}
-                    placeholder="A photo-sharing app where users post and like photos…"
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                  />
-                </div>
+              {apps.length === 0 && (
+                <p className="text-xs text-destructive">Select at least one app.</p>
               )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="new-project-description">
+                Initial prompt{' '}
+                <span className="text-xs font-normal text-muted-foreground">(optional)</span>
+              </Label>
+              <Textarea
+                id="new-project-description"
+                rows={3}
+                placeholder="A photo-sharing app where users post and like photos…"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Seeded into the chat when you open the project. Claude will build your schema from
+                this.
+              </p>
             </div>
 
             {preflightError && (
@@ -243,58 +259,6 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
         )}
       </DialogContent>
     </Dialog>
-  );
-}
-
-function SuccessView({
-  targetPath,
-  irPath,
-  logPath,
-  onOpenProject,
-}: {
-  targetPath: string;
-  irPath: string;
-  logPath: string;
-  onOpenProject?: (irPath: string) => void;
-}): React.JSX.Element {
-  const close = useNewProjectStore((s) => s.close);
-  function handleClose(): void {
-    onOpenProject?.(irPath);
-    close();
-  }
-  return (
-    <div data-testid="scaffold-success" className="space-y-3">
-      <div className="flex items-center gap-2 text-sm">
-        <span role="img" aria-label="success">
-          ✓
-        </span>
-        <span>Project scaffolded successfully.</span>
-      </div>
-      <div className="space-y-1">
-        <Label>Location</Label>
-        <p className="text-xs font-mono text-muted-foreground break-all">{targetPath}</p>
-      </div>
-      <div className="flex items-center gap-2 flex-wrap">
-        <Button variant="outline" onClick={() => void window.contexture?.shell.reveal(targetPath)}>
-          Reveal
-        </Button>
-        <Button
-          variant="outline"
-          onClick={() => void window.contexture?.shell.openInEditor(targetPath)}
-        >
-          Open in VS Code
-        </Button>
-        <Button variant="outline" onClick={() => void navigator.clipboard.writeText(targetPath)}>
-          Copy path
-        </Button>
-        <Button variant="outline" onClick={() => void window.contexture?.shell.reveal(logPath)}>
-          View log
-        </Button>
-        <Button data-testid="scaffold-success-close" onClick={handleClose}>
-          Close
-        </Button>
-      </div>
-    </div>
   );
 }
 
@@ -357,14 +321,15 @@ function FailureView({
   );
 }
 
-function ProgressView(): React.JSX.Element {
+function ProgressView({ apps }: { apps: AppKind[] }): React.JSX.Element {
   const stageStates = useNewProjectStore((s) => s.stageStates);
   const log = useNewProjectStore((s) => s.log);
+  const stages = deriveStages(apps);
 
   return (
     <div className="space-y-3">
       <ul className="space-y-1">
-        {STAGE_NUMBERS.map((n) => {
+        {stages.map((n) => {
           const status = stageStates[n] ?? 'pending';
           return (
             <li

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -1,14 +1,18 @@
 /**
- * New Project dialog — tracer shell.
+ * New Project dialog — form slice.
  *
- * This slice proves the end-to-end wiring: menu click in main process
- * → IPC → `useNewProjectStore.open()` → dialog renders. Subsequent
- * slices replace the placeholder body with the real form (name, parent
- * dir picker, starting point), the progress modal, and the success
- * panel. The dialog is intentionally unstyled beyond a title + Cancel
- * button so the tests assert behaviour rather than chrome.
+ * Collects the name + parent directory and shows the computed target
+ * path. Name input live-validates against `validateProjectName`; the
+ * Create button unlocks when the name is valid and a parent has been
+ * picked. Parent dir uses the OS folder picker through
+ * `window.contexture.file.pickDirectory`.
+ *
+ * Create is intentionally a no-op here; the next slice wires it to the
+ * scaffold pre-flight + progress modal.
  */
+import { validateProjectName } from '@renderer/model/validate-project-name';
 import { useNewProjectStore } from '@renderer/store/new-project';
+import { Folder } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -18,10 +22,25 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 export function NewProjectDialog(): React.JSX.Element {
   const isOpen = useNewProjectStore((s) => s.isOpen);
   const close = useNewProjectStore((s) => s.close);
+  const name = useNewProjectStore((s) => s.name);
+  const parentDir = useNewProjectStore((s) => s.parentDir);
+  const setName = useNewProjectStore((s) => s.setName);
+  const setParentDir = useNewProjectStore((s) => s.setParentDir);
+
+  const nameValidation = name === '' ? { ok: true as const } : validateProjectName(name);
+  const canCreate = name !== '' && nameValidation.ok && parentDir !== '';
+  const targetPath = parentDir && name ? `${parentDir}/${name}` : '';
+
+  async function handlePickFolder(): Promise<void> {
+    const picked = await window.contexture?.file.pickDirectory();
+    if (picked) setParentDir(picked);
+  }
 
   return (
     <Dialog
@@ -34,13 +53,53 @@ export function NewProjectDialog(): React.JSX.Element {
         <DialogHeader>
           <DialogTitle>New Project</DialogTitle>
           <DialogDescription>
-            Scaffold a Contexture monorepo. The form lands in a later slice.
+            Scaffold a Contexture monorepo under a folder you choose.
           </DialogDescription>
         </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="new-project-name">Project name</Label>
+            <Input
+              id="new-project-name"
+              autoFocus
+              placeholder="my-proj"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            {!nameValidation.ok && (
+              <p className="text-xs text-destructive">{nameValidation.reason}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label>Parent folder</Label>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" onClick={() => void handlePickFolder()}>
+                <Folder className="size-4" />
+                Choose folder…
+              </Button>
+              {parentDir && (
+                <span className="text-xs font-mono text-muted-foreground truncate">
+                  {parentDir}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {targetPath && (
+            <div className="space-y-1">
+              <Label>Target path</Label>
+              <p className="text-xs font-mono text-muted-foreground break-all">{targetPath}</p>
+            </div>
+          )}
+        </div>
+
         <DialogFooter>
           <Button variant="outline" onClick={close}>
             Cancel
           </Button>
+          <Button disabled={!canCreate}>Create</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 
 const STAGE_NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
 
@@ -39,6 +40,10 @@ export function NewProjectDialog(): React.JSX.Element {
   const parentDir = useNewProjectStore((s) => s.parentDir);
   const setName = useNewProjectStore((s) => s.setName);
   const setParentDir = useNewProjectStore((s) => s.setParentDir);
+  const startingPoint = useNewProjectStore((s) => s.startingPoint);
+  const description = useNewProjectStore((s) => s.description);
+  const setStartingPoint = useNewProjectStore((s) => s.setStartingPoint);
+  const setDescription = useNewProjectStore((s) => s.setDescription);
   const preflightError = useNewProjectStore((s) => s.preflightError);
   const setPreflightError = useNewProjectStore((s) => s.setPreflightError);
   const clearPreflightError = useNewProjectStore((s) => s.clearPreflightError);
@@ -48,7 +53,8 @@ export function NewProjectDialog(): React.JSX.Element {
   const resetProgress = useNewProjectStore((s) => s.resetProgress);
 
   const nameValidation = name === '' ? { ok: true as const } : validateProjectName(name);
-  const canCreate = name !== '' && nameValidation.ok && parentDir !== '';
+  const startingPointValid = startingPoint === 'describe' && description.trim() !== '';
+  const canCreate = name !== '' && nameValidation.ok && parentDir !== '' && startingPointValid;
   const targetPath = parentDir && name ? `${parentDir}/${name}` : '';
 
   useEffect(() => {
@@ -149,6 +155,48 @@ export function NewProjectDialog(): React.JSX.Element {
                 <p className="text-xs font-mono text-muted-foreground break-all">{targetPath}</p>
               </div>
             )}
+
+            <div className="space-y-2">
+              <Label>Starting point</Label>
+              <div className="space-y-2">
+                <label className="flex items-start gap-2 text-sm cursor-pointer">
+                  <input
+                    type="radio"
+                    name="starting-point"
+                    className="mt-1"
+                    checked={startingPoint === 'describe'}
+                    onChange={() => setStartingPoint('describe')}
+                    aria-label="Describe what you're building"
+                  />
+                  <span>Describe what you're building</span>
+                </label>
+                <label className="flex items-start gap-2 text-sm cursor-not-allowed text-muted-foreground">
+                  <input
+                    type="radio"
+                    name="starting-point"
+                    className="mt-1"
+                    disabled
+                    aria-label="Promote an existing scratch file"
+                  />
+                  <span>
+                    Promote an existing scratch file{' '}
+                    <span className="text-xs">(coming soon — #124)</span>
+                  </span>
+                </label>
+              </div>
+              {startingPoint === 'describe' && (
+                <div className="space-y-1">
+                  <Label htmlFor="new-project-description">Describe your project</Label>
+                  <Textarea
+                    id="new-project-description"
+                    rows={3}
+                    placeholder="A photo-sharing app where users post and like photos…"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                  />
+                </div>
+              )}
+            </div>
 
             {preflightError && (
               <p className="text-sm text-destructive" role="alert">

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -271,7 +271,10 @@ function SuccessView({
         <Label>Location</Label>
         <p className="text-xs font-mono text-muted-foreground break-all">{targetPath}</p>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        <Button variant="outline" onClick={() => void window.contexture?.shell.reveal(targetPath)}>
+          Reveal
+        </Button>
         <Button variant="outline" onClick={() => void navigator.clipboard.writeText(targetPath)}>
           Copy path
         </Button>

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -301,7 +301,20 @@ function FailureView({
 }): React.JSX.Element {
   const failure = useNewProjectStore((s) => s.failure);
   const close = useNewProjectStore((s) => s.close);
+  const setPhase = useNewProjectStore((s) => s.setPhase);
+  const resetProgress = useNewProjectStore((s) => s.resetProgress);
   const stageLabel = failure ? labelForStage(failure.stage) : '';
+
+  async function handleDelete(): Promise<void> {
+    if (!targetPath) return;
+    const confirmed = window.confirm(
+      `Delete ${targetPath} and start over? This removes everything under that folder.`,
+    );
+    if (!confirmed) return;
+    await window.contexture?.project.deleteDirectory(targetPath);
+    resetProgress();
+    setPhase('form');
+  }
   return (
     <div data-testid="scaffold-failure" className="space-y-3">
       <div className="flex items-center gap-2 text-sm text-destructive">
@@ -323,6 +336,9 @@ function FailureView({
       <div className="flex items-center gap-2 flex-wrap">
         <Button variant="outline" onClick={() => void window.contexture?.shell.reveal(targetPath)}>
           Open folder
+        </Button>
+        <Button variant="outline" onClick={() => void handleDelete()}>
+          Delete and start over
         </Button>
         <Button variant="outline" onClick={close}>
           Close

--- a/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
@@ -9,8 +9,9 @@
  */
 
 import { useClaude } from '@renderer/chat/useClaude';
+import { useDocumentStore } from '@renderer/store/document';
 import { useUIChromeStore } from '@renderer/store/ui-chrome';
-import { Bot, ChevronDown, Moon, PanelRight, Sun } from 'lucide-react';
+import { Bot, ChevronDown, Code, Moon, PanelRight, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -24,6 +25,12 @@ export function Toolbar(): React.JSX.Element {
   const sidebarVisible = useUIChromeStore((s) => s.sidebarVisible);
   const toggleSidebar = useUIChromeStore((s) => s.toggleSidebar);
   const { authMode, setAuthMode, apiKey, setApiKey, cliDetected, isReady } = useClaude();
+  const filePath = useDocumentStore((s) => s.filePath);
+  const documentMode = useDocumentStore((s) => s.mode);
+
+  // Project root is two dirs above the IR path (packages/schema/<name>.contexture.json).
+  const projectRoot =
+    filePath && documentMode === 'project' ? filePath.split('/').slice(0, -3).join('/') : null;
 
   return (
     <div
@@ -34,6 +41,19 @@ export function Toolbar(): React.JSX.Element {
       <div className="flex-1 flex justify-center">
         <GraphSearchBar />
       </div>
+
+      {projectRoot && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          title="Open project in VS Code"
+          onClick={() => void window.contexture?.shell.openInEditor(projectRoot)}
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        >
+          <Code className="size-4" />
+        </Button>
+      )}
 
       <Button
         variant="ghost"

--- a/apps/desktop/src/renderer/src/hooks/useNewProject.ts
+++ b/apps/desktop/src/renderer/src/hooks/useNewProject.ts
@@ -1,0 +1,20 @@
+/**
+ * `useNewProject` — wires the File → New Project… menu entry to the
+ * dialog store. Intentionally minimal for the tracer slice: a single
+ * subscription that flips `isOpen` when the menu fires. Later slices
+ * add scaffold-event subscription, cancel wiring, and success handling
+ * to this hook as the dialog grows.
+ */
+import { useEffect } from 'react';
+import { useNewProjectStore } from '../store/new-project';
+
+export function useNewProject(): void {
+  const open = useNewProjectStore((s) => s.open);
+  const fileApi = typeof window !== 'undefined' ? window.contexture?.file : undefined;
+
+  useEffect(() => {
+    if (!fileApi) return;
+    const unsubscribe = fileApi.onMenuNewProject(() => open());
+    return unsubscribe;
+  }, [fileApi, open]);
+}

--- a/apps/desktop/src/renderer/src/model/preflight-error-copy.ts
+++ b/apps/desktop/src/renderer/src/model/preflight-error-copy.ts
@@ -1,0 +1,33 @@
+/**
+ * Maps scaffolder pre-flight errors to user-facing copy. Kept pure so
+ * the dialog component stays dumb and every branch is unit-testable.
+ */
+export type PreflightError =
+  | { kind: 'missing-bun' }
+  | { kind: 'missing-git' }
+  | { kind: 'missing-node' }
+  | { kind: 'no-network' }
+  | { kind: 'parent-not-writable'; path: string }
+  | { kind: 'target-exists'; path: string }
+  | { kind: 'insufficient-space'; bytesFree: number };
+
+export function preflightErrorCopy(error: PreflightError): string {
+  switch (error.kind) {
+    case 'missing-bun':
+      return 'Bun is not installed. Install Bun (https://bun.sh) and try again.';
+    case 'missing-git':
+      return 'Git is not installed. Install Git and try again.';
+    case 'missing-node':
+      return 'Node.js is not installed. Install Node and try again.';
+    case 'no-network':
+      return 'No network connection to the npm registry. Check your connection.';
+    case 'parent-not-writable':
+      return `Parent folder isn't writable: ${error.path}. Pick another.`;
+    case 'target-exists':
+      return `A folder already exists at ${error.path}. Pick a different name or parent.`;
+    case 'insufficient-space': {
+      const mb = Math.round(error.bytesFree / (1024 * 1024));
+      return `Not enough free disk space (~${mb} MB available). Free up space or pick another drive.`;
+    }
+  }
+}

--- a/apps/desktop/src/renderer/src/model/scaffold-stage-labels.ts
+++ b/apps/desktop/src/renderer/src/model/scaffold-stage-labels.ts
@@ -1,19 +1,22 @@
 /**
- * Short, user-facing labels for the ten scaffolder stages. Kept in the
+ * Short, user-facing labels for scaffolder stages. Kept in the
  * renderer because only the UI needs them; main-side code works with
  * stage numbers directly.
  */
+import { STAGE } from '@main/scaffold/scaffold-project';
+
 export const SCAFFOLD_STAGE_LABELS: Readonly<Record<number, string>> = {
-  1: 'Scaffolding monorepo (Turborepo)',
-  2: 'Removing default web app',
-  3: 'Installing Next.js',
-  4: 'Adding shadcn/ui',
-  5: 'Provisioning Convex',
-  6: 'Emitting schema package',
-  7: 'Emitting Convex schema + seeds',
-  8: 'Stitching workspace + CLAUDE.md',
-  9: 'Installing dependencies',
-  10: 'Seeding initial IR',
+  [STAGE.TURBO_SKELETON]: 'Scaffolding monorepo',
+  [STAGE.WEB_NEXT]: 'Installing Next.js',
+  [STAGE.WEB_SHADCN]: 'Adding shadcn/ui',
+  [STAGE.MOBILE_EXPO]: 'Installing Expo (React Native)',
+  [STAGE.DESKTOP_ELECTRON]: 'Installing Electron (Forge)',
+  [STAGE.CONVEX_INIT]: 'Provisioning Convex',
+  [STAGE.SCHEMA_PACKAGE]: 'Emitting schema package',
+  [STAGE.CONVEX_EMIT]: 'Emitting Convex schema + seeds',
+  [STAGE.WORKSPACE_STITCH]: 'Stitching workspace + CLAUDE.md',
+  [STAGE.BUN_INSTALL]: 'Installing dependencies',
+  [STAGE.LLM_SEED]: 'Seeding initial IR',
 };
 
 export function labelForStage(stage: number): string {

--- a/apps/desktop/src/renderer/src/model/scaffold-stage-labels.ts
+++ b/apps/desktop/src/renderer/src/model/scaffold-stage-labels.ts
@@ -1,0 +1,21 @@
+/**
+ * Short, user-facing labels for the ten scaffolder stages. Kept in the
+ * renderer because only the UI needs them; main-side code works with
+ * stage numbers directly.
+ */
+export const SCAFFOLD_STAGE_LABELS: Readonly<Record<number, string>> = {
+  1: 'Scaffolding monorepo (Turborepo)',
+  2: 'Removing default web app',
+  3: 'Installing Next.js',
+  4: 'Adding shadcn/ui',
+  5: 'Provisioning Convex',
+  6: 'Emitting schema package',
+  7: 'Emitting Convex schema + seeds',
+  8: 'Stitching workspace + CLAUDE.md',
+  9: 'Installing dependencies',
+  10: 'Seeding initial IR',
+};
+
+export function labelForStage(stage: number): string {
+  return SCAFFOLD_STAGE_LABELS[stage] ?? `Stage ${stage}`;
+}

--- a/apps/desktop/src/renderer/src/model/validate-project-name.ts
+++ b/apps/desktop/src/renderer/src/model/validate-project-name.ts
@@ -1,0 +1,31 @@
+/**
+ * `validateProjectName` — enforces the name shape the scaffolder needs.
+ *
+ * The project name becomes all of: the monorepo directory, the npm
+ * scope in `@<name>/schema`, and the Convex project slug passed to
+ * `convex dev --project`. Intersecting those three rulesets gives us
+ * kebab-case, must-start-with-letter, and the npm 214-char cap.
+ */
+
+export type ValidationResult = { ok: true } | { ok: false; reason: string };
+
+const MAX_LEN = 214;
+const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+export function validateProjectName(raw: string): ValidationResult {
+  const name = raw.trim();
+  if (name.length === 0) return { ok: false, reason: 'Name cannot be empty.' };
+  if (name.length > MAX_LEN) {
+    return { ok: false, reason: `Name must be ${MAX_LEN} characters or fewer.` };
+  }
+  if (!KEBAB_CASE.test(name)) {
+    if (/[A-Z]/.test(name)) {
+      return { ok: false, reason: 'Name must be lowercase.' };
+    }
+    return {
+      ok: false,
+      reason: 'Name must be kebab-case (letters, digits, single hyphens; letter first).',
+    };
+  }
+  return { ok: true };
+}

--- a/apps/desktop/src/renderer/src/store/new-project.ts
+++ b/apps/desktop/src/renderer/src/store/new-project.ts
@@ -14,6 +14,7 @@ import { create } from 'zustand';
 
 export type NewProjectPhase = 'form' | 'running' | 'done' | 'failed';
 export type StageStatus = 'pending' | 'running' | 'done' | 'failed';
+export type StartingPoint = 'describe' | 'promote';
 
 const STAGES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
 
@@ -29,6 +30,8 @@ interface NewProjectState {
   isOpen: boolean;
   name: string;
   parentDir: string;
+  startingPoint: StartingPoint | null;
+  description: string;
   phase: NewProjectPhase;
   preflightError: PreflightError | null;
   stageStates: StageStates;
@@ -37,6 +40,8 @@ interface NewProjectState {
   close: () => void;
   setName: (name: string) => void;
   setParentDir: (path: string) => void;
+  setStartingPoint: (point: StartingPoint) => void;
+  setDescription: (desc: string) => void;
   setPreflightError: (err: PreflightError) => void;
   clearPreflightError: () => void;
   setPhase: (phase: NewProjectPhase) => void;
@@ -48,6 +53,8 @@ interface NewProjectState {
 const INITIAL = {
   name: '',
   parentDir: '',
+  startingPoint: null as StartingPoint | null,
+  description: '',
   phase: 'form' as NewProjectPhase,
   preflightError: null as PreflightError | null,
   stageStates: freshStageStates(),
@@ -61,6 +68,8 @@ export const useNewProjectStore = create<NewProjectState>((set) => ({
   close: () => set({ isOpen: false, ...INITIAL, stageStates: freshStageStates(), log: '' }),
   setName: (name) => set({ name }),
   setParentDir: (parentDir) => set({ parentDir }),
+  setStartingPoint: (startingPoint) => set({ startingPoint }),
+  setDescription: (description) => set({ description }),
   setPreflightError: (preflightError) => set({ preflightError, phase: 'form' }),
   clearPreflightError: () => set({ preflightError: null }),
   setPhase: (phase) => set({ phase }),

--- a/apps/desktop/src/renderer/src/store/new-project.ts
+++ b/apps/desktop/src/renderer/src/store/new-project.ts
@@ -16,6 +16,12 @@ export type NewProjectPhase = 'form' | 'running' | 'done' | 'failed';
 export type StageStatus = 'pending' | 'running' | 'done' | 'failed';
 export type StartingPoint = 'describe' | 'promote';
 
+export interface ScaffoldFailure {
+  stage: number;
+  stderr: string;
+  retrySafe: boolean;
+}
+
 const STAGES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
 
 export type StageStates = Readonly<Record<number, StageStatus>>;
@@ -34,6 +40,7 @@ interface NewProjectState {
   description: string;
   phase: NewProjectPhase;
   preflightError: PreflightError | null;
+  failure: ScaffoldFailure | null;
   stageStates: StageStates;
   log: string;
   open: () => void;
@@ -45,6 +52,7 @@ interface NewProjectState {
   setPreflightError: (err: PreflightError) => void;
   clearPreflightError: () => void;
   setPhase: (phase: NewProjectPhase) => void;
+  setFailure: (failure: ScaffoldFailure) => void;
   markStage: (stage: number, status: StageStatus) => void;
   appendLog: (chunk: string) => void;
   resetProgress: () => void;
@@ -57,6 +65,7 @@ const INITIAL = {
   description: '',
   phase: 'form' as NewProjectPhase,
   preflightError: null as PreflightError | null,
+  failure: null as ScaffoldFailure | null,
   stageStates: freshStageStates(),
   log: '',
 };
@@ -73,8 +82,10 @@ export const useNewProjectStore = create<NewProjectState>((set) => ({
   setPreflightError: (preflightError) => set({ preflightError, phase: 'form' }),
   clearPreflightError: () => set({ preflightError: null }),
   setPhase: (phase) => set({ phase }),
+  setFailure: (failure) => set({ failure, phase: 'failed' }),
   markStage: (stage, status) =>
     set((s) => ({ stageStates: { ...s.stageStates, [stage]: status } })),
   appendLog: (chunk) => set((s) => ({ log: s.log + chunk })),
-  resetProgress: () => set({ stageStates: freshStageStates(), log: '', preflightError: null }),
+  resetProgress: () =>
+    set({ stageStates: freshStageStates(), log: '', preflightError: null, failure: null }),
 }));

--- a/apps/desktop/src/renderer/src/store/new-project.ts
+++ b/apps/desktop/src/renderer/src/store/new-project.ts
@@ -1,30 +1,49 @@
 /**
  * `useNewProjectStore` — drives the New Project dialog.
  *
- * Holds the form state (name, parentDir) plus the dialog's open flag.
- * Later slices extend this with preflight errors, live scaffold event
- * state, and the resulting project path. Closing the dialog resets the
- * form so reopening doesn't surface stale input.
+ * Holds:
+ *   - form state (name, parentDir, isOpen)
+ *   - `phase` — where we are in the flow (form → running → done / failed)
+ *   - `preflightError` — surfaced in-dialog when stage 0 fails
+ *
+ * Closing resets everything so reopening doesn't show stale input or
+ * lingering errors.
  */
+import type { PreflightError } from '@renderer/model/preflight-error-copy';
 import { create } from 'zustand';
+
+export type NewProjectPhase = 'form' | 'running' | 'done' | 'failed';
 
 interface NewProjectState {
   isOpen: boolean;
   name: string;
   parentDir: string;
+  phase: NewProjectPhase;
+  preflightError: PreflightError | null;
   open: () => void;
   close: () => void;
   setName: (name: string) => void;
   setParentDir: (path: string) => void;
+  setPreflightError: (err: PreflightError) => void;
+  clearPreflightError: () => void;
+  setPhase: (phase: NewProjectPhase) => void;
 }
 
-const INITIAL_FORM = { name: '', parentDir: '' };
+const INITIAL = {
+  name: '',
+  parentDir: '',
+  phase: 'form' as NewProjectPhase,
+  preflightError: null as PreflightError | null,
+};
 
 export const useNewProjectStore = create<NewProjectState>((set) => ({
   isOpen: false,
-  ...INITIAL_FORM,
+  ...INITIAL,
   open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false, ...INITIAL_FORM }),
+  close: () => set({ isOpen: false, ...INITIAL }),
   setName: (name) => set({ name }),
   setParentDir: (parentDir) => set({ parentDir }),
+  setPreflightError: (preflightError) => set({ preflightError, phase: 'failed' }),
+  clearPreflightError: () => set({ preflightError: null }),
+  setPhase: (phase) => set({ phase }),
 }));

--- a/apps/desktop/src/renderer/src/store/new-project.ts
+++ b/apps/desktop/src/renderer/src/store/new-project.ts
@@ -1,21 +1,30 @@
 /**
- * `useNewProjectStore` — drives the New Project dialog visibility.
+ * `useNewProjectStore` — drives the New Project dialog.
  *
- * Deliberately thin in this slice: the dialog is a tracer that just
- * opens and closes. Subsequent slices grow the store to carry the form
- * state, preflight errors, live scaffold progress, and the resulting
- * project path — all driven off the scaffold IPC stream from #121.
+ * Holds the form state (name, parentDir) plus the dialog's open flag.
+ * Later slices extend this with preflight errors, live scaffold event
+ * state, and the resulting project path. Closing the dialog resets the
+ * form so reopening doesn't surface stale input.
  */
 import { create } from 'zustand';
 
 interface NewProjectState {
   isOpen: boolean;
+  name: string;
+  parentDir: string;
   open: () => void;
   close: () => void;
+  setName: (name: string) => void;
+  setParentDir: (path: string) => void;
 }
+
+const INITIAL_FORM = { name: '', parentDir: '' };
 
 export const useNewProjectStore = create<NewProjectState>((set) => ({
   isOpen: false,
+  ...INITIAL_FORM,
   open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false }),
+  close: () => set({ isOpen: false, ...INITIAL_FORM }),
+  setName: (name) => set({ name }),
+  setParentDir: (parentDir) => set({ parentDir }),
 }));

--- a/apps/desktop/src/renderer/src/store/new-project.ts
+++ b/apps/desktop/src/renderer/src/store/new-project.ts
@@ -2,7 +2,7 @@
  * `useNewProjectStore` — drives the New Project dialog.
  *
  * Holds:
- *   - form state (name, parentDir, isOpen)
+ *   - form state (name, parentDir, apps, isOpen)
  *   - `phase` — where we are in the flow (form → running → done / failed)
  *   - `preflightError` — surfaced in-dialog when stage 0 fails
  *   - `stageStates` + `log` — the live progress UI while stages run
@@ -12,9 +12,9 @@
 import type { PreflightError } from '@renderer/model/preflight-error-copy';
 import { create } from 'zustand';
 
+export type AppKind = 'web' | 'mobile' | 'desktop';
 export type NewProjectPhase = 'form' | 'running' | 'done' | 'failed';
 export type StageStatus = 'pending' | 'running' | 'done' | 'failed';
-export type StartingPoint = 'describe' | 'promote';
 
 export interface ScaffoldFailure {
   stage: number;
@@ -22,21 +22,13 @@ export interface ScaffoldFailure {
   retrySafe: boolean;
 }
 
-const STAGES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
-
 export type StageStates = Readonly<Record<number, StageStatus>>;
-
-function freshStageStates(): StageStates {
-  const out: Record<number, StageStatus> = {};
-  for (const n of STAGES) out[n] = 'pending';
-  return out;
-}
 
 interface NewProjectState {
   isOpen: boolean;
   name: string;
   parentDir: string;
-  startingPoint: StartingPoint | null;
+  apps: AppKind[];
   description: string;
   phase: NewProjectPhase;
   preflightError: PreflightError | null;
@@ -47,7 +39,7 @@ interface NewProjectState {
   close: () => void;
   setName: (name: string) => void;
   setParentDir: (path: string) => void;
-  setStartingPoint: (point: StartingPoint) => void;
+  toggleApp: (app: AppKind) => void;
   setDescription: (desc: string) => void;
   setPreflightError: (err: PreflightError) => void;
   clearPreflightError: () => void;
@@ -61,12 +53,12 @@ interface NewProjectState {
 const INITIAL = {
   name: '',
   parentDir: '',
-  startingPoint: null as StartingPoint | null,
+  apps: ['web'] as AppKind[],
   description: '',
   phase: 'form' as NewProjectPhase,
   preflightError: null as PreflightError | null,
   failure: null as ScaffoldFailure | null,
-  stageStates: freshStageStates(),
+  stageStates: {} as StageStates,
   log: '',
 };
 
@@ -74,11 +66,14 @@ export const useNewProjectStore = create<NewProjectState>((set) => ({
   isOpen: false,
   ...INITIAL,
   open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false, ...INITIAL, stageStates: freshStageStates(), log: '' }),
+  close: () => set({ isOpen: false, ...INITIAL }),
   setName: (name) => set({ name }),
   setParentDir: (parentDir) => set({ parentDir }),
-  setStartingPoint: (startingPoint) => set({ startingPoint }),
   setDescription: (description) => set({ description }),
+  toggleApp: (app) =>
+    set((s) => ({
+      apps: s.apps.includes(app) ? s.apps.filter((a) => a !== app) : [...s.apps, app],
+    })),
   setPreflightError: (preflightError) => set({ preflightError, phase: 'form' }),
   clearPreflightError: () => set({ preflightError: null }),
   setPhase: (phase) => set({ phase }),
@@ -86,6 +81,5 @@ export const useNewProjectStore = create<NewProjectState>((set) => ({
   markStage: (stage, status) =>
     set((s) => ({ stageStates: { ...s.stageStates, [stage]: status } })),
   appendLog: (chunk) => set((s) => ({ log: s.log + chunk })),
-  resetProgress: () =>
-    set({ stageStates: freshStageStates(), log: '', preflightError: null, failure: null }),
+  resetProgress: () => set({ stageStates: {}, log: '', preflightError: null, failure: null }),
 }));

--- a/apps/desktop/src/renderer/src/store/new-project.ts
+++ b/apps/desktop/src/renderer/src/store/new-project.ts
@@ -5,14 +5,25 @@
  *   - form state (name, parentDir, isOpen)
  *   - `phase` — where we are in the flow (form → running → done / failed)
  *   - `preflightError` — surfaced in-dialog when stage 0 fails
+ *   - `stageStates` + `log` — the live progress UI while stages run
  *
- * Closing resets everything so reopening doesn't show stale input or
- * lingering errors.
+ * Closing resets everything so reopening doesn't show stale state.
  */
 import type { PreflightError } from '@renderer/model/preflight-error-copy';
 import { create } from 'zustand';
 
 export type NewProjectPhase = 'form' | 'running' | 'done' | 'failed';
+export type StageStatus = 'pending' | 'running' | 'done' | 'failed';
+
+const STAGES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
+
+export type StageStates = Readonly<Record<number, StageStatus>>;
+
+function freshStageStates(): StageStates {
+  const out: Record<number, StageStatus> = {};
+  for (const n of STAGES) out[n] = 'pending';
+  return out;
+}
 
 interface NewProjectState {
   isOpen: boolean;
@@ -20,6 +31,8 @@ interface NewProjectState {
   parentDir: string;
   phase: NewProjectPhase;
   preflightError: PreflightError | null;
+  stageStates: StageStates;
+  log: string;
   open: () => void;
   close: () => void;
   setName: (name: string) => void;
@@ -27,6 +40,9 @@ interface NewProjectState {
   setPreflightError: (err: PreflightError) => void;
   clearPreflightError: () => void;
   setPhase: (phase: NewProjectPhase) => void;
+  markStage: (stage: number, status: StageStatus) => void;
+  appendLog: (chunk: string) => void;
+  resetProgress: () => void;
 }
 
 const INITIAL = {
@@ -34,16 +50,22 @@ const INITIAL = {
   parentDir: '',
   phase: 'form' as NewProjectPhase,
   preflightError: null as PreflightError | null,
+  stageStates: freshStageStates(),
+  log: '',
 };
 
 export const useNewProjectStore = create<NewProjectState>((set) => ({
   isOpen: false,
   ...INITIAL,
   open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false, ...INITIAL }),
+  close: () => set({ isOpen: false, ...INITIAL, stageStates: freshStageStates(), log: '' }),
   setName: (name) => set({ name }),
   setParentDir: (parentDir) => set({ parentDir }),
-  setPreflightError: (preflightError) => set({ preflightError, phase: 'failed' }),
+  setPreflightError: (preflightError) => set({ preflightError, phase: 'form' }),
   clearPreflightError: () => set({ preflightError: null }),
   setPhase: (phase) => set({ phase }),
+  markStage: (stage, status) =>
+    set((s) => ({ stageStates: { ...s.stageStates, [stage]: status } })),
+  appendLog: (chunk) => set((s) => ({ log: s.log + chunk })),
+  resetProgress: () => set({ stageStates: freshStageStates(), log: '', preflightError: null }),
 }));

--- a/apps/desktop/src/renderer/src/store/new-project.ts
+++ b/apps/desktop/src/renderer/src/store/new-project.ts
@@ -1,0 +1,21 @@
+/**
+ * `useNewProjectStore` — drives the New Project dialog visibility.
+ *
+ * Deliberately thin in this slice: the dialog is a tracer that just
+ * opens and closes. Subsequent slices grow the store to carry the form
+ * state, preflight errors, live scaffold progress, and the resulting
+ * project path — all driven off the scaffold IPC stream from #121.
+ */
+import { create } from 'zustand';
+
+interface NewProjectState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useNewProjectStore = create<NewProjectState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -1,15 +1,42 @@
 /**
- * `NewProjectDialog` — tracer slice. Asserts the dialog is driven by
- * `useNewProjectStore`: hidden when `isOpen` is false, visible when
- * true, and closing the dialog flips the store.
+ * `NewProjectDialog` — drives the New Project form. Covers:
+ *   - dialog open/close controlled by the store;
+ *   - project-name input live-validates via `validateProjectName`;
+ *   - parent-dir button invokes `window.contexture.file.pickDirectory`;
+ *   - target-path preview is `${parent}/${name}`;
+ *   - Create is disabled until name is valid AND parent is chosen.
  *
- * Later slices add assertions for the form fields, validation, the
- * progress modal state machine, and the success panel.
+ * The scaffold-start wiring + progress / success panels land in later
+ * slices; here we only confirm the form shape + gating.
  */
 import { NewProjectDialog } from '@renderer/components/dialogs/NewProjectDialog';
 import { useNewProjectStore } from '@renderer/store/new-project';
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function mockFileBridge(pickResult: string | null = null): {
+  pickDirectory: ReturnType<typeof vi.fn>;
+} {
+  const pickDirectory = vi.fn(async () => pickResult);
+  (window as unknown as { contexture: unknown }).contexture = {
+    chat: {},
+    file: {
+      openDialog: vi.fn(),
+      saveAsDialog: vi.fn(),
+      pickDirectory,
+      save: vi.fn(),
+      read: vi.fn(),
+      getRecentFiles: vi.fn(),
+      openRecent: vi.fn(),
+      onMenuNew: () => () => undefined,
+      onMenuOpen: () => () => undefined,
+      onMenuSave: () => () => undefined,
+      onMenuSaveAs: () => () => undefined,
+      onMenuNewProject: () => () => undefined,
+    },
+  };
+  return { pickDirectory };
+}
 
 beforeEach(() => {
   useNewProjectStore.getState().close();
@@ -17,28 +44,113 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
 });
 
 describe('NewProjectDialog', () => {
   it('is hidden when the store is closed', () => {
+    mockFileBridge();
     render(<NewProjectDialog />);
     expect(screen.queryByText(/New Project/i)).not.toBeInTheDocument();
   });
 
-  it('shows the dialog when the store opens', () => {
+  it('shows the form when the store opens', () => {
+    mockFileBridge();
     render(<NewProjectDialog />);
     act(() => {
       useNewProjectStore.getState().open();
     });
-    expect(screen.getByText(/New Project/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Project name/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Choose folder/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Create$/i })).toBeDisabled();
   });
 
-  it('Cancel closes the dialog via the store', () => {
+  it('shows an inline error for an invalid name', () => {
+    mockFileBridge();
     render(<NewProjectDialog />);
     act(() => {
       useNewProjectStore.getState().open();
     });
+    fireEvent.change(screen.getByLabelText(/Project name/i), { target: { value: 'Bad Name' } });
+    expect(screen.getByText(/lowercase/i)).toBeInTheDocument();
+  });
+
+  it('clears the error once the name is valid', () => {
+    mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+    });
+    fireEvent.change(screen.getByLabelText(/Project name/i), { target: { value: 'ok-name' } });
+    expect(screen.queryByText(/lowercase/i)).not.toBeInTheDocument();
+  });
+
+  it('parent-folder button calls the bridge and stores the picked path', async () => {
+    const { pickDirectory } = mockFileBridge('/Users/me/projects');
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Choose folder/i }));
+    await waitFor(() => {
+      expect(pickDirectory).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(useNewProjectStore.getState().parentDir).toBe('/Users/me/projects');
+    });
+  });
+
+  it('target-path preview is parent + / + name once both are set', async () => {
+    mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setParentDir('/Users/me/projects');
+      useNewProjectStore.getState().setName('my-proj');
+    });
+    expect(screen.getByText(/\/Users\/me\/projects\/my-proj/)).toBeInTheDocument();
+  });
+
+  it('Create is enabled only when name is valid AND parent is chosen', () => {
+    mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+    });
+    const create = screen.getByRole('button', { name: /^Create$/i });
+    expect(create).toBeDisabled();
+
+    // Name only — still disabled.
+    act(() => {
+      useNewProjectStore.getState().setName('my-proj');
+    });
+    expect(create).toBeDisabled();
+
+    // Add parent — now enabled.
+    act(() => {
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    expect(create).toBeEnabled();
+
+    // Invalid name with parent — disabled again.
+    act(() => {
+      useNewProjectStore.getState().setName('Bad');
+    });
+    expect(create).toBeDisabled();
+  });
+
+  it('Cancel closes the dialog and resets the form', () => {
+    mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('typed');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
     fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
-    expect(useNewProjectStore.getState().isOpen).toBe(false);
+    const state = useNewProjectStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.name).toBe('');
+    expect(state.parentDir).toBe('');
   });
 });

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -18,11 +18,13 @@ function mockFileBridge(pickResult: string | null = null): {
   pickDirectory: ReturnType<typeof vi.fn>;
   scaffoldStart: ReturnType<typeof vi.fn>;
   shellReveal: ReturnType<typeof vi.fn>;
+  projectDeleteDir: ReturnType<typeof vi.fn>;
   fireScaffoldEvent: (event: unknown) => void;
 } {
   const pickDirectory = vi.fn(async () => pickResult);
   const scaffoldStart = vi.fn(async () => undefined);
   const shellReveal = vi.fn(async () => undefined);
+  const projectDeleteDir = vi.fn(async () => undefined);
   let captured: ((event: unknown) => void) | null = null;
   (window as unknown as { contexture: unknown }).contexture = {
     chat: {},
@@ -52,11 +54,15 @@ function mockFileBridge(pickResult: string | null = null): {
     shell: {
       reveal: shellReveal,
     },
+    project: {
+      deleteDirectory: projectDeleteDir,
+    },
   };
   return {
     pickDirectory,
     scaffoldStart,
     shellReveal,
+    projectDeleteDir,
     fireScaffoldEvent: (event: unknown) => captured?.(event),
   };
 }
@@ -424,6 +430,63 @@ describe('NewProjectDialog', () => {
       expect(screen.getByTestId('scaffold-failure')).toBeInTheDocument();
     });
     expect(screen.getByRole('button', { name: /Try again/i })).toBeDisabled();
+  });
+
+  it('Delete and start over removes the target dir and returns to the form', async () => {
+    const bridge = mockFileBridge();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    act(() => {
+      bridge.fireScaffoldEvent({
+        kind: 'stage-failed',
+        stage: 3,
+        stderr: 'boom',
+        retrySafe: false,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Delete and start over/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Delete and start over/i }));
+    await waitFor(() => {
+      expect(bridge.projectDeleteDir).toHaveBeenCalledWith('/tmp/my-proj');
+    });
+    await waitFor(() => {
+      expect(useNewProjectStore.getState().phase).toBe('form');
+    });
+    expect(useNewProjectStore.getState().failure).toBeNull();
+    confirmSpy.mockRestore();
+  });
+
+  it('Delete and start over is a no-op when the user cancels the confirm', async () => {
+    const bridge = mockFileBridge();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    act(() => {
+      bridge.fireScaffoldEvent({
+        kind: 'stage-failed',
+        stage: 3,
+        stderr: 'boom',
+        retrySafe: false,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Delete and start over/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Delete and start over/i }));
+    expect(bridge.projectDeleteDir).not.toHaveBeenCalled();
+    expect(useNewProjectStore.getState().phase).toBe('failed');
+    confirmSpy.mockRestore();
   });
 
   it('Open folder on the failure panel reveals the target folder', async () => {

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -16,8 +16,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 function mockFileBridge(pickResult: string | null = null): {
   pickDirectory: ReturnType<typeof vi.fn>;
+  scaffoldStart: ReturnType<typeof vi.fn>;
+  fireScaffoldEvent: (event: unknown) => void;
 } {
   const pickDirectory = vi.fn(async () => pickResult);
+  const scaffoldStart = vi.fn(async () => undefined);
+  let captured: ((event: unknown) => void) | null = null;
   (window as unknown as { contexture: unknown }).contexture = {
     chat: {},
     file: {
@@ -34,8 +38,21 @@ function mockFileBridge(pickResult: string | null = null): {
       onMenuSaveAs: () => () => undefined,
       onMenuNewProject: () => () => undefined,
     },
+    scaffold: {
+      start: scaffoldStart,
+      onEvent: (listener: (e: unknown) => void) => {
+        captured = listener;
+        return () => {
+          captured = null;
+        };
+      },
+    },
   };
-  return { pickDirectory };
+  return {
+    pickDirectory,
+    scaffoldStart,
+    fireScaffoldEvent: (event: unknown) => captured?.(event),
+  };
 }
 
 beforeEach(() => {
@@ -137,6 +154,62 @@ describe('NewProjectDialog', () => {
       useNewProjectStore.getState().setName('Bad');
     });
     expect(create).toBeDisabled();
+  });
+
+  it('Create invokes scaffold.start with targetDir + projectName', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/Users/me/projects');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    await waitFor(() => {
+      expect(bridge.scaffoldStart).toHaveBeenCalledWith({
+        targetDir: '/Users/me/projects/my-proj',
+        projectName: 'my-proj',
+      });
+    });
+  });
+
+  it('shows an inline preflight error when main reports preflight-failed', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/Users/me/projects');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'preflight-failed', error: { kind: 'missing-bun' } });
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Bun is not installed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows the target-exists preflight error with the offending path', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/Users/me/projects');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({
+        kind: 'preflight-failed',
+        error: { kind: 'target-exists', path: '/Users/me/projects/my-proj' },
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'A folder already exists at /Users/me/projects/my-proj',
+      );
+    });
   });
 
   it('Cancel closes the dialog and resets the form', () => {

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * `NewProjectDialog` — tracer slice. Asserts the dialog is driven by
+ * `useNewProjectStore`: hidden when `isOpen` is false, visible when
+ * true, and closing the dialog flips the store.
+ *
+ * Later slices add assertions for the form fields, validation, the
+ * progress modal state machine, and the success panel.
+ */
+import { NewProjectDialog } from '@renderer/components/dialogs/NewProjectDialog';
+import { useNewProjectStore } from '@renderer/store/new-project';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+beforeEach(() => {
+  useNewProjectStore.getState().close();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('NewProjectDialog', () => {
+  it('is hidden when the store is closed', () => {
+    render(<NewProjectDialog />);
+    expect(screen.queryByText(/New Project/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the dialog when the store opens', () => {
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+    });
+    expect(screen.getByText(/New Project/i)).toBeInTheDocument();
+  });
+
+  it('Cancel closes the dialog via the store', () => {
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(useNewProjectStore.getState().isOpen).toBe(false);
+  });
+});

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -17,10 +17,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 function mockFileBridge(pickResult: string | null = null): {
   pickDirectory: ReturnType<typeof vi.fn>;
   scaffoldStart: ReturnType<typeof vi.fn>;
+  shellReveal: ReturnType<typeof vi.fn>;
   fireScaffoldEvent: (event: unknown) => void;
 } {
   const pickDirectory = vi.fn(async () => pickResult);
   const scaffoldStart = vi.fn(async () => undefined);
+  const shellReveal = vi.fn(async () => undefined);
   let captured: ((event: unknown) => void) | null = null;
   (window as unknown as { contexture: unknown }).contexture = {
     chat: {},
@@ -47,10 +49,14 @@ function mockFileBridge(pickResult: string | null = null): {
         };
       },
     },
+    shell: {
+      reveal: shellReveal,
+    },
   };
   return {
     pickDirectory,
     scaffoldStart,
+    shellReveal,
     fireScaffoldEvent: (event: unknown) => captured?.(event),
   };
 }
@@ -472,6 +478,27 @@ describe('NewProjectDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: /Copy path/i }));
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith('/tmp/my-proj');
+    });
+  });
+
+  it('Reveal on the success panel reveals the target folder', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Reveal/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Reveal/i }));
+    await waitFor(() => {
+      expect(bridge.shellReveal).toHaveBeenCalledWith('/tmp/my-proj');
     });
   });
 

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -373,6 +373,82 @@ describe('NewProjectDialog', () => {
     expect(screen.getByTestId('scaffold-success')).toHaveTextContent('/tmp/my-proj');
   });
 
+  it('shows the failure panel with the failed stage label when stage-failed fires', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 3 });
+      bridge.fireScaffoldEvent({
+        kind: 'stage-failed',
+        stage: 3,
+        stderr: 'next-app exited 1',
+        retrySafe: false,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('scaffold-failure')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('scaffold-failure')).toHaveTextContent(/Installing Next\.js/i);
+  });
+
+  it('Try again is disabled when the failed stage is not retry-safe', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({
+        kind: 'stage-failed',
+        stage: 2,
+        stderr: 'boom',
+        retrySafe: false,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('scaffold-failure')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /Try again/i })).toBeDisabled();
+  });
+
+  it('Try again is enabled and restarts the scaffolder when the failed stage is retry-safe', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    act(() => {
+      bridge.fireScaffoldEvent({
+        kind: 'stage-failed',
+        stage: 6,
+        stderr: 'convex hiccup',
+        retrySafe: true,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Try again/i })).not.toBeDisabled();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Try again/i }));
+    await waitFor(() => {
+      expect(bridge.scaffoldStart).toHaveBeenCalledTimes(1);
+    });
+    expect(bridge.scaffoldStart).toHaveBeenCalledWith({
+      targetDir: '/tmp/my-proj',
+      projectName: 'my-proj',
+    });
+  });
+
   it('Copy path writes the target path to the clipboard', async () => {
     const bridge = mockFileBridge();
     const writeText = vi.fn(async () => undefined);

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -336,6 +336,25 @@ describe('NewProjectDialog', () => {
     });
   });
 
+  it('transitions to the success panel when scaffold-done fires', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 1 });
+      bridge.fireScaffoldEvent({ kind: 'stage-done', stage: 1 });
+      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
+    });
+    await waitFor(() => {
+      expect(useNewProjectStore.getState().phase).toBe('done');
+    });
+  });
+
   it('Cancel closes the dialog and resets the form', () => {
     mockFileBridge();
     render(<NewProjectDialog />);

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -212,6 +212,76 @@ describe('NewProjectDialog', () => {
     });
   });
 
+  it('switches to the progress view on stage-start and shows all ten stage labels', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 1 });
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Scaffolding monorepo/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Installing dependencies/i)).toBeInTheDocument();
+    expect(screen.getByText(/Seeding initial IR/i)).toBeInTheDocument();
+  });
+
+  it('flips the active row to running and previous rows to done as events arrive', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 1 });
+      bridge.fireScaffoldEvent({ kind: 'stage-done', stage: 1 });
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 2 });
+    });
+    await waitFor(() => {
+      const row1 = screen.getByTestId('scaffold-stage-1');
+      expect(row1).toHaveAttribute('data-status', 'done');
+    });
+    expect(screen.getByTestId('scaffold-stage-2')).toHaveAttribute('data-status', 'running');
+    expect(screen.getByTestId('scaffold-stage-3')).toHaveAttribute('data-status', 'pending');
+  });
+
+  it('appends stdout/stderr chunks to the streaming log', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 1 });
+      bridge.fireScaffoldEvent({
+        kind: 'stdout-chunk',
+        stage: 1,
+        chunk: 'creating apps/...\n',
+      });
+      bridge.fireScaffoldEvent({
+        kind: 'stderr-chunk',
+        stage: 1,
+        chunk: 'warn: something\n',
+      });
+    });
+    await waitFor(() => {
+      const log = screen.getByTestId('scaffold-log');
+      expect(log.textContent).toContain('creating apps/...');
+      expect(log.textContent).toContain('warn: something');
+    });
+  });
+
   it('Cancel closes the dialog and resets the form', () => {
     mockFileBridge();
     render(<NewProjectDialog />);

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -128,7 +128,7 @@ describe('NewProjectDialog', () => {
     expect(screen.getByText(/\/Users\/me\/projects\/my-proj/)).toBeInTheDocument();
   });
 
-  it('Create is enabled only when name is valid AND parent is chosen', () => {
+  it('Create is enabled only when name is valid AND parent is chosen AND starting-point is valid', () => {
     mockFileBridge();
     render(<NewProjectDialog />);
     act(() => {
@@ -143,13 +143,20 @@ describe('NewProjectDialog', () => {
     });
     expect(create).toBeDisabled();
 
-    // Add parent — now enabled.
+    // Name + parent, no starting point — still disabled.
     act(() => {
       useNewProjectStore.getState().setParentDir('/tmp');
     });
+    expect(create).toBeDisabled();
+
+    // Add describe + description — now enabled.
+    act(() => {
+      useNewProjectStore.getState().setStartingPoint('describe');
+      useNewProjectStore.getState().setDescription('a blog');
+    });
     expect(create).toBeEnabled();
 
-    // Invalid name with parent — disabled again.
+    // Invalid name with everything else — disabled again.
     act(() => {
       useNewProjectStore.getState().setName('Bad');
     });
@@ -163,6 +170,8 @@ describe('NewProjectDialog', () => {
       useNewProjectStore.getState().open();
       useNewProjectStore.getState().setName('my-proj');
       useNewProjectStore.getState().setParentDir('/Users/me/projects');
+      useNewProjectStore.getState().setStartingPoint('describe');
+      useNewProjectStore.getState().setDescription('a blog');
     });
     fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
     await waitFor(() => {
@@ -171,6 +180,51 @@ describe('NewProjectDialog', () => {
         projectName: 'my-proj',
       });
     });
+  });
+
+  it('renders both starting-point radios; promote-scratch is disabled with #124 hint', () => {
+    mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+    });
+    const describe = screen.getByLabelText(/Describe what you're building/i);
+    const promote = screen.getByLabelText(/Promote an existing scratch/i);
+    expect(describe).toBeEnabled();
+    expect(promote).toBeDisabled();
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+  });
+
+  it('Create is disabled until a starting point is chosen (even with name+parent)', () => {
+    mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    expect(screen.getByRole('button', { name: /^Create$/i })).toBeDisabled();
+    act(() => {
+      useNewProjectStore.getState().setStartingPoint('describe');
+      useNewProjectStore.getState().setDescription('a blog');
+    });
+    expect(screen.getByRole('button', { name: /^Create$/i })).toBeEnabled();
+  });
+
+  it('describe path requires a non-empty description', () => {
+    mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+      useNewProjectStore.getState().setStartingPoint('describe');
+    });
+    expect(screen.getByRole('button', { name: /^Create$/i })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/Describe your project/i), {
+      target: { value: 'a photo app' },
+    });
+    expect(screen.getByRole('button', { name: /^Create$/i })).toBeEnabled();
   });
 
   it('shows an inline preflight error when main reports preflight-failed', async () => {

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -426,6 +426,31 @@ describe('NewProjectDialog', () => {
     expect(screen.getByRole('button', { name: /Try again/i })).toBeDisabled();
   });
 
+  it('Open folder on the failure panel reveals the target folder', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    act(() => {
+      bridge.fireScaffoldEvent({
+        kind: 'stage-failed',
+        stage: 3,
+        stderr: 'boom',
+        retrySafe: false,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Open folder/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Open folder/i }));
+    await waitFor(() => {
+      expect(bridge.shellReveal).toHaveBeenCalledWith('/tmp/my-proj');
+    });
+  });
+
   it('Try again is enabled and restarts the scaffolder when the failed stage is retry-safe', async () => {
     const bridge = mockFileBridge();
     render(<NewProjectDialog />);
@@ -499,6 +524,27 @@ describe('NewProjectDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: /Reveal/i }));
     await waitFor(() => {
       expect(bridge.shellReveal).toHaveBeenCalledWith('/tmp/my-proj');
+    });
+  });
+
+  it('View log on the success panel reveals the scaffold log file', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /View log/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /View log/i }));
+    await waitFor(() => {
+      expect(bridge.shellReveal).toHaveBeenCalledWith('/tmp/my-proj/.contexture/scaffold.log');
     });
   });
 

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -475,6 +475,29 @@ describe('NewProjectDialog', () => {
     });
   });
 
+  it('Close on the success panel opens the scaffolded IR before closing', async () => {
+    const bridge = mockFileBridge();
+    const onOpenProject = vi.fn();
+    render(<NewProjectDialog onOpenProject={onOpenProject} />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('scaffold-success-close')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('scaffold-success-close'));
+    expect(onOpenProject).toHaveBeenCalledWith(
+      '/tmp/my-proj/packages/schema/my-proj.contexture.json',
+    );
+    expect(useNewProjectStore.getState().isOpen).toBe(false);
+  });
+
   it('Close on the success panel closes and resets the store', async () => {
     const bridge = mockFileBridge();
     render(<NewProjectDialog />);

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -4,11 +4,11 @@
  *   - project-name input live-validates via `validateProjectName`;
  *   - parent-dir button invokes `window.contexture.file.pickDirectory`;
  *   - target-path preview is `${parent}/${name}`;
- *   - Create is disabled until name is valid AND parent is chosen.
- *
- * The scaffold-start wiring + progress / success panels land in later
- * slices; here we only confirm the form shape + gating.
+ *   - app picker checkboxes (web pre-checked, mobile/desktop unchecked);
+ *   - Create is disabled until name is valid AND parent is chosen AND
+ *     at least one app is selected.
  */
+import { STAGE } from '@main/scaffold/scaffold-project';
 import { NewProjectDialog } from '@renderer/components/dialogs/NewProjectDialog';
 import { useNewProjectStore } from '@renderer/store/new-project';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -144,7 +144,32 @@ describe('NewProjectDialog', () => {
     expect(screen.getByText(/\/Users\/me\/projects\/my-proj/)).toBeInTheDocument();
   });
 
-  it('Create is enabled only when name is valid AND parent is chosen AND starting-point is valid', () => {
+  it('app picker shows Web pre-checked, Mobile and Desktop unchecked', () => {
+    mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+    });
+    expect(screen.getByRole('checkbox', { name: /Web/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Mobile/i })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Desktop/i })).not.toBeChecked();
+  });
+
+  it('Create is disabled when no apps are selected', () => {
+    mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    // Uncheck Web (the only pre-checked app)
+    fireEvent.click(screen.getByRole('checkbox', { name: /Web/i }));
+    expect(screen.getByRole('button', { name: /^Create$/i })).toBeDisabled();
+    expect(screen.getByText('Select at least one app.')).toBeInTheDocument();
+  });
+
+  it('Create is enabled when name, parent, and at least one app are set', () => {
     mockFileBridge();
     render(<NewProjectDialog />);
     act(() => {
@@ -153,94 +178,40 @@ describe('NewProjectDialog', () => {
     const create = screen.getByRole('button', { name: /^Create$/i });
     expect(create).toBeDisabled();
 
-    // Name only — still disabled.
     act(() => {
       useNewProjectStore.getState().setName('my-proj');
     });
     expect(create).toBeDisabled();
 
-    // Name + parent, no starting point — still disabled.
     act(() => {
       useNewProjectStore.getState().setParentDir('/tmp');
     });
-    expect(create).toBeDisabled();
-
-    // Add describe + description — now enabled.
-    act(() => {
-      useNewProjectStore.getState().setStartingPoint('describe');
-      useNewProjectStore.getState().setDescription('a blog');
-    });
+    // Web is pre-checked so now all conditions are met.
     expect(create).toBeEnabled();
 
-    // Invalid name with everything else — disabled again.
+    // Invalid name — disabled again.
     act(() => {
       useNewProjectStore.getState().setName('Bad');
     });
     expect(create).toBeDisabled();
   });
 
-  it('Create invokes scaffold.start with targetDir + projectName', async () => {
+  it('Create invokes scaffold.start with targetDir, projectName, and selected apps', async () => {
     const bridge = mockFileBridge();
     render(<NewProjectDialog />);
     act(() => {
       useNewProjectStore.getState().open();
       useNewProjectStore.getState().setName('my-proj');
       useNewProjectStore.getState().setParentDir('/Users/me/projects');
-      useNewProjectStore.getState().setStartingPoint('describe');
-      useNewProjectStore.getState().setDescription('a blog');
     });
     fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
     await waitFor(() => {
       expect(bridge.scaffoldStart).toHaveBeenCalledWith({
         targetDir: '/Users/me/projects/my-proj',
         projectName: 'my-proj',
+        apps: ['web'],
       });
     });
-  });
-
-  it('renders both starting-point radios; promote-scratch is disabled with #124 hint', () => {
-    mockFileBridge();
-    render(<NewProjectDialog />);
-    act(() => {
-      useNewProjectStore.getState().open();
-    });
-    const describe = screen.getByLabelText(/Describe what you're building/i);
-    const promote = screen.getByLabelText(/Promote an existing scratch/i);
-    expect(describe).toBeEnabled();
-    expect(promote).toBeDisabled();
-    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
-  });
-
-  it('Create is disabled until a starting point is chosen (even with name+parent)', () => {
-    mockFileBridge();
-    render(<NewProjectDialog />);
-    act(() => {
-      useNewProjectStore.getState().open();
-      useNewProjectStore.getState().setName('my-proj');
-      useNewProjectStore.getState().setParentDir('/tmp');
-    });
-    expect(screen.getByRole('button', { name: /^Create$/i })).toBeDisabled();
-    act(() => {
-      useNewProjectStore.getState().setStartingPoint('describe');
-      useNewProjectStore.getState().setDescription('a blog');
-    });
-    expect(screen.getByRole('button', { name: /^Create$/i })).toBeEnabled();
-  });
-
-  it('describe path requires a non-empty description', () => {
-    mockFileBridge();
-    render(<NewProjectDialog />);
-    act(() => {
-      useNewProjectStore.getState().open();
-      useNewProjectStore.getState().setName('my-proj');
-      useNewProjectStore.getState().setParentDir('/tmp');
-      useNewProjectStore.getState().setStartingPoint('describe');
-    });
-    expect(screen.getByRole('button', { name: /^Create$/i })).toBeDisabled();
-    fireEvent.change(screen.getByLabelText(/Describe your project/i), {
-      target: { value: 'a photo app' },
-    });
-    expect(screen.getByRole('button', { name: /^Create$/i })).toBeEnabled();
   });
 
   it('shows an inline preflight error when main reports preflight-failed', async () => {
@@ -282,7 +253,7 @@ describe('NewProjectDialog', () => {
     });
   });
 
-  it('switches to the progress view on stage-start and shows all ten stage labels', async () => {
+  it('switches to the progress view on stage-start and shows stage labels', async () => {
     const bridge = mockFileBridge();
     render(<NewProjectDialog />);
     act(() => {
@@ -292,13 +263,31 @@ describe('NewProjectDialog', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
     act(() => {
-      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 1 });
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: STAGE.TURBO_SKELETON });
     });
     await waitFor(() => {
       expect(screen.getByText(/Scaffolding monorepo/i)).toBeInTheDocument();
     });
     expect(screen.getByText(/Installing dependencies/i)).toBeInTheDocument();
     expect(screen.getByText(/Seeding initial IR/i)).toBeInTheDocument();
+  });
+
+  it('shows web-specific stages (Next.js, shadcn) when web is selected', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: STAGE.TURBO_SKELETON });
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Installing Next\.js/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Adding shadcn\/ui/i)).toBeInTheDocument();
   });
 
   it('flips the active row to running and previous rows to done as events arrive', async () => {
@@ -311,16 +300,24 @@ describe('NewProjectDialog', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
     act(() => {
-      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 1 });
-      bridge.fireScaffoldEvent({ kind: 'stage-done', stage: 1 });
-      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 2 });
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: STAGE.TURBO_SKELETON });
+      bridge.fireScaffoldEvent({ kind: 'stage-done', stage: STAGE.TURBO_SKELETON });
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: STAGE.WEB_NEXT });
     });
     await waitFor(() => {
-      const row1 = screen.getByTestId('scaffold-stage-1');
-      expect(row1).toHaveAttribute('data-status', 'done');
+      expect(screen.getByTestId(`scaffold-stage-${STAGE.TURBO_SKELETON}`)).toHaveAttribute(
+        'data-status',
+        'done',
+      );
     });
-    expect(screen.getByTestId('scaffold-stage-2')).toHaveAttribute('data-status', 'running');
-    expect(screen.getByTestId('scaffold-stage-3')).toHaveAttribute('data-status', 'pending');
+    expect(screen.getByTestId(`scaffold-stage-${STAGE.WEB_NEXT}`)).toHaveAttribute(
+      'data-status',
+      'running',
+    );
+    expect(screen.getByTestId(`scaffold-stage-${STAGE.WEB_SHADCN}`)).toHaveAttribute(
+      'data-status',
+      'pending',
+    );
   });
 
   it('appends stdout/stderr chunks to the streaming log', async () => {
@@ -333,15 +330,15 @@ describe('NewProjectDialog', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
     act(() => {
-      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 1 });
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: STAGE.TURBO_SKELETON });
       bridge.fireScaffoldEvent({
         kind: 'stdout-chunk',
-        stage: 1,
+        stage: STAGE.TURBO_SKELETON,
         chunk: 'creating apps/...\n',
       });
       bridge.fireScaffoldEvent({
         kind: 'stderr-chunk',
-        stage: 1,
+        stage: STAGE.TURBO_SKELETON,
         chunk: 'warn: something\n',
       });
     });
@@ -352,28 +349,10 @@ describe('NewProjectDialog', () => {
     });
   });
 
-  it('transitions to the success panel when scaffold-done fires', async () => {
+  it('closes the dialog and calls onOpenProject with the IR path when scaffold-done fires', async () => {
     const bridge = mockFileBridge();
-    render(<NewProjectDialog />);
-    act(() => {
-      useNewProjectStore.getState().open();
-      useNewProjectStore.getState().setName('my-proj');
-      useNewProjectStore.getState().setParentDir('/tmp');
-    });
-    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
-    act(() => {
-      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 1 });
-      bridge.fireScaffoldEvent({ kind: 'stage-done', stage: 1 });
-      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
-    });
-    await waitFor(() => {
-      expect(useNewProjectStore.getState().phase).toBe('done');
-    });
-  });
-
-  it('shows the success panel with the target path when phase is done', async () => {
-    const bridge = mockFileBridge();
-    render(<NewProjectDialog />);
+    const onOpenProject = vi.fn();
+    render(<NewProjectDialog onOpenProject={onOpenProject} />);
     act(() => {
       useNewProjectStore.getState().open();
       useNewProjectStore.getState().setName('my-proj');
@@ -384,9 +363,11 @@ describe('NewProjectDialog', () => {
       bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
     });
     await waitFor(() => {
-      expect(screen.getByTestId('scaffold-success')).toBeInTheDocument();
+      expect(useNewProjectStore.getState().isOpen).toBe(false);
     });
-    expect(screen.getByTestId('scaffold-success')).toHaveTextContent('/tmp/my-proj');
+    expect(onOpenProject).toHaveBeenCalledWith(
+      '/tmp/my-proj/packages/schema/my-proj.contexture.json',
+    );
   });
 
   it('shows the failure panel with the failed stage label when stage-failed fires', async () => {
@@ -399,12 +380,12 @@ describe('NewProjectDialog', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
     act(() => {
-      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: 3 });
+      bridge.fireScaffoldEvent({ kind: 'stage-start', stage: STAGE.WEB_NEXT });
       bridge.fireScaffoldEvent({
         kind: 'stage-failed',
-        stage: 3,
+        stage: STAGE.WEB_NEXT,
         stderr: 'next-app exited 1',
-        retrySafe: false,
+        retrySafe: true,
       });
     });
     await waitFor(() => {
@@ -425,7 +406,7 @@ describe('NewProjectDialog', () => {
     act(() => {
       bridge.fireScaffoldEvent({
         kind: 'stage-failed',
-        stage: 2,
+        stage: STAGE.TURBO_SKELETON,
         stderr: 'boom',
         retrySafe: false,
       });
@@ -448,9 +429,9 @@ describe('NewProjectDialog', () => {
     act(() => {
       bridge.fireScaffoldEvent({
         kind: 'stage-failed',
-        stage: 3,
+        stage: STAGE.WEB_NEXT,
         stderr: 'boom',
-        retrySafe: false,
+        retrySafe: true,
       });
     });
     await waitFor(() => {
@@ -479,9 +460,9 @@ describe('NewProjectDialog', () => {
     act(() => {
       bridge.fireScaffoldEvent({
         kind: 'stage-failed',
-        stage: 3,
+        stage: STAGE.WEB_NEXT,
         stderr: 'boom',
-        retrySafe: false,
+        retrySafe: true,
       });
     });
     await waitFor(() => {
@@ -504,9 +485,9 @@ describe('NewProjectDialog', () => {
     act(() => {
       bridge.fireScaffoldEvent({
         kind: 'stage-failed',
-        stage: 3,
+        stage: STAGE.WEB_NEXT,
         stderr: 'boom',
-        retrySafe: false,
+        retrySafe: true,
       });
     });
     await waitFor(() => {
@@ -529,7 +510,7 @@ describe('NewProjectDialog', () => {
     act(() => {
       bridge.fireScaffoldEvent({
         kind: 'stage-failed',
-        stage: 6,
+        stage: STAGE.CONVEX_INIT,
         stderr: 'convex hiccup',
         retrySafe: true,
       });
@@ -544,36 +525,11 @@ describe('NewProjectDialog', () => {
     expect(bridge.scaffoldStart).toHaveBeenCalledWith({
       targetDir: '/tmp/my-proj',
       projectName: 'my-proj',
+      apps: ['web'],
     });
   });
 
-  it('Copy path writes the target path to the clipboard', async () => {
-    const bridge = mockFileBridge();
-    const writeText = vi.fn(async () => undefined);
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    });
-    render(<NewProjectDialog />);
-    act(() => {
-      useNewProjectStore.getState().open();
-      useNewProjectStore.getState().setName('my-proj');
-      useNewProjectStore.getState().setParentDir('/tmp');
-    });
-    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
-    act(() => {
-      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
-    });
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Copy path/i })).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByRole('button', { name: /Copy path/i }));
-    await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith('/tmp/my-proj');
-    });
-  });
-
-  it('Reveal on the success panel reveals the target folder', async () => {
+  it('closes the dialog even when no onOpenProject is provided', async () => {
     const bridge = mockFileBridge();
     render(<NewProjectDialog />);
     act(() => {
@@ -586,15 +542,11 @@ describe('NewProjectDialog', () => {
       bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
     });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Reveal/i })).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByRole('button', { name: /Reveal/i }));
-    await waitFor(() => {
-      expect(bridge.shellReveal).toHaveBeenCalledWith('/tmp/my-proj');
+      expect(useNewProjectStore.getState().isOpen).toBe(false);
     });
   });
 
-  it('Open in VS Code on the success panel opens the target folder in VS Code', async () => {
+  it('scaffold-done closes the dialog and resets the store', async () => {
     const bridge = mockFileBridge();
     render(<NewProjectDialog />);
     act(() => {
@@ -607,75 +559,8 @@ describe('NewProjectDialog', () => {
       bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
     });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Open in VS Code/i })).toBeInTheDocument();
+      expect(useNewProjectStore.getState().isOpen).toBe(false);
     });
-    fireEvent.click(screen.getByRole('button', { name: /Open in VS Code/i }));
-    await waitFor(() => {
-      expect(bridge.shellOpenInEditor).toHaveBeenCalledWith('/tmp/my-proj');
-    });
-  });
-
-  it('View log on the success panel reveals the scaffold log file', async () => {
-    const bridge = mockFileBridge();
-    render(<NewProjectDialog />);
-    act(() => {
-      useNewProjectStore.getState().open();
-      useNewProjectStore.getState().setName('my-proj');
-      useNewProjectStore.getState().setParentDir('/tmp');
-    });
-    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
-    act(() => {
-      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
-    });
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /View log/i })).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByRole('button', { name: /View log/i }));
-    await waitFor(() => {
-      expect(bridge.shellReveal).toHaveBeenCalledWith('/tmp/my-proj/.contexture/scaffold.log');
-    });
-  });
-
-  it('Close on the success panel opens the scaffolded IR before closing', async () => {
-    const bridge = mockFileBridge();
-    const onOpenProject = vi.fn();
-    render(<NewProjectDialog onOpenProject={onOpenProject} />);
-    act(() => {
-      useNewProjectStore.getState().open();
-      useNewProjectStore.getState().setName('my-proj');
-      useNewProjectStore.getState().setParentDir('/tmp');
-    });
-    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
-    act(() => {
-      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
-    });
-    await waitFor(() => {
-      expect(screen.getByTestId('scaffold-success-close')).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByTestId('scaffold-success-close'));
-    expect(onOpenProject).toHaveBeenCalledWith(
-      '/tmp/my-proj/packages/schema/my-proj.contexture.json',
-    );
-    expect(useNewProjectStore.getState().isOpen).toBe(false);
-  });
-
-  it('Close on the success panel closes and resets the store', async () => {
-    const bridge = mockFileBridge();
-    render(<NewProjectDialog />);
-    act(() => {
-      useNewProjectStore.getState().open();
-      useNewProjectStore.getState().setName('my-proj');
-      useNewProjectStore.getState().setParentDir('/tmp');
-    });
-    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
-    act(() => {
-      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
-    });
-    await waitFor(() => {
-      expect(screen.getByTestId('scaffold-success-close')).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByTestId('scaffold-success-close'));
-    expect(useNewProjectStore.getState().isOpen).toBe(false);
     expect(useNewProjectStore.getState().name).toBe('');
     expect(useNewProjectStore.getState().phase).toBe('form');
   });

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -355,6 +355,71 @@ describe('NewProjectDialog', () => {
     });
   });
 
+  it('shows the success panel with the target path when phase is done', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('scaffold-success')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('scaffold-success')).toHaveTextContent('/tmp/my-proj');
+  });
+
+  it('Copy path writes the target path to the clipboard', async () => {
+    const bridge = mockFileBridge();
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Copy path/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Copy path/i }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('/tmp/my-proj');
+    });
+  });
+
+  it('Close on the success panel closes and resets the store', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('scaffold-success-close')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('scaffold-success-close'));
+    expect(useNewProjectStore.getState().isOpen).toBe(false);
+    expect(useNewProjectStore.getState().name).toBe('');
+    expect(useNewProjectStore.getState().phase).toBe('form');
+  });
+
   it('Cancel closes the dialog and resets the form', () => {
     mockFileBridge();
     render(<NewProjectDialog />);

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -18,12 +18,14 @@ function mockFileBridge(pickResult: string | null = null): {
   pickDirectory: ReturnType<typeof vi.fn>;
   scaffoldStart: ReturnType<typeof vi.fn>;
   shellReveal: ReturnType<typeof vi.fn>;
+  shellOpenInEditor: ReturnType<typeof vi.fn>;
   projectDeleteDir: ReturnType<typeof vi.fn>;
   fireScaffoldEvent: (event: unknown) => void;
 } {
   const pickDirectory = vi.fn(async () => pickResult);
   const scaffoldStart = vi.fn(async () => undefined);
   const shellReveal = vi.fn(async () => undefined);
+  const shellOpenInEditor = vi.fn(async () => undefined);
   const projectDeleteDir = vi.fn(async () => undefined);
   let captured: ((event: unknown) => void) | null = null;
   (window as unknown as { contexture: unknown }).contexture = {
@@ -53,6 +55,7 @@ function mockFileBridge(pickResult: string | null = null): {
     },
     shell: {
       reveal: shellReveal,
+      openInEditor: shellOpenInEditor,
     },
     project: {
       deleteDirectory: projectDeleteDir,
@@ -62,6 +65,7 @@ function mockFileBridge(pickResult: string | null = null): {
     pickDirectory,
     scaffoldStart,
     shellReveal,
+    shellOpenInEditor,
     projectDeleteDir,
     fireScaffoldEvent: (event: unknown) => captured?.(event),
   };
@@ -587,6 +591,27 @@ describe('NewProjectDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: /Reveal/i }));
     await waitFor(() => {
       expect(bridge.shellReveal).toHaveBeenCalledWith('/tmp/my-proj');
+    });
+  });
+
+  it('Open in VS Code on the success panel opens the target folder in VS Code', async () => {
+    const bridge = mockFileBridge();
+    render(<NewProjectDialog />);
+    act(() => {
+      useNewProjectStore.getState().open();
+      useNewProjectStore.getState().setName('my-proj');
+      useNewProjectStore.getState().setParentDir('/tmp');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+    act(() => {
+      bridge.fireScaffoldEvent({ kind: 'scaffold-done' });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Open in VS Code/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Open in VS Code/i }));
+    await waitFor(() => {
+      expect(bridge.shellOpenInEditor).toHaveBeenCalledWith('/tmp/my-proj');
     });
   });
 

--- a/apps/desktop/tests/hooks/useFileMenu.test.tsx
+++ b/apps/desktop/tests/hooks/useFileMenu.test.tsx
@@ -34,6 +34,7 @@ function mockFileBridge(): {
       onMenuSave: () => () => undefined,
       onMenuSaveAs: () => () => undefined,
       onMenuNewProject: () => () => undefined,
+      pickDirectory: vi.fn(async () => null),
     },
   };
   return { openDialog, saveAsDialog, save, openRecent, getRecentFiles };

--- a/apps/desktop/tests/hooks/useFileMenu.test.tsx
+++ b/apps/desktop/tests/hooks/useFileMenu.test.tsx
@@ -33,6 +33,7 @@ function mockFileBridge(): {
       onMenuOpen: () => () => undefined,
       onMenuSave: () => () => undefined,
       onMenuSaveAs: () => () => undefined,
+      onMenuNewProject: () => () => undefined,
     },
   };
   return { openDialog, saveAsDialog, save, openRecent, getRecentFiles };

--- a/apps/desktop/tests/hooks/useNewProject.test.tsx
+++ b/apps/desktop/tests/hooks/useNewProject.test.tsx
@@ -29,6 +29,7 @@ function mockFileBridge(): { fire: () => void; unsubscribe: ReturnType<typeof vi
         captured = listener;
         return unsubscribe;
       },
+      pickDirectory: vi.fn(async () => null),
     },
   };
   return {

--- a/apps/desktop/tests/hooks/useNewProject.test.tsx
+++ b/apps/desktop/tests/hooks/useNewProject.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * `useNewProject` — subscribes to the File → New Project… menu and
+ * flips `useNewProjectStore` open when it fires. Keeps the wiring in
+ * one place so the dialog component can stay dumb. Tests drive the
+ * subscription via a fake `window.contexture.file` surface.
+ */
+import { useNewProject } from '@renderer/hooks/useNewProject';
+import { useNewProjectStore } from '@renderer/store/new-project';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function mockFileBridge(): { fire: () => void; unsubscribe: ReturnType<typeof vi.fn> } {
+  let captured: (() => void) | null = null;
+  const unsubscribe = vi.fn();
+  (window as unknown as { contexture: unknown }).contexture = {
+    chat: {},
+    file: {
+      openDialog: vi.fn(),
+      saveAsDialog: vi.fn(),
+      save: vi.fn(),
+      read: vi.fn(),
+      getRecentFiles: vi.fn(),
+      openRecent: vi.fn(),
+      onMenuNew: () => () => undefined,
+      onMenuOpen: () => () => undefined,
+      onMenuSave: () => () => undefined,
+      onMenuSaveAs: () => () => undefined,
+      onMenuNewProject: (listener: () => void) => {
+        captured = listener;
+        return unsubscribe;
+      },
+    },
+  };
+  return {
+    fire: () => captured?.(),
+    unsubscribe,
+  };
+}
+
+beforeEach(() => {
+  useNewProjectStore.getState().close();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('useNewProject', () => {
+  it('opens the dialog when the New Project menu fires', () => {
+    const bridge = mockFileBridge();
+    renderHook(() => useNewProject());
+    expect(useNewProjectStore.getState().isOpen).toBe(false);
+    act(() => {
+      bridge.fire();
+    });
+    expect(useNewProjectStore.getState().isOpen).toBe(true);
+  });
+
+  it('unsubscribes on unmount', () => {
+    const bridge = mockFileBridge();
+    const { unmount } = renderHook(() => useNewProject());
+    unmount();
+    expect(bridge.unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/tests/hooks/useProjectAutoSave.test.tsx
+++ b/apps/desktop/tests/hooks/useProjectAutoSave.test.tsx
@@ -24,6 +24,7 @@ function mockFileBridge(): { save: ReturnType<typeof vi.fn> } {
       onMenuSave: () => () => undefined,
       onMenuSaveAs: () => () => undefined,
       onMenuNewProject: () => () => undefined,
+      pickDirectory: vi.fn(async () => null),
     },
   };
   return { save };

--- a/apps/desktop/tests/hooks/useProjectAutoSave.test.tsx
+++ b/apps/desktop/tests/hooks/useProjectAutoSave.test.tsx
@@ -23,6 +23,7 @@ function mockFileBridge(): { save: ReturnType<typeof vi.fn> } {
       onMenuOpen: () => () => undefined,
       onMenuSave: () => () => undefined,
       onMenuSaveAs: () => () => undefined,
+      onMenuNewProject: () => () => undefined,
     },
   };
   return { save };

--- a/apps/desktop/tests/main/menu.test.ts
+++ b/apps/desktop/tests/main/menu.test.ts
@@ -31,6 +31,10 @@ describe('app menu', () => {
     expect(findItem(template, ['File', 'New Contexture File'])).toBeDefined();
   });
 
+  it('exposes a "New Project…" entry under File', () => {
+    expect(findItem(template, ['File', 'New Project…'])).toBeDefined();
+  });
+
   it('labels the Open item "Open Contexture File…"', () => {
     expect(findItem(template, ['File', 'Open Contexture File…'])).toBeDefined();
   });

--- a/apps/desktop/tests/main/scaffold-composite-runner.test.ts
+++ b/apps/desktop/tests/main/scaffold-composite-runner.test.ts
@@ -1,18 +1,20 @@
 /**
- * `createCompositeStageRunner` — the production StageRunner: delegates
- * shell-backed stages (1-5, 9) to the spawn runner, runs the in-process
- * stages (6 scaffold, 7 convex emit, 8 workspace stitch + git init,
- * 10 no-op) directly, and gives the orchestrator a single runner to
- * drive. Testing through fakes for fs + spawner so we can assert
- * dispatch without touching disk or shelling out.
+ * `createCompositeStageRunner` — dispatches shell-backed stages to the
+ * spawn runner and runs in-process stages directly. Tests use fakes for
+ * fs + spawner so dispatch is verified without touching disk or shelling out.
  */
 import type { FsAdapter } from '@main/documents/document-store';
 import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
 import { createCompositeStageRunner } from '@main/scaffold/composite-runner';
+import { STAGE } from '@main/scaffold/scaffold-project';
 import type { Spawner } from '@main/scaffold/spawn-runner';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+const config = {
+  targetDir: '/work/my-proj',
+  projectName: 'my-proj',
+  apps: ['web'] as const,
+};
 
 let fs: ReturnType<typeof createMemFsAdapter>;
 let spawnCalls: Array<{ cmd: string; args: string[]; cwd: string }>;
@@ -39,25 +41,52 @@ function okSpawner(): Spawner {
 }
 
 describe('createCompositeStageRunner', () => {
-  it('dispatches stage 1 to the spawner (bunx create-turbo)', async () => {
+  it('TURBO_SKELETON runs in-process — writes root package.json, turbo.json, .gitignore', async () => {
     const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
-    for await (const _ of runner.run(1, config)) {
+    for await (const _ of runner.run(STAGE.TURBO_SKELETON, config)) {
+      // drain
+    }
+    expect(fs.exists('/work/my-proj/package.json')).toBe(true);
+    expect(fs.exists('/work/my-proj/turbo.json')).toBe(true);
+    expect(fs.exists('/work/my-proj/.gitignore')).toBe(true);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it('WEB_NEXT dispatches to spawner (bunx create-next-app)', async () => {
+    const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
+    for await (const _ of runner.run(STAGE.WEB_NEXT, config)) {
       // drain
     }
     expect(spawnCalls).toHaveLength(1);
     expect(spawnCalls[0].cmd).toBe('bunx');
-    expect(spawnCalls[0].args[0]).toBe('create-turbo@latest');
+    expect(spawnCalls[0].args[0]).toBe('create-next-app@latest');
   });
 
-  it('stage 5: seeds packages/schema anchor + installs convex locally, then spawns convex dev there', async () => {
+  it('MOBILE_EXPO dispatches to spawner (bunx create-expo-app)', async () => {
     const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
-    for await (const _ of runner.run(5, config)) {
+    for await (const _ of runner.run(STAGE.MOBILE_EXPO, config)) {
       // drain
     }
-    // Anchor written with convex as a dep.
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].args[0]).toBe('create-expo-app@latest');
+  });
+
+  it('DESKTOP_ELECTRON dispatches to spawner (bunx create-electron-app)', async () => {
+    const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
+    for await (const _ of runner.run(STAGE.DESKTOP_ELECTRON, config)) {
+      // drain
+    }
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].args[0]).toBe('create-electron-app@latest');
+  });
+
+  it('CONVEX_INIT: seeds packages/schema anchor + installs convex locally, then spawns convex dev', async () => {
+    const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
+    for await (const _ of runner.run(STAGE.CONVEX_INIT, config)) {
+      // drain
+    }
     const pkg = JSON.parse(await fs.readFile('/work/my-proj/packages/schema/package.json'));
     expect(pkg.dependencies.convex).toBeDefined();
-    // Two spawns: `bun install` (so convex/server resolves), then convex dev.
     expect(spawnCalls).toHaveLength(2);
     expect(spawnCalls[0].cmd).toBe('bun');
     expect(spawnCalls[0].args).toEqual(['install']);
@@ -67,42 +96,38 @@ describe('createCompositeStageRunner', () => {
     expect(spawnCalls[1].cwd).toBe('/work/my-proj/packages/schema');
   });
 
-  it('runs stage 6 in-process — writes the schema package tree', async () => {
+  it('SCHEMA_PACKAGE runs in-process — writes the schema package tree', async () => {
     const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
-    for await (const _ of runner.run(6, config)) {
+    for await (const _ of runner.run(STAGE.SCHEMA_PACKAGE, config)) {
       // drain
     }
     expect(fs.exists('/work/my-proj/packages/schema/my-proj.contexture.json')).toBe(true);
     expect(fs.exists('/work/my-proj/packages/schema/package.json')).toBe(true);
-    // Spawner must not have been touched for in-process stages.
     expect(spawnCalls).toHaveLength(0);
   });
 
-  it('runs stage 7 in-process — writes the Convex schema', async () => {
-    // Stage 6 runs first in the real flow; emulate it.
+  it('CONVEX_EMIT runs in-process — writes the Convex schema', async () => {
     await fs.writeFile(
       `${config.targetDir}/packages/schema/my-proj.contexture.json`,
       JSON.stringify({ version: '1', types: [] }),
     );
     const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
-    for await (const _ of runner.run(7, config)) {
+    for await (const _ of runner.run(STAGE.CONVEX_EMIT, config)) {
       // drain
     }
     expect(fs.exists('/work/my-proj/packages/schema/convex/schema.ts')).toBe(true);
     expect(spawnCalls).toHaveLength(0);
   });
 
-  it('runs stage 8 — stitch + git init trio via spawner', async () => {
+  it('WORKSPACE_STITCH — stitch + git init trio via spawner', async () => {
     await seedWebPackageJson(fs);
     const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
-    for await (const _ of runner.run(8, config)) {
+    for await (const _ of runner.run(STAGE.WORKSPACE_STITCH, config)) {
       // drain
     }
-    // Files written by stitch half.
     expect(fs.exists('/work/my-proj/CLAUDE.md')).toBe(true);
     expect(fs.exists('/work/my-proj/biome.json')).toBe(true);
     expect(fs.exists('/work/my-proj/.gitignore')).toBe(true);
-    // Git trio dispatched to spawner.
     expect(spawnCalls.map((c) => c.args[0])).toEqual(['init', 'add', 'commit']);
     for (const c of spawnCalls) {
       expect(c.cmd).toBe('git');
@@ -110,9 +135,9 @@ describe('createCompositeStageRunner', () => {
     }
   });
 
-  it('dispatches stage 9 to the spawner (bun install)', async () => {
+  it('BUN_INSTALL dispatches to spawner (bun install)', async () => {
     const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
-    for await (const _ of runner.run(9, config)) {
+    for await (const _ of runner.run(STAGE.BUN_INSTALL, config)) {
       // drain
     }
     expect(spawnCalls).toHaveLength(1);
@@ -120,9 +145,9 @@ describe('createCompositeStageRunner', () => {
     expect(spawnCalls[0].args).toEqual(['install']);
   });
 
-  it('stage 10 is a no-op in v1 — no spawner, no file writes', async () => {
+  it('LLM_SEED is a no-op — no spawner calls, no file writes', async () => {
     const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
-    for await (const _ of runner.run(10, config)) {
+    for await (const _ of runner.run(STAGE.LLM_SEED, config)) {
       // drain
     }
     expect(spawnCalls).toHaveLength(0);

--- a/apps/desktop/tests/main/scaffold-convex-emit.test.ts
+++ b/apps/desktop/tests/main/scaffold-convex-emit.test.ts
@@ -9,7 +9,7 @@ import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
 import { scaffoldConvexEmit } from '@main/scaffold/convex-emit';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj', apps: ['web'] as const };
 const schemaDir = '/work/my-proj/packages/schema';
 
 let fs: ReturnType<typeof createMemFsAdapter>;

--- a/apps/desktop/tests/main/scaffold-e2e.test.ts
+++ b/apps/desktop/tests/main/scaffold-e2e.test.ts
@@ -16,6 +16,7 @@ import { handleScaffoldStart, type ScaffoldEvent } from '@main/ipc/scaffold';
 import { nodePreflightDeps } from '@main/scaffold/node-preflight-deps';
 import { nodeSpawner } from '@main/scaffold/node-spawner';
 import { runPreflight } from '@main/scaffold/preflight';
+import { deriveStages } from '@main/scaffold/scaffold-project';
 import { describe, expect, it } from 'vitest';
 
 const E2E = process.env.SCAFFOLD_E2E === '1';
@@ -31,7 +32,7 @@ describeOrSkip('scaffold end-to-end (SCAFFOLD_E2E=1)', () => {
       const events: ScaffoldEvent[] = [];
       try {
         await handleScaffoldStart(
-          { targetDir, projectName },
+          { targetDir, projectName, apps: ['web'] },
           {
             fs: nodeFsAdapter,
             spawner: nodeSpawner,
@@ -53,7 +54,7 @@ describeOrSkip('scaffold end-to-end (SCAFFOLD_E2E=1)', () => {
 
         // Every stage reached stage-done.
         const dones = events.filter((e) => e.kind === 'stage-done').map((e) => e.stage);
-        expect(dones).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        expect(dones).toEqual(deriveStages(['web']));
 
         // Key artefacts on disk.
         expect(existsSync(join(targetDir, 'apps/web/package.json'))).toBe(true);

--- a/apps/desktop/tests/main/scaffold-git-init.test.ts
+++ b/apps/desktop/tests/main/scaffold-git-init.test.ts
@@ -7,7 +7,7 @@
 import { gitInitStageSpec } from '@main/scaffold/git-init';
 import { describe, expect, it } from 'vitest';
 
-const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj', apps: ['web'] as const };
 
 describe('gitInitStageSpec', () => {
   it('runs `git init` then `git add -A` then `git commit` at the project root', () => {

--- a/apps/desktop/tests/main/scaffold-ipc.test.ts
+++ b/apps/desktop/tests/main/scaffold-ipc.test.ts
@@ -6,10 +6,11 @@
  */
 import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
 import { handleScaffoldStart } from '@main/ipc/scaffold';
+import { deriveStages } from '@main/scaffold/scaffold-project';
 import type { Spawner } from '@main/scaffold/spawn-runner';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj', apps: ['web'] as const };
 
 let fs: ReturnType<typeof createMemFsAdapter>;
 
@@ -25,8 +26,8 @@ function alwaysOkPreflight() {
 
 beforeEach(() => {
   fs = createMemFsAdapter();
-  // Seed the files that shell stages 1-5 would have laid down — the
-  // in-process stages reach for `apps/web/package.json` and the IR.
+  // Seed apps/web/package.json — WORKSPACE_STITCH reads it to add the schema dep.
+  // The real flow has WEB_NEXT create it; here the pass-through spawner skips that shell call.
   fs.writeFile(`${config.targetDir}/apps/web/package.json`, `${JSON.stringify({ name: 'web' })}\n`);
 });
 
@@ -43,8 +44,9 @@ describe('handleScaffoldStart', () => {
     });
     const starts = events.filter((e) => e.kind === 'stage-start').map((e) => e.stage);
     const dones = events.filter((e) => e.kind === 'stage-done').map((e) => e.stage);
-    expect(starts).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    expect(dones).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const expected = deriveStages(config.apps as ('web' | 'mobile' | 'desktop')[]);
+    expect(starts).toEqual(expected);
+    expect(dones).toEqual(expected);
   });
 
   it('emits a preflight-failed event and stops when preflight returns errors', async () => {

--- a/apps/desktop/tests/main/scaffold-orchestrator.test.ts
+++ b/apps/desktop/tests/main/scaffold-orchestrator.test.ts
@@ -57,8 +57,18 @@ describe('scaffoldProject', () => {
     const dones = events.filter((e) => e.kind === 'stage-done').map((e) => e.stage);
     expect(starts).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     expect(dones).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(events.at(-1)?.kind).toBe('scaffold-done');
     expect(logWrites).toHaveLength(1);
     expect(logWrites[0].path).toBe('/tmp/p/.contexture/scaffold.log');
+  });
+
+  it('does not emit scaffold-done when a stage fails', async () => {
+    const stream = scaffoldProject(
+      { targetDir: '/tmp/p', projectName: 'p' },
+      { runner: failAtRunner(2), writeLog: async () => undefined },
+    );
+    const events = await collect(stream);
+    expect(events.some((e) => e.kind === 'scaffold-done')).toBe(false);
   });
 
   it('stops at the first failing stage, emits stage-failed, and still writes the log', async () => {

--- a/apps/desktop/tests/main/scaffold-orchestrator.test.ts
+++ b/apps/desktop/tests/main/scaffold-orchestrator.test.ts
@@ -1,12 +1,13 @@
 /**
- * scaffoldProject — the ten-stage orchestrator that runs the preflight,
- * each stage, and writes `.contexture/scaffold.log` regardless of
- * outcome. This test drives it through an in-memory `StageRunner` and
- * fake log writer so we can assert the event stream order + shape
- * without actually shelling out. Real stage wiring comes in later
- * slices.
+ * scaffoldProject — the composable orchestrator that derives a dynamic
+ * stage list from config.apps, runs each stage, and writes
+ * `.contexture/scaffold.log` regardless of outcome. Driven through an
+ * in-memory `StageRunner` and fake log writer so we can assert the
+ * event stream order + shape without shelling out.
  */
 import {
+  deriveStages,
+  STAGE,
   type StageEvent,
   type StageRunner,
   scaffoldProject,
@@ -21,7 +22,6 @@ function collect(stream: AsyncIterable<StageEvent>): Promise<StageEvent[]> {
   })();
 }
 
-/** Makes a runner that succeeds for every stage. */
 function okRunner(): StageRunner {
   return {
     run: async function* () {
@@ -30,7 +30,6 @@ function okRunner(): StageRunner {
   };
 }
 
-/** Makes a runner that succeeds on stage N, then fails on stage N+1. */
 function failAtRunner(failStage: number, stderr = 'boom'): StageRunner {
   return {
     run: async function* (stage) {
@@ -42,73 +41,116 @@ function failAtRunner(failStage: number, stderr = 'boom'): StageRunner {
   };
 }
 
+const webConfig = { targetDir: '/tmp/p', projectName: 'p', apps: ['web'] as const };
+const allAppsConfig = {
+  targetDir: '/tmp/p',
+  projectName: 'p',
+  apps: ['web', 'mobile', 'desktop'] as const,
+};
+
+describe('deriveStages', () => {
+  it('web-only: includes turbo skeleton, web stages, convex + workspace stages', () => {
+    const stages = deriveStages(['web']);
+    expect(stages).toEqual([
+      STAGE.TURBO_SKELETON,
+      STAGE.WEB_NEXT,
+      STAGE.WEB_SHADCN,
+      STAGE.CONVEX_INIT,
+      STAGE.SCHEMA_PACKAGE,
+      STAGE.CONVEX_EMIT,
+      STAGE.WORKSPACE_STITCH,
+      STAGE.BUN_INSTALL,
+      STAGE.LLM_SEED,
+    ]);
+  });
+
+  it('mobile-only: no web stages, includes mobile expo stage', () => {
+    const stages = deriveStages(['mobile']);
+    expect(stages).toContain(STAGE.MOBILE_EXPO);
+    expect(stages).not.toContain(STAGE.WEB_NEXT);
+    expect(stages).not.toContain(STAGE.WEB_SHADCN);
+  });
+
+  it('all apps: includes all optional stages in order', () => {
+    const stages = deriveStages(['web', 'mobile', 'desktop']);
+    const idx = (s: number) => stages.indexOf(s);
+    expect(idx(STAGE.WEB_NEXT)).toBeLessThan(idx(STAGE.MOBILE_EXPO));
+    expect(idx(STAGE.MOBILE_EXPO)).toBeLessThan(idx(STAGE.DESKTOP_ELECTRON));
+    expect(idx(STAGE.DESKTOP_ELECTRON)).toBeLessThan(idx(STAGE.CONVEX_INIT));
+  });
+});
+
 describe('scaffoldProject', () => {
-  it('emits stage-start and stage-done for every stage on the happy path and writes the log', async () => {
+  it('emits stage-start and stage-done for every derived stage on the happy path and writes the log', async () => {
     const logWrites: Array<{ path: string; content: string }> = [];
-    const stream = scaffoldProject(
-      { targetDir: '/tmp/p', projectName: 'p' },
-      {
-        runner: okRunner(),
-        writeLog: async (path, content) => logWrites.push({ path, content }),
-      },
-    );
+    const stream = scaffoldProject(webConfig, {
+      runner: okRunner(),
+      writeLog: async (path, content) => logWrites.push({ path, content }),
+    });
     const events = await collect(stream);
+    const expectedStages = deriveStages(['web']);
     const starts = events.filter((e) => e.kind === 'stage-start').map((e) => e.stage);
     const dones = events.filter((e) => e.kind === 'stage-done').map((e) => e.stage);
-    expect(starts).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    expect(dones).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(starts).toEqual(expectedStages);
+    expect(dones).toEqual(expectedStages);
     expect(events.at(-1)?.kind).toBe('scaffold-done');
     expect(logWrites).toHaveLength(1);
     expect(logWrites[0].path).toBe('/tmp/p/.contexture/scaffold.log');
   });
 
   it('does not emit scaffold-done when a stage fails', async () => {
-    const stream = scaffoldProject(
-      { targetDir: '/tmp/p', projectName: 'p' },
-      { runner: failAtRunner(2), writeLog: async () => undefined },
-    );
+    const stream = scaffoldProject(webConfig, {
+      runner: failAtRunner(STAGE.WEB_NEXT),
+      writeLog: async () => undefined,
+    });
     const events = await collect(stream);
     expect(events.some((e) => e.kind === 'scaffold-done')).toBe(false);
   });
 
   it('stops at the first failing stage, emits stage-failed, and still writes the log', async () => {
     const logWrites: Array<{ path: string; content: string }> = [];
-    const stream = scaffoldProject(
-      { targetDir: '/tmp/p', projectName: 'p' },
-      {
-        runner: failAtRunner(3, 'next-app exited 1'),
-        writeLog: async (path, content) => logWrites.push({ path, content }),
-      },
-    );
+    const stream = scaffoldProject(webConfig, {
+      runner: failAtRunner(STAGE.WEB_NEXT, 'next-app exited 1'),
+      writeLog: async (path, content) => logWrites.push({ path, content }),
+    });
     const events = await collect(stream);
     const starts = events.filter((e) => e.kind === 'stage-start').map((e) => e.stage);
     const failed = events.find((e) => e.kind === 'stage-failed');
-    // Stages 1 and 2 ran, stage 3 started + failed; nothing after stage 3.
-    expect(starts).toEqual([1, 2, 3]);
+    expect(starts).toEqual([STAGE.TURBO_SKELETON, STAGE.WEB_NEXT]);
     expect(failed?.kind).toBe('stage-failed');
     if (failed?.kind === 'stage-failed') {
-      expect(failed.stage).toBe(3);
+      expect(failed.stage).toBe(STAGE.WEB_NEXT);
       expect(failed.stderr).toContain('next-app exited 1');
     }
     expect(logWrites).toHaveLength(1);
     expect(logWrites[0].content).toContain('next-app exited 1');
   });
 
-  it('stage-failed carries the retry-safe flag (false for 1-4, true for 5+)', async () => {
+  it('stage 1 (TURBO_SKELETON) is not retry-safe; all others are', async () => {
     async function firstFailedAt(stage: number) {
       const events = await collect(
-        scaffoldProject(
-          { targetDir: '/tmp/p', projectName: 'p' },
-          { runner: failAtRunner(stage), writeLog: async () => undefined },
-        ),
+        scaffoldProject(allAppsConfig, {
+          runner: failAtRunner(stage),
+          writeLog: async () => undefined,
+        }),
       );
       const failed = events.find((e) => e.kind === 'stage-failed');
       if (failed?.kind !== 'stage-failed') throw new Error('expected stage-failed');
       return failed;
     }
-    expect((await firstFailedAt(1)).retrySafe).toBe(false);
-    expect((await firstFailedAt(4)).retrySafe).toBe(false);
-    expect((await firstFailedAt(5)).retrySafe).toBe(true);
-    expect((await firstFailedAt(9)).retrySafe).toBe(true);
+    expect((await firstFailedAt(STAGE.TURBO_SKELETON)).retrySafe).toBe(false);
+    expect((await firstFailedAt(STAGE.WEB_NEXT)).retrySafe).toBe(true);
+    expect((await firstFailedAt(STAGE.CONVEX_INIT)).retrySafe).toBe(true);
+    expect((await firstFailedAt(STAGE.BUN_INSTALL)).retrySafe).toBe(true);
+  });
+
+  it('derives correct stage list for all-apps config', async () => {
+    const stream = scaffoldProject(allAppsConfig, {
+      runner: okRunner(),
+      writeLog: async () => undefined,
+    });
+    const events = await collect(stream);
+    const starts = events.filter((e) => e.kind === 'stage-start').map((e) => e.stage);
+    expect(starts).toEqual(deriveStages(['web', 'mobile', 'desktop']));
   });
 });

--- a/apps/desktop/tests/main/scaffold-schema-package.test.ts
+++ b/apps/desktop/tests/main/scaffold-schema-package.test.ts
@@ -9,7 +9,7 @@ import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
 import { scaffoldSchemaPackage } from '@main/scaffold/schema-package';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj', apps: ['web'] as const };
 const schemaDir = '/work/my-proj/packages/schema';
 
 let fs: ReturnType<typeof createMemFsAdapter>;
@@ -48,7 +48,7 @@ describe('scaffoldSchemaPackage', () => {
     expect(fs.exists(`${schemaDir}/.gitignore`)).toBe(true);
   });
 
-  it('seeds an empty layout.json, chat.json, and emitted.json under .contexture/', async () => {
+  it('seeds an empty chat.json when no description is provided', async () => {
     await scaffoldSchemaPackage(config, { fs });
     expect(JSON.parse(await fs.readFile(`${schemaDir}/.contexture/layout.json`))).toEqual({
       version: '1',
@@ -62,5 +62,24 @@ describe('scaffoldSchemaPackage', () => {
       version: '1',
       files: {},
     });
+  });
+
+  it('seeds chat.json with the description as the first user message when provided', async () => {
+    const withDesc = { ...config, description: 'A photo-sharing app' };
+    await scaffoldSchemaPackage(withDesc, { fs });
+    const chat = JSON.parse(await fs.readFile(`${schemaDir}/.contexture/chat.json`));
+    expect(chat.version).toBe('1');
+    expect(chat.messages).toHaveLength(1);
+    expect(chat.messages[0].role).toBe('user');
+    expect(chat.messages[0].content).toBe('A photo-sharing app');
+    expect(typeof chat.messages[0].id).toBe('string');
+    expect(typeof chat.messages[0].createdAt).toBe('number');
+  });
+
+  it('trims whitespace from the description before seeding', async () => {
+    const withDesc = { ...config, description: '  A blog platform  ' };
+    await scaffoldSchemaPackage(withDesc, { fs });
+    const chat = JSON.parse(await fs.readFile(`${schemaDir}/.contexture/chat.json`));
+    expect(chat.messages[0].content).toBe('A blog platform');
   });
 });

--- a/apps/desktop/tests/main/scaffold-spawn-runner.test.ts
+++ b/apps/desktop/tests/main/scaffold-spawn-runner.test.ts
@@ -5,10 +5,11 @@
  * as StageChunks, non-zero exit throws) without actually forking a
  * process. Real spawn wiring is a one-liner in production.
  */
+import { STAGE } from '@main/scaffold/scaffold-project';
 import { createSpawnStageRunner, type Spawner } from '@main/scaffold/spawn-runner';
 import { describe, expect, it } from 'vitest';
 
-const config = { targetDir: '/work/p', projectName: 'p' };
+const config = { targetDir: '/work/p', projectName: 'p', apps: ['web'] as const };
 
 function fakeSpawner(
   fn: (args: Parameters<Spawner>[0]) => {
@@ -34,13 +35,13 @@ describe('spawnStageRunner', () => {
     });
     const runner = createSpawnStageRunner(spawner);
     const chunks: Array<string> = [];
-    for await (const ev of runner.run(1, config)) {
+    for await (const ev of runner.run(STAGE.WEB_NEXT, config)) {
       if (ev.kind === 'stdout-chunk') chunks.push(ev.chunk);
     }
     expect(calls).toHaveLength(1);
     expect(calls[0].cmd).toBe('bunx');
-    expect(calls[0].args[0]).toBe('create-turbo@latest');
-    expect(calls[0].cwd).toBe('/work');
+    expect(calls[0].args[0]).toBe('create-next-app@latest');
+    expect(calls[0].cwd).toBe('/work/p');
     expect(chunks).toEqual(['creating...\n', 'done.\n']);
   });
 
@@ -49,7 +50,7 @@ describe('spawnStageRunner', () => {
     const runner = createSpawnStageRunner(spawner);
     let threw = false;
     try {
-      for await (const _ of runner.run(3, config)) {
+      for await (const _ of runner.run(STAGE.WEB_SHADCN, config)) {
         // drain
       }
     } catch (e) {

--- a/apps/desktop/tests/main/scaffold-stages.test.ts
+++ b/apps/desktop/tests/main/scaffold-stages.test.ts
@@ -1,36 +1,20 @@
 /**
- * Per-stage command/cwd/args derivation — separated from spawn/IO so
- * we can assert exactly what commands the scaffolder would run for a
- * given config. Stages 1-4 are fully external (Turbo, Next, shadcn);
- * they share the same spawn shape so only this pure-data derivation
- * is worth asserting here.
+ * Per-stage command/cwd/args derivation — asserts what commands the
+ * scaffolder would run for a given config. Only shell-backed stages
+ * have a spec; the in-process stages (TURBO_SKELETON, CONVEX_INIT,
+ * SCHEMA_PACKAGE, CONVEX_EMIT, WORKSPACE_STITCH, LLM_SEED) are not
+ * covered here.
  */
+import { STAGE } from '@main/scaffold/scaffold-project';
 import { shellStageSpecFor } from '@main/scaffold/stages';
 import { describe, expect, it } from 'vitest';
 
-const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
-const parent = '/work';
-const nextCwd = '/work/my-proj/apps/web';
+const config = { targetDir: '/work/my-proj', projectName: 'my-proj', apps: ['web'] as const };
+const webDir = '/work/my-proj/apps/web';
 
 describe('shellStageSpecFor', () => {
-  it('stage 1: bunx create-turbo in the parent dir, skip-install, bun package manager', () => {
-    const spec = shellStageSpecFor(1, config);
-    expect(spec).toEqual({
-      cmd: 'bunx',
-      args: ['create-turbo@latest', 'my-proj', '--package-manager', 'bun', '--skip-install'],
-      cwd: parent,
-    });
-  });
-
-  it('stage 2: removes apps/web that create-turbo just laid down', () => {
-    const spec = shellStageSpecFor(2, config);
-    expect(spec.cmd).toBe('rm');
-    expect(spec.args).toEqual(['-rf', 'apps/web']);
-    expect(spec.cwd).toBe('/work/my-proj');
-  });
-
-  it('stage 3: bunx create-next-app at apps/web with the non-interactive flag set', () => {
-    const spec = shellStageSpecFor(3, config);
+  it('WEB_NEXT: bunx create-next-app with non-interactive flags', () => {
+    const spec = shellStageSpecFor(STAGE.WEB_NEXT, config);
     expect(spec.cmd).toBe('bunx');
     expect(spec.args).toEqual([
       'create-next-app@latest',
@@ -45,17 +29,35 @@ describe('shellStageSpecFor', () => {
     expect(spec.cwd).toBe('/work/my-proj');
   });
 
-  it('stage 4: bunx shadcn init inside apps/web', () => {
-    const spec = shellStageSpecFor(4, config);
+  it('WEB_SHADCN: bunx shadcn init inside apps/web', () => {
+    const spec = shellStageSpecFor(STAGE.WEB_SHADCN, config);
     expect(spec).toEqual({
       cmd: 'bunx',
       args: ['shadcn@latest', 'init', '--yes'],
-      cwd: nextCwd,
+      cwd: webDir,
     });
   });
 
-  it('stage 5: convex dev one-shot configure, local backend, inside packages/schema', () => {
-    const spec = shellStageSpecFor(5, config);
+  it('MOBILE_EXPO: bunx create-expo-app with default template, no-install', () => {
+    const spec = shellStageSpecFor(STAGE.MOBILE_EXPO, config);
+    expect(spec.cmd).toBe('bunx');
+    expect(spec.args[0]).toBe('create-expo-app@latest');
+    expect(spec.args).toContain('apps/mobile');
+    expect(spec.args).toContain('--no-install');
+    expect(spec.cwd).toBe('/work/my-proj');
+  });
+
+  it('DESKTOP_ELECTRON: bunx create-electron-app with vite-typescript template', () => {
+    const spec = shellStageSpecFor(STAGE.DESKTOP_ELECTRON, config);
+    expect(spec.cmd).toBe('bunx');
+    expect(spec.args[0]).toBe('create-electron-app@latest');
+    expect(spec.args).toContain('apps/desktop');
+    expect(spec.args).toContain('--template=vite-typescript');
+    expect(spec.cwd).toBe('/work/my-proj');
+  });
+
+  it('CONVEX_INIT: convex dev one-shot configure, local backend, inside packages/schema', () => {
+    const spec = shellStageSpecFor(STAGE.CONVEX_INIT, config);
     expect(spec.cmd).toBe('bunx');
     expect(spec.args).toEqual([
       'convex@latest',
@@ -69,12 +71,16 @@ describe('shellStageSpecFor', () => {
     expect(spec.cwd).toBe('/work/my-proj/packages/schema');
   });
 
-  it('stage 9: bun install at the project root to resolve the new workspace dep', () => {
-    const spec = shellStageSpecFor(9, config);
+  it('BUN_INSTALL: bun install at the project root', () => {
+    const spec = shellStageSpecFor(STAGE.BUN_INSTALL, config);
     expect(spec).toEqual({
       cmd: 'bun',
       args: ['install'],
       cwd: '/work/my-proj',
     });
+  });
+
+  it('throws for unknown stage numbers', () => {
+    expect(() => shellStageSpecFor(999, config)).toThrow();
   });
 });

--- a/apps/desktop/tests/main/scaffold-workspace-stitch.test.ts
+++ b/apps/desktop/tests/main/scaffold-workspace-stitch.test.ts
@@ -1,16 +1,19 @@
 /**
- * `scaffoldWorkspaceStitch` (stage 8) — merges
- * `@<project>/schema: workspace:*` into `apps/web/package.json`,
- * writes the root `CLAUDE.md`, the workspace `biome.json`, and
- * ensures the root `.gitignore` has the usual entries. Pure file
- * manipulation against an injected FsAdapter; git init is handled
- * by a separate step so this slice stays testable without a shell.
+ * `scaffoldWorkspaceStitch` (stage 9) — when 'web' is in config.apps,
+ * merges `@<project>/schema: workspace:*` into `apps/web/package.json`;
+ * always writes the root `CLAUDE.md`, `biome.json`, and `.gitignore`.
+ * Pure file manipulation; git init is handled by a separate step.
  */
 import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
 import { scaffoldWorkspaceStitch } from '@main/scaffold/workspace-stitch';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-const config = { targetDir: '/work/my-proj', projectName: 'my-proj' };
+const webConfig = { targetDir: '/work/my-proj', projectName: 'my-proj', apps: ['web'] as const };
+const mobileConfig = {
+  targetDir: '/work/my-proj',
+  projectName: 'my-proj',
+  apps: ['mobile'] as const,
+};
 const webPkgPath = '/work/my-proj/apps/web/package.json';
 
 let fs: ReturnType<typeof createMemFsAdapter>;
@@ -20,29 +23,33 @@ beforeEach(() => {
 });
 
 describe('scaffoldWorkspaceStitch', () => {
-  it('adds @<project>/schema: workspace:* to apps/web/package.json dependencies', async () => {
+  it('adds @<project>/schema: workspace:* to apps/web/package.json dependencies when web selected', async () => {
     await fs.writeFile(
       webPkgPath,
       `${JSON.stringify({ name: 'web', dependencies: { next: '^15.0.0' } }, null, 2)}\n`,
     );
-    await scaffoldWorkspaceStitch(config, { fs });
+    await scaffoldWorkspaceStitch(webConfig, { fs });
     const pkg = JSON.parse(await fs.readFile(webPkgPath));
     expect(pkg.dependencies['@my-proj/schema']).toBe('workspace:*');
-    // Existing deps preserved.
     expect(pkg.dependencies.next).toBe('^15.0.0');
     expect(pkg.name).toBe('web');
   });
 
   it('creates a dependencies object if apps/web/package.json lacked one', async () => {
     await fs.writeFile(webPkgPath, `${JSON.stringify({ name: 'web' }, null, 2)}\n`);
-    await scaffoldWorkspaceStitch(config, { fs });
+    await scaffoldWorkspaceStitch(webConfig, { fs });
     const pkg = JSON.parse(await fs.readFile(webPkgPath));
     expect(pkg.dependencies['@my-proj/schema']).toBe('workspace:*');
   });
 
-  it('writes the root CLAUDE.md with {{PROJECT_NAME}} substituted', async () => {
+  it('skips web package.json when web is not in apps', async () => {
+    await scaffoldWorkspaceStitch(mobileConfig, { fs });
+    expect(fs.exists(webPkgPath)).toBe(false);
+  });
+
+  it('writes the root CLAUDE.md with project name substituted', async () => {
     await fs.writeFile(webPkgPath, `${JSON.stringify({ name: 'web' }, null, 2)}\n`);
-    await scaffoldWorkspaceStitch(config, { fs });
+    await scaffoldWorkspaceStitch(webConfig, { fs });
     const claude = await fs.readFile('/work/my-proj/CLAUDE.md');
     expect(claude).toContain('my-proj');
     expect(claude).not.toContain('{{PROJECT_NAME}}');
@@ -50,16 +57,15 @@ describe('scaffoldWorkspaceStitch', () => {
 
   it('writes biome.json at the project root', async () => {
     await fs.writeFile(webPkgPath, `${JSON.stringify({ name: 'web' }, null, 2)}\n`);
-    await scaffoldWorkspaceStitch(config, { fs });
+    await scaffoldWorkspaceStitch(webConfig, { fs });
     expect(fs.exists('/work/my-proj/biome.json')).toBe(true);
     const biome = JSON.parse(await fs.readFile('/work/my-proj/biome.json'));
-    // Minimal sanity: must be a valid biome config shape.
     expect(biome.$schema).toMatch(/biomejs/);
   });
 
-  it('writes a root .gitignore covering node_modules, .next, .convex, and .contexture internals', async () => {
+  it('writes a root .gitignore covering node_modules, .next, .convex', async () => {
     await fs.writeFile(webPkgPath, `${JSON.stringify({ name: 'web' }, null, 2)}\n`);
-    await scaffoldWorkspaceStitch(config, { fs });
+    await scaffoldWorkspaceStitch(webConfig, { fs });
     const gitignore = await fs.readFile('/work/my-proj/.gitignore');
     expect(gitignore).toMatch(/node_modules/);
     expect(gitignore).toMatch(/\.next/);
@@ -71,9 +77,9 @@ describe('scaffoldWorkspaceStitch', () => {
       webPkgPath,
       `${JSON.stringify({ name: 'web', dependencies: { next: '^15.0.0' } }, null, 2)}\n`,
     );
-    await scaffoldWorkspaceStitch(config, { fs });
+    await scaffoldWorkspaceStitch(webConfig, { fs });
     const first = await fs.readFile(webPkgPath);
-    await scaffoldWorkspaceStitch(config, { fs });
+    await scaffoldWorkspaceStitch(webConfig, { fs });
     const second = await fs.readFile(webPkgPath);
     expect(second).toBe(first);
   });

--- a/apps/desktop/tests/model/preflight-error-copy.test.ts
+++ b/apps/desktop/tests/model/preflight-error-copy.test.ts
@@ -1,0 +1,32 @@
+/**
+ * `preflightErrorCopy` — one line of UI copy per tagged preflight
+ * error. Every branch is covered so a future error shape gets a
+ * compile-time hole and a test hole at the same time.
+ */
+import { preflightErrorCopy } from '@renderer/model/preflight-error-copy';
+import { describe, expect, it } from 'vitest';
+
+describe('preflightErrorCopy', () => {
+  it('mentions Bun for missing-bun', () => {
+    expect(preflightErrorCopy({ kind: 'missing-bun' })).toMatch(/Bun/i);
+  });
+  it('mentions Git for missing-git', () => {
+    expect(preflightErrorCopy({ kind: 'missing-git' })).toMatch(/Git/i);
+  });
+  it('mentions Node for missing-node', () => {
+    expect(preflightErrorCopy({ kind: 'missing-node' })).toMatch(/Node/i);
+  });
+  it('mentions network / registry for no-network', () => {
+    expect(preflightErrorCopy({ kind: 'no-network' })).toMatch(/network|registry/i);
+  });
+  it('includes the offending path for parent-not-writable', () => {
+    expect(preflightErrorCopy({ kind: 'parent-not-writable', path: '/ro' })).toContain('/ro');
+  });
+  it('includes the target path for target-exists', () => {
+    expect(preflightErrorCopy({ kind: 'target-exists', path: '/tmp/x' })).toContain('/tmp/x');
+  });
+  it('renders a rounded MB figure for insufficient-space', () => {
+    const msg = preflightErrorCopy({ kind: 'insufficient-space', bytesFree: 104857600 });
+    expect(msg).toMatch(/100 MB/);
+  });
+});

--- a/apps/desktop/tests/model/validate-project-name.test.ts
+++ b/apps/desktop/tests/model/validate-project-name.test.ts
@@ -1,0 +1,69 @@
+/**
+ * `validateProjectName` — the rules the New Project dialog enforces on
+ * the project-name input. Kept as a pure helper so the dialog component
+ * stays dumb and the regression surface lives here.
+ *
+ * Kebab-case is the house style because it becomes the npm package name
+ * (`@<name>/schema`), the monorepo directory, and the Convex project
+ * slug — all three require the lowercase-letters-digits-hyphen shape.
+ */
+import { validateProjectName } from '@renderer/model/validate-project-name';
+import { describe, expect, it } from 'vitest';
+
+describe('validateProjectName', () => {
+  it('accepts a simple kebab-case name', () => {
+    expect(validateProjectName('my-proj')).toEqual({ ok: true });
+  });
+
+  it('accepts a single lowercase word', () => {
+    expect(validateProjectName('app')).toEqual({ ok: true });
+  });
+
+  it('rejects an empty string', () => {
+    const result = validateProjectName('');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/empty/i);
+  });
+
+  it('rejects whitespace-only input', () => {
+    const result = validateProjectName('   ');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects uppercase letters', () => {
+    const result = validateProjectName('MyProj');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/lowercase/i);
+  });
+
+  it('rejects underscores', () => {
+    const result = validateProjectName('my_proj');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects leading hyphen', () => {
+    expect(validateProjectName('-proj').ok).toBe(false);
+  });
+
+  it('rejects trailing hyphen', () => {
+    expect(validateProjectName('proj-').ok).toBe(false);
+  });
+
+  it('rejects double hyphens', () => {
+    expect(validateProjectName('my--proj').ok).toBe(false);
+  });
+
+  it('rejects names starting with a digit (npm requires a letter first)', () => {
+    expect(validateProjectName('1-proj').ok).toBe(false);
+  });
+
+  it('accepts digits after the first character', () => {
+    expect(validateProjectName('proj-v2').ok).toBe(true);
+  });
+
+  it('rejects names longer than 214 chars (npm package name limit)', () => {
+    const long = `a${'-x'.repeat(120)}`;
+    expect(long.length).toBeGreaterThan(214);
+    expect(validateProjectName(long).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #122.

## Summary

Renderer-side UI for the 10-stage scaffolder from #121. Adds **File → New Project…** menu entry and the full form → progress → success / failure flow, wired end-to-end through the scaffold IPC. Fourteen focused commits, each a single vertical TDD slice.

- **Form**: kebab-case live validation, folder picker, target-path preview, two starting-point radios (Describe wired, Promote scratch disabled with a #124 hint), description textarea
- **Progress**: 10 stage rows (`pending → running → done / failed`) + streaming stdout/stderr log
- **Preflight**: failures render inline in the form — no modal transition
- **Failure panel**: stage label + captured stderr + retry-safety copy; **Open folder**, **Delete and start over** (confirm), **Try again** (disabled when the failed stage isn't retry-safe)
- **Success panel**: green check, copyable path, **Reveal**, **Open in VS Code** (via `vscode://` URL, no `code` on PATH needed), **Copy path**, **View log** (reveals `.contexture/scaffold.log`), **Close**
- **Close on success** opens the scaffolded `packages/schema/<name>.contexture.json` in project mode via the existing open-path flow
- New IPC surfaces: `shell.reveal`, `shell.openInEditor`, `project.deleteDirectory`
- Added `scaffold-done` terminal event from the orchestrator so the dialog can flip to the success panel

## Not in this PR

- **Cancel button** (SIGTERM in-flight child) — split out; needs AbortController plumbed through the Spawner
- Runbook hint `cd <path> && bun run dev` on the success panel — minor follow-up
- Stage 10 LLM seeding is still a no-op stub (#123 activates it)

## Test plan

- [x] 718 vitest tests passing (31 in `NewProjectDialog.test.tsx` covering every view/button + store transitions)
- [x] Biome format + lint clean; `bun run typecheck` clean
- [ ] Playwright E2E spec (`e2e/new-project.spec.ts`) asserts menu → dialog open + invalid-name validation; runs in CI against the built app
- [ ] Manual smoke on macOS: menu entry opens dialog, Reveal hits Finder, Open in VS Code launches VS Code, Delete and start over wipes the target dir