### PR TITLE
feat(new-project): scratch-promotion path in New Project dialog

### DIFF
--- a/apps/desktop/src/main/ipc/file.ts
+++ b/apps/desktop/src/main/ipc/file.ts
@@ -133,6 +133,16 @@ export function registerFileIpc(mainWindow: BrowserWindow): void {
     return result.filePaths[0];
   });
 
+  ipcMain.handle('file:pick-contexture-file', async () => {
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: 'Choose Scratch IR File',
+      filters: [CONTEXTURE_OPEN_FILTER],
+      properties: ['openFile'],
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return result.filePaths[0];
+  });
+
   ipcMain.handle('file:save-as-dialog', async () => {
     const result = await dialog.showSaveDialog(mainWindow, {
       title: 'Save Contexture File As',

--- a/apps/desktop/src/main/ipc/scaffold.ts
+++ b/apps/desktop/src/main/ipc/scaffold.ts
@@ -7,9 +7,9 @@
  * Kept callback-shaped so tests can drive it without Electron;
  * `registerScaffoldIpc` binds it to `webContents.send`.
  */
+import { IRSchema } from '@renderer/model/ir';
 import type { BrowserWindow } from 'electron';
 import { ipcMain } from 'electron';
-
 import type { FsAdapter } from '../documents/document-store';
 import { nodeFsAdapter } from '../documents/node-fs-adapter';
 import { createCompositeStageRunner } from '../scaffold/composite-runner';
@@ -39,6 +39,23 @@ export async function handleScaffoldStart(
   deps: ScaffoldHandlerDeps,
 ): Promise<void> {
   const { fs, spawner, preflight, emit, writeLog } = deps;
+
+  // Validate the scratch IR before running any stages so we can surface
+  // the error inline in the dialog (same preflight-failed channel).
+  if (config.scratchPath) {
+    let raw: string;
+    try {
+      raw = await fs.readFile(config.scratchPath);
+    } catch {
+      emit({ kind: 'preflight-failed', error: { kind: 'scratch-unreadable' } });
+      return;
+    }
+    const parsed = IRSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) {
+      emit({ kind: 'preflight-failed', error: { kind: 'scratch-invalid-ir' } });
+      return;
+    }
+  }
 
   const preflightResult = await preflight(config);
   if (!preflightResult.ok) {

--- a/apps/desktop/src/main/scaffold/preflight.ts
+++ b/apps/desktop/src/main/scaffold/preflight.ts
@@ -29,7 +29,9 @@ export type PreflightError =
   | { kind: 'no-network' }
   | { kind: 'parent-not-writable'; path: string }
   | { kind: 'target-exists'; path: string }
-  | { kind: 'insufficient-space'; bytesFree: number };
+  | { kind: 'insufficient-space'; bytesFree: number }
+  | { kind: 'scratch-unreadable' }
+  | { kind: 'scratch-invalid-ir' };
 
 export type PreflightResult = { ok: true } | { ok: false; error: PreflightError };
 

--- a/apps/desktop/src/main/scaffold/scaffold-project.ts
+++ b/apps/desktop/src/main/scaffold/scaffold-project.ts
@@ -20,6 +20,8 @@ export interface ScaffoldConfig {
   apps: AppKind[];
   /** Initial user prompt seeded into chat.json when the project is created. */
   description?: string;
+  /** Absolute path to an existing scratch IR to promote instead of starting from an empty schema. */
+  scratchPath?: string;
 }
 
 /**

--- a/apps/desktop/src/main/scaffold/schema-package.ts
+++ b/apps/desktop/src/main/scaffold/schema-package.ts
@@ -11,7 +11,7 @@ import type { FsAdapter } from '@main/documents/document-store';
 import { emit as emitJsonSchema } from '@renderer/model/emit-json-schema';
 import { emit as emitSchemaIndex } from '@renderer/model/emit-schema-index';
 import { emit as emitZod } from '@renderer/model/emit-zod';
-import type { Schema } from '@renderer/model/ir';
+import { IRSchema, type Schema } from '@renderer/model/ir';
 
 import type { ScaffoldConfig } from './scaffold-project';
 
@@ -67,9 +67,16 @@ export async function scaffoldSchemaPackage(
   const gitignorePath = `${schemaDir}/.gitignore`;
   const ctxDir = `${schemaDir}/.contexture`;
 
-  await fs.writeFile(irPath, `${JSON.stringify(EMPTY_SCHEMA, null, 2)}\n`);
-  await fs.writeFile(schemaTsPath, emitZod(EMPTY_SCHEMA, irPath));
-  await fs.writeFile(schemaJsonPath, `${JSON.stringify(emitJsonSchema(EMPTY_SCHEMA), null, 2)}\n`);
+  // When promoting a scratch file, use its IR content instead of the empty schema.
+  let ir: Schema = EMPTY_SCHEMA;
+  if (config.scratchPath) {
+    const raw = await fs.readFile(config.scratchPath);
+    ir = IRSchema.parse(JSON.parse(raw));
+  }
+
+  await fs.writeFile(irPath, `${JSON.stringify(ir, null, 2)}\n`);
+  await fs.writeFile(schemaTsPath, emitZod(ir, irPath));
+  await fs.writeFile(schemaJsonPath, `${JSON.stringify(emitJsonSchema(ir), null, 2)}\n`);
   await fs.writeFile(indexPath, emitSchemaIndex(config.projectName));
   await fs.writeFile(pkgPath, makePackageJson(config.projectName));
   await fs.writeFile(gitignorePath, GITIGNORE);

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -103,6 +103,8 @@ export interface ContextureFileAPI {
   openDialog: () => Promise<OpenedDocument | null>;
   saveAsDialog: () => Promise<string | null>;
   pickDirectory: () => Promise<string | null>;
+  /** Pick a .contexture.json scratch file; returns the absolute path or null if cancelled. */
+  pickContextureFile: () => Promise<string | null>;
   save: (payload: {
     irPath: string;
     schema: unknown;
@@ -126,7 +128,9 @@ export type ScaffoldPreflightError =
   | { kind: 'no-network' }
   | { kind: 'parent-not-writable'; path: string }
   | { kind: 'target-exists'; path: string }
-  | { kind: 'insufficient-space'; bytesFree: number };
+  | { kind: 'insufficient-space'; bytesFree: number }
+  | { kind: 'scratch-unreadable' }
+  | { kind: 'scratch-invalid-ir' };
 
 export type ScaffoldEvent =
   | { kind: 'preflight-failed'; error: ScaffoldPreflightError }
@@ -145,6 +149,7 @@ export interface ContextureScaffoldAPI {
     projectName: string;
     apps: AppKind[];
     description?: string;
+    scratchPath?: string;
   }) => Promise<void>;
   onEvent: (listener: (event: ScaffoldEvent) => void) => Unsubscribe;
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -98,6 +98,9 @@ const file = {
   saveAsDialog: () => ipcRenderer.invoke('file:save-as-dialog') as Promise<string | null>,
   /** Show a directory picker; returns the selected folder or null if cancelled. */
   pickDirectory: () => ipcRenderer.invoke('file:pick-directory') as Promise<string | null>,
+  /** Show a file picker filtered to .contexture.json; returns path or null if cancelled. */
+  pickContextureFile: () =>
+    ipcRenderer.invoke('file:pick-contexture-file') as Promise<string | null>,
   /** Write the five-file bundle atomically under `irPath`. */
   save: (payload: {
     irPath: string;
@@ -131,6 +134,7 @@ const scaffold = {
     projectName: string;
     apps: string[];
     description?: string;
+    scratchPath?: string;
   }) => ipcRenderer.invoke('scaffold:start', config) as Promise<void>,
   /** Subscribe to preflight + stage events streamed from main. */
   onEvent: (listener: (event: unknown) => void) =>

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -15,8 +15,13 @@ import { deriveStages } from '@main/scaffold/scaffold-project';
 import { type PreflightError, preflightErrorCopy } from '@renderer/model/preflight-error-copy';
 import { labelForStage } from '@renderer/model/scaffold-stage-labels';
 import { validateProjectName } from '@renderer/model/validate-project-name';
-import { type AppKind, type StageStatus, useNewProjectStore } from '@renderer/store/new-project';
-import { Folder } from 'lucide-react';
+import {
+  type AppKind,
+  type StageStatus,
+  type StartingPoint,
+  useNewProjectStore,
+} from '@renderer/store/new-project';
+import { FileJson, Folder } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -38,6 +43,19 @@ const APP_OPTIONS: { kind: AppKind; label: string; description: string }[] = [
   { kind: 'desktop', label: 'Desktop', description: 'Electron Forge' },
 ];
 
+const STARTING_POINTS: { value: StartingPoint; label: string; description: string }[] = [
+  {
+    value: 'new',
+    label: 'Start fresh',
+    description: 'Begin with an empty schema and describe it in the chat.',
+  },
+  {
+    value: 'promote',
+    label: 'Promote scratch file',
+    description: 'Copy an existing .contexture.json into the new project as the initial schema.',
+  },
+];
+
 export interface NewProjectDialogProps {
   /** Called with the scaffolded IR path when the user dismisses the success panel. */
   onOpenProject?: (irPath: string) => void;
@@ -51,10 +69,16 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
   const parentDir = useNewProjectStore((s) => s.parentDir);
   const apps = useNewProjectStore((s) => s.apps);
   const description = useNewProjectStore((s) => s.description);
+  const startingPoint = useNewProjectStore((s) => s.startingPoint);
+  const scratchPath = useNewProjectStore((s) => s.scratchPath);
+  const scratchValidationError = useNewProjectStore((s) => s.scratchValidationError);
   const setName = useNewProjectStore((s) => s.setName);
   const setParentDir = useNewProjectStore((s) => s.setParentDir);
   const toggleApp = useNewProjectStore((s) => s.toggleApp);
   const setDescription = useNewProjectStore((s) => s.setDescription);
+  const setStartingPoint = useNewProjectStore((s) => s.setStartingPoint);
+  const setScratchPath = useNewProjectStore((s) => s.setScratchPath);
+  const setScratchValidationError = useNewProjectStore((s) => s.setScratchValidationError);
   const preflightError = useNewProjectStore((s) => s.preflightError);
   const setPreflightError = useNewProjectStore((s) => s.setPreflightError);
   const clearPreflightError = useNewProjectStore((s) => s.clearPreflightError);
@@ -65,7 +89,13 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
   const resetProgress = useNewProjectStore((s) => s.resetProgress);
 
   const nameValidation = name === '' ? { ok: true as const } : validateProjectName(name);
-  const canCreate = name !== '' && nameValidation.ok && parentDir !== '' && apps.length >= 1;
+  const isPromoting = startingPoint === 'promote';
+  const canCreate =
+    name !== '' &&
+    nameValidation.ok &&
+    parentDir !== '' &&
+    apps.length >= 1 &&
+    (!isPromoting || (scratchPath !== '' && scratchValidationError === null));
   const targetPath = parentDir && name ? `${parentDir}/${name}` : '';
 
   const onOpenProjectRef = useRef(onOpenProject);
@@ -114,6 +144,18 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
     if (picked) setParentDir(picked);
   }
 
+  async function handlePickScratch(): Promise<void> {
+    const picked = await window.contexture?.file.pickContextureFile();
+    if (!picked) return;
+    setScratchPath(picked);
+    setScratchValidationError(null);
+    // Basic filename heuristic — the real validation runs in handleScaffoldStart
+    // on the main side via IRSchema.parse; we just surface it early here.
+    if (!picked.endsWith('.contexture.json')) {
+      setScratchValidationError('File must end in .contexture.json');
+    }
+  }
+
   async function handleCreate(): Promise<void> {
     if (!targetPath) return;
     clearPreflightError();
@@ -122,7 +164,8 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
       targetDir: targetPath,
       projectName: name,
       apps,
-      description: description.trim() || undefined,
+      description: !isPromoting && description.trim() ? description.trim() : undefined,
+      scratchPath: isPromoting && scratchPath ? scratchPath : undefined,
     });
   }
 
@@ -197,7 +240,7 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
                 Convex is always included. Select at least one app layer.
               </p>
               <div className="space-y-2">
-                {APP_OPTIONS.map(({ kind, label, description }) => (
+                {APP_OPTIONS.map(({ kind, label, description: desc }) => (
                   <label
                     key={kind}
                     htmlFor={`app-${kind}`}
@@ -211,7 +254,7 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
                       className="mt-0.5"
                     />
                     <span>
-                      {label} <span className="text-xs text-muted-foreground">({description})</span>
+                      {label} <span className="text-xs text-muted-foreground">({desc})</span>
                     </span>
                   </label>
                 ))}
@@ -222,22 +265,68 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="new-project-description">
-                Initial prompt{' '}
-                <span className="text-xs font-normal text-muted-foreground">(optional)</span>
-              </Label>
-              <Textarea
-                id="new-project-description"
-                rows={3}
-                placeholder="A photo-sharing app where users post and like photos…"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">
-                Seeded into the chat when you open the project. Claude will build your schema from
-                this.
-              </p>
+              <Label>Starting point</Label>
+              <div className="space-y-2">
+                {STARTING_POINTS.map(({ value, label, description: desc }) => (
+                  <label
+                    key={value}
+                    htmlFor={`starting-point-${value}`}
+                    className="flex items-start gap-2 text-sm cursor-pointer"
+                  >
+                    <input
+                      type="radio"
+                      id={`starting-point-${value}`}
+                      name="starting-point"
+                      value={value}
+                      checked={startingPoint === value}
+                      onChange={() => setStartingPoint(value)}
+                      className="mt-0.5 accent-primary"
+                    />
+                    <span>
+                      {label} <span className="text-xs text-muted-foreground">— {desc}</span>
+                    </span>
+                  </label>
+                ))}
+              </div>
             </div>
+
+            {isPromoting ? (
+              <div className="space-y-2">
+                <Label>Scratch file</Label>
+                <div className="flex items-center gap-2">
+                  <Button variant="outline" onClick={() => void handlePickScratch()}>
+                    <FileJson className="size-4" />
+                    Choose .contexture.json…
+                  </Button>
+                  {scratchPath && (
+                    <span className="text-xs font-mono text-muted-foreground truncate">
+                      {scratchPath.split('/').pop()}
+                    </span>
+                  )}
+                </div>
+                {scratchValidationError && (
+                  <p className="text-xs text-destructive">{scratchValidationError}</p>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <Label htmlFor="new-project-description">
+                  Initial prompt{' '}
+                  <span className="text-xs font-normal text-muted-foreground">(optional)</span>
+                </Label>
+                <Textarea
+                  id="new-project-description"
+                  rows={3}
+                  placeholder="A photo-sharing app where users post and like photos…"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Seeded into the chat when you open the project. Claude will build your schema from
+                  this.
+                </p>
+              </div>
+            )}
 
             {preflightError && (
               <p className="text-sm text-destructive" role="alert">

--- a/apps/desktop/src/renderer/src/model/preflight-error-copy.ts
+++ b/apps/desktop/src/renderer/src/model/preflight-error-copy.ts
@@ -9,7 +9,9 @@ export type PreflightError =
   | { kind: 'no-network' }
   | { kind: 'parent-not-writable'; path: string }
   | { kind: 'target-exists'; path: string }
-  | { kind: 'insufficient-space'; bytesFree: number };
+  | { kind: 'insufficient-space'; bytesFree: number }
+  | { kind: 'scratch-unreadable' }
+  | { kind: 'scratch-invalid-ir' };
 
 export function preflightErrorCopy(error: PreflightError): string {
   switch (error.kind) {
@@ -29,5 +31,9 @@ export function preflightErrorCopy(error: PreflightError): string {
       const mb = Math.round(error.bytesFree / (1024 * 1024));
       return `Not enough free disk space (~${mb} MB available). Free up space or pick another drive.`;
     }
+    case 'scratch-unreadable':
+      return 'Could not read the selected scratch file. Check it exists and is readable.';
+    case 'scratch-invalid-ir':
+      return 'The selected file is not a valid Contexture IR. Choose a different .contexture.json.';
   }
 }

--- a/apps/desktop/src/renderer/src/store/new-project.ts
+++ b/apps/desktop/src/renderer/src/store/new-project.ts
@@ -15,6 +15,7 @@ import { create } from 'zustand';
 export type AppKind = 'web' | 'mobile' | 'desktop';
 export type NewProjectPhase = 'form' | 'running' | 'done' | 'failed';
 export type StageStatus = 'pending' | 'running' | 'done' | 'failed';
+export type StartingPoint = 'new' | 'promote';
 
 export interface ScaffoldFailure {
   stage: number;
@@ -30,6 +31,9 @@ interface NewProjectState {
   parentDir: string;
   apps: AppKind[];
   description: string;
+  startingPoint: StartingPoint;
+  scratchPath: string;
+  scratchValidationError: string | null;
   phase: NewProjectPhase;
   preflightError: PreflightError | null;
   failure: ScaffoldFailure | null;
@@ -41,6 +45,9 @@ interface NewProjectState {
   setParentDir: (path: string) => void;
   toggleApp: (app: AppKind) => void;
   setDescription: (desc: string) => void;
+  setStartingPoint: (sp: StartingPoint) => void;
+  setScratchPath: (path: string) => void;
+  setScratchValidationError: (err: string | null) => void;
   setPreflightError: (err: PreflightError) => void;
   clearPreflightError: () => void;
   setPhase: (phase: NewProjectPhase) => void;
@@ -55,6 +62,9 @@ const INITIAL = {
   parentDir: '',
   apps: ['web'] as AppKind[],
   description: '',
+  startingPoint: 'new' as StartingPoint,
+  scratchPath: '',
+  scratchValidationError: null as string | null,
   phase: 'form' as NewProjectPhase,
   preflightError: null as PreflightError | null,
   failure: null as ScaffoldFailure | null,
@@ -70,6 +80,9 @@ export const useNewProjectStore = create<NewProjectState>((set) => ({
   setName: (name) => set({ name }),
   setParentDir: (parentDir) => set({ parentDir }),
   setDescription: (description) => set({ description }),
+  setStartingPoint: (startingPoint) => set({ startingPoint }),
+  setScratchPath: (scratchPath) => set({ scratchPath }),
+  setScratchValidationError: (scratchValidationError) => set({ scratchValidationError }),
   toggleApp: (app) =>
     set((s) => ({
       apps: s.apps.includes(app) ? s.apps.filter((a) => a !== app) : [...s.apps, app],

--- a/apps/desktop/tests/main/scaffold-ipc.test.ts
+++ b/apps/desktop/tests/main/scaffold-ipc.test.ts
@@ -63,4 +63,37 @@ describe('handleScaffoldStart', () => {
     // No stages should have run.
     expect(events.some((e) => e.kind === 'stage-start')).toBe(false);
   });
+
+  it('emits scratch-unreadable preflight-failed when scratchPath does not exist', async () => {
+    const events: Array<{ kind: string; error?: unknown }> = [];
+    await handleScaffoldStart(
+      { ...config, scratchPath: '/nonexistent/scratch.contexture.json' },
+      {
+        fs,
+        spawner: passThroughSpawner(),
+        preflight: alwaysOkPreflight(),
+        emit: (ev) => events.push(ev),
+      },
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('preflight-failed');
+    expect((events[0].error as { kind: string }).kind).toBe('scratch-unreadable');
+  });
+
+  it('emits scratch-invalid-ir preflight-failed when scratchPath content is not valid IR', async () => {
+    fs.writeFile('/work/bad.contexture.json', JSON.stringify({ version: '1', types: 'oops' }));
+    const events: Array<{ kind: string; error?: unknown }> = [];
+    await handleScaffoldStart(
+      { ...config, scratchPath: '/work/bad.contexture.json' },
+      {
+        fs,
+        spawner: passThroughSpawner(),
+        preflight: alwaysOkPreflight(),
+        emit: (ev) => events.push(ev),
+      },
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('preflight-failed');
+    expect((events[0].error as { kind: string }).kind).toBe('scratch-invalid-ir');
+  });
 });

--- a/apps/desktop/tests/main/scaffold-schema-package.test.ts
+++ b/apps/desktop/tests/main/scaffold-schema-package.test.ts
@@ -82,4 +82,46 @@ describe('scaffoldSchemaPackage', () => {
     const chat = JSON.parse(await fs.readFile(`${schemaDir}/.contexture/chat.json`));
     expect(chat.messages[0].content).toBe('A blog platform');
   });
+
+  it('uses scratch IR content instead of empty schema when scratchPath is provided', async () => {
+    const scratchIr = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+          table: true,
+        },
+      ],
+    };
+    const seededFs = createMemFsAdapter({
+      '/scratch/post.contexture.json': `${JSON.stringify(scratchIr, null, 2)}\n`,
+    });
+    const withScratch = { ...config, scratchPath: '/scratch/post.contexture.json' };
+    await scaffoldSchemaPackage(withScratch, { fs: seededFs });
+
+    const irPath = `${schemaDir}/my-proj.contexture.json`;
+    const written = JSON.parse(await seededFs.readFile(irPath));
+    expect(written.types).toHaveLength(1);
+    expect(written.types[0].name).toBe('Post');
+  });
+
+  it('emits Zod and JSON mirrors from the promoted IR', async () => {
+    const scratchIr = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'User', fields: [{ name: 'email', type: { kind: 'string' } }] },
+      ],
+    };
+    const seededFs = createMemFsAdapter({
+      '/scratch/user.contexture.json': `${JSON.stringify(scratchIr, null, 2)}\n`,
+    });
+    const withScratch = { ...config, scratchPath: '/scratch/user.contexture.json' };
+    await scaffoldSchemaPackage(withScratch, { fs: seededFs });
+
+    const schemaTsPath = `${schemaDir}/my-proj.schema.ts`;
+    const schemaTs = await seededFs.readFile(schemaTsPath);
+    expect(schemaTs).toContain('User');
+  });
 });

--- a/apps/desktop/tests/model/preflight-error-copy.test.ts
+++ b/apps/desktop/tests/model/preflight-error-copy.test.ts
@@ -29,4 +29,10 @@ describe('preflightErrorCopy', () => {
     const msg = preflightErrorCopy({ kind: 'insufficient-space', bytesFree: 104857600 });
     expect(msg).toMatch(/100 MB/);
   });
+  it('returns a readable message for scratch-unreadable', () => {
+    expect(preflightErrorCopy({ kind: 'scratch-unreadable' })).toMatch(/scratch|read/i);
+  });
+  it('returns a readable message for scratch-invalid-ir', () => {
+    expect(preflightErrorCopy({ kind: 'scratch-invalid-ir' })).toMatch(/valid|Contexture/i);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #124.

- Enables the **Promote scratch file** starting-point radio in the New Project dialog — previously disabled with a `#124 hint`
- User picks a `.contexture.json` via a native file picker (new `file:pick-contexture-file` IPC), the file is validated via `IRSchema.parse` on the main side before any scaffold stages run
- On scaffold, the scratch IR content is copied as the initial IR instead of the empty default; all derived mirrors (Zod, JSON Schema, Convex schema, index.ts) re-emit from the promoted content
- When promoting, the description textarea is hidden (the IR is already populated, so no LLM seeding needed)
- Validation failures surface via the existing `preflight-failed` channel with two new error variants: `scratch-unreadable` and `scratch-invalid-ir`

## Files changed

- `new-project.ts` store: `startingPoint`, `scratchPath`, `scratchValidationError` state + actions
- `file.ts`: `file:pick-contexture-file` IPC handler
- `scaffold.ts`: scratch IR validation before preflight
- `schema-package.ts`: reads scratch IR when `scratchPath` is set
- `preflight.ts` + `preflight-error-copy.ts`: two new error variants
- `preload/index.ts` + `index.d.ts`: type surface for new APIs
- `NewProjectDialog.tsx`: starting-point radio group + conditional file picker / description sections

## Test plan

- [ ] Run `bun run test` — 729 tests pass
- [ ] Run `bun run typecheck` — clean
- [ ] Open New Project dialog → "Promote scratch file" radio enables file picker
- [ ] Pick a valid `.contexture.json` → Create becomes enabled
- [ ] Pick an invalid file → inline error shown, Create disabled
- [ ] Scaffold with promote → resulting project IR matches scratch content
- [ ] Scaffold with promote → `apps/web/convex/schema.ts` reflects promoted types