### PR TITLE
feat(sandcastle): validate planner <plan> output with Zod at parse boundary

### DIFF
--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -2,6 +2,8 @@ import { mkdirSync, appendFileSync } from "node:fs";
 import * as sandcastle from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 import type { AgentStreamEvent, LoggingOption } from "@ai-hero/sandcastle";
+import { parsePlan } from "./plan";
+import type { Issue } from "./plan";
 
 const MAX_ITERATIONS = 10;
 const MAX_PARALLEL = 4;
@@ -47,8 +49,6 @@ function streamLogger(name: string): LoggingOption {
     },
   };
 }
-
-type Issue = { number: number; title: string; branch: string; labels: string[] };
 
 const isDocsOnly = (issue: Issue) =>
   issue.labels.includes("documentation") &&
@@ -163,12 +163,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
 
   await Bun.write(`.sandcastle/logs/plans/plan-${iteration}.md`, plan.stdout);
 
-  const planMatch = plan.stdout.match(/<plan>([\s\S]*?)<\/plan>/);
-  if (!planMatch) {
-    throw new Error("Orchestrator did not produce a <plan> tag.\n\n" + plan.stdout);
-  }
-
-  const { issues } = JSON.parse(planMatch[1]!) as { issues: Issue[] };
+  const { issues } = parsePlan(plan.stdout);
 
   if (issues.length === 0) {
     console.log("No issues to work on. Exiting.");

--- a/.sandcastle/plan.test.ts
+++ b/.sandcastle/plan.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { parsePlan } from "./plan";
+
+const wrap = (json: string) => `prelude\n<plan>${json}</plan>\nepilogue`;
+
+const validIssue = {
+  number: 42,
+  title: "Fix auth bug",
+  branch: "sandcastle/issue-42-fix-auth-bug",
+  labels: ["bug", "Sandcastle"],
+};
+
+describe("parsePlan", () => {
+  test("accepts a well-formed plan", () => {
+    const plan = parsePlan(wrap(JSON.stringify({ issues: [validIssue] })));
+    expect(plan.issues).toHaveLength(1);
+    expect(plan.issues[0]?.number).toBe(42);
+  });
+
+  test("rejects a path-traversal branch", () => {
+    const bad = { ...validIssue, branch: "../../etc/passwd" };
+    expect(() => parsePlan(wrap(JSON.stringify({ issues: [bad] })))).toThrow();
+  });
+
+  test("rejects a branch missing the sandcastle/issue-N- prefix", () => {
+    const bad = { ...validIssue, branch: "feat/foo" };
+    expect(() => parsePlan(wrap(JSON.stringify({ issues: [bad] })))).toThrow();
+  });
+
+  test("rejects a branch over 200 characters", () => {
+    const longSlug = "a".repeat(250);
+    const bad = { ...validIssue, branch: `sandcastle/issue-42-${longSlug}` };
+    expect(() => parsePlan(wrap(JSON.stringify({ issues: [bad] })))).toThrow();
+  });
+
+  test("rejects issue number zero", () => {
+    const bad = { ...validIssue, number: 0 };
+    expect(() => parsePlan(wrap(JSON.stringify({ issues: [bad] })))).toThrow();
+  });
+
+  test("rejects negative issue number", () => {
+    const bad = { ...validIssue, number: -1 };
+    expect(() => parsePlan(wrap(JSON.stringify({ issues: [bad] })))).toThrow();
+  });
+
+  test("rejects non-integer issue number", () => {
+    const bad = { ...validIssue, number: 1.5 };
+    expect(() => parsePlan(wrap(JSON.stringify({ issues: [bad] })))).toThrow();
+  });
+
+  test("rejects an empty title", () => {
+    const bad = { ...validIssue, title: "" };
+    expect(() => parsePlan(wrap(JSON.stringify({ issues: [bad] })))).toThrow();
+  });
+
+  test("rejects a missing field", () => {
+    const { branch, ...incomplete } = validIssue;
+    void branch;
+    expect(() => parsePlan(wrap(JSON.stringify({ issues: [incomplete] })))).toThrow();
+  });
+
+  test("rejects malformed JSON inside <plan>", () => {
+    expect(() => parsePlan("<plan>{not json}</plan>")).toThrow();
+  });
+
+  test("rejects output with no <plan> tag", () => {
+    expect(() => parsePlan("nothing here")).toThrow(/did not produce a <plan> tag/);
+  });
+
+  test("accepts an empty issues array", () => {
+    const plan = parsePlan(wrap(JSON.stringify({ issues: [] })));
+    expect(plan.issues).toEqual([]);
+  });
+
+  test("accepts a branch with allowed slug characters (`.`, `_`, `-`, digits)", () => {
+    const ok = { ...validIssue, branch: "sandcastle/issue-7-foo.bar_baz-9" };
+    const plan = parsePlan(wrap(JSON.stringify({ issues: [ok] })));
+    expect(plan.issues[0]?.branch).toBe("sandcastle/issue-7-foo.bar_baz-9");
+  });
+});

--- a/.sandcastle/plan.ts
+++ b/.sandcastle/plan.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+// Branch names emitted by the planner agent must match this format. The agent
+// is instructed in plan-prompt.md to produce `sandcastle/issue-{number}-{slug}`
+// where slug is lowercase alphanumeric with `.`, `_`, `-` separators.
+const BRANCH_REGEX = /^sandcastle\/issue-\d+-[a-z0-9._-]+$/;
+
+export const Issue = z.object({
+  number: z.number().int().positive(),
+  title: z.string().min(1),
+  branch: z.string().regex(BRANCH_REGEX).max(200),
+  labels: z.array(z.string()),
+});
+export type Issue = z.infer<typeof Issue>;
+
+export const Plan = z.object({
+  issues: z.array(Issue),
+});
+export type Plan = z.infer<typeof Plan>;
+
+// Extract and validate the agent's <plan>{...}</plan> output. Throws if the
+// tag is missing, the JSON is malformed, or the shape fails validation.
+export function parsePlan(stdout: string): Plan {
+  const match = stdout.match(/<plan>([\s\S]*?)<\/plan>/);
+  if (!match) {
+    throw new Error("Orchestrator did not produce a <plan> tag.\n\n" + stdout);
+  }
+  return Plan.parse(JSON.parse(match[1] as string));
+}

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "ontograph",
       "dependencies": {
         "@ai-hero/sandcastle": "^0.5.5",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.9",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "turbo": "^2.5.4"
   },
   "dependencies": {
-    "@ai-hero/sandcastle": "^0.5.5"
+    "@ai-hero/sandcastle": "^0.5.5",
+    "zod": "^4.3.6"
   },
   "trustedDependencies": [
     "electron",


### PR DESCRIPTION
## Summary

- Adds `.sandcastle/plan.ts` with a Zod-validated `parsePlan()` helper that rejects malformed planner output before it reaches sandbox creation. Branch names must match `sandcastle/issue-{number}-{slug}` and cap at 200 chars; issue numbers must be positive integers.
- `main.ts` delegates to `parsePlan()` and imports the inferred `Issue` type.
- 13 unit tests covering path-traversal branches, oversized branches, zero/negative/non-integer issue numbers, missing fields, malformed JSON, and the missing-tag case.
- Adds `zod@^4.3.6` as a root dep (already used in workspaces).

This is PR 1 of 5 from the sandcastle harness roadmap (post-grilling). It establishes the parse-boundary principle that B.1 will reuse for `gh`-fetched data.

## Test plan

- [x] `bun test ./.sandcastle/plan.test.ts` — 13/13 pass
- [x] `bun run typecheck` — workspaces clean
- [x] `bun run check` — biome clean
- [x] Pre-commit hook (turbo test, 735 tests) — green