### PR TITLE
fix: update Next.js references from 15 to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Requires `ANTHROPIC_API_KEY` and `GH_TOKEN` environment variables — see
 
 - **Monorepo**: Turborepo, Bun workspaces
 - **Desktop**: Electron 35, React 19, TypeScript, Vite, Zustand, React Flow, Claude Agent SDK, Zod
-- **Web**: Next.js 15, React 19, TypeScript, Tailwind CSS 4, shadcn/ui
+- **Web**: Next.js 16, React 19, TypeScript, Tailwind CSS 4, shadcn/ui
 - **AI Night Shift**: Sandcastle, Claude Code, Docker
 
 ## License

--- a/apps/desktop/tests/main/scaffold-workspace-stitch.test.ts
+++ b/apps/desktop/tests/main/scaffold-workspace-stitch.test.ts
@@ -26,12 +26,12 @@ describe('scaffoldWorkspaceStitch', () => {
   it('adds @<project>/schema: workspace:* to apps/web/package.json dependencies when web selected', async () => {
     await fs.writeFile(
       webPkgPath,
-      `${JSON.stringify({ name: 'web', dependencies: { next: '^15.0.0' } }, null, 2)}\n`,
+      `${JSON.stringify({ name: 'web', dependencies: { next: '^16.0.0' } }, null, 2)}\n`,
     );
     await scaffoldWorkspaceStitch(webConfig, { fs });
     const pkg = JSON.parse(await fs.readFile(webPkgPath));
     expect(pkg.dependencies['@my-proj/schema']).toBe('workspace:*');
-    expect(pkg.dependencies.next).toBe('^15.0.0');
+    expect(pkg.dependencies.next).toBe('^16.0.0');
     expect(pkg.name).toBe('web');
   });
 
@@ -75,7 +75,7 @@ describe('scaffoldWorkspaceStitch', () => {
   it('is idempotent — running twice leaves the web package.json unchanged', async () => {
     await fs.writeFile(
       webPkgPath,
-      `${JSON.stringify({ name: 'web', dependencies: { next: '^15.0.0' } }, null, 2)}\n`,
+      `${JSON.stringify({ name: 'web', dependencies: { next: '^16.0.0' } }, null, 2)}\n`,
     );
     await scaffoldWorkspaceStitch(webConfig, { fs });
     const first = await fs.readFile(webPkgPath);

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -6,7 +6,7 @@ The Contexture marketing website built with Next.js.
 
 | Layer | Technology |
 |-------|-----------|
-| Framework | Next.js 15 (Turbopack) |
+| Framework | Next.js 16 (Turbopack) |
 | UI | React 19, TypeScript |
 | Styling | Tailwind CSS 4, shadcn/ui |
 | Fonts | Geist |


### PR DESCRIPTION
## Summary
- Updated all documentation references from Next.js 15 to Next.js 16 to match the actual dependency (`next: ^16.2.1`)
- Updated root `README.md` Tech Stack section
- Updated `apps/web/README.md` framework table
- Updated test fixtures in `scaffold-workspace-stitch.test.ts` to use `^16.0.0`

Closes #141

## Test plan
- [x] `bun run format:check` passes
- [x] `bun run lint` passes
- [x] All 759 tests pass (736 desktop + 24 web, 1 skipped)
- [x] TypeScript type checks pass across all 4 packages