### PR TITLE
chore(sandcastle): optimise Dockerfile PATH/cache and tighten agent prompts

### DIFF
--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -74,8 +74,21 @@ RUN chmod -R a+rwX /home/agent/.claude /home/agent/.claude.json /home/agent/.loc
 # $HOME defaults to "/" — bun install then tries to mkdir /.cache and
 # fails. Fixing HOME here lets every tool write to /home/agent/.cache
 # as intended.
-ENV PATH="/home/agent/.local/bin:$PATH"
+#
+# Also pre-resolve the workspace binaries the agents need. bun hoists
+# per-workspace, so the canonical path for `tsc` and `vitest` is the
+# workspace's own node_modules/.bin (root only has hoisted-to-root tools
+# like biome). Putting these on PATH means agents stop burning calls on
+# `which tsc` / `find -name vitest`.
+ENV PATH="/home/agent/workspace/apps/desktop/node_modules/.bin:/home/agent/workspace/node_modules/.bin:/home/agent/.local/bin:$PATH"
 ENV HOME=/home/agent
+
+# Sandcastle runs the container as the host UID, which has no write access to
+# the repo's .turbo/cache (owned by the host user inside the bind mount).
+# Pre-set TURBO_CACHE_DIR to a world-writable tmpfs path so `bun run ci` and
+# the husky pre-commit hook stop failing for permission reasons.
+ENV TURBO_CACHE_DIR=/tmp/turbo-cache
+RUN mkdir -p /tmp/turbo-cache && chmod 1777 /tmp/turbo-cache
 
 WORKDIR /home/agent
 

--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -12,7 +12,9 @@ Work on branch {{BRANCH}}. Make commits and run tests. Do NOT push the branch, o
 
 Read only what you need to make this specific change. Do not crawl the whole repo.
 
-1. Start from the issue body — it usually names the files or modules involved. Read those.
+1. Start from the issue body — it usually names the files or modules involved.
+   - **If the change is isolated to 1–3 named files**, read them directly.
+   - **If the issue spans multiple modules / layers, or you don't yet know which files to touch**, dispatch a single `Agent` call with `subagent_type: "Explore"` to map the relevant code in one round trip. Do not do 10+ narrow `find`/`grep` calls to discover the same thing — that wastes context.
 2. Use `grep` / `rg` to find direct callers and tests of the symbols you'll change. Read the closest tests.
 3. Stop exploring once you can describe the change you're about to make. If you find yourself reading unrelated code "for context", that's a signal to stop.
 
@@ -30,6 +32,8 @@ If applicable, use RGR to complete the task.
 # FEEDBACK LOOPS
 
 Run `bun run ci` to ensure typecheck, tests, and lint all pass. This is mandatory — do not commit if it fails. If `bun run ci` fails before you have made any changes, the sandbox itself is broken (e.g. corrupt `node_modules`); stop and report the failure rather than committing.
+
+When a lint/typecheck/test command fails, read the **full error output** before re-running. Do not pipe to `head` / `tail` / narrow `grep` on the first failure — you will miss the actual error and re-run unnecessarily. Once you have the error, fix it and verify with one re-run.
 
 # COMMIT
 

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -70,7 +70,7 @@ Never change what the code does - only how it does it. All original features, ou
 
 # EXECUTION
 
-1. Run `bun run ci` first to confirm the current state passes
+1. Run `bun run ci` first to confirm the current state passes. When any check fails, read the **full error output** before re-running. Do not pipe to `head` / `tail` / narrow `grep` on the first failure — you will miss the actual error and re-run unnecessarily. Once you have the error, fix it and verify with one re-run.
 2. Attempt to reproduce the original bug with new test cases — if you can, fix it
 3. Write edge case tests that stress the implementation
 4. Make any code quality improvements directly on this branch


### PR DESCRIPTION
## Summary
- Pre-resolve workspace `node_modules/.bin` on PATH and set `TURBO_CACHE_DIR=/tmp/turbo-cache` so `bun run ci` / husky stop hitting permission errors and agents stop burning calls locating `tsc`/`vitest`.
- Tighten implement/review prompts: dispatch a single `Explore` agent for multi-module changes instead of many narrow `grep`s, and read full error output on the first failure rather than piping to `head`/`tail`.

## Test plan
- [ ] Sandcastle container builds and `bun run ci` passes inside it without permission errors on `.turbo/cache`.
- [ ] `which tsc` / `which vitest` resolve inside the container without searching.
- [ ] Implement and review agent runs follow the updated prompt guidance on a sample issue.