### PR TITLE
feat(drift): extend drift detection to all generated files

### DIFF
--- a/apps/desktop/src/main/documents/drift-watcher.ts
+++ b/apps/desktop/src/main/documents/drift-watcher.ts
@@ -1,85 +1,117 @@
 /**
- * `createDriftWatcher` — watches a single file for hand-edits and
- * compares its SHA-256 hash against the expected hash stored in
- * `.contexture/emitted.json`. When the hashes differ the watcher
- * calls `onDrift`; when they match again (because Contexture rewrote
- * the file) it calls `onResolved`.
+ * Drift detection for `@contexture-generated` files.
  *
- * Only `apps/web/convex/schema.ts` is watched — nothing else.
+ * `detectDrift` is a pure function that reads `.contexture/emitted.json`,
+ * hashes every file listed in the manifest, and returns a per-file
+ * status (`match | drifted | unreadable`). It has no side effects and
+ * can be reused by the CLI's file-backed forward (#207).
+ *
+ * `createDriftWatcher` wraps `detectDrift` with `fs.watch` subscriptions
+ * so the Electron main process gets live callbacks when any manifest
+ * file is hand-edited (or returns to its expected hash).
  *
  * Self-write suppression: the DocumentStore writes `emitted.json`
- * before it writes the watched file in the atomic bundle; by the time
+ * before it writes the watched files in the atomic bundle; by the time
  * the watcher fires the hashes already match, so Contexture's own
  * writes are silently ignored.
  */
 import { createHash } from 'node:crypto';
 import { type FSWatcher, promises as fsPromises, watch } from 'node:fs';
 
+// ─── Pure detector ───────────────────────────────────────────────────
+
+export interface DriftResult {
+  path: string;
+  status: 'match' | 'drifted' | 'unreadable';
+}
+
+export async function detectDrift(
+  emittedJsonPath: string,
+  readFile: (path: string) => Promise<string> = (p) => fsPromises.readFile(p, 'utf-8'),
+): Promise<DriftResult[]> {
+  let manifest: { files?: Record<string, string> };
+  try {
+    const raw = await readFile(emittedJsonPath);
+    manifest = JSON.parse(raw) as { files?: Record<string, string> };
+  } catch {
+    return [];
+  }
+
+  const files = manifest.files;
+  if (!files || Object.keys(files).length === 0) return [];
+
+  const results: DriftResult[] = [];
+  for (const [filePath, expectedHash] of Object.entries(files)) {
+    let actual: string | null;
+    try {
+      const content = await readFile(filePath);
+      actual = createHash('sha256').update(content, 'utf8').digest('hex');
+    } catch {
+      actual = null;
+    }
+    if (actual === null) {
+      results.push({ path: filePath, status: 'unreadable' });
+    } else if (actual !== expectedHash) {
+      results.push({ path: filePath, status: 'drifted' });
+    } else {
+      results.push({ path: filePath, status: 'match' });
+    }
+  }
+  return results;
+}
+
+// ─── Watcher ─────────────────────────────────────────────────────────
+
 export interface DriftWatcher {
   start(): void;
   stop(): void;
-  /** Force an immediate hash check (used by window-focus handler). */
   check(): Promise<void>;
-  /** Reset the drifted flag without stopping the watcher (used after dismiss). */
   resetDrifted(): void;
 }
 
 export interface DriftWatcherOptions {
-  /** Absolute path to the file being watched (e.g. `.../convex/schema.ts`). */
-  watchedPath: string;
-  /** Absolute path to `.contexture/emitted.json`. */
   emittedJsonPath: string;
-  onDrift: () => void;
+  onDrift: (paths: string[]) => void;
   onResolved: () => void;
-  /** Debounce delay in ms (default 300). */
   debounceMs?: number;
-  /** Injected file reader — defaults to `fs.promises.readFile`. Tests stub this. */
   readFile?: (path: string) => Promise<string>;
 }
 
 export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
   const {
-    watchedPath,
     emittedJsonPath,
     onDrift,
     onResolved,
     debounceMs = 300,
     readFile = (p) => fsPromises.readFile(p, 'utf-8'),
   } = opts;
-  let watcher: FSWatcher | null = null;
+
+  let watchers: FSWatcher[] = [];
+  let watchedPaths: string[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;
-  let drifted = false;
-
-  async function computeHash(path: string): Promise<string | null> {
-    try {
-      const content = await readFile(path);
-      return createHash('sha256').update(content, 'utf8').digest('hex');
-    } catch {
-      return null;
-    }
-  }
-
-  async function expectedHash(): Promise<string | null> {
-    try {
-      const raw = await readFile(emittedJsonPath);
-      const manifest = JSON.parse(raw) as { files?: Record<string, string> };
-      return manifest.files?.[watchedPath] ?? null;
-    } catch {
-      return null;
-    }
-  }
+  let driftedSet: Set<string> = new Set();
 
   async function doCheck(): Promise<void> {
-    const [actual, expected] = await Promise.all([computeHash(watchedPath), expectedHash()]);
-    if (actual === null || expected === null) return;
-    const nowDrifted = actual !== expected;
-    if (nowDrifted && !drifted) {
-      drifted = true;
-      onDrift();
-    } else if (!nowDrifted && drifted) {
-      drifted = false;
+    const results = await detectDrift(emittedJsonPath, readFile);
+    if (results.length === 0) return;
+
+    const nowDrifted = results.filter((r) => r.status === 'drifted').map((r) => r.path);
+    const wasDrifted = driftedSet.size > 0;
+    const isDrifted = nowDrifted.length > 0;
+
+    if (isDrifted) {
+      const changed =
+        nowDrifted.length !== driftedSet.size || nowDrifted.some((p) => !driftedSet.has(p));
+      driftedSet = new Set(nowDrifted);
+      if (!wasDrifted || changed) {
+        onDrift(nowDrifted);
+      }
+    } else if (wasDrifted) {
+      driftedSet = new Set();
       onResolved();
     }
+
+    updateWatchers(results.map((r) => r.path));
   }
 
   function scheduleCheck(): void {
@@ -90,23 +122,36 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
     }, debounceMs);
   }
 
+  function updateWatchers(manifestPaths: string[]): void {
+    const newPaths = manifestPaths.filter((p) => !watchedPaths.includes(p));
+    for (const p of newPaths) {
+      try {
+        const w = watch(p, () => scheduleCheck());
+        watchers.push(w);
+      } catch {
+        // File may not exist yet — that's fine, we'll detect on next check.
+      }
+    }
+    watchedPaths = [...new Set([...watchedPaths, ...manifestPaths])];
+  }
+
   return {
     start() {
-      if (watcher) return;
-      watcher = watch(watchedPath, () => scheduleCheck());
+      void doCheck();
     },
     stop() {
-      watcher?.close();
-      watcher = null;
+      for (const w of watchers) w.close();
+      watchers = [];
+      watchedPaths = [];
       if (timer !== null) {
         clearTimeout(timer);
         timer = null;
       }
-      drifted = false;
+      driftedSet = new Set();
     },
     check: doCheck,
     resetDrifted() {
-      drifted = false;
+      driftedSet = new Set();
     },
   };
 }

--- a/apps/desktop/src/main/documents/drift-watcher.ts
+++ b/apps/desktop/src/main/documents/drift-watcher.ts
@@ -90,10 +90,11 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
   let watchedPaths: string[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;
   let driftedSet: Set<string> = new Set();
+  let stopped = false;
 
   async function doCheck(): Promise<void> {
     const results = await detectDrift(emittedJsonPath, readFile);
-    if (results.length === 0) return;
+    if (stopped || results.length === 0) return;
 
     const nowDrifted = results.filter((r) => r.status === 'drifted').map((r) => r.path);
     const wasDrifted = driftedSet.size > 0;
@@ -137,9 +138,11 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
 
   return {
     start() {
+      stopped = false;
       void doCheck();
     },
     stop() {
+      stopped = true;
       for (const w of watchers) w.close();
       watchers = [];
       watchedPaths = [];

--- a/apps/desktop/src/main/ipc/drift.ts
+++ b/apps/desktop/src/main/ipc/drift.ts
@@ -16,20 +16,16 @@ import { createDriftWatcher, type DriftWatcher } from '../documents/drift-watche
 let activeWatcher: DriftWatcher | null = null;
 
 export function registerDriftIpc(mainWindow: BrowserWindow): void {
-  ipcMain.handle(
-    'drift:watch',
-    (_evt, payload: { watchedPath: string; emittedJsonPath: string }) => {
-      activeWatcher?.stop();
-      activeWatcher = createDriftWatcher({
-        watchedPath: payload.watchedPath,
-        emittedJsonPath: payload.emittedJsonPath,
-        onDrift: () => mainWindow.webContents.send('drift:detected'),
-        onResolved: () => mainWindow.webContents.send('drift:resolved'),
-      });
-      activeWatcher.start();
-      return { ok: true };
-    },
-  );
+  ipcMain.handle('drift:watch', (_evt, payload: { emittedJsonPath: string }) => {
+    activeWatcher?.stop();
+    activeWatcher = createDriftWatcher({
+      emittedJsonPath: payload.emittedJsonPath,
+      onDrift: (paths) => mainWindow.webContents.send('drift:detected', { paths }),
+      onResolved: () => mainWindow.webContents.send('drift:resolved'),
+    });
+    activeWatcher.start();
+    return { ok: true };
+  });
 
   ipcMain.handle('drift:unwatch', () => {
     activeWatcher?.stop();

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -167,15 +167,15 @@ export interface ContextureProjectAPI {
 }
 
 export interface ContextureDriftAPI {
-  /** Start watching a file for drift against emitted.json. */
-  watch: (payload: { watchedPath: string; emittedJsonPath: string }) => Promise<{ ok: boolean }>;
+  /** Start watching all manifest files for drift against emitted.json. */
+  watch: (payload: { emittedJsonPath: string }) => Promise<{ ok: boolean }>;
   /** Stop the active watcher. */
   unwatch: () => Promise<{ ok: boolean }>;
   /** Trigger a manual hash check (window focus). */
   check: () => Promise<{ ok: boolean }>;
   /** Reset the main-side drifted flag after user dismisses the banner. */
   dismiss: () => Promise<{ ok: boolean }>;
-  onDetected: (listener: () => void) => Unsubscribe;
+  onDetected: (listener: (payload: { paths: string[] }) => void) => Unsubscribe;
   onResolved: (listener: () => void) => Unsubscribe;
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -157,8 +157,8 @@ const project = {
 };
 
 const drift = {
-  /** Start watching a file for drift; stops any previous watcher. */
-  watch: (payload: { watchedPath: string; emittedJsonPath: string }): Promise<{ ok: boolean }> =>
+  /** Start watching all manifest files for drift; stops any previous watcher. */
+  watch: (payload: { emittedJsonPath: string }): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('drift:watch', payload) as Promise<{ ok: boolean }>,
   /** Stop the active watcher. */
   unwatch: (): Promise<{ ok: boolean }> =>
@@ -169,8 +169,8 @@ const drift = {
   /** Reset the main-side drifted flag after user dismisses the banner. */
   dismiss: (): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('drift:dismiss') as Promise<{ ok: boolean }>,
-  onDetected: (listener: () => void) =>
-    subscribe('drift:detected', (() => listener()) as (p: unknown) => void),
+  onDetected: (listener: (payload: { paths: string[] }) => void) =>
+    subscribe('drift:detected', listener as (p: unknown) => void),
   onResolved: (listener: () => void) =>
     subscribe('drift:resolved', (() => listener()) as (p: unknown) => void),
 };

--- a/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
@@ -1,22 +1,45 @@
 /**
  * `DriftBanner` — non-blocking banner shown at the top of the graph
- * view when `packages/contexture/convex/schema.ts` has been hand-edited outside
- * Contexture (drift detected by the main-process watcher).
+ * view when any `@contexture-generated` file has been hand-edited
+ * outside Contexture (drift detected by the main-process watcher).
  *
- * "Review changes" opens the reconcile modal (see #126); "Dismiss"
- * hides the banner until the next drift event.
+ * Single-file drift shows the file path; multi-file drift shows a count.
+ * "Review changes" opens the reconcile modal; "Dismiss" hides the banner
+ * until the next drift event.
  */
 import { AlertTriangle } from 'lucide-react';
+import { useMemo } from 'react';
 import { useDriftStore } from '../../store/drift';
 import { useReconcileStore } from '../../store/reconcile';
 import { Button } from '../ui/button';
 
+function shortPath(fullPath: string): string {
+  const marker = 'packages/contexture/';
+  const idx = fullPath.lastIndexOf(marker);
+  if (idx !== -1) return fullPath.slice(idx);
+  const slash = fullPath.lastIndexOf('/');
+  return slash === -1 ? fullPath : fullPath.slice(slash + 1);
+}
+
 export function DriftBanner(): React.JSX.Element | null {
-  const isDrifted = useDriftStore((s) => s.isDrifted);
+  const driftedPaths = useDriftStore((s) => s.driftedPaths);
   const dismiss = useDriftStore((s) => s.dismiss);
   const openReconcile = useReconcileStore((s) => s.open);
 
-  if (!isDrifted) return null;
+  const message = useMemo(() => {
+    if (driftedPaths.length === 0) return null;
+    if (driftedPaths.length === 1) {
+      return (
+        <>
+          <code className="font-mono">{shortPath(driftedPaths[0])}</code> was modified outside
+          Contexture.
+        </>
+      );
+    }
+    return <>{driftedPaths.length} generated files were modified outside Contexture.</>;
+  }, [driftedPaths]);
+
+  if (!message) return null;
 
   return (
     <div
@@ -25,10 +48,7 @@ export function DriftBanner(): React.JSX.Element | null {
       className="flex items-center gap-2 px-3 py-2 bg-amber-50 dark:bg-amber-950/40 border-b border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200 text-xs"
     >
       <AlertTriangle className="size-3.5 shrink-0" />
-      <span className="flex-1">
-        <code className="font-mono">packages/contexture/convex/schema.ts</code> was modified outside
-        Contexture.
-      </span>
+      <span className="flex-1">{message}</span>
       <Button
         variant="outline"
         size="sm"

--- a/apps/desktop/src/renderer/src/hooks/useClaudeReconcile.ts
+++ b/apps/desktop/src/renderer/src/hooks/useClaudeReconcile.ts
@@ -20,7 +20,7 @@ import { useDocumentStore } from '../store/document';
 import { type ApplyResult, apply, type Op } from '../store/ops';
 import { type ReconcileOp, useReconcileStore } from '../store/reconcile';
 import { useUndoStore } from '../store/undo';
-import { driftPathsFor } from './useDrift';
+import { convexPathFor } from './useDrift';
 
 interface RawReconcileEntry {
   op: unknown;
@@ -54,14 +54,14 @@ export function useClaudeReconcile(): void {
       return;
     }
 
-    const paths = driftPathsFor(filePath);
-    if (!paths) {
+    const watchedPath = convexPathFor(filePath);
+    if (!watchedPath) {
       reconcileStore.setError('Could not derive Convex schema path from the open IR.');
       return;
     }
 
     void (async () => {
-      const convexSource = await window.api?.readFileSilent(paths.watchedPath);
+      const convexSource = await window.api?.readFileSilent(watchedPath);
       if (cancelledRef.current) return;
       if (convexSource === null || convexSource === undefined) {
         reconcileStore.setError('Cannot read convex/schema.ts.');

--- a/apps/desktop/src/renderer/src/hooks/useDrift.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDrift.ts
@@ -2,8 +2,8 @@
  * `useDrift` — mounts and tears down the drift watcher for the current
  * project-mode document.
  *
- * When a project-mode document is open, starts watching
- * `packages/contexture/convex/schema.ts` against `.contexture/emitted.json`.
+ * When a project-mode document is open, starts watching all
+ * `@contexture-generated` files listed in `.contexture/emitted.json`.
  * Also triggers a manual re-check on window focus so edits made while
  * Contexture was in the background are caught immediately on return.
  *
@@ -16,30 +16,29 @@ import { useDriftStore } from '../store/drift';
 const IR_SUFFIX = '.contexture.json';
 
 /**
- * Derives drift-related paths from the IR file path.
+ * Derives the emitted-manifest path from the IR file path.
  *
  * IR lives at: <root>/packages/contexture/<name>.contexture.json
- * Convex schema: <root>/packages/contexture/convex/schema.ts
- *   → same dir as the IR, subdir convex/
  * Emitted manifest: <root>/packages/contexture/.contexture/emitted.json
- *   → same dir as the IR, subdir .contexture/
- *
- * Both use the same base dir, so we never need to compute the monorepo
- * root — just strip the IR filename and append the relative paths.
- * This guarantees watchedPath matches the key written into emitted.json
- * by document-store (which also derives paths from the same IR path).
  */
-export function driftPathsFor(
-  irPath: string,
-): { watchedPath: string; emittedJsonPath: string } | null {
+export function emittedPathFor(irPath: string): string | null {
   if (!irPath.endsWith(IR_SUFFIX)) return null;
   const slash = irPath.lastIndexOf('/');
   if (slash === -1) return null;
-  const dir = irPath.slice(0, slash); // e.g. /proj/packages/contexture
-  return {
-    watchedPath: `${dir}/convex/schema.ts`,
-    emittedJsonPath: `${dir}/.contexture/emitted.json`,
-  };
+  const dir = irPath.slice(0, slash);
+  return `${dir}/.contexture/emitted.json`;
+}
+
+/**
+ * Derives the Convex schema path from the IR file path.
+ * Used by the reconcile hook to read the on-disk Convex source.
+ */
+export function convexPathFor(irPath: string): string | null {
+  if (!irPath.endsWith(IR_SUFFIX)) return null;
+  const slash = irPath.lastIndexOf('/');
+  if (slash === -1) return null;
+  const dir = irPath.slice(0, slash);
+  return `${dir}/convex/schema.ts`;
 }
 
 export function useDrift(): void {
@@ -56,17 +55,17 @@ export function useDrift(): void {
       return;
     }
 
-    const paths = driftPathsFor(filePath);
-    if (!paths) {
+    const emittedJsonPath = emittedPathFor(filePath);
+    if (!emittedJsonPath) {
       void driftApi.unwatch();
       return;
     }
 
-    const { watchedPath, emittedJsonPath } = paths;
+    void driftApi.watch({ emittedJsonPath });
 
-    void driftApi.watch({ watchedPath, emittedJsonPath });
-
-    const unDetected = driftApi.onDetected(() => useDriftStore.getState().setDrifted());
+    const unDetected = driftApi.onDetected((payload) =>
+      useDriftStore.getState().setDrifted(payload.paths),
+    );
     const unResolved = driftApi.onResolved(() => useDriftStore.getState().setResolved());
 
     function onFocus(): void {

--- a/apps/desktop/src/renderer/src/store/drift.ts
+++ b/apps/desktop/src/renderer/src/store/drift.ts
@@ -1,24 +1,24 @@
 /**
- * `useDriftStore` — tracks whether the Convex schema file has been
- * hand-edited outside Contexture. Set by drift IPC events from the
- * main process; cleared by user dismissal or when Contexture re-writes
- * the file (bringing hashes back into agreement).
+ * `useDriftStore` — tracks which generated files have been hand-edited
+ * outside Contexture. Set by drift IPC events from the main process;
+ * cleared by user dismissal or when Contexture re-writes the files
+ * (bringing hashes back into agreement).
  */
 import { create } from 'zustand';
 
 interface DriftState {
-  isDrifted: boolean;
-  setDrifted: () => void;
+  driftedPaths: string[];
+  setDrifted: (paths: string[]) => void;
   setResolved: () => void;
   dismiss: () => void;
 }
 
 export const useDriftStore = create<DriftState>((set) => ({
-  isDrifted: false,
-  setDrifted: () => set({ isDrifted: true }),
-  setResolved: () => set({ isDrifted: false }),
+  driftedPaths: [],
+  setDrifted: (paths: string[]) => set({ driftedPaths: paths }),
+  setResolved: () => set({ driftedPaths: [] }),
   dismiss: () => {
-    set({ isDrifted: false });
+    set({ driftedPaths: [] });
     void window.contexture?.drift.dismiss();
   },
 }));

--- a/apps/desktop/tests/hooks/useDrift.test.ts
+++ b/apps/desktop/tests/hooks/useDrift.test.ts
@@ -1,0 +1,37 @@
+import { convexPathFor, emittedPathFor } from '@renderer/hooks/useDrift';
+import { describe, expect, it } from 'vitest';
+
+describe('emittedPathFor', () => {
+  it('derives emitted.json path from a valid IR path', () => {
+    const ir = '/proj/packages/contexture/garden.contexture.json';
+    expect(emittedPathFor(ir)).toBe('/proj/packages/contexture/.contexture/emitted.json');
+  });
+
+  it('returns null for a non-IR path', () => {
+    expect(emittedPathFor('/proj/packages/contexture/schema.ts')).toBeNull();
+  });
+
+  it('returns null for a path with no slash', () => {
+    expect(emittedPathFor('garden.contexture.json')).toBeNull();
+  });
+
+  it('handles deeply nested IR paths', () => {
+    const ir = '/a/b/c/d/garden.contexture.json';
+    expect(emittedPathFor(ir)).toBe('/a/b/c/d/.contexture/emitted.json');
+  });
+});
+
+describe('convexPathFor', () => {
+  it('derives convex schema path from a valid IR path', () => {
+    const ir = '/proj/packages/contexture/garden.contexture.json';
+    expect(convexPathFor(ir)).toBe('/proj/packages/contexture/convex/schema.ts');
+  });
+
+  it('returns null for a non-IR path', () => {
+    expect(convexPathFor('/proj/packages/contexture/schema.ts')).toBeNull();
+  });
+
+  it('returns null for a path with no slash', () => {
+    expect(convexPathFor('garden.contexture.json')).toBeNull();
+  });
+});

--- a/apps/desktop/tests/main/drift-watcher.test.ts
+++ b/apps/desktop/tests/main/drift-watcher.test.ts
@@ -336,4 +336,37 @@ describe('createDriftWatcher', () => {
     await watcher.check();
     expect(onDrift).toHaveBeenCalledTimes(2);
   });
+
+  it('does not fire callbacks after stop() during in-flight check', async () => {
+    const original = 'defineSchema({})';
+    const edited = 'defineSchema({ posts: defineTable({}) })';
+    const flush = () => new Promise((r) => setTimeout(r, 0));
+    let resolveFileRead: ((value: string) => void) | null = null;
+    const readFile = async (path: string): Promise<string> => {
+      if (path === EMITTED) return makeManifestSingleHash(sha256(original));
+      if (path === WATCHED) {
+        return new Promise<string>((resolve) => {
+          resolveFileRead = resolve;
+        });
+      }
+      throw new Error('unexpected');
+    };
+    const onDrift = vi.fn();
+    const onResolved = vi.fn();
+    const watcher = createDriftWatcher({
+      emittedJsonPath: EMITTED,
+      onDrift,
+      onResolved,
+      readFile,
+    });
+
+    const checkPromise = watcher.check();
+    await flush();
+    watcher.stop();
+    resolveFileRead?.(edited);
+    await checkPromise;
+
+    expect(onDrift).not.toHaveBeenCalled();
+    expect(onResolved).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/tests/main/drift-watcher.test.ts
+++ b/apps/desktop/tests/main/drift-watcher.test.ts
@@ -1,21 +1,41 @@
 /**
- * `createDriftWatcher` — unit tests using injected `readFile` so we
- * don't need to mock node:fs modules. The watcher is exercised via
- * `check()` which runs the same logic as the debounced fs.watch handler.
+ * `createDriftWatcher` + `detectDrift` — unit tests using injected
+ * `readFile` so we don't need to mock node:fs modules. The watcher is
+ * exercised via `check()` which runs the same logic as the debounced
+ * fs.watch handler.
  */
 import { createHash } from 'node:crypto';
-import { createDriftWatcher } from '@main/documents/drift-watcher';
+import { createDriftWatcher, detectDrift } from '@main/documents/drift-watcher';
 import { describe, expect, it, vi } from 'vitest';
 
 const WATCHED = '/proj/apps/web/convex/schema.ts';
+const SCHEMA_TS = '/proj/packages/contexture/garden.schema.ts';
+const SCHEMA_JSON = '/proj/packages/contexture/garden.schema.json';
+const SCHEMA_INDEX = '/proj/packages/contexture/index.ts';
 const EMITTED = '/proj/packages/contexture/.contexture/emitted.json';
 
 function sha256(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
 }
 
-function makeManifest(hash: string): string {
+function makeManifest(files: Record<string, string>): string {
+  const hashed: Record<string, string> = {};
+  for (const [path, content] of Object.entries(files)) {
+    hashed[path] = sha256(content);
+  }
+  return JSON.stringify({ version: '1', files: hashed }, null, 2);
+}
+
+// Legacy single-file helper for backward-compat tests
+function makeManifestSingleHash(hash: string): string {
   return JSON.stringify({ version: '1', files: { [WATCHED]: hash } }, null, 2);
+}
+
+function makeReadFile(files: Record<string, string>) {
+  return async (path: string): Promise<string> => {
+    if (path in files) return files[path];
+    throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
+  };
 }
 
 function makeWatcher(
@@ -25,19 +45,95 @@ function makeWatcher(
     onResolved = vi.fn(),
   }: { onDrift?: ReturnType<typeof vi.fn>; onResolved?: ReturnType<typeof vi.fn> } = {},
 ) {
-  const readFile = async (path: string): Promise<string> => {
-    if (path in files) return files[path];
-    throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
-  };
   const watcher = createDriftWatcher({
-    watchedPath: WATCHED,
     emittedJsonPath: EMITTED,
     onDrift,
     onResolved,
-    readFile,
+    readFile: makeReadFile(files),
   });
   return { watcher, onDrift, onResolved };
 }
+
+// ─── detectDrift (pure function) ─────────────────────────────────────
+
+describe('detectDrift', () => {
+  it('returns "match" for all files when hashes agree', async () => {
+    const convex = 'defineSchema({})';
+    const zodTs = 'export const schema = z.object({})';
+    const jsonSchema = '{"type":"object"}';
+    const index = 'export * from "./garden.schema"';
+    const files: Record<string, string> = {
+      [WATCHED]: convex,
+      [SCHEMA_TS]: zodTs,
+      [SCHEMA_JSON]: jsonSchema,
+      [SCHEMA_INDEX]: index,
+      [EMITTED]: makeManifest({
+        [WATCHED]: convex,
+        [SCHEMA_TS]: zodTs,
+        [SCHEMA_JSON]: jsonSchema,
+        [SCHEMA_INDEX]: index,
+      }),
+    };
+    const results = await detectDrift(EMITTED, makeReadFile(files));
+    expect(results).toEqual([
+      { path: WATCHED, status: 'match' },
+      { path: SCHEMA_TS, status: 'match' },
+      { path: SCHEMA_JSON, status: 'match' },
+      { path: SCHEMA_INDEX, status: 'match' },
+    ]);
+  });
+
+  it('returns "drifted" for files whose hash differs', async () => {
+    const convex = 'defineSchema({})';
+    const editedConvex = 'defineSchema({ posts: defineTable({}) })';
+    const zodTs = 'export const schema = z.object({})';
+    const files: Record<string, string> = {
+      [WATCHED]: editedConvex,
+      [SCHEMA_TS]: zodTs,
+      [EMITTED]: makeManifest({
+        [WATCHED]: convex,
+        [SCHEMA_TS]: zodTs,
+      }),
+    };
+    const results = await detectDrift(EMITTED, makeReadFile(files));
+    expect(results).toEqual([
+      { path: WATCHED, status: 'drifted' },
+      { path: SCHEMA_TS, status: 'match' },
+    ]);
+  });
+
+  it('returns "unreadable" when a manifest file cannot be read', async () => {
+    const convex = 'defineSchema({})';
+    const files: Record<string, string> = {
+      [WATCHED]: convex,
+      // SCHEMA_TS is missing from disk
+      [EMITTED]: makeManifest({
+        [WATCHED]: convex,
+        [SCHEMA_TS]: 'some content',
+      }),
+    };
+    const results = await detectDrift(EMITTED, makeReadFile(files));
+    expect(results).toEqual([
+      { path: WATCHED, status: 'match' },
+      { path: SCHEMA_TS, status: 'unreadable' },
+    ]);
+  });
+
+  it('returns empty array when manifest cannot be read', async () => {
+    const results = await detectDrift(EMITTED, makeReadFile({}));
+    expect(results).toEqual([]);
+  });
+
+  it('returns empty array when manifest has no files', async () => {
+    const files: Record<string, string> = {
+      [EMITTED]: JSON.stringify({ version: '1', files: {} }),
+    };
+    const results = await detectDrift(EMITTED, makeReadFile(files));
+    expect(results).toEqual([]);
+  });
+});
+
+// ─── createDriftWatcher (multi-file) ─────────────────────────────────
 
 describe('createDriftWatcher', () => {
   it('calls onDrift when file hash differs from emitted manifest', async () => {
@@ -45,12 +141,13 @@ describe('createDriftWatcher', () => {
     const edited = 'defineSchema({ posts: defineTable({}) })';
     const { watcher, onDrift, onResolved } = makeWatcher({
       [WATCHED]: edited,
-      [EMITTED]: makeManifest(sha256(original)),
+      [EMITTED]: makeManifestSingleHash(sha256(original)),
     });
 
     await watcher.check();
 
     expect(onDrift).toHaveBeenCalledOnce();
+    expect(onDrift).toHaveBeenCalledWith([WATCHED]);
     expect(onResolved).not.toHaveBeenCalled();
   });
 
@@ -61,13 +158,12 @@ describe('createDriftWatcher', () => {
     let currentWatched = 'editedContent';
     const readFile = async (path: string): Promise<string> => {
       if (path === WATCHED) return currentWatched;
-      if (path === EMITTED) return makeManifest(hash);
+      if (path === EMITTED) return makeManifestSingleHash(hash);
       throw new Error('unexpected');
     };
     const onDrift = vi.fn();
     const onResolved = vi.fn();
     const watcher = createDriftWatcher({
-      watchedPath: WATCHED,
       emittedJsonPath: EMITTED,
       onDrift,
       onResolved,
@@ -87,7 +183,7 @@ describe('createDriftWatcher', () => {
     const hash = sha256(content);
     const { watcher, onDrift, onResolved } = makeWatcher({
       [WATCHED]: content,
-      [EMITTED]: makeManifest(hash),
+      [EMITTED]: makeManifestSingleHash(hash),
     });
 
     await watcher.check();
@@ -98,8 +194,8 @@ describe('createDriftWatcher', () => {
 
   it('does not call onDrift when the watched file cannot be read', async () => {
     const { watcher, onDrift } = makeWatcher({
-      [EMITTED]: makeManifest('somehash'),
-      // WATCHED is absent → ENOENT
+      [EMITTED]: makeManifestSingleHash('somehash'),
+      // WATCHED is absent → ENOENT → unreadable → not drifted
     });
 
     await watcher.check();
@@ -121,7 +217,7 @@ describe('createDriftWatcher', () => {
     const edited = 'defineSchema({ posts: defineTable({}) })';
     const { watcher, onDrift } = makeWatcher({
       [WATCHED]: edited,
-      [EMITTED]: makeManifest(sha256(original)),
+      [EMITTED]: makeManifestSingleHash(sha256(original)),
     });
 
     await watcher.check();
@@ -129,5 +225,115 @@ describe('createDriftWatcher', () => {
 
     // onDrift fires once — second check keeps the same drifted state.
     expect(onDrift).toHaveBeenCalledOnce();
+  });
+
+  it('calls onDrift with all drifted paths when multiple files drift', async () => {
+    const convex = 'defineSchema({})';
+    const zodTs = 'export const schema = z.object({})';
+    const editedConvex = 'defineSchema({ posts: defineTable({}) })';
+    const editedZod = 'export const schema = z.object({ name: z.string() })';
+    const { watcher, onDrift } = makeWatcher({
+      [WATCHED]: editedConvex,
+      [SCHEMA_TS]: editedZod,
+      [EMITTED]: makeManifest({
+        [WATCHED]: convex,
+        [SCHEMA_TS]: zodTs,
+      }),
+    });
+
+    await watcher.check();
+
+    expect(onDrift).toHaveBeenCalledOnce();
+    expect(onDrift).toHaveBeenCalledWith(expect.arrayContaining([WATCHED, SCHEMA_TS]));
+  });
+
+  it('updates drifted paths when a new file drifts', async () => {
+    const convex = 'defineSchema({})';
+    const zodTs = 'export const schema = z.object({})';
+    const editedConvex = 'defineSchema({ posts: defineTable({}) })';
+
+    let currentZod = zodTs;
+    const readFile = async (path: string): Promise<string> => {
+      if (path === WATCHED) return editedConvex;
+      if (path === SCHEMA_TS) return currentZod;
+      if (path === EMITTED) return makeManifest({ [WATCHED]: convex, [SCHEMA_TS]: zodTs });
+      throw new Error('unexpected');
+    };
+    const onDrift = vi.fn();
+    const onResolved = vi.fn();
+    const watcher = createDriftWatcher({
+      emittedJsonPath: EMITTED,
+      onDrift,
+      onResolved,
+      readFile,
+    });
+
+    await watcher.check();
+    expect(onDrift).toHaveBeenCalledWith([WATCHED]);
+
+    // Now the zod file also drifts
+    currentZod = 'edited zod';
+    await watcher.check();
+    expect(onDrift).toHaveBeenCalledTimes(2);
+    expect(onDrift).toHaveBeenLastCalledWith(expect.arrayContaining([WATCHED, SCHEMA_TS]));
+  });
+
+  it('only fires onResolved when ALL files return to matching', async () => {
+    const convex = 'defineSchema({})';
+    const zodTs = 'export const schema = z.object({})';
+    const editedConvex = 'defineSchema({ posts: defineTable({}) })';
+    const editedZod = 'edited zod';
+
+    let currentConvex = editedConvex;
+    let currentZod = editedZod;
+    const readFile = async (path: string): Promise<string> => {
+      if (path === WATCHED) return currentConvex;
+      if (path === SCHEMA_TS) return currentZod;
+      if (path === EMITTED) return makeManifest({ [WATCHED]: convex, [SCHEMA_TS]: zodTs });
+      throw new Error('unexpected');
+    };
+    const onDrift = vi.fn();
+    const onResolved = vi.fn();
+    const watcher = createDriftWatcher({
+      emittedJsonPath: EMITTED,
+      onDrift,
+      onResolved,
+      readFile,
+    });
+
+    // Both files drifted
+    await watcher.check();
+    expect(onDrift).toHaveBeenCalledOnce();
+
+    // Fix one file — still drifted (not resolved)
+    currentConvex = convex;
+    await watcher.check();
+    expect(onResolved).not.toHaveBeenCalled();
+    // onDrift fires again with updated paths
+    expect(onDrift).toHaveBeenCalledTimes(2);
+    expect(onDrift).toHaveBeenLastCalledWith([SCHEMA_TS]);
+
+    // Fix the other file — now resolved
+    currentZod = zodTs;
+    await watcher.check();
+    expect(onResolved).toHaveBeenCalledOnce();
+  });
+
+  it('resetDrifted clears all tracked paths', async () => {
+    const convex = 'defineSchema({})';
+    const editedConvex = 'defineSchema({ posts: defineTable({}) })';
+    const { watcher, onDrift } = makeWatcher({
+      [WATCHED]: editedConvex,
+      [EMITTED]: makeManifest({ [WATCHED]: convex }),
+    });
+
+    await watcher.check();
+    expect(onDrift).toHaveBeenCalledOnce();
+
+    watcher.resetDrifted();
+
+    // After reset, the same drift fires onDrift again
+    await watcher.check();
+    expect(onDrift).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary

- Extends drift detection from only `convex/schema.ts` to every file listed in `.contexture/emitted.json` (Zod barrel, JSON Schema, schema index, Convex schema)
- `detectDrift` extracted as a pure function returning `{path, status}[]` per manifest entry, enabling reuse by the CLI's file-backed forward
- Drift store now tracks `driftedPaths: string[]` instead of a boolean; DriftBanner shows the file path for single-file drift and a count for multi-file drift
- Fixes stop-during-check race in the drift watcher by adding a `stopped` guard after async `detectDrift` returns

Closes #160

## Test plan

- [x] 15 tests in `drift-watcher.test.ts` (9 new), all passing
- [x] `useDrift` hook tests for `emittedPathFor`/`convexPathFor` helpers
- [x] Race-condition regression test for stop-during-check
- [x] All 736 tests pass; lint, format, and typecheck clean