### PR TITLE
refactor(sandcastle): centralise harness config in workflow.ts

### DIFF
--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -4,15 +4,16 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 import type { AgentStreamEvent, LoggingOption } from "@ai-hero/sandcastle";
 import { parsePlan } from "./plan";
 import type { Issue } from "./plan";
-
-const MAX_ITERATIONS = 10;
-const MAX_PARALLEL = 4;
-
-// Skip host->worktree copy: this monorepo's node_modules is ~3.5GB and
-// blows past sandcastle's hard-coded 60s copy timeout. The implementer
-// sandbox runs `bun install` inside the container instead.
-// Env files are gitignored, so copy them in explicitly.
-const copyToWorktree: string[] = ["apps/desktop/.env", "apps/web/.env.local"];
+import {
+  AGENTS,
+  BRANCH_FORMAT,
+  COPY_TO_WORKTREE,
+  INSTALL_AND_VERIFY,
+  LABEL,
+  MAX_ITERATIONS,
+  MAX_PARALLEL,
+} from "./workflow";
+import type { AgentSpec } from "./workflow";
 
 // Each sandbox gets its own bun cache. Sharing ~/.bun/install/cache across
 // parallel sandboxes races on tarball extraction and silently produces broken
@@ -20,14 +21,16 @@ const copyToWorktree: string[] = ["apps/desktop/.env", "apps/web/.env.local"];
 // was never written). Cold installs are slower; broken node_modules are worse.
 const sandboxProvider = docker({});
 
-// Verify the install actually produced a usable workspace. `bun install` exits
-// 0 even when individual extractions are mangled, so we follow with `turbo
-// typecheck`, which resolves and loads imports across every workspace and
-// fails loudly if a package's main entry is missing.
-const installAndVerify = "bun install && bun run typecheck";
-
 mkdirSync(".sandcastle/logs/plans", { recursive: true });
 const STREAM_LOG_PATH = ".sandcastle/logs/stream.log";
+
+// Build a `claudeCode` agent invocation from an AgentSpec, threading the
+// optional `effort` setting through only when present.
+function agent(spec: AgentSpec) {
+  return spec.effort === undefined
+    ? sandcastle.claudeCode(spec.model)
+    : sandcastle.claudeCode(spec.model, { effort: spec.effort });
+}
 
 function streamLogger(name: string): LoggingOption {
   return {
@@ -52,7 +55,7 @@ function streamLogger(name: string): LoggingOption {
 
 const isDocsOnly = (issue: Issue) =>
   issue.labels.includes("documentation") &&
-  !issue.labels.some((l) => l !== "documentation" && l !== "Sandcastle");
+  !issue.labels.some((l) => l !== "documentation" && l !== LABEL);
 
 const isSandboxStartupError = (err: unknown): boolean => {
   const msg = err instanceof Error ? err.message : String(err);
@@ -75,8 +78,8 @@ async function createIssueSandboxWithRetry(issue: Issue) {
     return await sandcastle.createSandbox({
       sandbox: sandboxProvider,
       branch: issue.branch,
-      hooks: { sandbox: { onSandboxReady: [{ command: installAndVerify }] } },
-      copyToWorktree,
+      hooks: { sandbox: { onSandboxReady: [{ command: INSTALL_AND_VERIFY }] } },
+      copyToWorktree: [...COPY_TO_WORKTREE],
     });
   } catch (err) {
     if (!isSandboxStartupError(err)) throw err;
@@ -84,8 +87,8 @@ async function createIssueSandboxWithRetry(issue: Issue) {
     return sandcastle.createSandbox({
       sandbox: sandboxProvider,
       branch: issue.branch,
-      hooks: { sandbox: { onSandboxReady: [{ command: installAndVerify }] } },
-      copyToWorktree,
+      hooks: { sandbox: { onSandboxReady: [{ command: INSTALL_AND_VERIFY }] } },
+      copyToWorktree: [...COPY_TO_WORKTREE],
     });
   }
 }
@@ -94,19 +97,19 @@ async function runIssue(issue: Issue, iteration: number) {
   await using sandbox = await createIssueSandboxWithRetry(issue);
 
   const docsOnly = isDocsOnly(issue);
-  const implementPromptFile = docsOnly
-    ? "./.sandcastle/implement-docs-prompt.md"
-    : "./.sandcastle/implement-prompt.md";
+  const implementerSpec = docsOnly ? AGENTS.implementerDocs : AGENTS.implementer;
+
+  const issuePromptArgs = {
+    ISSUE_NUMBER: String(issue.number),
+    ISSUE_TITLE: issue.title,
+    BRANCH: issue.branch,
+  };
 
   const implementResult = await sandbox.run({
     name: "Implementer #" + issue.number,
-    agent: sandcastle.claudeCode("claude-opus-4-6"),
-    promptFile: implementPromptFile,
-    promptArgs: {
-      ISSUE_NUMBER: String(issue.number),
-      ISSUE_TITLE: issue.title,
-      BRANCH: issue.branch,
-    },
+    agent: agent(implementerSpec),
+    promptFile: implementerSpec.promptPath,
+    promptArgs: issuePromptArgs,
     logging: streamLogger(`iter${iteration}-implementer-${issue.number}`),
   });
 
@@ -123,26 +126,18 @@ async function runIssue(issue: Issue, iteration: number) {
   if (!skipReview) {
     await sandbox.run({
       name: "Reviewer #" + issue.number,
-      agent: sandcastle.claudeCode("claude-opus-4-6"),
-      promptFile: "./.sandcastle/review-prompt.md",
-      promptArgs: {
-        ISSUE_NUMBER: String(issue.number),
-        ISSUE_TITLE: issue.title,
-        BRANCH: issue.branch,
-      },
+      agent: agent(AGENTS.reviewer),
+      promptFile: AGENTS.reviewer.promptPath,
+      promptArgs: issuePromptArgs,
       logging: streamLogger(`iter${iteration}-reviewer-${issue.number}`),
     });
   }
 
   await sandbox.run({
     name: "PR-Opener #" + issue.number,
-    agent: sandcastle.claudeCode("claude-opus-4-6", { effort: "low" }),
-    promptFile: "./.sandcastle/pr-prompt.md",
-    promptArgs: {
-      ISSUE_NUMBER: String(issue.number),
-      ISSUE_TITLE: issue.title,
-      BRANCH: issue.branch,
-    },
+    agent: agent(AGENTS.prOpener),
+    promptFile: AGENTS.prOpener.promptPath,
+    promptArgs: issuePromptArgs,
     logging: streamLogger(`iter${iteration}-pr-${issue.number}`),
   });
 
@@ -156,8 +151,12 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   const plan = await sandcastle.run({
     sandbox: sandboxProvider,
     name: "Planner",
-    agent: sandcastle.claudeCode("claude-opus-4-6", { effort: "high" }),
-    promptFile: "./.sandcastle/plan-prompt.md",
+    agent: agent(AGENTS.planner),
+    promptFile: AGENTS.planner.promptPath,
+    promptArgs: {
+      LABEL,
+      BRANCH_FORMAT,
+    },
     logging: streamLogger(`iter${iteration}-planner`),
   });
 
@@ -175,7 +174,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     console.log(`  #${issue.number}: ${issue.title} → ${issue.branch} [${issue.labels.join(", ")}]`);
   }
 
-  // Phase 2: per-issue pipeline (implement → maybe review → open PR), max 4 in parallel
+  // Phase 2: per-issue pipeline (implement → maybe review → open PR), max N in parallel
   let running = 0;
   const queue: (() => void)[] = [];
   const acquire = () =>

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -24,12 +24,24 @@ const sandboxProvider = docker({});
 mkdirSync(".sandcastle/logs/plans", { recursive: true });
 const STREAM_LOG_PATH = ".sandcastle/logs/stream.log";
 
-// Build a `claudeCode` agent invocation from an AgentSpec, threading the
-// optional `effort` setting through only when present.
+// Build a sandcastle AgentProvider from an AgentSpec. Dispatches on the
+// `provider` discriminator so adding a new backend means adding a case here
+// (and a variant in workflow.ts), not touching every call site.
 function agent(spec: AgentSpec) {
-  return spec.effort === undefined
-    ? sandcastle.claudeCode(spec.model)
-    : sandcastle.claudeCode(spec.model, { effort: spec.effort });
+  switch (spec.provider) {
+    case "claudeCode":
+      return spec.effort === undefined
+        ? sandcastle.claudeCode(spec.model)
+        : sandcastle.claudeCode(spec.model, { effort: spec.effort });
+    case "codex":
+      return spec.effort === undefined
+        ? sandcastle.codex(spec.model)
+        : sandcastle.codex(spec.model, { effort: spec.effort });
+    case "opencode":
+      return sandcastle.opencode(spec.model);
+    case "pi":
+      return sandcastle.pi(spec.model);
+  }
 }
 
 function streamLogger(name: string): LoggingOption {

--- a/.sandcastle/plan-prompt.md
+++ b/.sandcastle/plan-prompt.md
@@ -4,7 +4,7 @@ Here are the open issues in the repo:
 
 <issues-json>
 
-!`gh issue list --state open --label Sandcastle --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+!`gh issue list --state open --label {{LABEL}} --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
 
 </issues-json>
 
@@ -30,7 +30,7 @@ An issue B is **blocked by** issue A if:
 
 An issue is **unblocked** if it has zero blocking dependencies on other open issues.
 
-For each unblocked issue, assign a branch name using the format `sandcastle/issue-{number}-{slug}`.
+For each unblocked issue, assign a branch name using the format `{{BRANCH_FORMAT}}`.
 
 If the issue appears to be a PRD and it has implementation issues which link to it, the PRD cannot be worked on.
 

--- a/.sandcastle/workflow.test.ts
+++ b/.sandcastle/workflow.test.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+import { AGENTS, BRANCH_FORMAT, LABEL, MAX_ITERATIONS, MAX_PARALLEL } from "./workflow";
+
+describe("workflow config", () => {
+  test("AGENTS exposes all five expected keys", () => {
+    expect(Object.keys(AGENTS).sort()).toEqual(
+      ["implementer", "implementerDocs", "planner", "prOpener", "reviewer"].sort(),
+    );
+  });
+
+  test("every agent has a non-empty model and a resolvable promptPath", () => {
+    for (const [key, spec] of Object.entries(AGENTS)) {
+      expect(spec.model.length, `${key}.model must be non-empty`).toBeGreaterThan(0);
+      expect(existsSync(spec.promptPath), `${key}.promptPath ${spec.promptPath} must resolve`).toBe(
+        true,
+      );
+    }
+  });
+
+  test("LABEL and BRANCH_FORMAT are non-empty", () => {
+    expect(LABEL.length).toBeGreaterThan(0);
+    expect(BRANCH_FORMAT.length).toBeGreaterThan(0);
+  });
+
+  test("MAX_ITERATIONS and MAX_PARALLEL are positive integers", () => {
+    expect(Number.isInteger(MAX_ITERATIONS)).toBe(true);
+    expect(MAX_ITERATIONS).toBeGreaterThan(0);
+    expect(Number.isInteger(MAX_PARALLEL)).toBe(true);
+    expect(MAX_PARALLEL).toBeGreaterThan(0);
+  });
+
+  test("plan-prompt.md references {{LABEL}} and {{BRANCH_FORMAT}} placeholders", () => {
+    const content = readFileSync(AGENTS.planner.promptPath, "utf8");
+    expect(content).toContain("{{LABEL}}");
+    expect(content).toContain("{{BRANCH_FORMAT}}");
+  });
+});

--- a/.sandcastle/workflow.test.ts
+++ b/.sandcastle/workflow.test.ts
@@ -9,8 +9,12 @@ describe("workflow config", () => {
     );
   });
 
-  test("every agent has a non-empty model and a resolvable promptPath", () => {
+  test("every agent has a known provider, non-empty model, and a resolvable promptPath", () => {
+    const validProviders = new Set(["claudeCode", "codex", "opencode", "pi"]);
     for (const [key, spec] of Object.entries(AGENTS)) {
+      expect(validProviders.has(spec.provider), `${key}.provider must be a known backend`).toBe(
+        true,
+      );
       expect(spec.model.length, `${key}.model must be non-empty`).toBeGreaterThan(0);
       expect(existsSync(spec.promptPath), `${key}.promptPath ${spec.promptPath} must resolve`).toBe(
         true,

--- a/.sandcastle/workflow.ts
+++ b/.sandcastle/workflow.ts
@@ -1,0 +1,75 @@
+// Single source of truth for sandcastle harness configuration.
+//
+// Values that historically lived inline in main.ts and were duplicated into
+// prompt files. Pulling them here means changing model/effort/labels happens
+// in one place; prompts receive the values via promptArgs.
+
+// ---------- Tracker conventions ----------
+
+// GitHub label used to opt issues into the Sandcastle workflow.
+export const LABEL = "Sandcastle";
+
+// Branch name template the planner must follow for each issue. The {number}
+// and {slug} placeholders are filled by the planner (or, post-B.1, by
+// pickEligible()). Validated against a regex in plan.ts at parse time.
+export const BRANCH_FORMAT = "sandcastle/issue-{number}-{slug}";
+
+// ---------- Orchestrator limits ----------
+
+export const MAX_ITERATIONS = 10;
+export const MAX_PARALLEL = 4;
+
+// ---------- Sandbox setup ----------
+
+// Skip host->worktree copy: this monorepo's node_modules is ~3.5GB and
+// blows past sandcastle's hard-coded 60s copy timeout. The implementer
+// sandbox runs `bun install` inside the container instead.
+// Env files are gitignored, so copy them in explicitly.
+export const COPY_TO_WORKTREE: readonly string[] = [
+  "apps/desktop/.env",
+  "apps/web/.env.local",
+];
+
+// Verify the install actually produced a usable workspace. `bun install` exits
+// 0 even when individual extractions are mangled, so we follow with `turbo
+// typecheck`, which resolves and loads imports across every workspace and
+// fails loudly if a package's main entry is missing.
+export const INSTALL_AND_VERIFY = "bun install && bun run typecheck";
+
+// ---------- Agent specs ----------
+
+export type AgentSpec = {
+  model: string;
+  effort?: "low" | "medium" | "high";
+  promptPath: string;
+};
+
+// Each agent is keyed by purpose. Control flow (which agent runs when, the
+// docs-only branching, the conditional reviewer skip) stays in main.ts —
+// only the agent invocation parameters live here.
+export const AGENTS = {
+  planner: {
+    model: "claude-opus-4-6",
+    effort: "high",
+    promptPath: "./.sandcastle/plan-prompt.md",
+  },
+  implementer: {
+    model: "claude-opus-4-6",
+    promptPath: "./.sandcastle/implement-prompt.md",
+  },
+  implementerDocs: {
+    model: "claude-opus-4-6",
+    promptPath: "./.sandcastle/implement-docs-prompt.md",
+  },
+  reviewer: {
+    model: "claude-opus-4-6",
+    promptPath: "./.sandcastle/review-prompt.md",
+  },
+  prOpener: {
+    model: "claude-opus-4-6",
+    effort: "low",
+    promptPath: "./.sandcastle/pr-prompt.md",
+  },
+} as const satisfies Record<string, AgentSpec>;
+
+export type AgentKey = keyof typeof AGENTS;

--- a/.sandcastle/workflow.ts
+++ b/.sandcastle/workflow.ts
@@ -38,34 +38,71 @@ export const INSTALL_AND_VERIFY = "bun install && bun run typecheck";
 
 // ---------- Agent specs ----------
 
-export type AgentSpec = {
+// Provider-tagged spec. Each agent declares which sandcastle agent provider
+// it uses (claudeCode | codex | opencode | pi); main.ts dispatches on the
+// `provider` discriminator. Adding a new backend (e.g. Gemini, Ollama) means
+// adding a variant here and a case in main.ts's `agent()` helper, with no
+// other downstream changes.
+//
+// Per-provider `effort` types are kept narrow to mirror sandcastle's own
+// option types: claudeCode supports low/medium/high/max, codex adds xhigh,
+// opencode and pi don't take an effort knob.
+
+export type ClaudeCodeSpec = {
+  provider: "claudeCode";
   model: string;
-  effort?: "low" | "medium" | "high";
+  effort?: "low" | "medium" | "high" | "max";
   promptPath: string;
 };
+
+export type CodexSpec = {
+  provider: "codex";
+  model: string;
+  effort?: "low" | "medium" | "high" | "xhigh";
+  promptPath: string;
+};
+
+export type OpenCodeSpec = {
+  provider: "opencode";
+  model: string;
+  promptPath: string;
+};
+
+export type PiSpec = {
+  provider: "pi";
+  model: string;
+  promptPath: string;
+};
+
+export type AgentSpec = ClaudeCodeSpec | CodexSpec | OpenCodeSpec | PiSpec;
 
 // Each agent is keyed by purpose. Control flow (which agent runs when, the
 // docs-only branching, the conditional reviewer skip) stays in main.ts —
 // only the agent invocation parameters live here.
 export const AGENTS = {
   planner: {
+    provider: "claudeCode",
     model: "claude-opus-4-6",
     effort: "high",
     promptPath: "./.sandcastle/plan-prompt.md",
   },
   implementer: {
+    provider: "claudeCode",
     model: "claude-opus-4-6",
     promptPath: "./.sandcastle/implement-prompt.md",
   },
   implementerDocs: {
+    provider: "claudeCode",
     model: "claude-opus-4-6",
     promptPath: "./.sandcastle/implement-docs-prompt.md",
   },
   reviewer: {
+    provider: "claudeCode",
     model: "claude-opus-4-6",
     promptPath: "./.sandcastle/review-prompt.md",
   },
   prOpener: {
+    provider: "claudeCode",
     model: "claude-opus-4-6",
     effort: "low",
     promptPath: "./.sandcastle/pr-prompt.md",


### PR DESCRIPTION
## Summary

- New `.sandcastle/workflow.ts` exports the harness's typed configuration: `LABEL`, `BRANCH_FORMAT`, `MAX_ITERATIONS`, `MAX_PARALLEL`, `COPY_TO_WORKTREE`, `INSTALL_AND_VERIFY`, plus an `AGENTS` record keyed by purpose (planner, implementer, implementerDocs, reviewer, prOpener) using a `satisfies` clause against `AgentSpec`.
- `main.ts` imports those values; replaces inline `claudeCode(...)` calls with a small `agent(spec)` helper that threads optional `effort` through.
- `plan-prompt.md` uses `{{LABEL}}` and `{{BRANCH_FORMAT}}` placeholders rather than hardcoded `"Sandcastle"` / `"sandcastle/issue-{number}-{slug}"`.
- `workflow.test.ts` smoke test asserts every agent key is present, every `promptPath` resolves on disk, the planner prompt references both placeholders, and numeric limits are positive integers.

No behaviour change — pure refactor. PR 2 of 5 from the sandcastle harness roadmap. Sets up A.3 (typed retry) and B.1 (`pickEligible`) to import their config from a single source.

## Test plan

- [x] `bun test ./.sandcastle/` — 18/18 pass (13 plan + 5 workflow)
- [x] `bun build .sandcastle/main.ts` — compiles cleanly
- [x] `bun run check` — biome clean
- [x] Pre-commit hook (turbo test) — green