### PR TITLE
Reconcile drift in any generated file, not just the Convex schema

### DIFF
--- a/apps/desktop/src/main/ipc/claude.ts
+++ b/apps/desktop/src/main/ipc/claude.ts
@@ -345,19 +345,19 @@ export function registerClaudeIpc(mainWindow: BrowserWindow): ClaudeIpc {
   // stay completely isolated from the modal's request/response.
   ipcMain.handle(
     'reconcile:query',
-    async (_evt, payload: { irJson: string; convexSource: string }) => {
+    async (_evt, payload: { irJson: string; onDiskSource: string; targetKind: string }) => {
       try {
         const env: Record<string, string> | undefined =
           currentAuth.mode === 'api-key' && currentAuth.key
             ? { ANTHROPIC_API_KEY: currentAuth.key }
             : undefined;
         const iterator = query({
-          prompt: buildReconcileUserTurn(payload.irJson, payload.convexSource),
+          prompt: buildReconcileUserTurn(payload.irJson, payload.onDiskSource, payload.targetKind),
           options: {
             // Raw systemPrompt (not preset+append): the reconcile turn
             // wants none of Claude Code's default tool/skill framing —
             // it's a single Q→A round-trip producing JSON.
-            systemPrompt: RECONCILE_SYSTEM_PROMPT,
+            systemPrompt: buildReconcileSystemPrompt(payload.targetKind),
             allowedTools: [],
             disallowedTools: DISALLOWED_BUILTINS,
             model: currentModel,
@@ -479,22 +479,47 @@ function toSdkTool(descriptor: OpToolDescriptor) {
 }
 
 /**
- * System prompt for `reconcile:query`. TypeScript-constructed (not a
- * skill file) per the issue spec — keeps the modal's prompt static,
- * cacheable, and decoupled from the chat-session prompt builder.
+ * Target-kind descriptions used in the reconcile system prompt.
+ * These are lightly tuned per target so the model understands the
+ * output format it is reconciling against.
+ */
+const TARGET_KIND_DESCRIPTIONS: Record<string, string> = {
+  convex:
+    'a hand-edited `convex/schema.ts` file (Convex database schema). ' +
+    'Focus on `defineTable`, `v.*` validators, and Convex index definitions.',
+  zod:
+    'a hand-edited `.schema.ts` file (Zod schema mirror). ' +
+    'Focus on `z.object`, `z.enum`, `z.discriminatedUnion`, and inferred TypeScript types.',
+  'json-schema':
+    'a hand-edited `.schema.json` file (JSON Schema). ' +
+    'Focus on `$defs`, `properties`, `required`, `type`, and `enum` arrays.',
+  'schema-index':
+    'a hand-edited `index.ts` schema-index file that re-exports named Zod schemas. ' +
+    'Focus on the set of exported names and their re-export paths.',
+};
+
+/**
+ * Build the reconcile system prompt for `reconcile:query`. Varies
+ * lightly by `targetKind` so the model understands which file format
+ * it is reconciling against. TypeScript-constructed (not a skill file)
+ * to keep the prompt static, cacheable, and decoupled from the
+ * chat-session prompt builder.
  *
  * The op-vocabulary list is duplicated from `system-prompt.ts` rather
  * than imported because that module lives in the renderer's path
  * (`@renderer/...`) and we want this file (which runs in the main
  * process bundle) to keep its imports narrow.
  */
-const RECONCILE_SYSTEM_PROMPT = `You are a schema reconciliation assistant for Contexture.
+function buildReconcileSystemPrompt(targetKind: string): string {
+  const kindDesc =
+    TARGET_KIND_DESCRIPTIONS[targetKind] ??
+    'a hand-edited generated file that has diverged from what Contexture would emit.';
 
-The user has a Contexture IR (a JSON description of a Zod schema) and a
-hand-edited \`convex/schema.ts\` file that has diverged from what Contexture
-would emit from that IR. Your job is to return a JSON array of ops that,
-when applied to the IR, would make Contexture emit a \`schema.ts\` as close
-as possible to the hand-edited file.
+  return `You are a schema reconciliation assistant for Contexture.
+
+The user has a Contexture IR (a JSON description of a schema) and ${kindDesc}
+Your job is to return a JSON array of ops that, when applied to the IR, would make
+Contexture emit an output as close as possible to the hand-edited file.
 
 ## Op vocabulary
 
@@ -547,17 +572,18 @@ Mark \`lossy: true\` for:
 
 If no ops are needed (the IR already produces the hand-edited file), return \`[]\`.
 
-The current IR and the hand-edited \`schema.ts\` are in the user message.`;
+The current IR and the hand-edited file are in the user message.`;
+}
 
-function buildReconcileUserTurn(irJson: string, convexSource: string): string {
+function buildReconcileUserTurn(irJson: string, onDiskSource: string, targetKind: string): string {
   return [
     '<current_ir>',
     irJson,
     '</current_ir>',
     '',
-    '<convex_source>',
-    convexSource,
-    '</convex_source>',
+    `<on_disk_source kind="${targetKind}">`,
+    onDiskSource,
+    '</on_disk_source>',
     '',
     'Return the reconcile ops JSON array.',
   ].join('\n');

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -182,13 +182,14 @@ export interface ContextureDriftAPI {
 export interface ContextureReconcileAPI {
   /**
    * Fire a one-shot Claude query that proposes IR ops to align the
-   * current schema with the user's hand-edited Convex source. The
+   * current schema with the user's hand-edited on-disk source. The
    * returned `ops` array is raw — the renderer validates each entry
    * via the op-applier before showing it in the modal.
    */
   query: (payload: {
     irJson: string;
-    convexSource: string;
+    onDiskSource: string;
+    targetKind: string;
   }) => Promise<{ ok: boolean; ops?: unknown[]; error?: string }>;
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -178,12 +178,13 @@ const drift = {
 const reconcile = {
   /**
    * Fire a one-shot Claude query that returns reconcile ops for the
-   * current IR + on-disk Convex source. Used by the reconcile modal
-   * to populate its op checklist.
+   * current IR + on-disk source of any emitted file. Used by the
+   * reconcile modal to populate its op checklist.
    */
   query: (payload: {
     irJson: string;
-    convexSource: string;
+    onDiskSource: string;
+    targetKind: string;
   }): Promise<{ ok: boolean; ops?: unknown[]; error?: string }> =>
     ipcRenderer.invoke('reconcile:query', payload) as Promise<{
       ok: boolean;

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -17,7 +17,7 @@
  * Cancel → leave drift state alone.
  */
 
-import { baseNameFor } from '@contexture/core';
+import { baseNameFor } from '@contexture/core/paths';
 import { MultiFileDiff } from '@pierre/diffs/react';
 import { useChatThreads } from '@renderer/chat/useChatThreads';
 import { useClaudeReconcile } from '@renderer/hooks/useClaudeReconcile';

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -70,7 +70,7 @@ function safeEmitForTarget(schema: Schema, targetPath: string, irPath: string | 
       case 'schema-index':
         source = emitSchemaIndex(irPath ? baseNameFor(irPath) : 'schema', irPath ?? undefined);
         break;
-      default:
+      case 'unknown':
         return { source: '', error: `Cannot emit for unknown target kind (${targetPath}).` };
     }
     return { source, error: null };
@@ -179,12 +179,18 @@ export function ReconcileModal(): React.JSX.Element {
 
   const handleDiscard = useCallback(() => {
     if (!targetPath || !projection.emit.source || projection.emit.error) return;
-    void window.api?.saveFile(targetPath, projection.emit.source).then(() => {
-      useDriftStore.getState().setResolved();
-      void window.contexture?.drift.dismiss();
-      close();
-    });
-  }, [targetPath, projection, close]);
+    void window.api
+      ?.saveFile(targetPath, projection.emit.source)
+      .then(() => {
+        useDriftStore.getState().setResolved();
+        void window.contexture?.drift.dismiss();
+        close();
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(`Failed to overwrite file: ${message}`);
+      });
+  }, [targetPath, projection, close, setError]);
 
   const handleOpenInChat = useCallback(() => {
     const irJson = JSON.stringify(schema, null, 2);

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -1,8 +1,8 @@
 /**
- * `ReconcileModal` — drift reconciliation surface (issue #126).
+ * `ReconcileModal` — drift reconciliation surface (issue #161).
  *
- * Opens from `DriftBanner`'s "Review changes" button when the watched
- * `convex/schema.ts` has been hand-edited. Two-pane layout:
+ * Opens from `DriftBanner`'s "Review changes" button when any watched
+ * generated file has been hand-edited. Two-pane layout:
  *
  *   - Left: LLM-proposed op checklist (each row = one IR op).
  *     Toggling a row re-renders the right pane.
@@ -11,19 +11,25 @@
  *     disk, with a residual changed-line count underneath.
  *
  * Apply selected → run checked ops through the undo store as one
- * transaction, mark drift resolved, close. Open in chat → seed a new
- * chat thread with IR + Convex source + proposed ops. Cancel → leave
- * drift state alone.
+ * transaction, mark drift resolved, close.
+ * Discard on-disk → overwrite the target file with the current emit.
+ * Open in chat → seed a new chat thread with IR + source + proposed ops.
+ * Cancel → leave drift state alone.
  */
+
+import { baseNameFor } from '@contexture/core';
 import { MultiFileDiff } from '@pierre/diffs/react';
 import { useChatThreads } from '@renderer/chat/useChatThreads';
 import { useClaudeReconcile } from '@renderer/hooks/useClaudeReconcile';
 import { emitConvexSchema } from '@renderer/model/emit-convex';
+import { emit as emitJsonSchema } from '@renderer/model/emit-json-schema';
+import { emit as emitSchemaIndex } from '@renderer/model/emit-schema-index';
+import { emit as emitZod } from '@renderer/model/emit-zod';
 import type { Schema } from '@renderer/model/ir';
 import { useDocumentStore } from '@renderer/store/document';
 import { useDriftStore } from '@renderer/store/drift';
 import { apply } from '@renderer/store/ops';
-import { type ReconcileOp, useReconcileStore } from '@renderer/store/reconcile';
+import { type ReconcileOp, targetKindFor, useReconcileStore } from '@renderer/store/reconcile';
 import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import { useUndoStore } from '@renderer/store/undo';
 import { diffLines } from 'diff';
@@ -47,9 +53,27 @@ interface EmitResult {
   error: string | null;
 }
 
-function safeEmit(schema: Schema): EmitResult {
+function safeEmitForTarget(schema: Schema, targetPath: string, irPath: string | null): EmitResult {
+  const kind = targetKindFor(targetPath);
   try {
-    return { source: emitConvexSchema(schema), error: null };
+    let source: string;
+    switch (kind) {
+      case 'convex':
+        source = emitConvexSchema(schema, irPath ?? undefined);
+        break;
+      case 'zod':
+        source = emitZod(schema, irPath ?? '<unknown>');
+        break;
+      case 'json-schema':
+        source = `${JSON.stringify(emitJsonSchema(schema, undefined, irPath ?? undefined), null, 2)}\n`;
+        break;
+      case 'schema-index':
+        source = emitSchemaIndex(irPath ? baseNameFor(irPath) : 'schema', irPath ?? undefined);
+        break;
+      default:
+        return { source: '', error: `Cannot emit for unknown target kind (${targetPath}).` };
+    }
+    return { source, error: null };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { source: '', error: message };
@@ -83,13 +107,23 @@ function countResidualLines(left: string, right: string): number {
   return n;
 }
 
+/** Short display name for a path, trimmed to the portion after `packages/contexture/`. */
+function shortPath(fullPath: string): string {
+  const marker = 'packages/contexture/';
+  const idx = fullPath.lastIndexOf(marker);
+  if (idx !== -1) return fullPath.slice(idx + marker.length);
+  const slash = fullPath.lastIndexOf('/');
+  return slash === -1 ? fullPath : fullPath.slice(slash + 1);
+}
+
 export function ReconcileModal(): React.JSX.Element {
   const isOpen = useReconcileStore((s) => s.isOpen);
   const status = useReconcileStore((s) => s.status);
   const proposedOps = useReconcileStore((s) => s.proposedOps);
   const selectedIndices = useReconcileStore((s) => s.selectedIndices);
   const error = useReconcileStore((s) => s.error);
-  const convexSource = useReconcileStore((s) => s.convexSource);
+  const onDiskSource = useReconcileStore((s) => s.onDiskSource);
+  const targetPath = useReconcileStore((s) => s.targetPath);
   const close = useReconcileStore((s) => s.close);
   const setLoading = useReconcileStore((s) => s.setLoading);
   const setError = useReconcileStore((s) => s.setError);
@@ -104,21 +138,25 @@ export function ReconcileModal(): React.JSX.Element {
   useClaudeReconcile();
 
   const schema = useUndoStore((s) => s.schema);
+  const filePath = useDocumentStore((s) => s.filePath);
 
-  // Recompute the would-be Convex emit each time the user toggles an
-  // op. Cheap (pure function, < 10ms even on large schemas), so a
+  const displayName = targetPath ? shortPath(targetPath) : 'generated file';
+
+  // Recompute the would-be emit each time the user toggles an op.
+  // Cheap (pure function, < 10ms even on large schemas), so a
   // simple `useMemo` is sufficient — no need to debounce.
   const projection = useMemo(() => {
+    if (!targetPath) return { schema, error: null, emit: { source: '', error: 'No target.' } };
     const projected = applySelectedOps(schema, proposedOps, selectedIndices);
-    const emit = safeEmit(projected.schema);
+    const emit = safeEmitForTarget(projected.schema, targetPath, filePath);
     return { ...projected, emit };
-  }, [schema, proposedOps, selectedIndices]);
+  }, [schema, proposedOps, selectedIndices, targetPath, filePath]);
 
   const residualLines = useMemo(() => {
-    if (convexSource === null) return 0;
+    if (onDiskSource === null) return 0;
     if (projection.emit.error) return 0;
-    return countResidualLines(projection.emit.source, convexSource);
-  }, [convexSource, projection]);
+    return countResidualLines(projection.emit.source, onDiskSource);
+  }, [onDiskSource, projection]);
 
   const handleApply = useCallback(() => {
     setApplying();
@@ -139,21 +177,29 @@ export function ReconcileModal(): React.JSX.Element {
     close();
   }, [proposedOps, selectedIndices, setApplying, setError, close]);
 
+  const handleDiscard = useCallback(() => {
+    if (!targetPath || !projection.emit.source || projection.emit.error) return;
+    void window.api?.saveFile(targetPath, projection.emit.source).then(() => {
+      useDriftStore.getState().setResolved();
+      void window.contexture?.drift.dismiss();
+      close();
+    });
+  }, [targetPath, projection, close]);
+
   const handleOpenInChat = useCallback(() => {
-    const filePath = useDocumentStore.getState().filePath;
     const irJson = JSON.stringify(schema, null, 2);
     const opsJson = JSON.stringify(proposedOps, null, 2);
     const message = [
-      'Help me reconcile a Convex schema drift. Context follows.',
+      `Help me reconcile a drift in \`${displayName}\`. Context follows.`,
       '',
       '## Current IR',
       '```json',
       irJson,
       '```',
       '',
-      '## Hand-edited convex/schema.ts',
-      '```ts',
-      convexSource ?? '(unavailable)',
+      `## Hand-edited \`${displayName}\``,
+      '```',
+      onDiskSource ?? '(unavailable)',
       '```',
       '',
       '## Proposed reconcile ops',
@@ -174,7 +220,7 @@ export function ReconcileModal(): React.JSX.Element {
     useUIChromeStore.getState().setSidebarTab('chat');
     useUIChromeStore.getState().setSidebarVisible(true);
     close();
-  }, [schema, proposedOps, convexSource, history, close]);
+  }, [schema, proposedOps, onDiskSource, displayName, filePath, history, close]);
 
   const handleRetry = useCallback(() => {
     setLoading();
@@ -182,6 +228,9 @@ export function ReconcileModal(): React.JSX.Element {
 
   const applyDisabled =
     status !== 'ready' || selectedIndices.size === 0 || proposedOps.length === 0;
+
+  const discardDisabled =
+    status !== 'ready' || !targetPath || !!projection.emit.error || !projection.emit.source;
 
   return (
     <Dialog
@@ -192,10 +241,10 @@ export function ReconcileModal(): React.JSX.Element {
     >
       <DialogContent className="max-w-6xl w-full">
         <DialogHeader>
-          <DialogTitle>Reconcile schema changes</DialogTitle>
+          <DialogTitle>Reconcile changes</DialogTitle>
           <DialogDescription>
-            <code className="font-mono">convex/schema.ts</code> was edited outside Contexture.
-            Select the ops to bring the IR in line with the file, or open the proposal in chat for
+            <code className="font-mono">{displayName}</code> was edited outside Contexture. Select
+            the ops to bring the IR in line with the file, or open the proposal in chat for
             iteration.
           </DialogDescription>
         </DialogHeader>
@@ -288,7 +337,7 @@ export function ReconcileModal(): React.JSX.Element {
                 </p>
               )}
               {(status === 'ready' || status === 'applying') &&
-                convexSource !== null &&
+                onDiskSource !== null &&
                 (projection.emit.error ? (
                   <p className="p-3 text-sm text-destructive">
                     Cannot emit current schema: {projection.emit.error}
@@ -296,17 +345,21 @@ export function ReconcileModal(): React.JSX.Element {
                 ) : (
                   <MultiFileDiff
                     oldFile={{
-                      name: 'schema.ts',
+                      name: displayName,
                       contents: projection.emit.source,
-                      lang: 'ts',
+                      lang: displayName.endsWith('.json') ? 'json' : 'ts',
                     }}
-                    newFile={{ name: 'schema.ts', contents: convexSource, lang: 'ts' }}
+                    newFile={{
+                      name: displayName,
+                      contents: onDiskSource,
+                      lang: displayName.endsWith('.json') ? 'json' : 'ts',
+                    }}
                     options={{ diffStyle: 'split', disableFileHeader: true }}
                     disableWorkerPool={true}
                   />
                 ))}
             </div>
-            {(status === 'ready' || status === 'applying') && convexSource !== null && (
+            {(status === 'ready' || status === 'applying') && onDiskSource !== null && (
               <div className="px-3 py-2 border-t text-xs text-muted-foreground">
                 Residual: {residualLines} changed line{residualLines !== 1 ? 's' : ''} not covered
                 by selected ops
@@ -318,6 +371,14 @@ export function ReconcileModal(): React.JSX.Element {
         <DialogFooter>
           <Button variant="ghost" onClick={close}>
             Cancel
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handleDiscard}
+            disabled={discardDisabled}
+            title="Overwrite the on-disk file with what Contexture would emit"
+          >
+            Discard on-disk changes
           </Button>
           <Button
             variant="outline"

--- a/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
@@ -4,8 +4,8 @@
  * outside Contexture (drift detected by the main-process watcher).
  *
  * Single-file drift shows the file path; multi-file drift shows a count.
- * "Review changes" opens the reconcile modal; "Dismiss" hides the banner
- * until the next drift event.
+ * "Review changes" opens the reconcile modal for the first drifted file;
+ * "Dismiss" hides the banner until the next drift event.
  */
 import { AlertTriangle } from 'lucide-react';
 import { useMemo } from 'react';
@@ -41,6 +41,11 @@ export function DriftBanner(): React.JSX.Element | null {
 
   if (!message) return null;
 
+  // For multi-file drift, review the first drifted file. The user can
+  // dismiss and let the banner re-appear for subsequent files, or use
+  // the per-file list that drift detection surfaces.
+  const reviewTarget = driftedPaths[0];
+
   return (
     <div
       role="alert"
@@ -53,7 +58,7 @@ export function DriftBanner(): React.JSX.Element | null {
         variant="outline"
         size="sm"
         className="h-6 px-2 text-xs"
-        onClick={openReconcile}
+        onClick={() => reviewTarget && openReconcile(reviewTarget)}
         aria-label="Review changes"
       >
         Review changes

--- a/apps/desktop/src/renderer/src/hooks/useClaudeReconcile.ts
+++ b/apps/desktop/src/renderer/src/hooks/useClaudeReconcile.ts
@@ -3,14 +3,15 @@
  * when the modal opens and feeds the result into the reconcile store.
  *
  * Sequence:
- *   1. Read the on-disk Convex source via the legacy preload helper
- *      `window.api.readFileSilent` (already wired to Node fs).
+ *   1. Read the on-disk source for the target path via the legacy preload
+ *      helper `window.api.readFileSilent` (already wired to Node fs).
  *   2. Snapshot the current IR from the undo store.
- *   3. Round-trip via `window.contexture.reconcile.query`.
- *   4. Validate each returned op by attempting to apply it to a copy
+ *   3. Derive the target kind from the file path.
+ *   4. Round-trip via `window.contexture.reconcile.query`.
+ *   5. Validate each returned op by attempting to apply it to a copy
  *      of the schema — invalid entries are dropped with a console
  *      warning rather than failing the whole load.
- *   5. Push the surviving ops into the reconcile store.
+ *   6. Push the surviving ops into the reconcile store.
  *
  * Drops state updates after the modal closes (re-mounts on next
  * `open()` get a fresh effect run).
@@ -18,9 +19,8 @@
 import { useEffect, useRef } from 'react';
 import { useDocumentStore } from '../store/document';
 import { type ApplyResult, apply, type Op } from '../store/ops';
-import { type ReconcileOp, useReconcileStore } from '../store/reconcile';
+import { type ReconcileOp, targetKindFor, useReconcileStore } from '../store/reconcile';
 import { useUndoStore } from '../store/undo';
-import { convexPathFor } from './useDrift';
 
 interface RawReconcileEntry {
   op: unknown;
@@ -46,25 +46,24 @@ export function useClaudeReconcile(): void {
 
     const reconcileStore = useReconcileStore.getState();
     const docStore = useDocumentStore.getState();
-    const filePath = docStore.filePath;
     const mode = docStore.mode;
 
-    if (mode !== 'project' || !filePath) {
+    if (mode !== 'project') {
       reconcileStore.setError('Reconcile is only available for project-mode documents.');
       return;
     }
 
-    const watchedPath = convexPathFor(filePath);
-    if (!watchedPath) {
-      reconcileStore.setError('Could not derive Convex schema path from the open IR.');
+    const targetPath = reconcileStore.targetPath;
+    if (!targetPath) {
+      reconcileStore.setError('No target file specified for reconciliation.');
       return;
     }
 
     void (async () => {
-      const convexSource = await window.api?.readFileSilent(watchedPath);
+      const onDiskSource = await window.api?.readFileSilent(targetPath);
       if (cancelledRef.current) return;
-      if (convexSource === null || convexSource === undefined) {
-        reconcileStore.setError('Cannot read convex/schema.ts.');
+      if (onDiskSource === null || onDiskSource === undefined) {
+        reconcileStore.setError(`Cannot read ${targetPath}.`);
         return;
       }
 
@@ -75,11 +74,14 @@ export function useClaudeReconcile(): void {
         return;
       }
 
+      const targetKind = targetKindFor(targetPath);
+
       let result: { ok: boolean; ops?: unknown[]; error?: string };
       try {
         result = await reconcileApi.query({
           irJson: JSON.stringify(schema),
-          convexSource,
+          onDiskSource,
+          targetKind,
         });
       } catch (err) {
         if (cancelledRef.current) return;
@@ -116,7 +118,7 @@ export function useClaudeReconcile(): void {
       }
 
       // Empty array is a valid result — schemas already aligned.
-      reconcileStore.setReady(validated, convexSource);
+      reconcileStore.setReady(validated, onDiskSource);
     })();
 
     return () => {

--- a/apps/desktop/src/renderer/src/store/reconcile.ts
+++ b/apps/desktop/src/renderer/src/store/reconcile.ts
@@ -2,7 +2,7 @@
  * `useReconcileStore` — UI state for the drift-reconciliation modal.
  *
  * The modal is opened from the DriftBanner's "Review changes" button
- * when the watched Convex schema has been hand-edited. It hosts a
+ * when any watched generated file has been hand-edited. It hosts a
  * checklist of LLM-proposed ops on the left and a live `@pierre/diffs`
  * split view on the right. This store holds only UI state — the IR
  * itself stays in `useUndoStore` and is mutated through the normal
@@ -24,6 +24,25 @@ import type { Op } from './ops';
 
 export type ReconcileStatus = 'idle' | 'loading' | 'ready' | 'error' | 'applying';
 
+/** Which emitted-file kind the modal is reconciling against. */
+export type TargetKind = 'convex' | 'zod' | 'json-schema' | 'schema-index' | 'unknown';
+
+/**
+ * Detect the target kind from an absolute emitted-file path.
+ * Patterns mirror `bundlePathsFor` in `@contexture/core/pipeline`:
+ *   convex   → .../convex/schema.ts
+ *   zod      → .../<name>.schema.ts
+ *   json-schema → .../<name>.schema.json
+ *   schema-index → .../index.ts
+ */
+export function targetKindFor(path: string): TargetKind {
+  if (path.endsWith('/convex/schema.ts')) return 'convex';
+  if (path.endsWith('.schema.ts')) return 'zod';
+  if (path.endsWith('.schema.json')) return 'json-schema';
+  if (path.endsWith('/index.ts')) return 'schema-index';
+  return 'unknown';
+}
+
 export interface ReconcileOp {
   /** Stable React-list key. Generated when the op enters the store. */
   id: string;
@@ -41,13 +60,15 @@ interface ReconcileState {
   proposedOps: ReconcileOp[];
   selectedIndices: Set<number>;
   error: string | null;
-  /** On-disk contents of `convex/schema.ts` captured when the modal opened. */
-  convexSource: string | null;
+  /** Absolute path of the emitted file being reconciled. */
+  targetPath: string | null;
+  /** On-disk contents of the target file captured when the modal opened. */
+  onDiskSource: string | null;
 
-  open: () => void;
+  open: (targetPath: string) => void;
   close: () => void;
   setLoading: () => void;
-  setReady: (ops: ReconcileOp[], convexSource: string) => void;
+  setReady: (ops: ReconcileOp[], onDiskSource: string) => void;
   setError: (message: string) => void;
   setApplying: () => void;
   toggleOp: (index: number) => void;
@@ -74,32 +95,34 @@ const INITIAL: Omit<
   proposedOps: [],
   selectedIndices: new Set(),
   error: null,
-  convexSource: null,
+  targetPath: null,
+  onDiskSource: null,
 };
 
 export const useReconcileStore = create<ReconcileState>((set, get) => ({
   ...INITIAL,
 
-  open: () =>
+  open: (targetPath) =>
     set({
       isOpen: true,
       status: 'loading',
       proposedOps: [],
       selectedIndices: new Set(),
       error: null,
-      convexSource: null,
+      targetPath,
+      onDiskSource: null,
     }),
 
   close: () => set({ ...INITIAL }),
 
   setLoading: () => set({ status: 'loading', error: null }),
 
-  setReady: (ops, convexSource) =>
+  setReady: (ops, onDiskSource) =>
     set({
       status: 'ready',
       proposedOps: ops,
       selectedIndices: new Set(ops.map((_, i) => i)),
-      convexSource,
+      onDiskSource,
       error: null,
     }),
 

--- a/apps/desktop/tests/store/reconcile.test.ts
+++ b/apps/desktop/tests/store/reconcile.test.ts
@@ -25,4 +25,22 @@ describe('targetKindFor', () => {
   it('does not confuse a non-convex schema.ts with convex', () => {
     expect(targetKindFor('/proj/packages/other/schema.ts')).toBe('unknown');
   });
+
+  it('returns unknown for an empty string', () => {
+    expect(targetKindFor('')).toBe('unknown');
+  });
+
+  it('does not match index.ts without a leading slash', () => {
+    expect(targetKindFor('index.ts')).toBe('unknown');
+  });
+
+  it('does not match convex/schema.ts without a leading slash', () => {
+    expect(targetKindFor('convex/schema.ts')).toBe('unknown');
+  });
+
+  it('does not confuse a nested index.ts under a non-schema directory', () => {
+    // /index.ts suffix matches any /index.ts — that is expected behaviour per the
+    // bundlePathsFor contract, but confirm a deeply-nested path still resolves.
+    expect(targetKindFor('/proj/packages/contexture/src/index.ts')).toBe('schema-index');
+  });
 });

--- a/apps/desktop/tests/store/reconcile.test.ts
+++ b/apps/desktop/tests/store/reconcile.test.ts
@@ -1,0 +1,28 @@
+import { targetKindFor } from '@renderer/store/reconcile';
+import { describe, expect, it } from 'vitest';
+
+describe('targetKindFor', () => {
+  it('detects convex schema', () => {
+    expect(targetKindFor('/proj/packages/contexture/convex/schema.ts')).toBe('convex');
+  });
+
+  it('detects zod .schema.ts', () => {
+    expect(targetKindFor('/proj/packages/contexture/garden.schema.ts')).toBe('zod');
+  });
+
+  it('detects JSON schema .schema.json', () => {
+    expect(targetKindFor('/proj/packages/contexture/garden.schema.json')).toBe('json-schema');
+  });
+
+  it('detects schema-index index.ts', () => {
+    expect(targetKindFor('/proj/packages/contexture/index.ts')).toBe('schema-index');
+  });
+
+  it('returns unknown for unrecognised paths', () => {
+    expect(targetKindFor('/proj/packages/contexture/CLAUDE.md')).toBe('unknown');
+  });
+
+  it('does not confuse a non-convex schema.ts with convex', () => {
+    expect(targetKindFor('/proj/packages/other/schema.ts')).toBe('unknown');
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "./migrations": "./src/migrations/index.ts",
     "./ops": "./src/ops.ts",
     "./op-tools": "./src/op-tools.ts",
+    "./paths": "./src/paths.ts",
     "./pipeline": "./src/pipeline.ts"
   },
   "scripts": {

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,0 +1,57 @@
+export const IR_SUFFIX = '.contexture.json';
+export const SCHEMA_TS_SUFFIX = '.schema.ts';
+export const SCHEMA_JSON_SUFFIX = '.schema.json';
+export const LAYOUT_FILE = 'layout.json';
+export const CHAT_FILE = 'chat.json';
+export const EMITTED_FILE = 'emitted.json';
+
+export interface BundlePaths {
+  ir: string;
+  layout: string;
+  chat: string;
+  emitted: string;
+  schemaTs: string;
+  schemaJson: string;
+  schemaIndex: string;
+  convex: string;
+}
+
+export function contextureDirFor(irPath: string): string {
+  const slash = irPath.lastIndexOf('/');
+  const dir = slash === -1 ? '' : irPath.slice(0, slash);
+  return `${dir}/.contexture`;
+}
+
+export function baseNameFor(irPath: string): string {
+  const slash = irPath.lastIndexOf('/');
+  const leaf = slash === -1 ? irPath : irPath.slice(slash + 1);
+  return leaf.slice(0, -IR_SUFFIX.length);
+}
+
+export function projectRootFor(irPath: string): string | null {
+  const suffix = '/packages/contexture/';
+  const slash = irPath.lastIndexOf('/');
+  if (slash === -1) return null;
+  const dir = irPath.slice(0, slash);
+  if (!dir.endsWith('/packages/contexture')) return null;
+  return dir.slice(0, -suffix.length + 1);
+}
+
+export function bundlePathsFor(irPath: string): BundlePaths {
+  if (!irPath.endsWith(IR_SUFFIX)) {
+    throw new Error(`Expected a ${IR_SUFFIX} path, got: ${irPath}`);
+  }
+  const base = irPath.slice(0, -IR_SUFFIX.length);
+  const ctxDir = contextureDirFor(irPath);
+  const dir = ctxDir.slice(0, -'/.contexture'.length);
+  return {
+    ir: irPath,
+    layout: `${ctxDir}/${LAYOUT_FILE}`,
+    chat: `${ctxDir}/${CHAT_FILE}`,
+    emitted: `${ctxDir}/${EMITTED_FILE}`,
+    schemaTs: `${base}${SCHEMA_TS_SUFFIX}`,
+    schemaJson: `${base}${SCHEMA_JSON_SUFFIX}`,
+    schemaIndex: `${dir}/index.ts`,
+    convex: `${dir}/convex/schema.ts`,
+  };
+}

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -4,28 +4,25 @@ import { emit as emitJsonSchema } from './emit-json-schema';
 import { emit as emitSchemaIndex } from './emit-schema-index';
 import { emit as emitZod } from './emit-zod';
 import type { Schema } from './ir';
+import { type BundlePaths, baseNameFor, bundlePathsFor } from './paths';
 
-export const IR_SUFFIX = '.contexture.json';
-export const SCHEMA_TS_SUFFIX = '.schema.ts';
-export const SCHEMA_JSON_SUFFIX = '.schema.json';
-export const LAYOUT_FILE = 'layout.json';
-export const CHAT_FILE = 'chat.json';
-export const EMITTED_FILE = 'emitted.json';
+export type { BundlePaths } from './paths';
+export {
+  baseNameFor,
+  bundlePathsFor,
+  CHAT_FILE,
+  contextureDirFor,
+  EMITTED_FILE,
+  IR_SUFFIX,
+  LAYOUT_FILE,
+  projectRootFor,
+  SCHEMA_JSON_SUFFIX,
+  SCHEMA_TS_SUFFIX,
+} from './paths';
 
 export interface EmittedManifest {
   version: '1';
   files: Record<string, string>;
-}
-
-export interface BundlePaths {
-  ir: string;
-  layout: string;
-  chat: string;
-  emitted: string;
-  schemaTs: string;
-  schemaJson: string;
-  schemaIndex: string;
-  convex: string;
 }
 
 export interface FileEntry {
@@ -45,46 +42,6 @@ export interface EmitPipelineDeps {
   emitConvex?: (schema: Schema, sourcePath?: string) => string;
 }
 
-export function contextureDirFor(irPath: string): string {
-  const slash = irPath.lastIndexOf('/');
-  const dir = slash === -1 ? '' : irPath.slice(0, slash);
-  return `${dir}/.contexture`;
-}
-
-export function baseNameFor(irPath: string): string {
-  const slash = irPath.lastIndexOf('/');
-  const leaf = slash === -1 ? irPath : irPath.slice(slash + 1);
-  return leaf.slice(0, -IR_SUFFIX.length);
-}
-
-export function projectRootFor(irPath: string): string | null {
-  const suffix = '/packages/contexture/';
-  const slash = irPath.lastIndexOf('/');
-  if (slash === -1) return null;
-  const dir = irPath.slice(0, slash);
-  if (!dir.endsWith('/packages/contexture')) return null;
-  return dir.slice(0, -suffix.length + 1);
-}
-
-export function bundlePathsFor(irPath: string): BundlePaths {
-  if (!irPath.endsWith(IR_SUFFIX)) {
-    throw new Error(`Expected a ${IR_SUFFIX} path, got: ${irPath}`);
-  }
-  const base = irPath.slice(0, -IR_SUFFIX.length);
-  const ctxDir = contextureDirFor(irPath);
-  const dir = ctxDir.slice(0, -'/.contexture'.length);
-  return {
-    ir: irPath,
-    layout: `${ctxDir}/${LAYOUT_FILE}`,
-    chat: `${ctxDir}/${CHAT_FILE}`,
-    emitted: `${ctxDir}/${EMITTED_FILE}`,
-    schemaTs: `${base}${SCHEMA_TS_SUFFIX}`,
-    schemaJson: `${base}${SCHEMA_JSON_SUFFIX}`,
-    schemaIndex: `${dir}/index.ts`,
-    convex: `${dir}/convex/schema.ts`,
-  };
-}
-
 function sha256(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
 }
@@ -100,7 +57,7 @@ export function runEmitPipeline(
   irPath: string,
   deps: EmitPipelineDeps = {},
 ): EmitPipelineResult {
-  const paths = bundlePathsFor(irPath);
+  const paths: BundlePaths = bundlePathsFor(irPath);
   const {
     emitZod: emitZodImpl = emitZod,
     emitJsonSchema: emitJsonSchemaImpl = (s: Schema, sp?: string) =>


### PR DESCRIPTION
## Summary

- Generalised the reconcile modal to work with any emitted file (convex schema, Zod, JSON Schema, schema index) instead of just `convex/schema.ts`
- Added `targetKindFor()` utility to detect the target kind from file path, and updated the IPC bridge to route to the correct emitter
- Added "Discard on-disk changes" button as an escape hatch to resolve drift without accepting Claude's changes

Closes #161