### PR TITLE
feat(sandcastle): typed retry helper for sandbox creation

### DIFF
--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -4,6 +4,7 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 import type { AgentStreamEvent, LoggingOption } from "@ai-hero/sandcastle";
 import { parsePlan } from "./plan";
 import type { Issue } from "./plan";
+import { isSandboxStartupRetryable, retryWithBackoff } from "./retry";
 import {
   AGENTS,
   BRANCH_FORMAT,
@@ -69,11 +70,6 @@ const isDocsOnly = (issue: Issue) =>
   issue.labels.includes("documentation") &&
   !issue.labels.some((l) => l !== "documentation" && l !== LABEL);
 
-const isSandboxStartupError = (err: unknown): boolean => {
-  const msg = err instanceof Error ? err.message : String(err);
-  return /docker|sandbox|container|image|network|ECONNREFUSED|EPIPE/i.test(msg);
-};
-
 async function changedPaths(worktreePath: string): Promise<string[]> {
   const proc = Bun.spawn(["git", "diff", "--name-only", "main..HEAD"], {
     cwd: worktreePath,
@@ -86,23 +82,27 @@ async function changedPaths(worktreePath: string): Promise<string[]> {
 }
 
 async function createIssueSandboxWithRetry(issue: Issue) {
-  try {
-    return await sandcastle.createSandbox({
-      sandbox: sandboxProvider,
-      branch: issue.branch,
-      hooks: { sandbox: { onSandboxReady: [{ command: INSTALL_AND_VERIFY }] } },
-      copyToWorktree: [...COPY_TO_WORKTREE],
-    });
-  } catch (err) {
-    if (!isSandboxStartupError(err)) throw err;
-    console.warn(`  ↻ #${issue.number} retry after sandbox startup error: ${err}`);
-    return sandcastle.createSandbox({
-      sandbox: sandboxProvider,
-      branch: issue.branch,
-      hooks: { sandbox: { onSandboxReady: [{ command: INSTALL_AND_VERIFY }] } },
-      copyToWorktree: [...COPY_TO_WORKTREE],
-    });
-  }
+  return retryWithBackoff(
+    () =>
+      sandcastle.createSandbox({
+        sandbox: sandboxProvider,
+        branch: issue.branch,
+        hooks: { sandbox: { onSandboxReady: [{ command: INSTALL_AND_VERIFY }] } },
+        copyToWorktree: [...COPY_TO_WORKTREE],
+      }),
+    {
+      maxAttempts: 2,
+      baseMs: 2000,
+      jitter: true,
+      isRetryable: isSandboxStartupRetryable,
+      onRetry: ({ attempt, nextDelayMs, error }) => {
+        const tag = (error as { _tag?: unknown })._tag ?? "unknown";
+        console.warn(
+          `  ↻ #${issue.number} attempt ${attempt} failed (${tag}); retrying in ${nextDelayMs}ms`,
+        );
+      },
+    },
+  );
 }
 
 async function runIssue(issue: Issue, iteration: number) {
@@ -213,7 +213,18 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
 
   for (const [i, outcome] of settled.entries()) {
     if (outcome.status === "rejected") {
-      console.error(`  ✗ #${issues[i]!.number} (${issues[i]!.branch}) failed: ${outcome.reason}`);
+      const issue = issues[i]!;
+      const reason: unknown = outcome.reason;
+      const errorTag =
+        typeof reason === "object" && reason !== null && "_tag" in reason
+          ? String((reason as { _tag: unknown })._tag)
+          : reason instanceof Error
+            ? reason.constructor.name
+            : "UnknownError";
+      const message = reason instanceof Error ? reason.message : String(reason);
+      console.error(
+        `  ✗ #${issue.number} (${issue.branch}) failed [${errorTag}]: ${message}`,
+      );
     }
   }
 

--- a/.sandcastle/retry.test.ts
+++ b/.sandcastle/retry.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "bun:test";
+import { isSandboxStartupRetryable, retryWithBackoff } from "./retry";
+
+// Real sandcastle errors are Effect tagged errors carrying a string `_tag`.
+// We mimic that minimal shape here so the predicate and helper can be tested
+// without standing up a real sandbox.
+const tagged = (tag: string, message = "boom") =>
+  Object.assign(new Error(message), { _tag: tag });
+
+const noSleep = async () => {};
+
+describe("isSandboxStartupRetryable", () => {
+  test.each([
+    "DockerError",
+    "PodmanError",
+    "ContainerStartTimeoutError",
+    "WorktreeError",
+    "WorktreeTimeoutError",
+    "CopyError",
+    "CopyToWorktreeTimeoutError",
+    "SyncError",
+    "SyncInTimeoutError",
+    "GitSetupTimeoutError",
+    "HookTimeoutError",
+  ])("%s is retryable", (tag) => {
+    expect(isSandboxStartupRetryable(tagged(tag))).toBe(true);
+  });
+
+  test.each([
+    "AgentError",
+    "ConfigDirError",
+    "InitError",
+    "CwdError",
+    "ExecHostError",
+    "PromptError",
+  ])("%s is not retryable", (tag) => {
+    expect(isSandboxStartupRetryable(tagged(tag))).toBe(false);
+  });
+
+  test("plain Error is not retryable", () => {
+    expect(isSandboxStartupRetryable(new Error("plain"))).toBe(false);
+  });
+
+  test("non-object thrown values are not retryable", () => {
+    expect(isSandboxStartupRetryable("string error")).toBe(false);
+    expect(isSandboxStartupRetryable(undefined)).toBe(false);
+    expect(isSandboxStartupRetryable(null)).toBe(false);
+  });
+});
+
+describe("retryWithBackoff", () => {
+  test("returns the value on first-attempt success", async () => {
+    let calls = 0;
+    const result = await retryWithBackoff(
+      async () => {
+        calls++;
+        return "ok";
+      },
+      { maxAttempts: 2, baseMs: 1, jitter: false, isRetryable: () => true, sleep: noSleep },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  test("retries on a retryable error and succeeds on attempt 2", async () => {
+    let calls = 0;
+    const result = await retryWithBackoff(
+      async () => {
+        calls++;
+        if (calls === 1) throw tagged("DockerError");
+        return "ok";
+      },
+      {
+        maxAttempts: 2,
+        baseMs: 1,
+        jitter: false,
+        isRetryable: isSandboxStartupRetryable,
+        sleep: noSleep,
+      },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(2);
+  });
+
+  test("exhausts attempts and rethrows the last error", async () => {
+    let calls = 0;
+    await expect(
+      retryWithBackoff(
+        async () => {
+          calls++;
+          throw tagged("DockerError", `attempt ${calls}`);
+        },
+        {
+          maxAttempts: 2,
+          baseMs: 1,
+          jitter: false,
+          isRetryable: isSandboxStartupRetryable,
+          sleep: noSleep,
+        },
+      ),
+    ).rejects.toMatchObject({ _tag: "DockerError", message: "attempt 2" });
+    expect(calls).toBe(2);
+  });
+
+  test("does not retry a non-retryable error", async () => {
+    let calls = 0;
+    await expect(
+      retryWithBackoff(
+        async () => {
+          calls++;
+          throw tagged("CwdError", "bad cwd");
+        },
+        {
+          maxAttempts: 5,
+          baseMs: 1,
+          jitter: false,
+          isRetryable: isSandboxStartupRetryable,
+          sleep: noSleep,
+        },
+      ),
+    ).rejects.toMatchObject({ _tag: "CwdError" });
+    expect(calls).toBe(1);
+  });
+
+  test("invokes onRetry between failed attempts with attempt number and delay", async () => {
+    const events: { attempt: number; nextDelayMs: number }[] = [];
+    let calls = 0;
+    await retryWithBackoff(
+      async () => {
+        calls++;
+        if (calls < 3) throw tagged("DockerError");
+        return "ok";
+      },
+      {
+        maxAttempts: 3,
+        baseMs: 100,
+        jitter: false,
+        isRetryable: isSandboxStartupRetryable,
+        sleep: noSleep,
+        onRetry: ({ attempt, nextDelayMs }) => events.push({ attempt, nextDelayMs }),
+      },
+    );
+    expect(events).toEqual([
+      { attempt: 1, nextDelayMs: 100 },
+      { attempt: 2, nextDelayMs: 100 },
+    ]);
+    expect(calls).toBe(3);
+  });
+
+  test("with jitter, delay falls in [0.5*base, 1.5*base]", async () => {
+    const observed: number[] = [];
+    let calls = 0;
+    await retryWithBackoff(
+      async () => {
+        calls++;
+        if (calls < 4) throw tagged("DockerError");
+        return "ok";
+      },
+      {
+        maxAttempts: 4,
+        baseMs: 1000,
+        jitter: true,
+        isRetryable: isSandboxStartupRetryable,
+        sleep: noSleep,
+        onRetry: ({ nextDelayMs }) => observed.push(nextDelayMs),
+      },
+    );
+    for (const ms of observed) {
+      expect(ms).toBeGreaterThanOrEqual(500);
+      expect(ms).toBeLessThanOrEqual(1500);
+    }
+  });
+
+  test("uses the injected sleep between retries", async () => {
+    const sleeps: number[] = [];
+    const fakeSleep = async (ms: number) => {
+      sleeps.push(ms);
+    };
+    let calls = 0;
+    await retryWithBackoff(
+      async () => {
+        calls++;
+        if (calls < 2) throw tagged("DockerError");
+        return "ok";
+      },
+      {
+        maxAttempts: 2,
+        baseMs: 2000,
+        jitter: false,
+        isRetryable: isSandboxStartupRetryable,
+        sleep: fakeSleep,
+      },
+    );
+    expect(sleeps).toEqual([2000]);
+  });
+});

--- a/.sandcastle/retry.ts
+++ b/.sandcastle/retry.ts
@@ -1,0 +1,82 @@
+// Genuinely transient sandbox-creation failures: container/orchestrator hiccup,
+// network blip during git sync or copy, races during install hooks. Anything
+// else (CwdError, ConfigDirError, InitError, AgentError, ExecHostError) is
+// either a configuration mistake or a logic failure that won't fix itself on
+// retry, so we let it propagate.
+//
+// We match on sandcastle's Effect-style `_tag` string rather than `instanceof`
+// because the error classes themselves are not re-exported from the public
+// `@ai-hero/sandcastle` entry — only `CwdError` is. The `_tag` field is the
+// Effect convention and is part of the documented error shape, so this is
+// stable across minor version bumps.
+const RETRYABLE_TAGS = new Set([
+  "ContainerStartTimeoutError",
+  "CopyError",
+  "CopyToWorktreeTimeoutError",
+  "DockerError",
+  "GitSetupTimeoutError",
+  "HookTimeoutError",
+  "PodmanError",
+  "SyncError",
+  "SyncInTimeoutError",
+  "WorktreeError",
+  "WorktreeTimeoutError",
+]);
+
+function tagOf(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  const tag = (err as { _tag?: unknown })._tag;
+  return typeof tag === "string" ? tag : undefined;
+}
+
+export function isSandboxStartupRetryable(err: unknown): boolean {
+  const tag = tagOf(err);
+  return tag !== undefined && RETRYABLE_TAGS.has(tag);
+}
+
+export type RetryOptions = {
+  maxAttempts: number;
+  baseMs: number;
+  jitter: boolean;
+  isRetryable: (err: unknown) => boolean;
+  // Injected so tests can run without real timers. Defaults to setTimeout.
+  sleep?: (ms: number) => Promise<void>;
+  // Called once per retry decision (after a retryable failure). Useful for
+  // surfacing the attempt + cause in orchestrator logs.
+  onRetry?: (info: { attempt: number; nextDelayMs: number; error: unknown }) => void;
+};
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// Run `fn` up to `maxAttempts` times. Between failed attempts that the
+// `isRetryable` predicate accepts, sleep `baseMs` (with optional ±50% jitter).
+// Non-retryable errors bubble immediately. After the final attempt, the last
+// error is rethrown.
+//
+// Flat delay (not exponential): the operations we wrap take minutes; backing
+// off further between attempts buys nothing useful and just delays an
+// AFK overnight run.
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions,
+): Promise<T> {
+  const sleep = opts.sleep ?? defaultSleep;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (!opts.isRetryable(err) || attempt === opts.maxAttempts) {
+        throw err;
+      }
+      const delay = opts.jitter
+        ? Math.round(opts.baseMs * (0.5 + Math.random()))
+        : opts.baseMs;
+      opts.onRetry?.({ attempt, nextDelayMs: delay, error: err });
+      await sleep(delay);
+    }
+  }
+  // Unreachable — the loop either returns or throws inside.
+  throw lastError;
+}


### PR DESCRIPTION
## Summary

- New `.sandcastle/retry.ts` exports `retryWithBackoff(fn, opts)` with injected `sleep` for testability and an `onRetry` callback for orchestrator logs.
- New `isSandboxStartupRetryable(err)` predicate matches sandcastle's Effect-style `_tag` field (stable across minor bumps; sandcastle's error classes are not re-exported from its public entry, so `instanceof` isn't viable).
- `main.ts` `createIssueSandboxWithRetry` now uses the helper. Retry policy: `maxAttempts: 2`, `baseMs: 2000` with ±50% jitter, flat (not exponential — sandbox creation is multi-minute; backoff between attempts buys nothing).
- The per-issue rejection summary now logs `[ErrorTag]: message` separately so failure classes are visible without scrolling stack traces.
- 13 unit tests covering 11 retryable tags, 6 non-retryable tags, plain `Error`, non-object thrown values, retry-success, retry-exhaustion, fail-fast, jitter range, and injected sleep.

PR 3 of 5 from the sandcastle harness roadmap.

## Test plan

- [x] `bun test ./.sandcastle/` — 44/44 pass (13 plan + 5 workflow + 26 retry)
- [x] `bun build ./.sandcastle/main.ts` — compiles cleanly
- [x] `bun run check` — biome clean
- [x] Pre-commit hook (turbo test) — green