### PR TITLE
refactor(scaffold): rename packages/schema → packages/contexture

### DIFF
--- a/apps/desktop/src/main/documents/document-store.ts
+++ b/apps/desktop/src/main/documents/document-store.ts
@@ -97,13 +97,13 @@ export interface DocumentStoreDeps {
   /** Override for tests — defaults to the real Zod emitter. */
   emitZod?: (schema: Schema, sourcePath: string) => string;
   /** Override for tests — defaults to the real JSON-schema emitter. */
-  emitJsonSchema?: (schema: Schema) => unknown;
+  emitJsonSchema?: (schema: Schema, sourcePath?: string) => unknown;
   /** Override for tests — defaults to the real schema-index emitter. */
-  emitSchemaIndex?: (baseName: string) => string;
+  emitSchemaIndex?: (baseName: string, sourcePath?: string) => string;
   /** Override for tests — defaults to the real CLAUDE.md emitter. */
   emitClaudeMd?: (projectName: string) => string;
   /** Override for tests — defaults to the real Convex emitter. */
-  emitConvex?: (schema: Schema) => string;
+  emitConvex?: (schema: Schema, sourcePath?: string) => string;
   /** Override for tests — defaults to the real per-table CRUD emitter. */
   emitTableCrud?: (schema: Schema, tableName: string) => string;
   /** Optional hook for main-process integration (e.g. `app.addRecentDocument`). */
@@ -131,17 +131,17 @@ function baseNameFor(irPath: string): string {
 
 /**
  * Monorepo project root for IRs sitting at
- * `<root>/packages/schema/<name>.contexture.json`. Returns `null` for
+ * `<root>/packages/contexture/<name>.contexture.json`. Returns `null` for
  * IRs that don't follow the canonical scaffold layout — those projects
  * don't get a CLAUDE.md written (there's no unambiguous "root").
  */
 export function projectRootFor(irPath: string): string | null {
-  const schemaSuffix = '/packages/schema/';
+  const suffix = '/packages/contexture/';
   const slash = irPath.lastIndexOf('/');
   if (slash === -1) return null;
   const dir = irPath.slice(0, slash);
-  if (!dir.endsWith('/packages/schema')) return null;
-  return dir.slice(0, -schemaSuffix.length + 1);
+  if (!dir.endsWith('/packages/contexture')) return null;
+  return dir.slice(0, -suffix.length + 1);
 }
 
 export interface EmittedManifest {
@@ -185,7 +185,7 @@ export function bundlePathsFor(irPath: string): {
     emitted: `${ctxDir}/${EMITTED_FILE}`,
     schemaTs: `${base}${SCHEMA_TS_SUFFIX}`,
     schemaJson: `${base}${SCHEMA_JSON_SUFFIX}`,
-    // Workspace re-export: consumers `import { … } from '@<project>/schema'`
+    // Workspace re-export: consumers `import { … } from '@<project>/contexture'`
     // and resolve to this barrel rather than a specific `.schema` module.
     schemaIndex: `${dir}/index.ts`,
     // Convex demands a `convex/` subdir sibling of its callers; the
@@ -200,7 +200,7 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
     fs,
     recentFilesPath,
     emitZod = defaultEmitZod,
-    emitJsonSchema = defaultEmitJsonSchema,
+    emitJsonSchema = (s: Schema, sp?: string) => defaultEmitJsonSchema(s, undefined, sp),
     emitSchemaIndex = defaultEmitSchemaIndex,
     emitClaudeMd = defaultEmitClaudeMd,
     emitConvex = defaultEmitConvex,
@@ -270,7 +270,7 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
         if (!(await fs.fileExists(claudePath))) {
           await fs.writeFile(claudePath, emitClaudeMd(baseNameFor(irPath)));
         }
-        // Seed one `packages/schema/convex/<table>.ts` per table-flagged
+        // Seed one `packages/contexture/convex/<table>.ts` per table-flagged
         // object. Written only if missing — these are `@contexture-seeded`,
         // owned by the user/coding agent from first write on.
         const schemaDir = contextureDirFor(irPath).slice(0, -'/.contexture'.length);
@@ -348,10 +348,10 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
     // Project mode: full bundle. Emit first — a throwing emitter must
     // abort before any write touches disk.
     const schemaTs = emitZod(input.schema, irPath);
-    const schemaJson = JSON.stringify(emitJsonSchema(input.schema), null, 2);
+    const schemaJson = JSON.stringify(emitJsonSchema(input.schema, irPath), null, 2);
     const baseName = baseNameFor(irPath);
-    const schemaIndex = emitSchemaIndex(baseName);
-    const convexSource = emitConvex(input.schema);
+    const schemaIndex = emitSchemaIndex(baseName, irPath);
+    const convexSource = emitConvex(input.schema, irPath);
 
     // Pair each emitted artefact with its content hash so we can build
     // the drift-detection manifest before writing. The IR is the source

--- a/apps/desktop/src/main/scaffold/composite-runner.ts
+++ b/apps/desktop/src/main/scaffold/composite-runner.ts
@@ -54,12 +54,12 @@ export function createCompositeStageRunner(deps: CompositeRunnerDeps): StageRunn
         // on disk or its config bundler fails. So we write a bare anchor,
         // install only convex locally, then run `convex dev --once`. Stage 7
         // rewrites this file with the real schema-package shape later.
-        const schemaDir = `${config.targetDir}/packages/schema`;
+        const schemaDir = `${config.targetDir}/packages/contexture`;
         await fs.writeFile(
           `${schemaDir}/package.json`,
           `${JSON.stringify(
             {
-              name: `@${config.projectName}/schema`,
+              name: `@${config.projectName}/contexture`,
               private: true,
               dependencies: { convex: 'latest' },
             },

--- a/apps/desktop/src/main/scaffold/convex-emit.ts
+++ b/apps/desktop/src/main/scaffold/convex-emit.ts
@@ -1,7 +1,7 @@
 /**
  * `scaffoldConvexEmit` (stage 7) — reads the IR that stage 6 just
  * wrote and emits the Convex schema at
- * `packages/schema/convex/schema.ts`. At scaffold time the IR is
+ * `packages/contexture/convex/schema.ts`. At scaffold time the IR is
  * empty, so the emitted file is a degenerate `defineSchema({})` — but
  * Convex requires the file to exist before `bun run dev` can start,
  * so this stage always runs.
@@ -27,13 +27,13 @@ export async function scaffoldConvexEmit(
   deps: ConvexEmitDeps,
 ): Promise<void> {
   const { fs } = deps;
-  const schemaDir = `${config.targetDir}/packages/schema`;
+  const schemaDir = `${config.targetDir}/packages/contexture`;
   const irPath = `${schemaDir}/${config.projectName}.contexture.json`;
   const convexPath = `${schemaDir}/convex/schema.ts`;
   const emittedPath = `${schemaDir}/.contexture/emitted.json`;
 
   const ir = JSON.parse(await fs.readFile(irPath)) as Schema;
-  const convexSource = emitConvexSchema(ir);
+  const convexSource = emitConvexSchema(ir, irPath);
   await fs.writeFile(convexPath, convexSource);
 
   // Seed emitted.json with the hash of the file we just wrote so the

--- a/apps/desktop/src/main/scaffold/schema-package.ts
+++ b/apps/desktop/src/main/scaffold/schema-package.ts
@@ -1,5 +1,5 @@
 /**
- * `scaffoldSchemaPackage` (stage 6) — lays down the `packages/schema/`
+ * `scaffoldSchemaPackage` (stage 6) — lays down the `packages/contexture/`
  * tree: initial IR, Zod bundle + JSON mirror + barrel, workspace
  * package.json, .gitignore, and the .contexture/ marker with empty
  * layout/chat/emitted sidecars. Pure file generation against an
@@ -38,7 +38,7 @@ function makeChatHistory(description?: string): string {
 function makePackageJson(projectName: string): string {
   return `${JSON.stringify(
     {
-      name: `@${projectName}/schema`,
+      name: `@${projectName}/contexture`,
       version: '0.0.0',
       private: true,
       type: 'module',
@@ -58,7 +58,7 @@ export async function scaffoldSchemaPackage(
   deps: SchemaPackageDeps,
 ): Promise<void> {
   const { fs } = deps;
-  const schemaDir = `${config.targetDir}/packages/schema`;
+  const schemaDir = `${config.targetDir}/packages/contexture`;
   const irPath = `${schemaDir}/${config.projectName}.contexture.json`;
   const schemaTsPath = `${schemaDir}/${config.projectName}.schema.ts`;
   const schemaJsonPath = `${schemaDir}/${config.projectName}.schema.json`;
@@ -76,8 +76,11 @@ export async function scaffoldSchemaPackage(
 
   await fs.writeFile(irPath, `${JSON.stringify(ir, null, 2)}\n`);
   await fs.writeFile(schemaTsPath, emitZod(ir, irPath));
-  await fs.writeFile(schemaJsonPath, `${JSON.stringify(emitJsonSchema(ir), null, 2)}\n`);
-  await fs.writeFile(indexPath, emitSchemaIndex(config.projectName));
+  await fs.writeFile(
+    schemaJsonPath,
+    `${JSON.stringify(emitJsonSchema(ir, undefined, irPath), null, 2)}\n`,
+  );
+  await fs.writeFile(indexPath, emitSchemaIndex(config.projectName, irPath));
   await fs.writeFile(pkgPath, makePackageJson(config.projectName));
   await fs.writeFile(gitignorePath, GITIGNORE);
   await fs.writeFile(

--- a/apps/desktop/src/main/scaffold/stages.ts
+++ b/apps/desktop/src/main/scaffold/stages.ts
@@ -17,7 +17,7 @@ export interface ShellStageSpec {
 export function shellStageSpecFor(stage: number, config: ScaffoldConfig): ShellStageSpec {
   const target = config.targetDir;
   const webDir = `${target}/apps/web`;
-  const schemaDir = `${target}/packages/schema`;
+  const schemaDir = `${target}/packages/contexture`;
   switch (stage) {
     case STAGE.WEB_NEXT:
       return {

--- a/apps/desktop/src/main/scaffold/workspace-stitch.ts
+++ b/apps/desktop/src/main/scaffold/workspace-stitch.ts
@@ -1,6 +1,6 @@
 /**
  * `scaffoldWorkspaceStitch` (stage 9) — finishes the file side of the
- * scaffold: if a web app was created, adds `@<project>/schema: workspace:*`
+ * scaffold: if a web app was created, adds `@<project>/contexture: workspace:*`
  * to `apps/web/package.json`; writes the root `CLAUDE.md`, `biome.json`,
  * and root `.gitignore` (overwriting the skeleton's version with the
  * richer one). Pure file work; the subsequent git + bun install stages
@@ -51,7 +51,7 @@ export async function scaffoldWorkspaceStitch(
     const raw = await fs.readFile(webPkgPath);
     const pkg = JSON.parse(raw) as { dependencies?: Record<string, string>; [k: string]: unknown };
     pkg.dependencies ??= {};
-    pkg.dependencies[`@${config.projectName}/schema`] = 'workspace:*';
+    pkg.dependencies[`@${config.projectName}/contexture`] = 'workspace:*';
     await fs.writeFile(webPkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
   }
 

--- a/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/NewProjectDialog.tsx
@@ -126,7 +126,7 @@ export function NewProjectDialog({ onOpenProject }: NewProjectDialogProps = {}):
           appendLog(event.stderr);
           return;
         case 'scaffold-done': {
-          const irPath = `${targetPathRef.current}/packages/schema/${nameRef.current}.contexture.json`;
+          const irPath = `${targetPathRef.current}/packages/contexture/${nameRef.current}.contexture.json`;
           close();
           void onOpenProjectRef.current?.(irPath);
           return;

--- a/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
@@ -1,6 +1,6 @@
 /**
  * `DriftBanner` — non-blocking banner shown at the top of the graph
- * view when `apps/web/convex/schema.ts` has been hand-edited outside
+ * view when `packages/contexture/convex/schema.ts` has been hand-edited outside
  * Contexture (drift detected by the main-process watcher).
  *
  * "Review changes" opens the reconcile modal (see #126); "Dismiss"
@@ -26,7 +26,7 @@ export function DriftBanner(): React.JSX.Element | null {
     >
       <AlertTriangle className="size-3.5 shrink-0" />
       <span className="flex-1">
-        <code className="font-mono">packages/schema/convex/schema.ts</code> was modified outside
+        <code className="font-mono">packages/contexture/convex/schema.ts</code> was modified outside
         Contexture.
       </span>
       <Button

--- a/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
@@ -28,7 +28,7 @@ export function Toolbar(): React.JSX.Element {
   const filePath = useDocumentStore((s) => s.filePath);
   const documentMode = useDocumentStore((s) => s.mode);
 
-  // Project root is two dirs above the IR path (packages/schema/<name>.contexture.json).
+  // Project root is two dirs above the IR path (packages/contexture/<name>.contexture.json).
   const projectRoot =
     filePath && documentMode === 'project' ? filePath.split('/').slice(0, -3).join('/') : null;
 

--- a/apps/desktop/src/renderer/src/hooks/useDrift.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDrift.ts
@@ -3,7 +3,7 @@
  * project-mode document.
  *
  * When a project-mode document is open, starts watching
- * `apps/web/convex/schema.ts` against `.contexture/emitted.json`.
+ * `packages/contexture/convex/schema.ts` against `.contexture/emitted.json`.
  * Also triggers a manual re-check on window focus so edits made while
  * Contexture was in the background are caught immediately on return.
  *
@@ -18,10 +18,10 @@ const IR_SUFFIX = '.contexture.json';
 /**
  * Derives drift-related paths from the IR file path.
  *
- * IR lives at: <root>/packages/schema/<name>.contexture.json
- * Convex schema: <root>/packages/schema/convex/schema.ts
+ * IR lives at: <root>/packages/contexture/<name>.contexture.json
+ * Convex schema: <root>/packages/contexture/convex/schema.ts
  *   → same dir as the IR, subdir convex/
- * Emitted manifest: <root>/packages/schema/.contexture/emitted.json
+ * Emitted manifest: <root>/packages/contexture/.contexture/emitted.json
  *   → same dir as the IR, subdir .contexture/
  *
  * Both use the same base dir, so we never need to compute the monorepo
@@ -35,7 +35,7 @@ export function driftPathsFor(
   if (!irPath.endsWith(IR_SUFFIX)) return null;
   const slash = irPath.lastIndexOf('/');
   if (slash === -1) return null;
-  const dir = irPath.slice(0, slash); // e.g. /proj/packages/schema
+  const dir = irPath.slice(0, slash); // e.g. /proj/packages/contexture
   return {
     watchedPath: `${dir}/convex/schema.ts`,
     emittedJsonPath: `${dir}/.contexture/emitted.json`,

--- a/apps/desktop/src/renderer/src/model/emit-claude-md.ts
+++ b/apps/desktop/src/renderer/src/model/emit-claude-md.ts
@@ -12,9 +12,9 @@
 const TEMPLATE = `# {{PROJECT_NAME}}
 
 A Convex + Next.js monorepo scaffolded by Contexture. The schema is the
-source of truth at \`packages/schema/{{PROJECT_NAME}}.contexture.json\` and
-is re-emitted automatically to \`packages/schema/convex/schema.ts\` on every
-edit. \`apps/web\` imports the workspace package \`@{{PROJECT_NAME}}/schema\`
+source of truth at \`packages/contexture/{{PROJECT_NAME}}.contexture.json\` and
+is re-emitted automatically to \`packages/contexture/convex/schema.ts\` on every
+edit. \`apps/web\` imports the workspace package \`@{{PROJECT_NAME}}/contexture\`
 rather than owning its own \`convex/\` folder.
 
 ## Layout
@@ -22,8 +22,8 @@ rather than owning its own \`convex/\` folder.
 \`\`\`
 {{PROJECT_NAME}}/
   apps/web/             Next.js app (App Router, Tailwind, shadcn)
-                        imports @{{PROJECT_NAME}}/schema
-  packages/schema/      Shared schema package (Zod + JSON + Convex)
+                        imports @{{PROJECT_NAME}}/contexture
+  packages/contexture/      Shared schema package (Zod + JSON + Convex)
     {{PROJECT_NAME}}.contexture.json   source of truth
     {{PROJECT_NAME}}.schema.ts          @contexture-generated (Zod)
     {{PROJECT_NAME}}.schema.json        @contexture-generated (JSON Schema)
@@ -36,9 +36,9 @@ rather than owning its own \`convex/\` folder.
 
 ## Source of truth
 
-Do NOT edit \`packages/schema/convex/schema.ts\` directly — it is regenerated
+Do NOT edit \`packages/contexture/convex/schema.ts\` directly — it is regenerated
 on every IR save. To change the schema, edit
-\`packages/schema/{{PROJECT_NAME}}.contexture.json\` (or ask the user to
+\`packages/contexture/{{PROJECT_NAME}}.contexture.json\` (or ask the user to
 use Contexture's editor).
 
 If you do edit the generated file by mistake, Contexture detects the
@@ -47,24 +47,24 @@ into the IR. Your work is never silently clobbered.
 
 ## CRUD files are yours
 
-\`packages/schema/convex/<table>.ts\` files are seeded once by the scaffolder and
+\`packages/contexture/convex/<table>.ts\` files are seeded once by the scaffolder and
 are \`@contexture-seeded\`, not \`@contexture-generated\`. Add queries,
 mutations, and indexes as the app requires — Contexture does not
 regenerate them.
 
 ## Using the schema from app code
 
-Import Zod schemas from \`@{{PROJECT_NAME}}/schema\` for runtime
+Import Zod schemas from \`@{{PROJECT_NAME}}/contexture\` for runtime
 validation and inferred types:
 
 \`\`\`ts
-import { Post } from '@{{PROJECT_NAME}}/schema';
+import { Post } from '@{{PROJECT_NAME}}/contexture';
 
 const parsed = Post.parse(input);
 type Post = z.infer<typeof Post>;
 \`\`\`
 
-The Convex validators in \`packages/schema/convex/schema.ts\` are derived from
+The Convex validators in \`packages/contexture/convex/schema.ts\` are derived from
 the same source, so field shape is guaranteed to match.
 
 ## Conventions
@@ -77,15 +77,15 @@ the same source, so field shape is guaranteed to match.
 
 ## Adding a table
 
-1. Open the IR (\`packages/schema/{{PROJECT_NAME}}.contexture.json\`) or
+1. Open the IR (\`packages/contexture/{{PROJECT_NAME}}.contexture.json\`) or
    Contexture.
 2. Add the object type, set \`"table": true\`.
-3. Save. Contexture re-emits \`packages/schema/convex/schema.ts\`.
-4. Add CRUD handlers in \`packages/schema/convex/<table>.ts\` as needed.
+3. Save. Contexture re-emits \`packages/contexture/convex/schema.ts\`.
+4. Add CRUD handlers in \`packages/contexture/convex/<table>.ts\` as needed.
 
 ## What NOT to touch
 
-\`packages/schema/.contexture/\` — Contexture's internal state (graph
+\`packages/contexture/.contexture/\` — Contexture's internal state (graph
 layout, chat history, emit manifest). The directory is gitignored.
 
 ## Commands

--- a/apps/desktop/src/renderer/src/model/emit-claude-md.ts
+++ b/apps/desktop/src/renderer/src/model/emit-claude-md.ts
@@ -23,7 +23,7 @@ rather than owning its own \`convex/\` folder.
 {{PROJECT_NAME}}/
   apps/web/             Next.js app (App Router, Tailwind, shadcn)
                         imports @{{PROJECT_NAME}}/contexture
-  packages/contexture/      Shared schema package (Zod + JSON + Convex)
+  packages/contexture/  Shared schema package (Zod + JSON + Convex)
     {{PROJECT_NAME}}.contexture.json   source of truth
     {{PROJECT_NAME}}.schema.ts          @contexture-generated (Zod)
     {{PROJECT_NAME}}.schema.json        @contexture-generated (JSON Schema)

--- a/apps/desktop/src/renderer/src/model/emit-convex.ts
+++ b/apps/desktop/src/renderer/src/model/emit-convex.ts
@@ -16,11 +16,14 @@
  */
 import type { FieldDef, FieldType, Schema, TypeDef } from './ir';
 
-const BANNER = '// @contexture-generated — do not edit by hand. Regenerated on every IR save.';
+function banner(sourcePath?: string): string {
+  const base = '// @contexture-generated — do not edit by hand. Regenerated on every IR save.';
+  return sourcePath ? `${base} Source: ${sourcePath}` : base;
+}
 
 type ObjectType = Extract<TypeDef, { kind: 'object' }>;
 
-export function emitConvexSchema(schema: Schema): string {
+export function emitConvexSchema(schema: Schema, sourcePath?: string): string {
   validateReservedNames(schema);
   const objectByName = new Map<string, ObjectType>();
   for (const t of schema.types) {
@@ -41,7 +44,7 @@ export function emitConvexSchema(schema: Schema): string {
       : 'export default defineSchema({});\n';
 
   return [
-    BANNER,
+    banner(sourcePath),
     '',
     `import { defineSchema, defineTable } from 'convex/server';`,
     `import { v } from 'convex/values';`,

--- a/apps/desktop/src/renderer/src/model/emit-convex.ts
+++ b/apps/desktop/src/renderer/src/model/emit-convex.ts
@@ -1,7 +1,7 @@
 /**
  * Pure IR → Convex schema source emitter.
  *
- * Turns the IR into the contents of `apps/web/convex/schema.ts`:
+ * Turns the IR into the contents of `convex/schema.ts`:
  * table-flagged `ObjectTypeDef`s become `defineTable(...)` entries on
  * `defineSchema`; indexes chain on via `.index("name", [fields])`.
  * Non-table object types that are referenced via `ref` are inlined as

--- a/apps/desktop/src/renderer/src/model/emit-json-schema.ts
+++ b/apps/desktop/src/renderer/src/model/emit-json-schema.ts
@@ -23,10 +23,12 @@
 import type { FieldDef, FieldType, ImportDecl, Schema, TypeDef } from './ir';
 
 const DRAFT = 'https://json-schema.org/draft/2020-12/schema';
-const GENERATED_MARKER =
-  '@contexture-generated — do not edit by hand. Regenerated on every IR save.';
+function generatedMarker(sourcePath?: string): string {
+  const base = '@contexture-generated — do not edit by hand. Regenerated on every IR save.';
+  return sourcePath ? `${base} Source: ${sourcePath}` : base;
+}
 
-export function emit(schema: Schema, rootTypeName?: string): object {
+export function emit(schema: Schema, rootTypeName?: string, sourcePath?: string): object {
   const aliases = new Map<string, ImportDecl>();
   (schema.imports ?? []).forEach((imp) => {
     aliases.set(imp.alias, imp);
@@ -46,13 +48,13 @@ export function emit(schema: Schema, rootTypeName?: string): object {
     const rootSchema = emitTypeDef(root, aliases) as Record<string, unknown>;
     return {
       $schema: DRAFT,
-      $contexture_generated: GENERATED_MARKER,
+      $contexture_generated: generatedMarker(sourcePath),
       ...rootSchema,
       ...(Object.keys(defs).length > 0 ? { $defs: defs } : {}),
     };
   }
 
-  return { $schema: DRAFT, $contexture_generated: GENERATED_MARKER, $defs: defs };
+  return { $schema: DRAFT, $contexture_generated: generatedMarker(sourcePath), $defs: defs };
 }
 
 function emitTypeDef(type: TypeDef, aliases: Map<string, ImportDecl>): object {

--- a/apps/desktop/src/renderer/src/model/emit-schema-index.ts
+++ b/apps/desktop/src/renderer/src/model/emit-schema-index.ts
@@ -1,6 +1,6 @@
 /**
- * Pure emitter for `packages/schema/index.ts` — the workspace re-export that
- * lets `apps/*` import schemas as `import { Post } from '@<project>/schema'`
+ * Pure emitter for `packages/contexture/index.ts` — the workspace re-export that
+ * lets `apps/*` import schemas as `import { Post } from '@<project>/contexture'`
  * without caring which sibling `.schema.ts` module a name lives in.
  *
  * With a single IR per project the output is trivial: one re-export from
@@ -8,8 +8,11 @@
  * support the same function extends to emitting one `export *` per base.
  */
 
-const HEADER = '// @contexture-generated — do not edit by hand. Regenerated on every IR save.\n';
+function header(sourcePath?: string): string {
+  const base = '// @contexture-generated — do not edit by hand. Regenerated on every IR save.';
+  return sourcePath ? `${base} Source: ${sourcePath}\n` : `${base}\n`;
+}
 
-export function emit(baseName: string): string {
-  return `${HEADER}export * from './${baseName}.schema';\n`;
+export function emit(baseName: string, sourcePath?: string): string {
+  return `${header(sourcePath)}export * from './${baseName}.schema';\n`;
 }

--- a/apps/desktop/src/renderer/src/model/validate-project-name.ts
+++ b/apps/desktop/src/renderer/src/model/validate-project-name.ts
@@ -2,7 +2,7 @@
  * `validateProjectName` — enforces the name shape the scaffolder needs.
  *
  * The project name becomes all of: the monorepo directory, the npm
- * scope in `@<name>/schema`, and the Convex project slug passed to
+ * scope in `@<name>/contexture`, and the Convex project slug passed to
  * `convex dev --project`. Intersecting those three rulesets gives us
  * kebab-case, must-start-with-letter, and the npm 214-char cap.
  */

--- a/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
+++ b/apps/desktop/tests/components/dialogs/NewProjectDialog.test.tsx
@@ -366,7 +366,7 @@ describe('NewProjectDialog', () => {
       expect(useNewProjectStore.getState().isOpen).toBe(false);
     });
     expect(onOpenProject).toHaveBeenCalledWith(
-      '/tmp/my-proj/packages/schema/my-proj.contexture.json',
+      '/tmp/my-proj/packages/contexture/my-proj.contexture.json',
     );
   });
 

--- a/apps/desktop/tests/main/document-store.test.ts
+++ b/apps/desktop/tests/main/document-store.test.ts
@@ -229,10 +229,10 @@ describe('DocumentStore', () => {
   });
 
   it('project-mode open writes CLAUDE.md at the project root if missing, with {{PROJECT_NAME}} substituted', async () => {
-    const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
+    const monorepoIrPath = '/proj/packages/contexture/my-app.contexture.json';
     const { store, fs } = setup({
       [monorepoIrPath]: JSON.stringify(sampleIR),
-      '/proj/packages/schema/.contexture/.keep': '',
+      '/proj/packages/contexture/.contexture/.keep': '',
     });
     const bundle = await store.open(monorepoIrPath);
     expect(bundle.mode).toBe('project');
@@ -243,10 +243,10 @@ describe('DocumentStore', () => {
   });
 
   it('project-mode open never overwrites an existing CLAUDE.md', async () => {
-    const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
+    const monorepoIrPath = '/proj/packages/contexture/my-app.contexture.json';
     const { store, fs } = setup({
       [monorepoIrPath]: JSON.stringify(sampleIR),
-      '/proj/packages/schema/.contexture/.keep': '',
+      '/proj/packages/contexture/.contexture/.keep': '',
       '/proj/CLAUDE.md': '# user-owned notes\n',
     });
     await store.open(monorepoIrPath);
@@ -255,7 +255,7 @@ describe('DocumentStore', () => {
   });
 
   it('project-mode open seeds apps/web/convex/<table>.ts for each table-flagged type when missing', async () => {
-    const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
+    const monorepoIrPath = '/proj/packages/contexture/my-app.contexture.json';
     const tableSchema: Schema = {
       version: '1',
       types: [
@@ -275,23 +275,23 @@ describe('DocumentStore', () => {
     };
     const { store, fs } = setup({
       [monorepoIrPath]: JSON.stringify(tableSchema),
-      '/proj/packages/schema/.contexture/.keep': '',
+      '/proj/packages/contexture/.contexture/.keep': '',
     });
     await store.open(monorepoIrPath);
-    const postPath = '/proj/packages/schema/convex/Post.ts';
+    const postPath = '/proj/packages/contexture/convex/Post.ts';
     expect(fs.exists(postPath)).toBe(true);
     const contents = await fs.readFile(postPath);
     expect(contents).toContain('@contexture-seeded');
     expect(contents).toContain('ctx.db.query("Post")');
     // Non-table types get no file.
-    expect(fs.exists('/proj/packages/schema/convex/Inline.ts')).toBe(false);
+    expect(fs.exists('/proj/packages/contexture/convex/Inline.ts')).toBe(false);
   });
 
   it('auto-save never clobbers a user-edited seeded CRUD file', async () => {
     // Seeded CRUD files are @contexture-seeded, not @contexture-generated.
     // Once seeded, they must survive every subsequent IR save — the user
     // or coding agent owns them.
-    const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
+    const monorepoIrPath = '/proj/packages/contexture/my-app.contexture.json';
     const tableSchema: Schema = {
       version: '1',
       types: [
@@ -305,10 +305,10 @@ describe('DocumentStore', () => {
     };
     const { store, fs } = setup({
       [monorepoIrPath]: JSON.stringify(tableSchema),
-      '/proj/packages/schema/.contexture/.keep': '',
+      '/proj/packages/contexture/.contexture/.keep': '',
     });
     await store.open(monorepoIrPath);
-    const crudPath = '/proj/packages/schema/convex/Post.ts';
+    const crudPath = '/proj/packages/contexture/convex/Post.ts';
     // User edits the seeded file.
     const userEdit = '// user took over\nexport const list = () => 42;\n';
     await fs.writeFile(crudPath, userEdit);
@@ -323,7 +323,7 @@ describe('DocumentStore', () => {
   });
 
   it('project-mode open never overwrites an existing per-table CRUD file', async () => {
-    const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
+    const monorepoIrPath = '/proj/packages/contexture/my-app.contexture.json';
     const tableSchema: Schema = {
       version: '1',
       types: [
@@ -338,11 +338,11 @@ describe('DocumentStore', () => {
     const userOwned = '// user-modified CRUD, do not touch\nexport const list = null;\n';
     const { store, fs } = setup({
       [monorepoIrPath]: JSON.stringify(tableSchema),
-      '/proj/packages/schema/.contexture/.keep': '',
-      '/proj/packages/schema/convex/Post.ts': userOwned,
+      '/proj/packages/contexture/.contexture/.keep': '',
+      '/proj/packages/contexture/convex/Post.ts': userOwned,
     });
     await store.open(monorepoIrPath);
-    expect(await fs.readFile('/proj/packages/schema/convex/Post.ts')).toBe(userOwned);
+    expect(await fs.readFile('/proj/packages/contexture/convex/Post.ts')).toBe(userOwned);
   });
 
   it('scratch-mode open does not seed per-table CRUD files', async () => {
@@ -360,8 +360,8 @@ describe('DocumentStore', () => {
     const { store, fs } = setup({ [irPath]: JSON.stringify(tableSchema) });
     await store.open(irPath);
     // Scratch mode has no project root, so no convex tree can be seeded.
-    expect(fs.exists('/packages/schema/convex/Post.ts')).toBe(false);
-    expect(fs.exists('/work/packages/schema/convex/Post.ts')).toBe(false);
+    expect(fs.exists('/packages/contexture/convex/Post.ts')).toBe(false);
+    expect(fs.exists('/work/packages/contexture/convex/Post.ts')).toBe(false);
   });
 
   it('scratch-mode open does not write CLAUDE.md', async () => {
@@ -406,7 +406,7 @@ describe('DocumentStore', () => {
     // Seeded files are not @contexture-generated, so they must not appear
     // in the drift manifest. A drift check flags regen-on-mismatch;
     // listing seeded files there would cause them to be regenerated.
-    const monorepoIrPath = '/proj/packages/schema/my-app.contexture.json';
+    const monorepoIrPath = '/proj/packages/contexture/my-app.contexture.json';
     const tableSchema: Schema = {
       version: '1',
       types: [
@@ -420,7 +420,7 @@ describe('DocumentStore', () => {
     };
     const { store, fs } = setup({
       [monorepoIrPath]: JSON.stringify(tableSchema),
-      '/proj/packages/schema/.contexture/.keep': '',
+      '/proj/packages/contexture/.contexture/.keep': '',
     });
     await store.open(monorepoIrPath);
     await store.save({
@@ -430,9 +430,9 @@ describe('DocumentStore', () => {
       chat: { version: '1', messages: [] },
     });
     const manifest = JSON.parse(
-      await fs.readFile('/proj/packages/schema/.contexture/emitted.json'),
+      await fs.readFile('/proj/packages/contexture/.contexture/emitted.json'),
     ) as { files: Record<string, string> };
-    expect(Object.keys(manifest.files)).not.toContain('/proj/packages/schema/convex/Post.ts');
+    expect(Object.keys(manifest.files)).not.toContain('/proj/packages/contexture/convex/Post.ts');
   });
 
   it('scratch-mode save does not write a schema index', async () => {

--- a/apps/desktop/tests/main/drift-watcher.test.ts
+++ b/apps/desktop/tests/main/drift-watcher.test.ts
@@ -8,7 +8,7 @@ import { createDriftWatcher } from '@main/documents/drift-watcher';
 import { describe, expect, it, vi } from 'vitest';
 
 const WATCHED = '/proj/apps/web/convex/schema.ts';
-const EMITTED = '/proj/packages/schema/.contexture/emitted.json';
+const EMITTED = '/proj/packages/contexture/.contexture/emitted.json';
 
 function sha256(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');

--- a/apps/desktop/tests/main/scaffold-composite-runner.test.ts
+++ b/apps/desktop/tests/main/scaffold-composite-runner.test.ts
@@ -80,20 +80,20 @@ describe('createCompositeStageRunner', () => {
     expect(spawnCalls[0].args[0]).toBe('create-electron-app@latest');
   });
 
-  it('CONVEX_INIT: seeds packages/schema anchor + installs convex locally, then spawns convex dev', async () => {
+  it('CONVEX_INIT: seeds packages/contexture anchor + installs convex locally, then spawns convex dev', async () => {
     const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
     for await (const _ of runner.run(STAGE.CONVEX_INIT, config)) {
       // drain
     }
-    const pkg = JSON.parse(await fs.readFile('/work/my-proj/packages/schema/package.json'));
+    const pkg = JSON.parse(await fs.readFile('/work/my-proj/packages/contexture/package.json'));
     expect(pkg.dependencies.convex).toBeDefined();
     expect(spawnCalls).toHaveLength(2);
     expect(spawnCalls[0].cmd).toBe('bun');
     expect(spawnCalls[0].args).toEqual(['install']);
-    expect(spawnCalls[0].cwd).toBe('/work/my-proj/packages/schema');
+    expect(spawnCalls[0].cwd).toBe('/work/my-proj/packages/contexture');
     expect(spawnCalls[1].cmd).toBe('bunx');
     expect(spawnCalls[1].args[0]).toBe('convex@latest');
-    expect(spawnCalls[1].cwd).toBe('/work/my-proj/packages/schema');
+    expect(spawnCalls[1].cwd).toBe('/work/my-proj/packages/contexture');
   });
 
   it('SCHEMA_PACKAGE runs in-process — writes the schema package tree', async () => {
@@ -101,21 +101,21 @@ describe('createCompositeStageRunner', () => {
     for await (const _ of runner.run(STAGE.SCHEMA_PACKAGE, config)) {
       // drain
     }
-    expect(fs.exists('/work/my-proj/packages/schema/my-proj.contexture.json')).toBe(true);
-    expect(fs.exists('/work/my-proj/packages/schema/package.json')).toBe(true);
+    expect(fs.exists('/work/my-proj/packages/contexture/my-proj.contexture.json')).toBe(true);
+    expect(fs.exists('/work/my-proj/packages/contexture/package.json')).toBe(true);
     expect(spawnCalls).toHaveLength(0);
   });
 
   it('CONVEX_EMIT runs in-process — writes the Convex schema', async () => {
     await fs.writeFile(
-      `${config.targetDir}/packages/schema/my-proj.contexture.json`,
+      `${config.targetDir}/packages/contexture/my-proj.contexture.json`,
       JSON.stringify({ version: '1', types: [] }),
     );
     const runner = createCompositeStageRunner({ fs, spawner: okSpawner() });
     for await (const _ of runner.run(STAGE.CONVEX_EMIT, config)) {
       // drain
     }
-    expect(fs.exists('/work/my-proj/packages/schema/convex/schema.ts')).toBe(true);
+    expect(fs.exists('/work/my-proj/packages/contexture/convex/schema.ts')).toBe(true);
     expect(spawnCalls).toHaveLength(0);
   });
 

--- a/apps/desktop/tests/main/scaffold-convex-emit.test.ts
+++ b/apps/desktop/tests/main/scaffold-convex-emit.test.ts
@@ -1,7 +1,7 @@
 /**
  * `scaffoldConvexEmit` (stage 7) — emits the Convex schema (and
  * per-table CRUD seeds, if the initial IR had any tables) at
- * `packages/schema/convex/`. At scaffold time the IR is empty, so
+ * `packages/contexture/convex/`. At scaffold time the IR is empty, so
  * the convex schema is the degenerate `defineSchema({})`. The stage
  * still needs to run so `bun run dev` finds a valid schema file.
  */
@@ -10,7 +10,7 @@ import { scaffoldConvexEmit } from '@main/scaffold/convex-emit';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 const config = { targetDir: '/work/my-proj', projectName: 'my-proj', apps: ['web'] as const };
-const schemaDir = '/work/my-proj/packages/schema';
+const schemaDir = '/work/my-proj/packages/contexture';
 
 let fs: ReturnType<typeof createMemFsAdapter>;
 
@@ -19,7 +19,7 @@ beforeEach(() => {
 });
 
 describe('scaffoldConvexEmit', () => {
-  it('writes packages/schema/convex/schema.ts with the contexture-generated banner', async () => {
+  it('writes packages/contexture/convex/schema.ts with the contexture-generated banner', async () => {
     // Stage 6 has already written the empty IR; we read it back.
     const irPath = `${schemaDir}/my-proj.contexture.json`;
     await fs.writeFile(irPath, JSON.stringify({ version: '1', types: [] }));

--- a/apps/desktop/tests/main/scaffold-e2e.test.ts
+++ b/apps/desktop/tests/main/scaffold-e2e.test.ts
@@ -59,9 +59,9 @@ describeOrSkip('scaffold end-to-end (SCAFFOLD_E2E=1)', () => {
         // Key artefacts on disk.
         expect(existsSync(join(targetDir, 'apps/web/package.json'))).toBe(true);
         expect(
-          existsSync(join(targetDir, 'packages/schema', `${projectName}.contexture.json`)),
+          existsSync(join(targetDir, 'packages/contexture', `${projectName}.contexture.json`)),
         ).toBe(true);
-        expect(existsSync(join(targetDir, 'packages/schema/convex/schema.ts'))).toBe(true);
+        expect(existsSync(join(targetDir, 'packages/contexture/convex/schema.ts'))).toBe(true);
         expect(existsSync(join(targetDir, 'CLAUDE.md'))).toBe(true);
         expect(existsSync(join(targetDir, 'biome.json'))).toBe(true);
         expect(existsSync(join(targetDir, '.git'))).toBe(true);

--- a/apps/desktop/tests/main/scaffold-schema-package.test.ts
+++ b/apps/desktop/tests/main/scaffold-schema-package.test.ts
@@ -1,5 +1,5 @@
 /**
- * `scaffoldSchemaPackage` (stage 6) — lays down `packages/schema/`
+ * `scaffoldSchemaPackage` (stage 6) — lays down `packages/contexture/`
  * with the initial IR, empty sidecars, a workspace package.json, a
  * `.gitignore`, and the `.contexture/` marker dir with empty
  * layout/chat/emitted stubs. Drives through MemFsAdapter so the
@@ -10,7 +10,7 @@ import { scaffoldSchemaPackage } from '@main/scaffold/schema-package';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 const config = { targetDir: '/work/my-proj', projectName: 'my-proj', apps: ['web'] as const };
-const schemaDir = '/work/my-proj/packages/schema';
+const schemaDir = '/work/my-proj/packages/contexture';
 
 let fs: ReturnType<typeof createMemFsAdapter>;
 
@@ -36,10 +36,10 @@ describe('scaffoldSchemaPackage', () => {
     expect(index).toContain(`export * from './my-proj.schema';`);
   });
 
-  it('writes a workspace package.json with the @<project>/schema name', async () => {
+  it('writes a workspace package.json with the @<project>/contexture name', async () => {
     await scaffoldSchemaPackage(config, { fs });
     const pkg = JSON.parse(await fs.readFile(`${schemaDir}/package.json`));
-    expect(pkg.name).toBe('@my-proj/schema');
+    expect(pkg.name).toBe('@my-proj/contexture');
     expect(pkg.private).toBe(true);
   });
 

--- a/apps/desktop/tests/main/scaffold-stages.test.ts
+++ b/apps/desktop/tests/main/scaffold-stages.test.ts
@@ -56,7 +56,7 @@ describe('shellStageSpecFor', () => {
     expect(spec.cwd).toBe('/work/my-proj');
   });
 
-  it('CONVEX_INIT: convex dev one-shot configure, local backend, inside packages/schema', () => {
+  it('CONVEX_INIT: convex dev one-shot configure, local backend, inside packages/contexture', () => {
     const spec = shellStageSpecFor(STAGE.CONVEX_INIT, config);
     expect(spec.cmd).toBe('bunx');
     expect(spec.args).toEqual([
@@ -68,7 +68,7 @@ describe('shellStageSpecFor', () => {
       '--project',
       'my-proj',
     ]);
-    expect(spec.cwd).toBe('/work/my-proj/packages/schema');
+    expect(spec.cwd).toBe('/work/my-proj/packages/contexture');
   });
 
   it('BUN_INSTALL: bun install at the project root', () => {

--- a/apps/desktop/tests/main/scaffold-workspace-stitch.test.ts
+++ b/apps/desktop/tests/main/scaffold-workspace-stitch.test.ts
@@ -1,6 +1,6 @@
 /**
  * `scaffoldWorkspaceStitch` (stage 9) — when 'web' is in config.apps,
- * merges `@<project>/schema: workspace:*` into `apps/web/package.json`;
+ * merges `@<project>/contexture: workspace:*` into `apps/web/package.json`;
  * always writes the root `CLAUDE.md`, `biome.json`, and `.gitignore`.
  * Pure file manipulation; git init is handled by a separate step.
  */
@@ -23,14 +23,14 @@ beforeEach(() => {
 });
 
 describe('scaffoldWorkspaceStitch', () => {
-  it('adds @<project>/schema: workspace:* to apps/web/package.json dependencies when web selected', async () => {
+  it('adds @<project>/contexture: workspace:* to apps/web/package.json dependencies when web selected', async () => {
     await fs.writeFile(
       webPkgPath,
       `${JSON.stringify({ name: 'web', dependencies: { next: '^16.0.0' } }, null, 2)}\n`,
     );
     await scaffoldWorkspaceStitch(webConfig, { fs });
     const pkg = JSON.parse(await fs.readFile(webPkgPath));
-    expect(pkg.dependencies['@my-proj/schema']).toBe('workspace:*');
+    expect(pkg.dependencies['@my-proj/contexture']).toBe('workspace:*');
     expect(pkg.dependencies.next).toBe('^16.0.0');
     expect(pkg.name).toBe('web');
   });
@@ -39,7 +39,7 @@ describe('scaffoldWorkspaceStitch', () => {
     await fs.writeFile(webPkgPath, `${JSON.stringify({ name: 'web' }, null, 2)}\n`);
     await scaffoldWorkspaceStitch(webConfig, { fs });
     const pkg = JSON.parse(await fs.readFile(webPkgPath));
-    expect(pkg.dependencies['@my-proj/schema']).toBe('workspace:*');
+    expect(pkg.dependencies['@my-proj/contexture']).toBe('workspace:*');
   });
 
   it('skips web package.json when web is not in apps', async () => {

--- a/apps/desktop/tests/model/emit-claude-md.test.ts
+++ b/apps/desktop/tests/model/emit-claude-md.test.ts
@@ -11,18 +11,18 @@ describe('emit (CLAUDE.md)', () => {
   it('tells coding agents the schema source-of-truth rule', () => {
     const out = emit('my-blog');
     expect(out).toMatch(/source of truth/i);
-    expect(out).toMatch(/packages\/schema\/my-blog\.contexture\.json/);
+    expect(out).toMatch(/packages\/contexture\/my-blog\.contexture\.json/);
   });
 
   it('warns against editing the generated Convex schema directly', () => {
     const out = emit('my-blog');
-    expect(out).toMatch(/packages\/schema\/convex\/schema\.ts/);
+    expect(out).toMatch(/packages\/contexture\/convex\/schema\.ts/);
     expect(out).toMatch(/do not edit|regenerat/i);
   });
 
-  it('names the workspace package as @{{PROJECT_NAME}}/schema', () => {
+  it('names the workspace package as @{{PROJECT_NAME}}/contexture', () => {
     const out = emit('my-blog');
-    expect(out).toContain('@my-blog/schema');
+    expect(out).toContain('@my-blog/contexture');
   });
 
   it('mentions the .contexture/ internal directory as off-limits', () => {

--- a/apps/desktop/tests/model/emit-convex.test.ts
+++ b/apps/desktop/tests/model/emit-convex.test.ts
@@ -178,6 +178,18 @@ describe('emitConvexSchema', () => {
     expect(() => emitConvexSchema(ir)).toThrow(/_id.*reserves/);
   });
 
+  it('includes the IR source path in the banner when provided', () => {
+    const ir: Schema = { version: '1', types: [] };
+    const out = emitConvexSchema(ir, '/proj/packages/contexture/app.contexture.json');
+    expect(out).toContain('Source: /proj/packages/contexture/app.contexture.json');
+  });
+
+  it('omits source path from the banner when not provided', () => {
+    const ir: Schema = { version: '1', types: [] };
+    const out = emitConvexSchema(ir);
+    expect(out).not.toContain('Source:');
+  });
+
   it('does not flag `_`-prefix on non-table object types', () => {
     const ir: Schema = {
       version: '1',

--- a/apps/desktop/tests/model/emit-json-schema.test.ts
+++ b/apps/desktop/tests/model/emit-json-schema.test.ts
@@ -18,6 +18,18 @@ describe('emit (JSON Schema)', () => {
     expect(out.$contexture_generated).toContain('@contexture-generated');
   });
 
+  it('includes the IR source path in the marker when provided', () => {
+    const out = emit({ version: '1', types: [] }, undefined, '/proj/ir.contexture.json') as {
+      $contexture_generated?: string;
+    };
+    expect(out.$contexture_generated).toContain('Source: /proj/ir.contexture.json');
+  });
+
+  it('omits source path from the marker when not provided', () => {
+    const out = emit({ version: '1', types: [] }) as { $contexture_generated?: string };
+    expect(out.$contexture_generated).not.toContain('Source:');
+  });
+
   it('emits an object TypeDef as an object schema in $defs', () => {
     const out = emit({
       version: '1',

--- a/apps/desktop/tests/model/emit-schema-index.test.ts
+++ b/apps/desktop/tests/model/emit-schema-index.test.ts
@@ -15,4 +15,14 @@ describe('emit (schema index re-export)', () => {
   it('works for other base names', () => {
     expect(emit('my-app')).toContain(`export * from './my-app.schema';`);
   });
+
+  it('includes the IR source path in the banner when provided', () => {
+    const out = emit('blog', '/proj/packages/contexture/blog.contexture.json');
+    expect(out).toContain('Source: /proj/packages/contexture/blog.contexture.json');
+  });
+
+  it('omits source path from the banner when not provided', () => {
+    const out = emit('blog');
+    expect(out).not.toContain('Source:');
+  });
 });

--- a/apps/desktop/tests/model/validate-project-name.test.ts
+++ b/apps/desktop/tests/model/validate-project-name.test.ts
@@ -4,7 +4,7 @@
  * stays dumb and the regression surface lives here.
  *
  * Kebab-case is the house style because it becomes the npm package name
- * (`@<name>/schema`), the monorepo directory, and the Convex project
+ * (`@<name>/contexture`), the monorepo directory, and the Convex project
  * slug — all three require the lowercase-letters-digits-hyphen shape.
  */
 import { validateProjectName } from '@renderer/model/validate-project-name';


### PR DESCRIPTION
## Summary

- Renamed `packages/schema/` → `packages/contexture/` and `@<project>/schema` → `@<project>/contexture` across all scaffolder stages, document-store, UI components, and drift detection
- Unified emitter banners to include IR source path for traceability (added `sourcePath` parameter to convex, json-schema, and schema-index emitters)
- Updated CLAUDE.md template paths/package name and added test coverage for the new `sourcePath` banner lines

Closes #155

## Test plan

- [x] All 721 tests pass
- [x] Lint and format clean
- [x] Typecheck clean