### PR TITLE
feat(drift): detect hand-edits to apps/web/convex/schema.ts in project mode

### DIFF
--- a/apps/desktop/src/main/documents/drift-watcher.ts
+++ b/apps/desktop/src/main/documents/drift-watcher.ts
@@ -1,0 +1,107 @@
+/**
+ * `createDriftWatcher` — watches a single file for hand-edits and
+ * compares its SHA-256 hash against the expected hash stored in
+ * `.contexture/emitted.json`. When the hashes differ the watcher
+ * calls `onDrift`; when they match again (because Contexture rewrote
+ * the file) it calls `onResolved`.
+ *
+ * Only `apps/web/convex/schema.ts` is watched — nothing else.
+ *
+ * Self-write suppression: the DocumentStore writes `emitted.json`
+ * before it writes the watched file in the atomic bundle; by the time
+ * the watcher fires the hashes already match, so Contexture's own
+ * writes are silently ignored.
+ */
+import { createHash } from 'node:crypto';
+import { type FSWatcher, promises as fsPromises, watch } from 'node:fs';
+
+export interface DriftWatcher {
+  start(): void;
+  stop(): void;
+  /** Force an immediate hash check (used by window-focus handler). */
+  check(): Promise<void>;
+}
+
+export interface DriftWatcherOptions {
+  /** Absolute path to the file being watched (e.g. `.../convex/schema.ts`). */
+  watchedPath: string;
+  /** Absolute path to `.contexture/emitted.json`. */
+  emittedJsonPath: string;
+  onDrift: () => void;
+  onResolved: () => void;
+  /** Debounce delay in ms (default 300). */
+  debounceMs?: number;
+  /** Injected file reader — defaults to `fs.promises.readFile`. Tests stub this. */
+  readFile?: (path: string) => Promise<string>;
+}
+
+export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
+  const {
+    watchedPath,
+    emittedJsonPath,
+    onDrift,
+    onResolved,
+    debounceMs = 300,
+    readFile = (p) => fsPromises.readFile(p, 'utf-8'),
+  } = opts;
+  let watcher: FSWatcher | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let drifted = false;
+
+  async function computeHash(path: string): Promise<string | null> {
+    try {
+      const content = await readFile(path);
+      return createHash('sha256').update(content, 'utf8').digest('hex');
+    } catch {
+      return null;
+    }
+  }
+
+  async function expectedHash(): Promise<string | null> {
+    try {
+      const raw = await readFile(emittedJsonPath);
+      const manifest = JSON.parse(raw) as { files?: Record<string, string> };
+      return manifest.files?.[watchedPath] ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function doCheck(): Promise<void> {
+    const [actual, expected] = await Promise.all([computeHash(watchedPath), expectedHash()]);
+    if (actual === null || expected === null) return;
+    const nowDrifted = actual !== expected;
+    if (nowDrifted && !drifted) {
+      drifted = true;
+      onDrift();
+    } else if (!nowDrifted && drifted) {
+      drifted = false;
+      onResolved();
+    }
+  }
+
+  function scheduleCheck(): void {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      void doCheck();
+    }, debounceMs);
+  }
+
+  return {
+    start() {
+      if (watcher) return;
+      watcher = watch(watchedPath, () => scheduleCheck());
+    },
+    stop() {
+      watcher?.close();
+      watcher = null;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      drifted = false;
+    },
+    check: doCheck,
+  };
+}

--- a/apps/desktop/src/main/documents/drift-watcher.ts
+++ b/apps/desktop/src/main/documents/drift-watcher.ts
@@ -20,6 +20,8 @@ export interface DriftWatcher {
   stop(): void;
   /** Force an immediate hash check (used by window-focus handler). */
   check(): Promise<void>;
+  /** Reset the drifted flag without stopping the watcher (used after dismiss). */
+  resetDrifted(): void;
 }
 
 export interface DriftWatcherOptions {
@@ -103,5 +105,8 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
       drifted = false;
     },
     check: doCheck,
+    resetDrifted() {
+      drifted = false;
+    },
   };
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ syncShellEnvironment();
 import { join } from 'node:path';
 import { electronApp, is, optimizer } from '@electron-toolkit/utils';
 import { registerClaudeIpc } from './ipc/claude';
+import { registerDriftIpc } from './ipc/drift';
 import { registerFileIpc } from './ipc/file';
 import { registerProjectIpc } from './ipc/project';
 import { registerScaffoldIpc } from './ipc/scaffold';
@@ -78,6 +79,7 @@ app.whenReady().then(() => {
   registerShellIpc();
   registerProjectIpc();
   registerClaudeIpc(mainWindow);
+  registerDriftIpc(mainWindow);
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/apps/desktop/src/main/ipc/drift.ts
+++ b/apps/desktop/src/main/ipc/drift.ts
@@ -1,0 +1,45 @@
+/**
+ * Drift IPC — registers the main-side watcher lifecycle and bridges
+ * drift/resolved events to the renderer via `webContents.send`.
+ *
+ * Called once at startup from `main/index.ts` alongside the other IPC
+ * registrations. The watcher is started/stopped in response to
+ * `drift:watch` / `drift:unwatch` IPC messages sent by the renderer
+ * when a project-mode document opens or closes.
+ *
+ * `drift:check` is a one-shot manual re-check (window focus trigger).
+ */
+import type { BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
+import { createDriftWatcher, type DriftWatcher } from '../documents/drift-watcher';
+
+let activeWatcher: DriftWatcher | null = null;
+
+export function registerDriftIpc(mainWindow: BrowserWindow): void {
+  ipcMain.handle(
+    'drift:watch',
+    (_evt, payload: { watchedPath: string; emittedJsonPath: string }) => {
+      activeWatcher?.stop();
+      activeWatcher = createDriftWatcher({
+        watchedPath: payload.watchedPath,
+        emittedJsonPath: payload.emittedJsonPath,
+        onDrift: () => mainWindow.webContents.send('drift:detected'),
+        onResolved: () => mainWindow.webContents.send('drift:resolved'),
+      });
+      activeWatcher.start();
+      return { ok: true };
+    },
+  );
+
+  ipcMain.handle('drift:unwatch', () => {
+    activeWatcher?.stop();
+    activeWatcher = null;
+    return { ok: true };
+  });
+
+  ipcMain.handle('drift:check', async () => {
+    if (!activeWatcher) return { ok: false };
+    await activeWatcher.check();
+    return { ok: true };
+  });
+}

--- a/apps/desktop/src/main/ipc/drift.ts
+++ b/apps/desktop/src/main/ipc/drift.ts
@@ -42,4 +42,9 @@ export function registerDriftIpc(mainWindow: BrowserWindow): void {
     await activeWatcher.check();
     return { ok: true };
   });
+
+  ipcMain.handle('drift:dismiss', () => {
+    activeWatcher?.resetDrifted();
+    return { ok: true };
+  });
 }

--- a/apps/desktop/src/main/scaffold/convex-emit.ts
+++ b/apps/desktop/src/main/scaffold/convex-emit.ts
@@ -11,6 +11,7 @@
  * tables; the subsequent save then seeds CRUD via the DocumentStore's
  * open-time seed loop.
  */
+import { createHash } from 'node:crypto';
 import type { FsAdapter } from '@main/documents/document-store';
 import { emitConvexSchema } from '@renderer/model/emit-convex';
 import type { Schema } from '@renderer/model/ir';
@@ -28,6 +29,16 @@ export async function scaffoldConvexEmit(
   const { fs } = deps;
   const schemaDir = `${config.targetDir}/packages/schema`;
   const irPath = `${schemaDir}/${config.projectName}.contexture.json`;
+  const convexPath = `${schemaDir}/convex/schema.ts`;
+  const emittedPath = `${schemaDir}/.contexture/emitted.json`;
+
   const ir = JSON.parse(await fs.readFile(irPath)) as Schema;
-  await fs.writeFile(`${schemaDir}/convex/schema.ts`, emitConvexSchema(ir));
+  const convexSource = emitConvexSchema(ir);
+  await fs.writeFile(convexPath, convexSource);
+
+  // Seed emitted.json with the hash of the file we just wrote so the
+  // drift watcher has a baseline to compare against on first open.
+  const hash = createHash('sha256').update(convexSource, 'utf8').digest('hex');
+  const manifest = { version: '1', files: { [convexPath]: hash } };
+  await fs.writeFile(emittedPath, `${JSON.stringify(manifest, null, 2)}\n`);
 }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -173,6 +173,8 @@ export interface ContextureDriftAPI {
   unwatch: () => Promise<{ ok: boolean }>;
   /** Trigger a manual hash check (window focus). */
   check: () => Promise<{ ok: boolean }>;
+  /** Reset the main-side drifted flag after user dismisses the banner. */
+  dismiss: () => Promise<{ ok: boolean }>;
   onDetected: (listener: () => void) => Unsubscribe;
   onResolved: (listener: () => void) => Unsubscribe;
 }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -166,12 +166,24 @@ export interface ContextureProjectAPI {
   deleteDirectory: (path: string) => Promise<void>;
 }
 
+export interface ContextureDriftAPI {
+  /** Start watching a file for drift against emitted.json. */
+  watch: (payload: { watchedPath: string; emittedJsonPath: string }) => Promise<{ ok: boolean }>;
+  /** Stop the active watcher. */
+  unwatch: () => Promise<{ ok: boolean }>;
+  /** Trigger a manual hash check (window focus). */
+  check: () => Promise<{ ok: boolean }>;
+  onDetected: (listener: () => void) => Unsubscribe;
+  onResolved: (listener: () => void) => Unsubscribe;
+}
+
 export interface ContextureAPI {
   chat: ContextureChatAPI;
   file: ContextureFileAPI;
   scaffold: ContextureScaffoldAPI;
   shell: ContextureShellAPI;
   project: ContextureProjectAPI;
+  drift: ContextureDriftAPI;
 }
 
 declare global {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -166,6 +166,9 @@ const drift = {
   /** Trigger a manual hash re-check (called on window focus). */
   check: (): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('drift:check') as Promise<{ ok: boolean }>,
+  /** Reset the main-side drifted flag after user dismisses the banner. */
+  dismiss: (): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('drift:dismiss') as Promise<{ ok: boolean }>,
   onDetected: (listener: () => void) =>
     subscribe('drift:detected', (() => listener()) as (p: unknown) => void),
   onResolved: (listener: () => void) =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -156,7 +156,23 @@ const project = {
     ipcRenderer.invoke('project:delete-directory', path) as Promise<void>,
 };
 
-const contexture = { chat, file, scaffold, shell, project };
+const drift = {
+  /** Start watching a file for drift; stops any previous watcher. */
+  watch: (payload: { watchedPath: string; emittedJsonPath: string }): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('drift:watch', payload) as Promise<{ ok: boolean }>,
+  /** Stop the active watcher. */
+  unwatch: (): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('drift:unwatch') as Promise<{ ok: boolean }>,
+  /** Trigger a manual hash re-check (called on window focus). */
+  check: (): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('drift:check') as Promise<{ ok: boolean }>,
+  onDetected: (listener: () => void) =>
+    subscribe('drift:detected', (() => listener()) as (p: unknown) => void),
+  onResolved: (listener: () => void) =>
+    subscribe('drift:resolved', (() => listener()) as (p: unknown) => void),
+};
+
+const contexture = { chat, file, scaffold, shell, project, drift };
 
 /**
  * Legacy surface. Sidecar reads/writes use the preload process's

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -33,6 +33,7 @@ import { NewProjectDialog } from './components/dialogs/NewProjectDialog';
 import { EvalPanel } from './components/eval/EvalPanel';
 import { GraphBackground } from './components/graph/GraphBackground';
 import { type CanvasPosition, GraphCanvas } from './components/graph/GraphCanvas';
+import { DriftBanner } from './components/hud/DriftBanner';
 import { SchemaPanel } from './components/schema/SchemaPanel';
 import { StatusBar } from './components/status-bar/StatusBar';
 import { GraphControlsPanel } from './components/toolbar/GraphControlsPanel';
@@ -48,6 +49,7 @@ import {
 } from './components/ui/empty';
 import { Popover, PopoverContent, PopoverTrigger } from './components/ui/popover';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './components/ui/resizable';
+import { useDrift } from './hooks/useDrift';
 import { useFileMenu } from './hooks/useFileMenu';
 import { useNewProject } from './hooks/useNewProject';
 import { useProjectAutoSave } from './hooks/useProjectAutoSave';
@@ -153,6 +155,7 @@ export default function App(): React.JSX.Element {
   const pendingAutoSendRef = useRef<string | null>(null);
 
   useNewProject();
+  useDrift();
 
   const fileMenu = useFileMenu({
     getLayout: () => ({ version: '1', positions: positionsRef.current }),
@@ -268,37 +271,40 @@ export default function App(): React.JSX.Element {
         id="main-layout"
       >
         <ResizablePanel id="graph-panel" defaultSize="70%" minSize="30%">
-          <div className="relative w-full h-full">
-            {hasSchema && (
-              <div className="absolute top-2 left-2 z-10">
-                <Popover open={showGraphControls} onOpenChange={setShowGraphControls}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="secondary"
-                      className="h-8 px-2 gap-1.5 shadow-sm"
-                      title="Graph controls"
-                    >
-                      <SlidersHorizontal className="size-4" />
-                      <ChevronDown className="size-3" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="p-0 w-72" align="start">
-                    <GraphControlsPanel onClose={() => setShowGraphControls(false)} />
-                  </PopoverContent>
-                </Popover>
-              </div>
-            )}
-            {hasSchema ? (
-              <GraphCanvas positions={positions} onPositionsChange={setPositions} />
-            ) : (
-              <EmptyState
-                onLoadSample={loadSample}
-                recentFiles={recentFiles}
-                onOpenRecent={fileMenu.handleOpenPath}
-                isNewProject={documentMode === 'project'}
-                projectName={filePath?.split('/').at(-1)?.replace('.contexture.json', '') ?? null}
-              />
-            )}
+          <div className="flex flex-col w-full h-full">
+            <DriftBanner />
+            <div className="relative flex-1 min-h-0">
+              {hasSchema && (
+                <div className="absolute top-2 left-2 z-10">
+                  <Popover open={showGraphControls} onOpenChange={setShowGraphControls}>
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant="secondary"
+                        className="h-8 px-2 gap-1.5 shadow-sm"
+                        title="Graph controls"
+                      >
+                        <SlidersHorizontal className="size-4" />
+                        <ChevronDown className="size-3" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="p-0 w-72" align="start">
+                      <GraphControlsPanel onClose={() => setShowGraphControls(false)} />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              )}
+              {hasSchema ? (
+                <GraphCanvas positions={positions} onPositionsChange={setPositions} />
+              ) : (
+                <EmptyState
+                  onLoadSample={loadSample}
+                  recentFiles={recentFiles}
+                  onOpenRecent={fileMenu.handleOpenPath}
+                  isNewProject={documentMode === 'project'}
+                  projectName={filePath?.split('/').at(-1)?.replace('.contexture.json', '') ?? null}
+                />
+              )}
+            </div>
           </div>
         </ResizablePanel>
 

--- a/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
@@ -1,0 +1,58 @@
+/**
+ * `DriftBanner` — non-blocking banner shown at the top of the graph
+ * view when `apps/web/convex/schema.ts` has been hand-edited outside
+ * Contexture (drift detected by the main-process watcher).
+ *
+ * "Review changes" is disabled in this slice (reconcile modal lands in
+ * #126). "Dismiss" hides the banner until the next drift event.
+ */
+import { AlertTriangle } from 'lucide-react';
+import { useDriftStore } from '../../store/drift';
+import { Button } from '../ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+
+export function DriftBanner(): React.JSX.Element | null {
+  const isDrifted = useDriftStore((s) => s.isDrifted);
+  const dismiss = useDriftStore((s) => s.dismiss);
+
+  if (!isDrifted) return null;
+
+  return (
+    <div
+      role="alert"
+      data-testid="drift-banner"
+      className="flex items-center gap-2 px-3 py-2 bg-amber-50 dark:bg-amber-950/40 border-b border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200 text-xs"
+    >
+      <AlertTriangle className="size-3.5 shrink-0" />
+      <span className="flex-1">
+        <code className="font-mono">apps/web/convex/schema.ts</code> was modified outside
+        Contexture.
+      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span tabIndex={-1}>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-6 px-2 text-xs"
+              disabled
+              aria-label="Review changes (coming soon)"
+            >
+              Review changes
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>Reconcile modal coming in the next release.</TooltipContent>
+      </Tooltip>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 px-2 text-xs"
+        onClick={dismiss}
+        aria-label="Dismiss drift banner"
+      >
+        Dismiss
+      </Button>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
@@ -9,7 +9,7 @@
 import { AlertTriangle } from 'lucide-react';
 import { useDriftStore } from '../../store/drift';
 import { Button } from '../ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 
 export function DriftBanner(): React.JSX.Element | null {
   const isDrifted = useDriftStore((s) => s.isDrifted);
@@ -28,22 +28,24 @@ export function DriftBanner(): React.JSX.Element | null {
         <code className="font-mono">apps/web/convex/schema.ts</code> was modified outside
         Contexture.
       </span>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span tabIndex={-1}>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-6 px-2 text-xs"
-              disabled
-              aria-label="Review changes (coming soon)"
-            >
-              Review changes
-            </Button>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>Reconcile modal coming in the next release.</TooltipContent>
-      </Tooltip>
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span tabIndex={-1}>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                disabled
+                aria-label="Review changes (coming soon)"
+              >
+                Review changes
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>Reconcile modal coming in the next release.</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
       <Button
         variant="ghost"
         size="sm"

--- a/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
@@ -25,7 +25,7 @@ export function DriftBanner(): React.JSX.Element | null {
     >
       <AlertTriangle className="size-3.5 shrink-0" />
       <span className="flex-1">
-        <code className="font-mono">apps/web/convex/schema.ts</code> was modified outside
+        <code className="font-mono">packages/schema/convex/schema.ts</code> was modified outside
         Contexture.
       </span>
       <TooltipProvider delayDuration={300}>

--- a/apps/desktop/src/renderer/src/hooks/useDrift.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDrift.ts
@@ -9,10 +9,29 @@
  *
  * Renders nothing — call once from App.tsx.
  */
-import { bundlePathsFor, projectRootFor } from '@main/documents/document-store';
 import { useEffect } from 'react';
 import { useDocumentStore } from '../store/document';
 import { useDriftStore } from '../store/drift';
+
+const IR_SUFFIX = '.contexture.json';
+const PACKAGES_SCHEMA_SUFFIX = '/packages/schema/';
+
+/** Returns the monorepo root for a canonical scaffold IR path, or null. */
+function projectRootFor(irPath: string): string | null {
+  if (!irPath.endsWith(IR_SUFFIX)) return null;
+  const slash = irPath.lastIndexOf('/');
+  if (slash === -1) return null;
+  const dir = irPath.slice(0, slash);
+  if (!dir.endsWith('/packages/schema')) return null;
+  return dir.slice(0, -PACKAGES_SCHEMA_SUFFIX.length + 1);
+}
+
+/** Returns the emitted.json path for a given IR path. */
+function emittedJsonPathFor(irPath: string): string {
+  const slash = irPath.lastIndexOf('/');
+  const dir = slash === -1 ? '' : irPath.slice(0, slash);
+  return `${dir}/.contexture/emitted.json`;
+}
 
 export function useDrift(): void {
   const filePath = useDocumentStore((s) => s.filePath);
@@ -34,9 +53,8 @@ export function useDrift(): void {
       return;
     }
 
-    const paths = bundlePathsFor(filePath);
     const watchedPath = `${root}/apps/web/convex/schema.ts`;
-    const emittedJsonPath = paths.emitted;
+    const emittedJsonPath = emittedJsonPathFor(filePath);
 
     void driftApi.watch({ watchedPath, emittedJsonPath });
 

--- a/apps/desktop/src/renderer/src/hooks/useDrift.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDrift.ts
@@ -14,23 +14,30 @@ import { useDocumentStore } from '../store/document';
 import { useDriftStore } from '../store/drift';
 
 const IR_SUFFIX = '.contexture.json';
-const PACKAGES_SCHEMA_SUFFIX = '/packages/schema/';
 
-/** Returns the monorepo root for a canonical scaffold IR path, or null. */
-function projectRootFor(irPath: string): string | null {
+/**
+ * Derives drift-related paths from the IR file path.
+ *
+ * IR lives at: <root>/packages/schema/<name>.contexture.json
+ * Convex schema: <root>/packages/schema/convex/schema.ts
+ *   → same dir as the IR, subdir convex/
+ * Emitted manifest: <root>/packages/schema/.contexture/emitted.json
+ *   → same dir as the IR, subdir .contexture/
+ *
+ * Both use the same base dir, so we never need to compute the monorepo
+ * root — just strip the IR filename and append the relative paths.
+ * This guarantees watchedPath matches the key written into emitted.json
+ * by document-store (which also derives paths from the same IR path).
+ */
+function driftPathsFor(irPath: string): { watchedPath: string; emittedJsonPath: string } | null {
   if (!irPath.endsWith(IR_SUFFIX)) return null;
   const slash = irPath.lastIndexOf('/');
   if (slash === -1) return null;
-  const dir = irPath.slice(0, slash);
-  if (!dir.endsWith('/packages/schema')) return null;
-  return dir.slice(0, -PACKAGES_SCHEMA_SUFFIX.length + 1);
-}
-
-/** Returns the emitted.json path for a given IR path. */
-function emittedJsonPathFor(irPath: string): string {
-  const slash = irPath.lastIndexOf('/');
-  const dir = slash === -1 ? '' : irPath.slice(0, slash);
-  return `${dir}/.contexture/emitted.json`;
+  const dir = irPath.slice(0, slash); // e.g. /proj/packages/schema
+  return {
+    watchedPath: `${dir}/convex/schema.ts`,
+    emittedJsonPath: `${dir}/.contexture/emitted.json`,
+  };
 }
 
 export function useDrift(): void {
@@ -47,14 +54,13 @@ export function useDrift(): void {
       return;
     }
 
-    const root = projectRootFor(filePath);
-    if (!root) {
+    const paths = driftPathsFor(filePath);
+    if (!paths) {
       void driftApi.unwatch();
       return;
     }
 
-    const watchedPath = `${root}/packages/schema/convex/schema.ts`;
-    const emittedJsonPath = emittedJsonPathFor(filePath);
+    const { watchedPath, emittedJsonPath } = paths;
 
     void driftApi.watch({ watchedPath, emittedJsonPath });
 

--- a/apps/desktop/src/renderer/src/hooks/useDrift.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDrift.ts
@@ -1,0 +1,58 @@
+/**
+ * `useDrift` — mounts and tears down the drift watcher for the current
+ * project-mode document.
+ *
+ * When a project-mode document is open, starts watching
+ * `apps/web/convex/schema.ts` against `.contexture/emitted.json`.
+ * Also triggers a manual re-check on window focus so edits made while
+ * Contexture was in the background are caught immediately on return.
+ *
+ * Renders nothing — call once from App.tsx.
+ */
+import { bundlePathsFor, projectRootFor } from '@main/documents/document-store';
+import { useEffect } from 'react';
+import { useDocumentStore } from '../store/document';
+import { useDriftStore } from '../store/drift';
+
+export function useDrift(): void {
+  const filePath = useDocumentStore((s) => s.filePath);
+  const mode = useDocumentStore((s) => s.mode);
+
+  useEffect(() => {
+    const driftApi = window.contexture?.drift;
+    if (!driftApi) return;
+
+    if (mode !== 'project' || !filePath) {
+      void driftApi.unwatch();
+      useDriftStore.getState().setResolved();
+      return;
+    }
+
+    const root = projectRootFor(filePath);
+    if (!root) {
+      void driftApi.unwatch();
+      return;
+    }
+
+    const paths = bundlePathsFor(filePath);
+    const watchedPath = `${root}/apps/web/convex/schema.ts`;
+    const emittedJsonPath = paths.emitted;
+
+    void driftApi.watch({ watchedPath, emittedJsonPath });
+
+    const unDetected = driftApi.onDetected(() => useDriftStore.getState().setDrifted());
+    const unResolved = driftApi.onResolved(() => useDriftStore.getState().setResolved());
+
+    function onFocus(): void {
+      void driftApi?.check();
+    }
+    window.addEventListener('focus', onFocus);
+
+    return () => {
+      void driftApi.unwatch();
+      unDetected();
+      unResolved();
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [filePath, mode]);
+}

--- a/apps/desktop/src/renderer/src/hooks/useDrift.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDrift.ts
@@ -53,7 +53,7 @@ export function useDrift(): void {
       return;
     }
 
-    const watchedPath = `${root}/apps/web/convex/schema.ts`;
+    const watchedPath = `${root}/packages/schema/convex/schema.ts`;
     const emittedJsonPath = emittedJsonPathFor(filePath);
 
     void driftApi.watch({ watchedPath, emittedJsonPath });

--- a/apps/desktop/src/renderer/src/store/drift.ts
+++ b/apps/desktop/src/renderer/src/store/drift.ts
@@ -1,0 +1,21 @@
+/**
+ * `useDriftStore` — tracks whether the Convex schema file has been
+ * hand-edited outside Contexture. Set by drift IPC events from the
+ * main process; cleared by user dismissal or when Contexture re-writes
+ * the file (bringing hashes back into agreement).
+ */
+import { create } from 'zustand';
+
+interface DriftState {
+  isDrifted: boolean;
+  setDrifted: () => void;
+  setResolved: () => void;
+  dismiss: () => void;
+}
+
+export const useDriftStore = create<DriftState>((set) => ({
+  isDrifted: false,
+  setDrifted: () => set({ isDrifted: true }),
+  setResolved: () => set({ isDrifted: false }),
+  dismiss: () => set({ isDrifted: false }),
+}));

--- a/apps/desktop/src/renderer/src/store/drift.ts
+++ b/apps/desktop/src/renderer/src/store/drift.ts
@@ -17,5 +17,8 @@ export const useDriftStore = create<DriftState>((set) => ({
   isDrifted: false,
   setDrifted: () => set({ isDrifted: true }),
   setResolved: () => set({ isDrifted: false }),
-  dismiss: () => set({ isDrifted: false }),
+  dismiss: () => {
+    set({ isDrifted: false });
+    void window.contexture?.drift.dismiss();
+  },
 }));

--- a/apps/desktop/tests/main/drift-watcher.test.ts
+++ b/apps/desktop/tests/main/drift-watcher.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `createDriftWatcher` — unit tests using injected `readFile` so we
+ * don't need to mock node:fs modules. The watcher is exercised via
+ * `check()` which runs the same logic as the debounced fs.watch handler.
+ */
+import { createHash } from 'node:crypto';
+import { createDriftWatcher } from '@main/documents/drift-watcher';
+import { describe, expect, it, vi } from 'vitest';
+
+const WATCHED = '/proj/apps/web/convex/schema.ts';
+const EMITTED = '/proj/packages/schema/.contexture/emitted.json';
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function makeManifest(hash: string): string {
+  return JSON.stringify({ version: '1', files: { [WATCHED]: hash } }, null, 2);
+}
+
+function makeWatcher(
+  files: Record<string, string>,
+  {
+    onDrift = vi.fn(),
+    onResolved = vi.fn(),
+  }: { onDrift?: ReturnType<typeof vi.fn>; onResolved?: ReturnType<typeof vi.fn> } = {},
+) {
+  const readFile = async (path: string): Promise<string> => {
+    if (path in files) return files[path];
+    throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
+  };
+  const watcher = createDriftWatcher({
+    watchedPath: WATCHED,
+    emittedJsonPath: EMITTED,
+    onDrift,
+    onResolved,
+    readFile,
+  });
+  return { watcher, onDrift, onResolved };
+}
+
+describe('createDriftWatcher', () => {
+  it('calls onDrift when file hash differs from emitted manifest', async () => {
+    const original = 'defineSchema({})';
+    const edited = 'defineSchema({ posts: defineTable({}) })';
+    const { watcher, onDrift, onResolved } = makeWatcher({
+      [WATCHED]: edited,
+      [EMITTED]: makeManifest(sha256(original)),
+    });
+
+    await watcher.check();
+
+    expect(onDrift).toHaveBeenCalledOnce();
+    expect(onResolved).not.toHaveBeenCalled();
+  });
+
+  it('calls onResolved when hashes match after being drifted', async () => {
+    const content = 'defineSchema({})';
+    const hash = sha256(content);
+
+    let currentWatched = 'editedContent';
+    const readFile = async (path: string): Promise<string> => {
+      if (path === WATCHED) return currentWatched;
+      if (path === EMITTED) return makeManifest(hash);
+      throw new Error('unexpected');
+    };
+    const onDrift = vi.fn();
+    const onResolved = vi.fn();
+    const watcher = createDriftWatcher({
+      watchedPath: WATCHED,
+      emittedJsonPath: EMITTED,
+      onDrift,
+      onResolved,
+      readFile,
+    });
+
+    await watcher.check();
+    expect(onDrift).toHaveBeenCalledOnce();
+
+    currentWatched = content;
+    await watcher.check();
+    expect(onResolved).toHaveBeenCalledOnce();
+  });
+
+  it('does not call onDrift when hashes match (self-write suppression)', async () => {
+    const content = 'defineSchema({})';
+    const hash = sha256(content);
+    const { watcher, onDrift, onResolved } = makeWatcher({
+      [WATCHED]: content,
+      [EMITTED]: makeManifest(hash),
+    });
+
+    await watcher.check();
+
+    expect(onDrift).not.toHaveBeenCalled();
+    expect(onResolved).not.toHaveBeenCalled();
+  });
+
+  it('does not call onDrift when the watched file cannot be read', async () => {
+    const { watcher, onDrift } = makeWatcher({
+      [EMITTED]: makeManifest('somehash'),
+      // WATCHED is absent → ENOENT
+    });
+
+    await watcher.check();
+    expect(onDrift).not.toHaveBeenCalled();
+  });
+
+  it('does not call onDrift when the emitted manifest cannot be read', async () => {
+    const { watcher, onDrift } = makeWatcher({
+      [WATCHED]: 'defineSchema({})',
+      // EMITTED is absent → ENOENT
+    });
+
+    await watcher.check();
+    expect(onDrift).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onDrift twice for repeated drifted checks', async () => {
+    const original = 'defineSchema({})';
+    const edited = 'defineSchema({ posts: defineTable({}) })';
+    const { watcher, onDrift } = makeWatcher({
+      [WATCHED]: edited,
+      [EMITTED]: makeManifest(sha256(original)),
+    });
+
+    await watcher.check();
+    await watcher.check();
+
+    // onDrift fires once — second check keeps the same drifted state.
+    expect(onDrift).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #125.

Watches `apps/web/convex/schema.ts` in project mode for hand-edits made outside Contexture and surfaces a non-blocking amber banner when drift is detected. Two detection mechanisms run in parallel: `fs.watch` (debounced 300ms) and a window-focus re-check. Self-write suppression is automatic — the DocumentStore already writes `emitted.json` before the watched file in every bundle write, so Contexture's own saves are silently ignored.

## Files

- **`drift-watcher.ts`** — pure watcher with injected `readFile` for testability; 300ms debounce + SHA-256 comparison against `emitted.json`
- **`ipc/drift.ts`** — `drift:watch` / `drift:unwatch` / `drift:check` handlers; emits `drift:detected` / `drift:resolved` to renderer
- **`preload/index.ts` + `index.d.ts`** — `ContextureDriftAPI` surface
- **`store/drift.ts`** — `useDriftStore` with `isDrifted`, `setDrifted`, `setResolved`, `dismiss`
- **`hooks/useDrift.ts`** — mounts/tears down watcher on project open/close; window-focus listener
- **`components/hud/DriftBanner.tsx`** — amber banner with "Review changes" (disabled, #126 placeholder) + "Dismiss"
- **`App.tsx`** — mounts `useDrift()` and renders `<DriftBanner />` above the canvas

## Test plan

- [ ] 735 tests pass (`bun run test`)
- [ ] `bun run typecheck` — clean
- [ ] Open project → hand-edit `apps/web/convex/schema.ts` → amber banner appears within 300ms
- [ ] Save from Contexture → banner disappears (self-write suppression)
- [ ] Dismiss banner → banner hidden until next drift event
- [ ] Switch away from Contexture, edit file, switch back → banner appears on window focus