### PR TITLE
feat(sandcastle): stream.log analyzer for harness improvements

### DIFF
--- a/.sandcastle/analyze.ts
+++ b/.sandcastle/analyze.ts
@@ -1,0 +1,121 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { loadBaseline, saveBaseline } from "./analyzer/baseline";
+import { bashInsteadOfDedicated } from "./analyzer/detectors/bash-instead-of-dedicated";
+import { excessiveExploration } from "./analyzer/detectors/excessive-exploration";
+import { failedToolRetry } from "./analyzer/detectors/failed-tool-retry";
+import { hardFailure } from "./analyzer/detectors/hard-failure";
+import { redundantToolCall } from "./analyzer/detectors/redundant-tool-call";
+import { reviewerReReads } from "./analyzer/detectors/reviewer-rereads";
+import { runOutlier, updateBaseline } from "./analyzer/detectors/run-outlier";
+import type { Event, Finding } from "./analyzer/detectors/types";
+import { llmGrade } from "./analyzer/llm-grader";
+import { groupByRun, parseStreamLog } from "./analyzer/parse";
+import { renderReport } from "./analyzer/report";
+
+const STREAM_LOG_PATH = ".sandcastle/logs/stream.log";
+const ANALYSIS_LATEST = ".sandcastle/logs/analysis.md";
+const ANALYSIS_ARCHIVE_DIR = ".sandcastle/logs/analysis";
+const BASELINE_PATH = ".sandcastle/logs/baseline.json";
+
+type Args = {
+  llm: boolean;
+  logPath: string;
+};
+
+function parseArgs(argv: readonly string[]): Args {
+  let llm = false;
+  let logPath = STREAM_LOG_PATH;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--llm") llm = true;
+    else if (arg === "--log" && i + 1 < argv.length) {
+      logPath = argv[++i] ?? logPath;
+    }
+  }
+  return { llm, logPath };
+}
+
+async function main(): Promise<void> {
+  const { llm, logPath } = parseArgs(process.argv.slice(2));
+
+  if (!existsSync(logPath)) {
+    console.log(`No stream log at ${logPath}; nothing to analyze.`);
+    return;
+  }
+
+  const events = parseStreamLog(logPath);
+  const runs = groupByRun(events);
+  if (runs.length === 0) {
+    console.log("Empty stream log; nothing to analyze.");
+    return;
+  }
+
+  // Always analyse the most recent run; baselines aggregate across all runs
+  // in the file (and across previous baseline.json state).
+  const latestRun = runs[runs.length - 1];
+  if (!latestRun) return;
+  const runEvents = latestRun.events;
+
+  const baseline = loadBaseline(BASELINE_PATH);
+
+  const findings: Finding[] = [
+    ...redundantToolCall.run(runEvents),
+    ...failedToolRetry.run(runEvents),
+    ...bashInsteadOfDedicated.run(runEvents),
+    ...excessiveExploration.run(runEvents),
+    ...reviewerReReads.run(runEvents),
+    ...hardFailure.run(runEvents),
+    ...runOutlier(runEvents, baseline),
+  ];
+
+  if (llm) {
+    try {
+      const llmFindings = await llmGrade(runEvents);
+      findings.push(...llmFindings);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`LLM grading failed: ${msg}`);
+    }
+  }
+
+  const report = renderReport({
+    runId: latestRun.runId,
+    events: runEvents,
+    findings,
+    generatedAt: new Date().toISOString(),
+  });
+
+  ensureDir(ANALYSIS_LATEST);
+  ensureDir(`${ANALYSIS_ARCHIVE_DIR}/.x`);
+  writeFileSync(ANALYSIS_LATEST, report);
+  writeFileSync(`${ANALYSIS_ARCHIVE_DIR}/${latestRun.runId}.md`, report);
+
+  // Update baseline with this run's measurements after analysis (so the
+  // current run isn't graded against itself).
+  saveBaseline(BASELINE_PATH, updateBaseline(baseline, runEvents));
+
+  printStdoutSummary(latestRun.runId, findings);
+}
+
+function printStdoutSummary(runId: string, findings: readonly Finding[]): void {
+  const sorted = [...findings].sort((a, b) => {
+    if (b.wastedToolCalls !== a.wastedToolCalls) return b.wastedToolCalls - a.wastedToolCalls;
+    return b.wastedSeconds - a.wastedSeconds;
+  });
+  const totalCalls = findings.reduce((s, f) => s + f.wastedToolCalls, 0);
+  const totalSecs = findings.reduce((s, f) => s + f.wastedSeconds, 0);
+  console.log(`\nSandcastle analysis (${runId})`);
+  console.log(`  ${findings.length} finding${findings.length === 1 ? "" : "s"}, ~${totalCalls} wasted call${totalCalls === 1 ? "" : "s"}, ~${Math.round(totalSecs)}s`);
+  for (const f of sorted.slice(0, 3)) {
+    console.log(`  - [${f.detector}] ${f.message} (${f.agentName}, ~${Math.round(f.wastedSeconds)}s)`);
+  }
+  console.log(`  Full report: ${ANALYSIS_LATEST}`);
+}
+
+function ensureDir(filePath: string): void {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+await main();

--- a/.sandcastle/analyzer/baseline.ts
+++ b/.sandcastle/analyzer/baseline.ts
@@ -1,0 +1,22 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import type { Baseline } from "./detectors/run-outlier";
+import { emptyBaseline } from "./detectors/run-outlier";
+
+// Read the rolling baseline from disk. Missing or unparseable file is
+// treated as "no history yet"; we don't crash on a corrupt baseline because
+// the analyzer is best-effort.
+export function loadBaseline(path: string): Baseline {
+  if (!existsSync(path)) return emptyBaseline();
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw) as Baseline;
+    if (parsed && typeof parsed === "object" && parsed.byPhase) return parsed;
+    return emptyBaseline();
+  } catch {
+    return emptyBaseline();
+  }
+}
+
+export function saveBaseline(path: string, baseline: Baseline): void {
+  writeFileSync(path, `${JSON.stringify(baseline, null, 2)}\n`);
+}

--- a/.sandcastle/analyzer/detectors/bash-instead-of-dedicated.test.ts
+++ b/.sandcastle/analyzer/detectors/bash-instead-of-dedicated.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { bashInsteadOfDedicated } from "./bash-instead-of-dedicated";
+import type { Event } from "./types";
+
+const tool = (overrides: Partial<Extract<Event, { type: "tool" }>>): Event => ({
+  type: "tool",
+  runId: "r1",
+  name: "iter1-implementer-42",
+  iter: 1,
+  t: "2026-04-30T12:00:00Z",
+  tool: "Bash",
+  args: "cat foo.ts",
+  ...overrides,
+});
+
+describe("bashInsteadOfDedicated (A4)", () => {
+  test("flags cat / head / tail / grep / find / ls", () => {
+    const cmds = ["cat a", "head -20 b", "tail -f c", "grep foo .", "rg foo", "find . -name", "ls src/"];
+    const events: Event[] = cmds.map((c, i) =>
+      tool({ args: c, t: `2026-04-30T12:00:${String(i).padStart(2, "0")}Z` }),
+    );
+    const findings = bashInsteadOfDedicated.run(events);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.wastedToolCalls).toBe(7);
+  });
+
+  test("does not flag other Bash uses", () => {
+    const events: Event[] = [tool({ args: "bun install" }), tool({ args: "git status" })];
+    expect(bashInsteadOfDedicated.run(events)).toHaveLength(0);
+  });
+
+  test("does not flag non-Bash tool calls", () => {
+    const events: Event[] = [tool({ tool: "Read", args: "/foo.ts" })];
+    expect(bashInsteadOfDedicated.run(events)).toHaveLength(0);
+  });
+
+  test("groups per agent", () => {
+    const events: Event[] = [
+      tool({ name: "iter1-implementer-42", args: "cat a" }),
+      tool({ name: "iter1-reviewer-42", args: "cat b" }),
+    ];
+    const findings = bashInsteadOfDedicated.run(events);
+    expect(findings).toHaveLength(2);
+  });
+});

--- a/.sandcastle/analyzer/detectors/bash-instead-of-dedicated.ts
+++ b/.sandcastle/analyzer/detectors/bash-instead-of-dedicated.ts
@@ -1,0 +1,69 @@
+import type { Detector, Event, Finding, ToolEvent } from "./types";
+import { averageInterToolSeconds, toolsOnly } from "./util";
+
+// Maps a Bash command pattern to the dedicated tool that should have been
+// used. Patterns are anchored to common command starts; we deliberately
+// don't try to parse pipelines because the cost of false positives outweighs
+// the value of catching every variation.
+const BASH_REPLACEMENTS: Array<{ pattern: RegExp; tool: string }> = [
+  { pattern: /^\s*cat\b/, tool: "Read" },
+  { pattern: /^\s*head\b/, tool: "Read" },
+  { pattern: /^\s*tail\b/, tool: "Read" },
+  { pattern: /^\s*(rg|grep)\b/, tool: "Grep" },
+  { pattern: /^\s*find\b/, tool: "Glob" },
+  { pattern: /^\s*ls\b/, tool: "Glob" },
+  { pattern: /^\s*sed\b/, tool: "Edit" },
+  { pattern: /^\s*awk\b/, tool: "Edit" },
+];
+
+// A4: Bash invocations whose first command has a dedicated equivalent
+// (Read/Grep/Glob/Edit). These usually indicate the agent didn't internalise
+// the dedicated tool's affordance — fix is in the prompt, not the agent.
+export const bashInsteadOfDedicated: Detector = {
+  id: "A4-bash-instead-of-dedicated",
+  run(events) {
+    const findings: Finding[] = [];
+    const byAgent = new Map<string, Event[]>();
+    for (const ev of events) {
+      if (ev.type === "run_start") continue;
+      const list = byAgent.get(ev.name) ?? [];
+      list.push(ev);
+      byAgent.set(ev.name, list);
+    }
+
+    for (const [agentName, evs] of byAgent) {
+      const tools = toolsOnly(evs);
+      const hits: Array<{ tool: ToolEvent; replacement: string }> = [];
+      for (const t of tools) {
+        if (t.tool !== "Bash") continue;
+        for (const { pattern, tool: replacement } of BASH_REPLACEMENTS) {
+          if (pattern.test(t.args)) {
+            hits.push({ tool: t, replacement });
+            break;
+          }
+        }
+      }
+      if (hits.length === 0) continue;
+      const avg = averageInterToolSeconds(evs);
+      const examples = hits
+        .slice(0, 3)
+        .map((h) => `${h.replacement} via Bash: ${truncate(h.tool.args, 60)}`)
+        .join(" | ");
+      findings.push({
+        detector: bashInsteadOfDedicated.id,
+        agentName,
+        message: `${hits.length} Bash call${hits.length === 1 ? "" : "s"} that could have used a dedicated tool`,
+        evidence: examples,
+        wastedToolCalls: hits.length,
+        wastedSeconds: hits.length * avg,
+        suggestedFix: "Reinforce in the prompt: prefer Read/Grep/Glob/Edit over Bash for these operations.",
+        source: "deterministic",
+      });
+    }
+    return findings;
+  },
+};
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n)}…`;
+}

--- a/.sandcastle/analyzer/detectors/excessive-exploration.test.ts
+++ b/.sandcastle/analyzer/detectors/excessive-exploration.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { excessiveExploration } from "./excessive-exploration";
+import type { Event } from "./types";
+
+const tool = (overrides: Partial<Extract<Event, { type: "tool" }>>): Event => ({
+  type: "tool",
+  runId: "r1",
+  name: "iter1-implementer-42",
+  iter: 1,
+  t: "2026-04-30T12:00:00Z",
+  tool: "Read",
+  args: "/foo.ts",
+  ...overrides,
+});
+
+describe("excessiveExploration (B6)", () => {
+  test("flags >12 reads before first edit", () => {
+    const reads: Event[] = Array.from({ length: 15 }, (_, i) =>
+      tool({ tool: "Read", args: `/f${i}.ts`, t: `2026-04-30T12:00:${String(i).padStart(2, "0")}Z` }),
+    );
+    const events: Event[] = [...reads, tool({ tool: "Edit", args: "x", t: "2026-04-30T12:01:00Z" })];
+    const findings = excessiveExploration.run(events);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.wastedToolCalls).toBe(3);
+  });
+
+  test("does not flag modest exploration", () => {
+    const reads: Event[] = Array.from({ length: 5 }, (_, i) =>
+      tool({ args: `/f${i}.ts`, t: `2026-04-30T12:00:${String(i).padStart(2, "0")}Z` }),
+    );
+    expect(excessiveExploration.run(reads)).toHaveLength(0);
+  });
+
+  test("counts all reads when no write ever happens", () => {
+    const reads: Event[] = Array.from({ length: 20 }, (_, i) =>
+      tool({ args: `/f${i}.ts`, t: `2026-04-30T12:00:${String(i).padStart(2, "0")}Z` }),
+    );
+    const findings = excessiveExploration.run(reads);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.wastedToolCalls).toBe(8);
+  });
+
+  test("ignores PR-opener (not an editing role for our purposes)", () => {
+    const reads: Event[] = Array.from({ length: 20 }, (_, i) =>
+      tool({ name: "iter1-pr-42", args: `/f${i}.ts`, t: `2026-04-30T12:00:${String(i).padStart(2, "0")}Z` }),
+    );
+    expect(excessiveExploration.run(reads)).toHaveLength(0);
+  });
+});

--- a/.sandcastle/analyzer/detectors/excessive-exploration.ts
+++ b/.sandcastle/analyzer/detectors/excessive-exploration.ts
@@ -1,0 +1,52 @@
+import type { Detector, Event, Finding, ToolEvent } from "./types";
+import { averageInterToolSeconds, toolsOnly } from "./util";
+
+const READ_TOOLS = new Set(["Read", "Grep", "Glob", "LS"]);
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
+const EXPLORATION_THRESHOLD = 12;
+
+// B6: An implementer that spends many read/search calls before its first
+// write usually wasn't anchored well by the prompt. The threshold is
+// deliberately high — quick exploration is fine; the signal is *excess*.
+export const excessiveExploration: Detector = {
+  id: "B6-excessive-exploration",
+  run(events) {
+    const findings: Finding[] = [];
+    const byAgent = new Map<string, Event[]>();
+    for (const ev of events) {
+      if (ev.type === "run_start") continue;
+      const list = byAgent.get(ev.name) ?? [];
+      list.push(ev);
+      byAgent.set(ev.name, list);
+    }
+
+    for (const [agentName, evs] of byAgent) {
+      // Only meaningful for agents whose job is to make edits.
+      if (!agentName.includes("implementer") && !agentName.includes("reviewer")) continue;
+      const tools = toolsOnly(evs);
+      const firstWriteIdx = tools.findIndex((t) => WRITE_TOOLS.has(t.tool));
+      const explorationSlice: ToolEvent[] = firstWriteIdx === -1 ? tools : tools.slice(0, firstWriteIdx);
+      const reads = explorationSlice.filter((t) => READ_TOOLS.has(t.tool));
+      if (reads.length <= EXPLORATION_THRESHOLD) continue;
+      const excess = reads.length - EXPLORATION_THRESHOLD;
+      const avg = averageInterToolSeconds(evs);
+      findings.push({
+        detector: excessiveExploration.id,
+        agentName,
+        message: `${reads.length} read/search calls before first edit (threshold ${EXPLORATION_THRESHOLD})`,
+        evidence: `Tools used: ${countByTool(reads)}`,
+        wastedToolCalls: excess,
+        wastedSeconds: excess * avg,
+        suggestedFix: "Anchor the prompt with the specific files/symbols to start from, or pre-compute a file map.",
+        source: "deterministic",
+      });
+    }
+    return findings;
+  },
+};
+
+function countByTool(tools: ToolEvent[]): string {
+  const counts = new Map<string, number>();
+  for (const t of tools) counts.set(t.tool, (counts.get(t.tool) ?? 0) + 1);
+  return [...counts.entries()].map(([k, v]) => `${k}×${v}`).join(", ");
+}

--- a/.sandcastle/analyzer/detectors/failed-tool-retry.test.ts
+++ b/.sandcastle/analyzer/detectors/failed-tool-retry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { failedToolRetry } from "./failed-tool-retry";
+import type { Event } from "./types";
+
+const tool = (overrides: Partial<Extract<Event, { type: "tool" }>>): Event => ({
+  type: "tool",
+  runId: "r1",
+  name: "iter1-implementer-42",
+  iter: 1,
+  t: "2026-04-30T12:00:00Z",
+  tool: "Read",
+  args: "/foo/bar.ts",
+  ...overrides,
+});
+
+describe("failedToolRetry (A3)", () => {
+  test("flags two near-identical Reads close in time", () => {
+    const events: Event[] = [
+      tool({ args: "/foo/bar.ts", t: "2026-04-30T12:00:00Z" }),
+      tool({ args: "/foo/baz.ts", t: "2026-04-30T12:00:03Z" }),
+    ];
+    const findings = failedToolRetry.run(events);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.wastedToolCalls).toBe(1);
+  });
+
+  test("ignores very different args even when same tool", () => {
+    const events: Event[] = [
+      tool({ args: "/apps/web/src/server/auth.ts", t: "2026-04-30T12:00:00Z" }),
+      tool({ args: "/packages/stdlib/cli/main.ts", t: "2026-04-30T12:00:03Z" }),
+    ];
+    expect(failedToolRetry.run(events)).toHaveLength(0);
+  });
+
+  test("ignores far-apart calls (outside retry window)", () => {
+    const events: Event[] = [
+      tool({ args: "/foo/bar.ts", t: "2026-04-30T12:00:00Z" }),
+      tool({ args: "/foo/baz.ts", t: "2026-04-30T12:01:00Z" }),
+    ];
+    expect(failedToolRetry.run(events)).toHaveLength(0);
+  });
+
+  test("ignores identical args (that's A1's job)", () => {
+    const events: Event[] = [
+      tool({ args: "/foo/bar.ts", t: "2026-04-30T12:00:00Z" }),
+      tool({ args: "/foo/bar.ts", t: "2026-04-30T12:00:03Z" }),
+    ];
+    expect(failedToolRetry.run(events)).toHaveLength(0);
+  });
+
+  test("ignores when tools differ", () => {
+    const events: Event[] = [
+      tool({ tool: "Read", args: "/foo.ts", t: "2026-04-30T12:00:00Z" }),
+      tool({ tool: "Edit", args: "/foo.ts", t: "2026-04-30T12:00:03Z" }),
+    ];
+    expect(failedToolRetry.run(events)).toHaveLength(0);
+  });
+});

--- a/.sandcastle/analyzer/detectors/failed-tool-retry.ts
+++ b/.sandcastle/analyzer/detectors/failed-tool-retry.ts
@@ -1,0 +1,100 @@
+import type { Detector, Event, Finding, ToolEvent } from "./types";
+import { averageInterToolSeconds, secondsBetween, toolsOnly } from "./util";
+
+const RETRY_WINDOW_SECONDS = 8;
+
+// A3: A tool call closely followed by another invocation of the same tool
+// with substantially-overlapping but non-identical args is a strong signal
+// of a retry — typically the agent fixing a wrong path, typo'd flag, or
+// failed match. We don't see the tool result in the stream, so this is
+// heuristic; the window keeps it from misfiring on legitimate sequential
+// reads.
+export const failedToolRetry: Detector = {
+  id: "A3-failed-tool-retry",
+  run(events) {
+    const findings: Finding[] = [];
+    const byAgent = new Map<string, Event[]>();
+    for (const ev of events) {
+      if (ev.type === "run_start") continue;
+      const list = byAgent.get(ev.name) ?? [];
+      list.push(ev);
+      byAgent.set(ev.name, list);
+    }
+
+    for (const [agentName, evs] of byAgent) {
+      const tools = toolsOnly(evs);
+      const avg = averageInterToolSeconds(evs);
+      let retries = 0;
+      const examples: string[] = [];
+      for (let i = 1; i < tools.length; i++) {
+        const prev = tools[i - 1];
+        const curr = tools[i];
+        if (!prev || !curr) continue;
+        if (prev.tool !== curr.tool) continue;
+        if (prev.args === curr.args) continue;
+        const gap = secondsBetween(prev.t, curr.t);
+        if (gap > RETRY_WINDOW_SECONDS) continue;
+        if (!isLikelyRetryPair(prev, curr)) continue;
+        retries++;
+        if (examples.length < 3) examples.push(`${prev.tool}: ${shortDiff(prev.args, curr.args)}`);
+      }
+      if (retries === 0) continue;
+      findings.push({
+        detector: failedToolRetry.id,
+        agentName,
+        message: `${retries} likely tool retry${retries === 1 ? "" : "s"} (same tool, similar args, <${RETRY_WINDOW_SECONDS}s apart)`,
+        evidence: examples.join(" | "),
+        wastedToolCalls: retries,
+        wastedSeconds: retries * avg,
+        suggestedFix: "Improve tool affordance — surface valid paths/options in the prompt or tool description.",
+        source: "deterministic",
+      });
+    }
+    return findings;
+  },
+};
+
+// Two args look like a retry when their normalized edit distance is small:
+// most characters match, only a handful differ. This catches typo'd paths,
+// flag-name fixes, and small refinements while rejecting unrelated calls
+// that happen to share an extension or a leading slash.
+const RETRY_DISTANCE_THRESHOLD = 0.3;
+
+function isLikelyRetryPair(prev: ToolEvent, curr: ToolEvent): boolean {
+  const a = prev.args;
+  const b = curr.args;
+  const maxLen = Math.max(a.length, b.length);
+  if (maxLen === 0) return false;
+  return editDistance(a, b) / maxLen <= RETRY_DISTANCE_THRESHOLD;
+}
+
+// Standard Levenshtein. Args are short (paths, flags, snippets) so the O(nm)
+// table is fine — capping max args length at ~512 keeps it safe.
+function editDistance(a: string, b: string): number {
+  const A = a.length > 512 ? a.slice(0, 512) : a;
+  const B = b.length > 512 ? b.slice(0, 512) : b;
+  const m = A.length;
+  const n = B.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  let prev = new Array<number>(n + 1);
+  let curr = new Array<number>(n + 1);
+  for (let j = 0; j <= n; j++) prev[j] = j;
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = A[i - 1] === B[j - 1] ? 0 : 1;
+      curr[j] = Math.min((curr[j - 1] ?? 0) + 1, (prev[j] ?? 0) + 1, (prev[j - 1] ?? 0) + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n] ?? 0;
+}
+
+function shortDiff(a: string, b: string): string {
+  return `'${truncate(a, 40)}' → '${truncate(b, 40)}'`;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n)}…`;
+}

--- a/.sandcastle/analyzer/detectors/hard-failure.test.ts
+++ b/.sandcastle/analyzer/detectors/hard-failure.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { hardFailure } from "./hard-failure";
+import type { Event } from "./types";
+
+const text = (overrides: Partial<Extract<Event, { type: "text" }>>): Event => ({
+  type: "text",
+  runId: "r1",
+  name: "iter1-implementer-42",
+  iter: 1,
+  t: "2026-04-30T12:00:00Z",
+  text: "ok",
+  ...overrides,
+});
+
+const tool = (overrides: Partial<Extract<Event, { type: "tool" }>>): Event => ({
+  type: "tool",
+  runId: "r1",
+  name: "iter1-implementer-42",
+  iter: 1,
+  t: "2026-04-30T12:00:00Z",
+  tool: "Read",
+  args: "/foo.ts",
+  ...overrides,
+});
+
+describe("hardFailure (D10)", () => {
+  test("flags an agent that produced text but no tool calls", () => {
+    const events: Event[] = [text({ text: "starting up" })];
+    const findings = hardFailure.run(events);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.message).toContain("no tool calls");
+  });
+
+  test("flags trailing error-tone text", () => {
+    const events: Event[] = [tool({}), text({ text: "Encountered an error reading the file" })];
+    const findings = hardFailure.run(events);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.message).toContain("error-tone");
+  });
+
+  test("does not flag a healthy run", () => {
+    const events: Event[] = [tool({}), text({ text: "Done." })];
+    expect(hardFailure.run(events)).toHaveLength(0);
+  });
+
+  test("does not flag an empty run", () => {
+    expect(hardFailure.run([])).toHaveLength(0);
+  });
+});

--- a/.sandcastle/analyzer/detectors/hard-failure.ts
+++ b/.sandcastle/analyzer/detectors/hard-failure.ts
@@ -1,0 +1,72 @@
+import type { Detector, Event, Finding, TextEvent, ToolEvent } from "./types";
+import { secondsBetween } from "./util";
+
+const ERROR_KEYWORDS = /\b(error|failed|failure|timed out|aborted|exception|cannot|unable to)\b/i;
+
+// D10: Hard failures — an agent run that visibly errored or never made
+// progress. Two complementary signals:
+//   (a) the trailing text events contain error keywords, suggesting the
+//       agent crashed or gave up;
+//   (b) zero tool calls across the run, suggesting the harness failed to
+//       launch the agent at all.
+export const hardFailure: Detector = {
+  id: "D10-hard-failure",
+  run(events) {
+    const findings: Finding[] = [];
+    const byAgent = new Map<string, Event[]>();
+    for (const ev of events) {
+      if (ev.type === "run_start") continue;
+      const list = byAgent.get(ev.name) ?? [];
+      list.push(ev);
+      byAgent.set(ev.name, list);
+    }
+
+    for (const [agentName, evs] of byAgent) {
+      const tools = evs.filter((e): e is ToolEvent => e.type === "tool");
+      const texts = evs.filter((e): e is TextEvent => e.type === "text");
+
+      if (tools.length === 0 && texts.length > 0) {
+        findings.push({
+          detector: hardFailure.id,
+          agentName,
+          message: "Agent produced text but made no tool calls — likely failed to engage",
+          evidence: truncate(texts[0]?.text ?? "", 160),
+          wastedToolCalls: 1,
+          wastedSeconds: durationOf(evs),
+          suggestedFix: "Check the prompt and provider config; agent never reached the tool-use loop.",
+          source: "deterministic",
+        });
+        continue;
+      }
+
+      // Look at the last few text events for error-tone language.
+      const tail = texts.slice(-3);
+      const errorTexts = tail.filter((t) => ERROR_KEYWORDS.test(t.text));
+      if (errorTexts.length > 0) {
+        findings.push({
+          detector: hardFailure.id,
+          agentName,
+          message: "Agent run ended with error-tone text",
+          evidence: truncate(errorTexts[errorTexts.length - 1]?.text ?? "", 160),
+          wastedToolCalls: tools.length,
+          wastedSeconds: durationOf(evs),
+          suggestedFix: "Inspect the surrounding tool calls; consider adding retry or fallback in the harness.",
+          source: "deterministic",
+        });
+      }
+    }
+    return findings;
+  },
+};
+
+function durationOf(events: Event[]): number {
+  if (events.length < 2) return 0;
+  const first = events[0];
+  const last = events[events.length - 1];
+  if (!first || !last) return 0;
+  return secondsBetween(first.t, last.t);
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n)}…`;
+}

--- a/.sandcastle/analyzer/detectors/redundant-tool-call.test.ts
+++ b/.sandcastle/analyzer/detectors/redundant-tool-call.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { redundantToolCall } from "./redundant-tool-call";
+import type { Event } from "./types";
+
+const tool = (overrides: Partial<Extract<Event, { type: "tool" }>>): Event => ({
+  type: "tool",
+  runId: "r1",
+  name: "iter1-implementer-42",
+  iter: 1,
+  t: "2026-04-30T12:00:00Z",
+  tool: "Read",
+  args: "/foo.ts",
+  ...overrides,
+});
+
+describe("redundantToolCall (A1)", () => {
+  test("flags identical (tool, args) pairs and reports one wasted call per repeat", () => {
+    const events: Event[] = [
+      tool({ t: "2026-04-30T12:00:00Z" }),
+      tool({ t: "2026-04-30T12:00:10Z" }),
+      tool({ t: "2026-04-30T12:00:20Z" }),
+    ];
+    const findings = redundantToolCall.run(events);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.wastedToolCalls).toBe(2);
+    expect(findings[0]?.message).toContain("Read called 3×");
+  });
+
+  test("does not flag distinct args", () => {
+    const events: Event[] = [
+      tool({ args: "/a.ts" }),
+      tool({ args: "/b.ts" }),
+    ];
+    expect(redundantToolCall.run(events)).toHaveLength(0);
+  });
+
+  test("groups per agent — no false positive across agent runs", () => {
+    const events: Event[] = [
+      tool({ name: "iter1-implementer-42", args: "/foo.ts" }),
+      tool({ name: "iter1-reviewer-42", args: "/foo.ts" }),
+    ];
+    expect(redundantToolCall.run(events)).toHaveLength(0);
+  });
+
+  test("estimates wasted seconds from the average inter-tool gap", () => {
+    const events: Event[] = [
+      tool({ t: "2026-04-30T12:00:00Z" }),
+      tool({ t: "2026-04-30T12:00:10Z" }),
+      tool({ t: "2026-04-30T12:00:20Z" }),
+    ];
+    const findings = redundantToolCall.run(events);
+    expect(findings[0]?.wastedSeconds).toBe(20);
+  });
+});

--- a/.sandcastle/analyzer/detectors/redundant-tool-call.ts
+++ b/.sandcastle/analyzer/detectors/redundant-tool-call.ts
@@ -1,0 +1,49 @@
+import type { Detector, Event, Finding } from "./types";
+import { averageInterToolSeconds, toolsOnly } from "./util";
+
+// A1: Identical (tool, args) pair invoked more than once within the same
+// agent run. Strong signal of context-loss or missing in-harness caching.
+// Counts only repeats — the first occurrence is real work.
+export const redundantToolCall: Detector = {
+  id: "A1-redundant-tool-call",
+  run(events) {
+    const findings: Finding[] = [];
+    const byAgent = new Map<string, Event[]>();
+    for (const ev of events) {
+      if (ev.type === "run_start") continue;
+      const list = byAgent.get(ev.name) ?? [];
+      list.push(ev);
+      byAgent.set(ev.name, list);
+    }
+
+    for (const [agentName, evs] of byAgent) {
+      const tools = toolsOnly(evs);
+      const seen = new Map<string, number>();
+      for (const t of tools) {
+        const key = `${t.tool}\x00${t.args}`;
+        seen.set(key, (seen.get(key) ?? 0) + 1);
+      }
+      const avg = averageInterToolSeconds(evs);
+      for (const [key, count] of seen) {
+        if (count <= 1) continue;
+        const repeats = count - 1;
+        const [tool, args] = key.split("\x00");
+        findings.push({
+          detector: redundantToolCall.id,
+          agentName,
+          message: `${tool} called ${count}× with identical args`,
+          evidence: `args: ${truncate(args ?? "", 120)}`,
+          wastedToolCalls: repeats,
+          wastedSeconds: repeats * avg,
+          suggestedFix: "Add caching at the harness layer or pass the prior result forward in the prompt.",
+          source: "deterministic",
+        });
+      }
+    }
+    return findings;
+  },
+};
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n)}…`;
+}

--- a/.sandcastle/analyzer/detectors/reviewer-rereads.test.ts
+++ b/.sandcastle/analyzer/detectors/reviewer-rereads.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { reviewerReReads } from "./reviewer-rereads";
+import type { Event } from "./types";
+
+const tool = (overrides: Partial<Extract<Event, { type: "tool" }>>): Event => ({
+  type: "tool",
+  runId: "r1",
+  name: "iter1-implementer-42",
+  iter: 1,
+  t: "2026-04-30T12:00:00Z",
+  tool: "Read",
+  args: "/foo.ts",
+  ...overrides,
+});
+
+describe("reviewerReReads (C8)", () => {
+  test("flags reviewer Reads of paths the implementer wrote", () => {
+    const events: Event[] = [
+      tool({ name: "iter1-implementer-42", tool: "Edit", args: "/apps/web/src/auth.ts" }),
+      tool({ name: "iter1-implementer-42", tool: "Write", args: "/apps/web/src/auth.test.ts" }),
+      tool({ name: "iter1-reviewer-42", tool: "Read", args: "/apps/web/src/auth.ts", t: "2026-04-30T12:01:00Z" }),
+      tool({ name: "iter1-reviewer-42", tool: "Read", args: "/apps/web/src/auth.test.ts", t: "2026-04-30T12:01:05Z" }),
+    ];
+    const findings = reviewerReReads.run(events);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.wastedToolCalls).toBe(2);
+    expect(findings[0]?.issueNumber).toBe(42);
+  });
+
+  test("does not flag reviewer reading a path the implementer never touched", () => {
+    const events: Event[] = [
+      tool({ name: "iter1-implementer-42", tool: "Edit", args: "/a.ts" }),
+      tool({ name: "iter1-reviewer-42", tool: "Read", args: "/b.ts" }),
+    ];
+    expect(reviewerReReads.run(events)).toHaveLength(0);
+  });
+
+  test("scopes by issue (reviewer for #43 should not match implementer #42)", () => {
+    const events: Event[] = [
+      tool({ name: "iter1-implementer-42", tool: "Edit", args: "/shared.ts" }),
+      tool({ name: "iter1-reviewer-43", tool: "Read", args: "/shared.ts" }),
+    ];
+    expect(reviewerReReads.run(events)).toHaveLength(0);
+  });
+});

--- a/.sandcastle/analyzer/detectors/reviewer-rereads.ts
+++ b/.sandcastle/analyzer/detectors/reviewer-rereads.ts
@@ -1,0 +1,86 @@
+import type { Detector, Event, Finding, ToolEvent } from "./types";
+import { inferIssueFromLogName } from "../parse";
+import { averageInterToolSeconds, toolsOnly } from "./util";
+
+// C8: Reviewer reads a file the implementer wrote in the same issue's run.
+// The harness could pass the implementer's diff or full file contents
+// directly to the reviewer, saving a round-trip per file.
+export const reviewerReReads: Detector = {
+  id: "C8-reviewer-rereads",
+  run(events) {
+    const findings: Finding[] = [];
+    const byAgent = new Map<string, Event[]>();
+    for (const ev of events) {
+      if (ev.type === "run_start") continue;
+      const list = byAgent.get(ev.name) ?? [];
+      list.push(ev);
+      byAgent.set(ev.name, list);
+    }
+
+    // Build per-issue index: implementer-written paths.
+    const writtenByIssue = new Map<number, Set<string>>();
+    for (const [agentName, evs] of byAgent) {
+      if (!agentName.includes("implementer")) continue;
+      const issue = inferIssueFromLogName(agentName);
+      if (issue === undefined) continue;
+      const paths = writtenByIssue.get(issue) ?? new Set<string>();
+      for (const t of toolsOnly(evs)) {
+        if (t.tool === "Write" || t.tool === "Edit" || t.tool === "MultiEdit") {
+          const p = extractPath(t.args);
+          if (p) paths.add(p);
+        }
+      }
+      writtenByIssue.set(issue, paths);
+    }
+
+    // For each reviewer run, count Reads whose path is in the matching set.
+    for (const [agentName, evs] of byAgent) {
+      if (!agentName.includes("reviewer")) continue;
+      const issue = inferIssueFromLogName(agentName);
+      if (issue === undefined) continue;
+      const written = writtenByIssue.get(issue);
+      if (!written || written.size === 0) continue;
+
+      const rereads: ToolEvent[] = [];
+      for (const t of toolsOnly(evs)) {
+        if (t.tool !== "Read") continue;
+        const p = extractPath(t.args);
+        if (p && written.has(p)) rereads.push(t);
+      }
+      if (rereads.length === 0) continue;
+
+      const avg = averageInterToolSeconds(evs);
+      const examples = rereads
+        .slice(0, 3)
+        .map((t) => extractPath(t.args) ?? "")
+        .filter(Boolean)
+        .join(", ");
+      findings.push({
+        detector: reviewerReReads.id,
+        agentName,
+        issueNumber: issue,
+        message: `Reviewer re-read ${rereads.length} file${rereads.length === 1 ? "" : "s"} the implementer just wrote`,
+        evidence: `paths: ${examples}`,
+        wastedToolCalls: rereads.length,
+        wastedSeconds: rereads.length * avg,
+        suggestedFix: "Pass the implementer's diff (or full new file contents) into the reviewer prompt instead.",
+        source: "deterministic",
+      });
+    }
+    return findings;
+  },
+};
+
+// Best-effort path extraction from a `formattedArgs` string. Sandcastle
+// formats tool args as a human-readable line; the path is typically the
+// first token starting with `/` or `./`, or the first quoted path. Returns
+// undefined when no clear path is present.
+function extractPath(args: string): string | undefined {
+  // 1) absolute path
+  const abs = args.match(/(?:^|\s|["'])(\/[^\s"']+)/);
+  if (abs?.[1]) return abs[1];
+  // 2) relative path (./ or workspace-relative starting with letter+/)
+  const rel = args.match(/(?:^|\s|["'])((?:\.\/)?(?:[\w@-]+\/)+[\w@.-]+)/);
+  if (rel?.[1]) return rel[1];
+  return undefined;
+}

--- a/.sandcastle/analyzer/detectors/run-outlier.test.ts
+++ b/.sandcastle/analyzer/detectors/run-outlier.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { emptyBaseline, runOutlier, updateBaseline } from "./run-outlier";
+import type { Event } from "./types";
+
+const tool = (overrides: Partial<Extract<Event, { type: "tool" }>>): Event => ({
+  type: "tool",
+  runId: "r1",
+  name: "iter1-implementer-42",
+  iter: 1,
+  t: "2026-04-30T12:00:00Z",
+  tool: "Read",
+  args: "/foo.ts",
+  ...overrides,
+});
+
+// Build an agent run with `count` reads over `durationSec` seconds.
+function agentRun(name: string, count: number, durationSec: number): Event[] {
+  const start = Date.parse("2026-04-30T12:00:00Z");
+  return Array.from({ length: count }, (_, i) =>
+    tool({
+      name,
+      args: `/f${i}.ts`,
+      t: new Date(start + (durationSec * 1000 * i) / Math.max(1, count - 1)).toISOString(),
+    }),
+  );
+}
+
+describe("runOutlier (E12)", () => {
+  test("returns no findings when baseline is too small", () => {
+    const baseline = updateBaseline(emptyBaseline(), agentRun("iter1-implementer-1", 30, 60));
+    const events = agentRun("iter2-implementer-2", 100, 600);
+    expect(runOutlier(events, baseline)).toHaveLength(0);
+  });
+
+  test("flags a run >2σ above the historical mean", () => {
+    let baseline = emptyBaseline();
+    // Vary both tool count and duration so we have real variance.
+    const sizes = [8, 10, 12, 9, 11, 10, 13, 8, 11, 9];
+    for (let i = 0; i < sizes.length; i++) {
+      baseline = updateBaseline(
+        baseline,
+        agentRun(`iter${i}-implementer-${i}`, sizes[i] ?? 10, 60 + (sizes[i] ?? 10) * 2),
+      );
+    }
+    const outlier = agentRun("iterN-implementer-99", 100, 600);
+    const findings = runOutlier(outlier, baseline);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.detector).toBe("E12-run-outlier");
+  });
+
+  test("does not flag runs near the mean", () => {
+    let baseline = emptyBaseline();
+    const sizes = [8, 10, 12, 9, 11, 10, 13, 8, 11, 9];
+    for (let i = 0; i < sizes.length; i++) {
+      baseline = updateBaseline(
+        baseline,
+        agentRun(`iter${i}-implementer-${i}`, sizes[i] ?? 10, 60 + (sizes[i] ?? 10) * 2),
+      );
+    }
+    const normal = agentRun("iterN-implementer-99", 11, 80);
+    expect(runOutlier(normal, baseline)).toHaveLength(0);
+  });
+});

--- a/.sandcastle/analyzer/detectors/run-outlier.ts
+++ b/.sandcastle/analyzer/detectors/run-outlier.ts
@@ -1,0 +1,141 @@
+import type { Event, Finding, ToolEvent } from "./types";
+
+// Persistent baseline kept across runs so we can flag the current run's
+// agents when they spike vs historical averages. Stats are tracked per
+// "phase" (implementer / reviewer / pr-opener) — the three roles have
+// very different expected costs and shouldn't share a baseline.
+export type BaselineStats = {
+  count: number;
+  meanToolCalls: number;
+  m2ToolCalls: number; // sum of squared deviations, for online variance
+  meanSeconds: number;
+  m2Seconds: number;
+};
+
+export type Baseline = {
+  byPhase: Record<string, BaselineStats>;
+};
+
+export const emptyBaseline = (): Baseline => ({ byPhase: {} });
+
+const Z_THRESHOLD = 2;
+
+// E12: Agent runs whose tool-call count or wall-clock is >2σ above the
+// historical mean for that phase. Below 5 historical samples we don't have
+// enough signal — silently skip.
+export function runOutlier(events: readonly Event[], baseline: Baseline): Finding[] {
+  const findings: Finding[] = [];
+  const byAgent = new Map<string, Event[]>();
+  for (const ev of events) {
+    if (ev.type === "run_start") continue;
+    const list = byAgent.get(ev.name) ?? [];
+    list.push(ev);
+    byAgent.set(ev.name, list);
+  }
+
+  for (const [agentName, evs] of byAgent) {
+    const phase = phaseFromName(agentName);
+    if (!phase) continue;
+    const stats = baseline.byPhase[phase];
+    if (!stats || stats.count < 5) continue;
+
+    const tools = evs.filter((e): e is ToolEvent => e.type === "tool");
+    const toolCount = tools.length;
+    const seconds = durationOf(evs);
+
+    const toolStd = stdDev(stats.m2ToolCalls, stats.count);
+    const secStd = stdDev(stats.m2Seconds, stats.count);
+
+    const toolZ = toolStd > 0 ? (toolCount - stats.meanToolCalls) / toolStd : 0;
+    const secZ = secStd > 0 ? (seconds - stats.meanSeconds) / secStd : 0;
+
+    if (toolZ < Z_THRESHOLD && secZ < Z_THRESHOLD) continue;
+
+    const reasons: string[] = [];
+    if (toolZ >= Z_THRESHOLD) {
+      reasons.push(`${toolCount} tool calls vs baseline ${stats.meanToolCalls.toFixed(0)} (z=${toolZ.toFixed(1)})`);
+    }
+    if (secZ >= Z_THRESHOLD) {
+      reasons.push(`${seconds.toFixed(0)}s vs baseline ${stats.meanSeconds.toFixed(0)}s (z=${secZ.toFixed(1)})`);
+    }
+
+    const wastedTools = Math.max(0, toolCount - stats.meanToolCalls);
+    const wastedSecs = Math.max(0, seconds - stats.meanSeconds);
+    findings.push({
+      detector: "E12-run-outlier",
+      agentName,
+      message: `${phase} run is an outlier vs historical baseline`,
+      evidence: reasons.join("; "),
+      wastedToolCalls: Math.round(wastedTools),
+      wastedSeconds: Math.round(wastedSecs),
+      suggestedFix: "Compare this run's tool sequence against a typical one; the prompt or the issue may be off-pattern.",
+      source: "deterministic",
+    });
+  }
+  return findings;
+}
+
+// Update baseline with this run's per-agent measurements. Uses Welford's
+// online algorithm so we don't need to keep history — count, mean, M2
+// are sufficient.
+export function updateBaseline(baseline: Baseline, events: readonly Event[]): Baseline {
+  const byAgent = new Map<string, Event[]>();
+  for (const ev of events) {
+    if (ev.type === "run_start") continue;
+    const list = byAgent.get(ev.name) ?? [];
+    list.push(ev);
+    byAgent.set(ev.name, list);
+  }
+
+  const next: Baseline = { byPhase: { ...baseline.byPhase } };
+  for (const [agentName, evs] of byAgent) {
+    const phase = phaseFromName(agentName);
+    if (!phase) continue;
+    const tools = evs.filter((e): e is ToolEvent => e.type === "tool");
+    const toolCount = tools.length;
+    const seconds = durationOf(evs);
+    const prev = next.byPhase[phase] ?? {
+      count: 0,
+      meanToolCalls: 0,
+      m2ToolCalls: 0,
+      meanSeconds: 0,
+      m2Seconds: 0,
+    };
+    next.byPhase[phase] = welford(prev, toolCount, seconds);
+  }
+  return next;
+}
+
+function welford(stats: BaselineStats, toolCount: number, seconds: number): BaselineStats {
+  const count = stats.count + 1;
+  const dTool = toolCount - stats.meanToolCalls;
+  const meanToolCalls = stats.meanToolCalls + dTool / count;
+  const m2ToolCalls = stats.m2ToolCalls + dTool * (toolCount - meanToolCalls);
+  const dSec = seconds - stats.meanSeconds;
+  const meanSeconds = stats.meanSeconds + dSec / count;
+  const m2Seconds = stats.m2Seconds + dSec * (seconds - meanSeconds);
+  return { count, meanToolCalls, m2ToolCalls, meanSeconds, m2Seconds };
+}
+
+function stdDev(m2: number, count: number): number {
+  if (count < 2) return 0;
+  return Math.sqrt(m2 / (count - 1));
+}
+
+function phaseFromName(agentName: string): string | undefined {
+  if (agentName.includes("implementer")) return "implementer";
+  if (agentName.includes("reviewer")) return "reviewer";
+  if (agentName.includes("pr-")) return "pr-opener";
+  return undefined;
+}
+
+function durationOf(events: Event[]): number {
+  if (events.length < 2) return 0;
+  const first = events[0];
+  const last = events[events.length - 1];
+  if (!first || !last) return 0;
+  const ta = Date.parse(first.t);
+  const tb = Date.parse(last.t);
+  if (Number.isNaN(ta) || Number.isNaN(tb)) return 0;
+  return Math.max(0, (tb - ta) / 1000);
+}

--- a/.sandcastle/analyzer/detectors/types.ts
+++ b/.sandcastle/analyzer/detectors/types.ts
@@ -1,0 +1,83 @@
+// Shared types for the sandcastle log analyzer. Every detector consumes
+// `Event[]` and returns `Finding[]`; the report renderer ranks findings by
+// estimated cost and groups them per-issue.
+
+export type RunStartEvent = {
+  type: "run_start";
+  runId: string;
+  t: string;
+};
+
+export type TextEvent = {
+  type: "text";
+  runId: string;
+  name: string;
+  iter: number;
+  t: string;
+  text: string;
+};
+
+export type ToolEvent = {
+  type: "tool";
+  runId: string;
+  name: string;
+  iter: number;
+  t: string;
+  tool: string;
+  args: string;
+};
+
+export type UsageEvent = {
+  type: "usage";
+  runId: string;
+  name: string;
+  iter: number;
+  subIter: number;
+  t: string;
+  inputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  outputTokens: number;
+};
+
+export type Event = RunStartEvent | TextEvent | ToolEvent | UsageEvent;
+
+// One detected harness-improvement opportunity. `wastedToolCalls` is the
+// detector's estimate of how many tool calls (or equivalents) were wasted;
+// `wastedSeconds` is the wall-clock cost. The renderer ranks by these.
+export type Finding = {
+  detector: string;
+  agentName: string;
+  issueNumber?: number;
+  iter?: number;
+  message: string;
+  evidence: string;
+  wastedToolCalls: number;
+  wastedSeconds: number;
+  suggestedFix: string;
+  source?: "deterministic" | "llm";
+};
+
+export type Detector = {
+  id: string;
+  run(events: readonly Event[]): Finding[];
+};
+
+// Extract issue number from a sandcastle agent name like "Implementer #42",
+// "Reviewer #42", or "PR-Opener #42".
+export function parseIssueNumber(agentName: string): number | undefined {
+  const match = agentName.match(/#(\d+)\s*$/);
+  return match ? Number(match[1]) : undefined;
+}
+
+// Coarse phase classification from agent name. Used to group per-issue and
+// to drive cross-agent detectors (e.g. reviewer re-reads implementer files).
+export type AgentPhase = "implementer" | "reviewer" | "pr-opener" | "other";
+
+export function phaseOf(agentName: string): AgentPhase {
+  const n = agentName.toLowerCase();
+  if (n.includes("pr-opener") || n.includes("propener") || n.startsWith("pr ")) return "pr-opener";
+  if (n.includes("reviewer")) return "reviewer";
+  if (n.includes("implementer")) return "implementer";
+  return "other";
+}

--- a/.sandcastle/analyzer/detectors/util.ts
+++ b/.sandcastle/analyzer/detectors/util.ts
@@ -1,0 +1,34 @@
+import type { Event, ToolEvent } from "./types";
+
+// Best-effort wall-clock seconds between two ISO timestamps. Returns 0 on
+// parse failure so detector cost-estimates degrade gracefully.
+export function secondsBetween(a: string, b: string): number {
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  if (Number.isNaN(ta) || Number.isNaN(tb)) return 0;
+  return Math.max(0, (tb - ta) / 1000);
+}
+
+// Average gap between consecutive tool calls within an agent run. Used to
+// price wasted-tool-calls in seconds for detectors that can't directly
+// observe a duration (e.g. "this Read was redundant").
+export function averageInterToolSeconds(events: readonly Event[]): number {
+  const tools = events.filter((e): e is ToolEvent => e.type === "tool");
+  if (tools.length < 2) return 0;
+  let total = 0;
+  let n = 0;
+  for (let i = 1; i < tools.length; i++) {
+    const prev = tools[i - 1];
+    const curr = tools[i];
+    if (prev && curr) {
+      total += secondsBetween(prev.t, curr.t);
+      n++;
+    }
+  }
+  return n === 0 ? 0 : total / n;
+}
+
+// Filter to ToolEvents only, preserving order.
+export function toolsOnly(events: readonly Event[]): ToolEvent[] {
+  return events.filter((e): e is ToolEvent => e.type === "tool");
+}

--- a/.sandcastle/analyzer/llm-grader.ts
+++ b/.sandcastle/analyzer/llm-grader.ts
@@ -1,0 +1,149 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { Event, Finding, ToolEvent } from "./detectors/types";
+import { groupByAgentRun, groupByIssue } from "./parse";
+
+// Whole-issue LLM grading. For each issue's bundle of agent runs, ask Haiku
+// to identify harness/prompt mistakes the deterministic detectors couldn't
+// pattern-match. The grader emits structured JSON which we coerce into
+// `Finding[]` and merge into the same report.
+
+const MODEL = "claude-haiku-4-5-20251001";
+const MAX_TOKENS = 1024;
+
+const SYSTEM_PROMPT = `You analyse the tool-use traces of LLM agents working on coding tasks.
+Your job is to spot harness or prompt mistakes — moments where the agent wasted effort because of how the harness was set up, not because the task was hard.
+
+You are looking for things deterministic pattern-matching cannot easily catch:
+- Agent confusion that suggests prompt ambiguity
+- Missed affordances (the agent didn't know about a tool or convention)
+- Cross-agent inefficiencies (e.g. reviewer redoing work the implementer already did)
+- Repeated reasoning loops where the prompt failed to anchor the next step
+
+For each issue you analyse, return a JSON object:
+{
+  "findings": [
+    {
+      "agentName": "<the agent name from the trace>",
+      "message": "<concise description of the mistake>",
+      "evidence": "<one short quote or summary that supports it>",
+      "wastedToolCalls": <integer estimate>,
+      "wastedSeconds": <integer estimate>,
+      "suggestedFix": "<one sentence on how to fix the harness or prompt>"
+    }
+  ]
+}
+
+If the trace looks healthy, return {"findings": []}. Be conservative — false positives waste the user's time.`;
+
+export async function llmGrade(events: readonly Event[]): Promise<Finding[]> {
+  const client = new Anthropic();
+  const byAgent = groupByAgentRun(events);
+  const byIssue = groupByIssue(byAgent);
+  const out: Finding[] = [];
+
+  for (const [issueKey, perAgent] of byIssue) {
+    if (issueKey === "unknown") continue;
+    const summary = summariseIssue(perAgent);
+    if (summary.length === 0) continue;
+
+    const message = await client.messages.create({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
+      messages: [
+        {
+          role: "user",
+          content: `Issue #${issueKey}\n\n${summary}\n\nReturn the JSON object only, no prose.`,
+        },
+      ],
+    });
+
+    const text = extractText(message);
+    const parsed = safeParse(text);
+    for (const f of parsed) {
+      out.push({
+        detector: "LLM-grader",
+        agentName: f.agentName,
+        issueNumber: typeof issueKey === "number" ? issueKey : undefined,
+        message: f.message,
+        evidence: f.evidence,
+        wastedToolCalls: f.wastedToolCalls,
+        wastedSeconds: f.wastedSeconds,
+        suggestedFix: f.suggestedFix,
+        source: "llm",
+      });
+    }
+  }
+
+  return out;
+}
+
+// Compact, LLM-friendly summary of one issue's traces. Limit each agent to
+// its first ~120 tool-call lines to keep token spend bounded — the late
+// tail rarely changes the verdict.
+function summariseIssue(perAgent: Map<string, Event[]>): string {
+  const blocks: string[] = [];
+  for (const [name, evs] of perAgent) {
+    const lines: string[] = [`AGENT ${name}`];
+    let toolCount = 0;
+    for (const ev of evs) {
+      if (ev.type === "tool" && toolCount < 120) {
+        lines.push(`  tool ${ev.tool}: ${truncate((ev as ToolEvent).args, 120)}`);
+        toolCount++;
+      } else if (ev.type === "text") {
+        const t = ev.text.trim();
+        if (t.length > 0) lines.push(`  text: ${truncate(t, 200)}`);
+      }
+    }
+    blocks.push(lines.join("\n"));
+  }
+  return blocks.join("\n\n");
+}
+
+function extractText(message: Anthropic.Messages.Message): string {
+  for (const block of message.content) {
+    if (block.type === "text") return block.text;
+  }
+  return "";
+}
+
+type LlmFinding = {
+  agentName: string;
+  message: string;
+  evidence: string;
+  wastedToolCalls: number;
+  wastedSeconds: number;
+  suggestedFix: string;
+};
+
+function safeParse(raw: string): LlmFinding[] {
+  // The model occasionally wraps JSON in fences or adds prose; extract the
+  // outermost {...} block before parsing.
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return [];
+  try {
+    const parsed = JSON.parse(raw.slice(start, end + 1)) as { findings?: LlmFinding[] };
+    if (!parsed || !Array.isArray(parsed.findings)) return [];
+    return parsed.findings.filter(isLlmFinding);
+  } catch {
+    return [];
+  }
+}
+
+function isLlmFinding(v: unknown): v is LlmFinding {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.agentName === "string" &&
+    typeof o.message === "string" &&
+    typeof o.evidence === "string" &&
+    typeof o.wastedToolCalls === "number" &&
+    typeof o.wastedSeconds === "number" &&
+    typeof o.suggestedFix === "string"
+  );
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n)}…`;
+}

--- a/.sandcastle/analyzer/parse.test.ts
+++ b/.sandcastle/analyzer/parse.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import {
+  groupByAgentRun,
+  groupByIssue,
+  groupByRun,
+  inferIssueFromLogName,
+  parseStreamLogText,
+} from "./parse";
+
+const line = (obj: object) => JSON.stringify(obj);
+
+describe("parseStreamLogText", () => {
+  test("parses well-formed lines and skips garbage", () => {
+    const text = [
+      line({ type: "run_start", runId: "r1", t: "2026-04-30T12:00:00Z" }),
+      "not json",
+      line({ type: "text", runId: "r1", name: "iter1-implementer-42", iter: 1, t: "x", text: "hi" }),
+      "",
+      line({ type: "tool", runId: "r1", name: "iter1-implementer-42", iter: 1, t: "x", tool: "Read", args: "a" }),
+    ].join("\n");
+    const events = parseStreamLogText(text);
+    expect(events).toHaveLength(3);
+    expect(events[0]?.type).toBe("run_start");
+    expect(events[1]?.type).toBe("text");
+    expect(events[2]?.type).toBe("tool");
+  });
+
+  test("rejects unknown event types", () => {
+    const text = line({ type: "weird", runId: "r1" });
+    expect(parseStreamLogText(text)).toEqual([]);
+  });
+});
+
+describe("groupByRun", () => {
+  test("groups by runId and captures startedAt from run_start", () => {
+    const events = parseStreamLogText(
+      [
+        line({ type: "run_start", runId: "r1", t: "2026-04-30T12:00:00Z" }),
+        line({ type: "tool", runId: "r1", name: "n", iter: 1, t: "x", tool: "Read", args: "" }),
+        line({ type: "run_start", runId: "r2", t: "2026-04-30T13:00:00Z" }),
+        line({ type: "tool", runId: "r2", name: "n", iter: 1, t: "x", tool: "Read", args: "" }),
+      ].join("\n"),
+    );
+    const runs = groupByRun(events);
+    expect(runs).toHaveLength(2);
+    expect(runs[0]?.startedAt).toBe("2026-04-30T12:00:00Z");
+    expect(runs[1]?.startedAt).toBe("2026-04-30T13:00:00Z");
+  });
+
+  test("buckets events without runId into 'legacy'", () => {
+    const events = parseStreamLogText(
+      // legacy line with no runId field
+      [line({ type: "tool", name: "n", iter: 1, t: "x", tool: "Read", args: "" })].join("\n"),
+    );
+    const runs = groupByRun(events);
+    expect(runs[0]?.runId).toBe("legacy");
+  });
+});
+
+describe("groupByAgentRun", () => {
+  test("groups by name and excludes run_start", () => {
+    const events = parseStreamLogText(
+      [
+        line({ type: "run_start", runId: "r1", t: "x" }),
+        line({ type: "tool", runId: "r1", name: "iter1-implementer-42", iter: 1, t: "x", tool: "Read", args: "" }),
+        line({ type: "tool", runId: "r1", name: "iter1-reviewer-42", iter: 1, t: "x", tool: "Read", args: "" }),
+        line({ type: "tool", runId: "r1", name: "iter1-implementer-42", iter: 1, t: "x", tool: "Edit", args: "" }),
+      ].join("\n"),
+    );
+    const byAgent = groupByAgentRun(events);
+    expect(byAgent.size).toBe(2);
+    expect(byAgent.get("iter1-implementer-42")).toHaveLength(2);
+  });
+});
+
+describe("inferIssueFromLogName", () => {
+  test("extracts trailing number", () => {
+    expect(inferIssueFromLogName("iter3-implementer-42")).toBe(42);
+    expect(inferIssueFromLogName("iter1-pr-99")).toBe(99);
+  });
+  test("returns undefined when no number", () => {
+    expect(inferIssueFromLogName("nope")).toBeUndefined();
+  });
+});
+
+describe("groupByIssue", () => {
+  test("collects all phases for an issue under one key", () => {
+    const events = parseStreamLogText(
+      [
+        line({ type: "tool", runId: "r1", name: "iter1-implementer-42", iter: 1, t: "x", tool: "Read", args: "" }),
+        line({ type: "tool", runId: "r1", name: "iter1-reviewer-42", iter: 1, t: "x", tool: "Read", args: "" }),
+        line({ type: "tool", runId: "r1", name: "iter1-pr-42", iter: 1, t: "x", tool: "Bash", args: "" }),
+      ].join("\n"),
+    );
+    const byIssue = groupByIssue(groupByAgentRun(events));
+    expect(byIssue.get(42)?.size).toBe(3);
+  });
+});

--- a/.sandcastle/analyzer/parse.ts
+++ b/.sandcastle/analyzer/parse.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import type { Event } from "./detectors/types";
+
+// Parse a stream.log file into a flat Event[]. Malformed lines are skipped
+// silently — the analyzer is best-effort over a possibly truncated tail.
+export function parseStreamLog(path: string): Event[] {
+  const raw = readFileSync(path, "utf8");
+  return parseStreamLogText(raw);
+}
+
+export function parseStreamLogText(raw: string): Event[] {
+  const events: Event[] = [];
+  for (const line of raw.split("\n")) {
+    if (line.length === 0) continue;
+    try {
+      const parsed = JSON.parse(line) as Event;
+      if (isEvent(parsed)) events.push(parsed);
+    } catch {
+      // skip malformed line
+    }
+  }
+  return events;
+}
+
+function isEvent(v: unknown): v is Event {
+  if (typeof v !== "object" || v === null) return false;
+  const t = (v as { type?: unknown }).type;
+  return t === "run_start" || t === "text" || t === "tool" || t === "usage";
+}
+
+// Group events by `runId`. Events without a `runId` (legacy logs predating
+// the run_start marker) are bucketed under "legacy".
+export type Run = {
+  runId: string;
+  startedAt: string | undefined;
+  events: Event[];
+};
+
+export function groupByRun(events: readonly Event[]): Run[] {
+  const byId = new Map<string, Run>();
+  for (const ev of events) {
+    const id = "runId" in ev && typeof ev.runId === "string" ? ev.runId : "legacy";
+    let run = byId.get(id);
+    if (!run) {
+      run = { runId: id, startedAt: undefined, events: [] };
+      byId.set(id, run);
+    }
+    if (ev.type === "run_start" && run.startedAt === undefined) run.startedAt = ev.t;
+    run.events.push(ev);
+  }
+  return [...byId.values()];
+}
+
+// Group events within a run by `name` (one bucket per agent run, e.g.
+// "iter1-implementer-42"). Run-level events (run_start) are excluded.
+export function groupByAgentRun(events: readonly Event[]): Map<string, Event[]> {
+  const byName = new Map<string, Event[]>();
+  for (const ev of events) {
+    if (ev.type === "run_start") continue;
+    const list = byName.get(ev.name) ?? [];
+    list.push(ev);
+    byName.set(ev.name, list);
+  }
+  return byName;
+}
+
+// Group an agent run's events by issue number, derived from the agent's
+// display name embedded in tool/text events. Used for per-issue reporting.
+export function groupByIssue(byAgent: Map<string, Event[]>): Map<number | "unknown", Map<string, Event[]>> {
+  const byIssue = new Map<number | "unknown", Map<string, Event[]>>();
+  for (const [agentName, evs] of byAgent) {
+    const issueKey = inferIssueFromLogName(agentName) ?? "unknown";
+    const existing = byIssue.get(issueKey) ?? new Map<string, Event[]>();
+    existing.set(agentName, evs);
+    byIssue.set(issueKey, existing);
+  }
+  return byIssue;
+}
+
+// Extract issue number from a log-channel name like "iter3-implementer-42"
+// or "iter1-pr-99". The orchestrator names channels with the issue suffix.
+export function inferIssueFromLogName(name: string): number | undefined {
+  const match = name.match(/-(\d+)$/);
+  return match ? Number(match[1]) : undefined;
+}

--- a/.sandcastle/analyzer/report.test.ts
+++ b/.sandcastle/analyzer/report.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import type { Finding } from "./detectors/types";
+import { renderReport } from "./report";
+
+const finding = (overrides: Partial<Finding> = {}): Finding => ({
+  detector: "A1-redundant-tool-call",
+  agentName: "iter1-implementer-42",
+  message: "Read called 3× with identical args",
+  evidence: "args: /foo.ts",
+  wastedToolCalls: 2,
+  wastedSeconds: 20,
+  suggestedFix: "Cache it.",
+  source: "deterministic",
+  ...overrides,
+});
+
+describe("renderReport", () => {
+  test("includes summary, biggest win, and per-issue sections", () => {
+    const out = renderReport({
+      runId: "r1",
+      events: [],
+      findings: [finding(), finding({ message: "Other thing", wastedToolCalls: 5 })],
+      generatedAt: "2026-04-30T13:00:00Z",
+    });
+    expect(out).toContain("# Sandcastle harness analysis");
+    expect(out).toContain("Run: `r1`");
+    expect(out).toContain("Biggest win:");
+    expect(out).toContain("Other thing");
+    expect(out).toContain("## Issue #42");
+    expect(out).toContain("### Implementer");
+  });
+
+  test("ranks findings within a phase by cost (desc)", () => {
+    const out = renderReport({
+      runId: "r1",
+      events: [],
+      findings: [
+        finding({ message: "Cheap", wastedToolCalls: 1 }),
+        finding({ message: "Expensive", wastedToolCalls: 10 }),
+      ],
+      generatedAt: "2026-04-30T13:00:00Z",
+    });
+    const expensiveIdx = out.indexOf("Expensive");
+    const cheapIdx = out.indexOf("Cheap");
+    expect(expensiveIdx).toBeGreaterThan(-1);
+    expect(expensiveIdx).toBeLessThan(cheapIdx);
+  });
+
+  test("groups by issue and orders implementer → reviewer → pr-opener", () => {
+    const out = renderReport({
+      runId: "r1",
+      events: [],
+      findings: [
+        finding({ agentName: "iter1-pr-42", message: "PR thing" }),
+        finding({ agentName: "iter1-implementer-42", message: "Impl thing" }),
+        finding({ agentName: "iter1-reviewer-42", message: "Rev thing" }),
+      ],
+      generatedAt: "2026-04-30T13:00:00Z",
+    });
+    const implIdx = out.indexOf("### Implementer");
+    const revIdx = out.indexOf("### Reviewer");
+    const prIdx = out.indexOf("### Pr-opener");
+    expect(implIdx).toBeGreaterThan(-1);
+    expect(implIdx).toBeLessThan(revIdx);
+    expect(revIdx).toBeLessThan(prIdx);
+  });
+
+  test("clean run produces a 'no findings' note", () => {
+    const out = renderReport({
+      runId: "r1",
+      events: [],
+      findings: [],
+      generatedAt: "2026-04-30T13:00:00Z",
+    });
+    expect(out).toContain("No findings");
+  });
+
+  test("includes per-phase usage line when usage events present", () => {
+    const out = renderReport({
+      runId: "r1",
+      events: [
+        {
+          type: "usage",
+          runId: "r1",
+          name: "iter1-implementer-42",
+          iter: 1,
+          subIter: 1,
+          t: "x",
+          inputTokens: 1000,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 5000,
+          outputTokens: 200,
+        },
+      ],
+      findings: [finding()],
+      generatedAt: "2026-04-30T13:00:00Z",
+    });
+    expect(out).toContain("Usage:");
+    expect(out).toContain("Tokens this run:");
+  });
+});

--- a/.sandcastle/analyzer/report.ts
+++ b/.sandcastle/analyzer/report.ts
@@ -1,0 +1,189 @@
+import type { Event, Finding, UsageEvent } from "./detectors/types";
+import { inferIssueFromLogName } from "./parse";
+
+export type ReportInput = {
+  runId: string;
+  events: readonly Event[];
+  findings: readonly Finding[];
+  generatedAt: string;
+};
+
+// Render a markdown report grouping findings per-issue and ranking each
+// section by cost (wasted tool calls, then wasted seconds). Emits a header
+// summary so the user can decide whether to read further.
+export function renderReport(input: ReportInput): string {
+  const { runId, events, findings, generatedAt } = input;
+  const usageByName = collectUsage(events);
+  const lines: string[] = [];
+
+  lines.push(`# Sandcastle harness analysis`);
+  lines.push("");
+  lines.push(`- Run: \`${runId}\``);
+  lines.push(`- Generated: ${generatedAt}`);
+  lines.push("");
+
+  // Header summary
+  const totalWastedTools = findings.reduce((s, f) => s + f.wastedToolCalls, 0);
+  const totalWastedSecs = findings.reduce((s, f) => s + f.wastedSeconds, 0);
+  const detTotal = findings.filter((f) => f.source !== "llm").length;
+  const llmTotal = findings.filter((f) => f.source === "llm").length;
+  const sortedAll = [...findings].sort(byCost);
+  const top = sortedAll[0];
+
+  lines.push(`## Summary`);
+  lines.push("");
+  lines.push(
+    `- ${findings.length} finding${findings.length === 1 ? "" : "s"} (${detTotal} deterministic, ${llmTotal} LLM)`,
+  );
+  lines.push(`- Estimated waste: ${totalWastedTools} tool call${totalWastedTools === 1 ? "" : "s"}, ~${Math.round(totalWastedSecs)}s`);
+  if (top) {
+    lines.push(`- Biggest win: **${top.message}** in \`${top.agentName}\` (${top.wastedToolCalls} calls, ~${Math.round(top.wastedSeconds)}s)`);
+  }
+  if (usageByName.size > 0) {
+    const totals = sumUsage([...usageByName.values()].flat());
+    const grand =
+      totals.inputTokens +
+      totals.cacheCreationInputTokens +
+      totals.cacheReadInputTokens +
+      totals.outputTokens;
+    lines.push(
+      `- Tokens this run: input ${fmt(totals.inputTokens)}, cache-create ${fmt(totals.cacheCreationInputTokens)}, cache-read ${fmt(totals.cacheReadInputTokens)}, output ${fmt(totals.outputTokens)} (total ${fmt(grand)})`,
+    );
+  }
+  lines.push("");
+
+  // Per-issue grouping
+  const byIssue = groupFindingsByIssue(findings);
+  const issueKeys = [...byIssue.keys()].sort((a, b) => issueSortKey(a) - issueSortKey(b));
+
+  for (const issue of issueKeys) {
+    const issueFindings = byIssue.get(issue) ?? [];
+    if (issueFindings.length === 0) continue;
+    lines.push(`## Issue ${issue === "unknown" ? "(unknown)" : `#${issue}`}`);
+    lines.push("");
+
+    // Sub-group by phase, ordered implementer → reviewer → pr-opener → other.
+    const byPhase = groupFindingsByPhase(issueFindings);
+    for (const phase of ["implementer", "reviewer", "pr-opener", "other"] as const) {
+      const phaseFindings = (byPhase.get(phase) ?? []).slice().sort(byCost);
+      if (phaseFindings.length === 0) continue;
+      lines.push(`### ${capitalise(phase)}`);
+      lines.push("");
+      const phaseUsage = phaseUsageFor(usageByName, phase, issue);
+      if (phaseUsage) {
+        lines.push(`_Usage: ${phaseUsage}_`);
+        lines.push("");
+      }
+      for (const f of phaseFindings) {
+        lines.push(`- **${f.message}** (${f.detector}${f.source === "llm" ? ", llm" : ""})`);
+        lines.push(`  - Cost: ${f.wastedToolCalls} call${f.wastedToolCalls === 1 ? "" : "s"}, ~${Math.round(f.wastedSeconds)}s`);
+        if (f.evidence) lines.push(`  - Evidence: ${f.evidence}`);
+        lines.push(`  - Suggested fix: ${f.suggestedFix}`);
+      }
+      lines.push("");
+    }
+  }
+
+  if (findings.length === 0) {
+    lines.push(`_No findings — clean run._`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function byCost(a: Finding, b: Finding): number {
+  if (b.wastedToolCalls !== a.wastedToolCalls) return b.wastedToolCalls - a.wastedToolCalls;
+  return b.wastedSeconds - a.wastedSeconds;
+}
+
+function groupFindingsByIssue(findings: readonly Finding[]): Map<number | "unknown", Finding[]> {
+  const out = new Map<number | "unknown", Finding[]>();
+  for (const f of findings) {
+    const key: number | "unknown" =
+      f.issueNumber ?? inferIssueFromLogName(f.agentName) ?? "unknown";
+    const list = out.get(key) ?? [];
+    list.push(f);
+    out.set(key, list);
+  }
+  return out;
+}
+
+function groupFindingsByPhase(findings: readonly Finding[]): Map<string, Finding[]> {
+  const out = new Map<string, Finding[]>();
+  for (const f of findings) {
+    const phase = phaseOfName(f.agentName);
+    const list = out.get(phase) ?? [];
+    list.push(f);
+    out.set(phase, list);
+  }
+  return out;
+}
+
+function phaseOfName(agentName: string): "implementer" | "reviewer" | "pr-opener" | "other" {
+  if (agentName.includes("implementer")) return "implementer";
+  if (agentName.includes("reviewer")) return "reviewer";
+  if (agentName.includes("pr-")) return "pr-opener";
+  return "other";
+}
+
+function collectUsage(events: readonly Event[]): Map<string, UsageEvent[]> {
+  const out = new Map<string, UsageEvent[]>();
+  for (const ev of events) {
+    if (ev.type !== "usage") continue;
+    const list = out.get(ev.name) ?? [];
+    list.push(ev);
+    out.set(ev.name, list);
+  }
+  return out;
+}
+
+function phaseUsageFor(
+  usageByName: Map<string, UsageEvent[]>,
+  phase: string,
+  issue: number | "unknown",
+): string | undefined {
+  if (issue === "unknown") return undefined;
+  const matching: UsageEvent[] = [];
+  for (const [name, evs] of usageByName) {
+    if (phaseOfName(name) !== phase) continue;
+    if (inferIssueFromLogName(name) !== issue) continue;
+    matching.push(...evs);
+  }
+  if (matching.length === 0) return undefined;
+  const tot = sumUsage(matching);
+  const grand =
+    tot.inputTokens + tot.cacheCreationInputTokens + tot.cacheReadInputTokens + tot.outputTokens;
+  return `total ${fmt(grand)} tokens (in ${fmt(tot.inputTokens)}, cache-c ${fmt(tot.cacheCreationInputTokens)}, cache-r ${fmt(tot.cacheReadInputTokens)}, out ${fmt(tot.outputTokens)})`;
+}
+
+function sumUsage(evs: UsageEvent[]): {
+  inputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  outputTokens: number;
+} {
+  return evs.reduce(
+    (acc, e) => ({
+      inputTokens: acc.inputTokens + e.inputTokens,
+      cacheCreationInputTokens: acc.cacheCreationInputTokens + e.cacheCreationInputTokens,
+      cacheReadInputTokens: acc.cacheReadInputTokens + e.cacheReadInputTokens,
+      outputTokens: acc.outputTokens + e.outputTokens,
+    }),
+    { inputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, outputTokens: 0 },
+  );
+}
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function issueSortKey(k: number | "unknown"): number {
+  return k === "unknown" ? Number.POSITIVE_INFINITY : k;
+}
+
+function capitalise(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/.sandcastle/harness.ts
+++ b/.sandcastle/harness.ts
@@ -4,6 +4,8 @@ import type {
   AgentStreamEvent,
   ClaudeCodeOptions,
   CodexOptions,
+  IterationResult,
+  IterationUsage,
   LoggingOption,
 } from "@ai-hero/sandcastle";
 
@@ -44,6 +46,60 @@ export type AgentSpec = ClaudeCodeSpec | CodexSpec | OpenCodeSpec | PiSpec;
 
 export const STREAM_LOG_PATH = ".sandcastle/logs/stream.log";
 
+// Stable id for this orchestrator process. Stamped onto every stream-log
+// line so the analyzer can group events by run without guessing boundaries
+// from `iter` resets.
+export const RUN_ID = `${new Date().toISOString().replace(/[:.]/g, "-")}-${process.pid}`;
+
+function appendStreamLine(obj: object): void {
+  appendFileSync(STREAM_LOG_PATH, JSON.stringify(obj) + "\n");
+}
+
+// Append a one-off marker so the analyzer can split a multi-run stream.log
+// into discrete runs. Call once at orchestrator start.
+export function emitRunStart(): void {
+  appendStreamLine({
+    type: "run_start",
+    runId: RUN_ID,
+    t: new Date().toISOString(),
+  });
+}
+
+// Append the usage tally returned by sandcastle for one internal
+// iteration of an agent run. `iter` here is the orchestrator's outer
+// iteration; `subIter` is sandcastle's per-run iteration index.
+export function emitUsage(
+  name: string,
+  iter: number,
+  subIter: number,
+  usage: IterationUsage,
+): void {
+  appendStreamLine({
+    type: "usage",
+    runId: RUN_ID,
+    name,
+    iter,
+    subIter,
+    t: new Date().toISOString(),
+    inputTokens: usage.inputTokens,
+    cacheCreationInputTokens: usage.cacheCreationInputTokens,
+    cacheReadInputTokens: usage.cacheReadInputTokens,
+    outputTokens: usage.outputTokens,
+  });
+}
+
+// Emit a usage record for each iteration that carries usage data. Iterations
+// without `usage` (provider opted out, capture disabled) are silently skipped.
+export function emitUsageFromRun(
+  name: string,
+  iter: number,
+  iterations: readonly IterationResult[],
+): void {
+  iterations.forEach((it, idx) => {
+    if (it.usage) emitUsage(name, iter, idx + 1, it.usage);
+  });
+}
+
 // Build a sandcastle AgentProvider from an AgentSpec. Each provider's options
 // object accepts an optional `effort` (or has no effort at all), so we can
 // always pass options through — no need to branch on whether effort is set.
@@ -65,24 +121,12 @@ export function streamLogger(name: string): LoggingOption {
     type: "file",
     path: `.sandcastle/logs/${name}.log`,
     onAgentStreamEvent: (event: AgentStreamEvent) => {
-      const line =
+      const base = { runId: RUN_ID, name, iter: event.iteration, t: event.timestamp };
+      appendStreamLine(
         event.type === "text"
-          ? JSON.stringify({
-              name,
-              iter: event.iteration,
-              t: event.timestamp,
-              type: "text",
-              text: event.message,
-            })
-          : JSON.stringify({
-              name,
-              iter: event.iteration,
-              t: event.timestamp,
-              type: "tool",
-              tool: event.name,
-              args: event.formattedArgs,
-            });
-      appendFileSync(STREAM_LOG_PATH, line + "\n");
+          ? { ...base, type: "text", text: event.message }
+          : { ...base, type: "tool", tool: event.name, args: event.formattedArgs },
+      );
     },
   };
 }

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -232,3 +232,15 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
 }
 
 console.log("\nAll done.");
+
+// Auto-run the analyzer at end-of-orchestration so every run produces a
+// fresh `.sandcastle/logs/analysis.md`. Skipped with --no-analyze; failures
+// are non-fatal (we don't want a bad analyzer to break sandcastle).
+if (!process.argv.includes("--no-analyze")) {
+  try {
+    await import("./analyze");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Analyzer failed: ${msg}`);
+  }
+}

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -3,7 +3,7 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 import { evaluate, pickEligible } from "./eligibility";
 import type { ExclusionReason } from "./eligibility";
 import { fetchIssueLiveState, fetchOpenLabelledIssues, fetchOpenPRsClosingIssues } from "./github";
-import { agent, streamLogger } from "./harness";
+import { agent, emitRunStart, emitUsageFromRun, streamLogger } from "./harness";
 import type { AgentSpec } from "./harness";
 import type { Issue } from "./issue";
 
@@ -111,6 +111,8 @@ async function pathsTouchedByCommits(worktreePath: string, commits: { sha: strin
   return out.split("\n").filter((p) => p.length > 0);
 }
 
+emitRunStart();
+
 for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   console.log(`\n=== Iteration ${iteration}/${MAX_ITERATIONS} ===\n`);
 
@@ -165,13 +167,15 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
       BRANCH: issue.branch,
     };
 
+    const implementerLogName = `iter${iteration}-implementer-${issue.number}`;
     const implementResult = await sandbox.run({
       name: "Implementer #" + issue.number,
       agent: agent(implementerSpec),
       promptFile: implementerSpec.promptPath,
       promptArgs: issuePromptArgs,
-      logging: streamLogger(`iter${iteration}-implementer-${issue.number}`),
+      logging: streamLogger(implementerLogName),
     });
+    emitUsageFromRun(implementerLogName, iteration, implementResult.iterations);
 
     // Both reviewer and PR-opener gate on whether *this* implementer run made
     // commits. Comparing `main..HEAD` would be incorrect when the orchestrator
@@ -190,22 +194,26 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     const skipReview = docsOnly || allMarkdown;
 
     if (!skipReview) {
-      await sandbox.run({
+      const reviewerLogName = `iter${iteration}-reviewer-${issue.number}`;
+      const reviewerResult = await sandbox.run({
         name: "Reviewer #" + issue.number,
         agent: agent(AGENTS.reviewer),
         promptFile: AGENTS.reviewer.promptPath,
         promptArgs: issuePromptArgs,
-        logging: streamLogger(`iter${iteration}-reviewer-${issue.number}`),
+        logging: streamLogger(reviewerLogName),
       });
+      emitUsageFromRun(reviewerLogName, iteration, reviewerResult.iterations);
     }
 
-    await sandbox.run({
+    const prLogName = `iter${iteration}-pr-${issue.number}`;
+    const prResult = await sandbox.run({
       name: "PR-Opener #" + issue.number,
       agent: agent(AGENTS.prOpener),
       promptFile: AGENTS.prOpener.promptPath,
       promptArgs: issuePromptArgs,
-      logging: streamLogger(`iter${iteration}-pr-${issue.number}`),
+      logging: streamLogger(prLogName),
     });
+    emitUsageFromRun(prLogName, iteration, prResult.iterations);
   } catch (reason) {
     const errorTag =
       typeof reason === "object" && reason !== null && "_tag" in reason

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "ontograph",
       "dependencies": {
         "@ai-hero/sandcastle": "^0.5.5",
+        "@anthropic-ai/sdk": "^0.91.1",
         "@sindresorhus/slugify": "^3.0.0",
         "zod": "^4.3.6",
       },
@@ -196,6 +197,8 @@
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.85", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-/ohKLtP1zy6aWXLW/9KTYBveJPEtAfdO96qiP1Cl5S7LgVq/qRDUl7AUw5YGrBaK6YWHEE/rfMQZGwP/i5zIvQ=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.0.1", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.6" } }, "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw=="],
 
@@ -2047,6 +2050,8 @@
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
@@ -2796,6 +2801,8 @@
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "truncate-utf8-bytes": ["truncate-utf8-bytes@1.0.2", "", { "dependencies": { "utf8-byte-length": "^1.0.1" } }, "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@ai-hero/sandcastle": "^0.5.5",
+    "@anthropic-ai/sdk": "^0.91.1",
     "@sindresorhus/slugify": "^3.0.0",
     "zod": "^4.3.6"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ci": "turbo typecheck && turbo test && biome check .",
     "prepare": "husky",
     "sandcastle": "bun .sandcastle/main.ts",
+    "sandcastle:analyze": "bun .sandcastle/analyze.ts",
     "sandcastle:build": "bunx sandcastle docker build-image",
     "cleanup": "bun scripts/cleanup-branches.ts"
   },


### PR DESCRIPTION
## Summary

- Adds `.sandcastle/analyzer/` — a per-run log analyzer that flags harness/prompt mistakes from `stream.log` and emits a markdown report (`.sandcastle/logs/analysis.md`) ranked by estimated wasted tool calls and wall-clock seconds.
- Stamps `stream.log` with a one-time `run_start` marker and per-iteration `usage` records (token totals from `IterationResult.usage`), so the analyzer can split multi-run logs and reason about real cost.
- Auto-invokes the analyzer at the end of every sandcastle run; opt-in `--llm` flag adds a whole-issue grading pass via Haiku 4.5.

### Detectors (deterministic, always run)

- A1 redundant identical tool call
- A3 likely tool retry (same tool, near-identical args, <8s apart)
- A4 Bash where a dedicated tool exists (Read/Grep/Glob/Edit)
- B6 excessive exploration before first edit
- C8 reviewer re-reads files the implementer just wrote
- D10 hard failures (no tool calls, or trailing error-tone text)
- E12 per-phase outliers vs a rolling Welford baseline (`baseline.json`)

### LLM pass (opt-in)

- `bun .sandcastle/analyze.ts --llm`
- Whole-issue grading with Haiku 4.5, prompt-cached system prompt
- Findings tagged `(llm)` in the same report

### Report shape

- Per-issue grouping with implementer / reviewer / pr-opener sub-sections
- Header summary: counts, estimated waste, biggest win, run-level token totals
- Latest at `.sandcastle/logs/analysis.md`; archive at `.sandcastle/logs/analysis/<run-id>.md`

## Test plan

- [x] `bun test` in `.sandcastle/` — 71 tests pass
- [x] `bun run format:check` and `bun run lint` clean
- [x] End-to-end smoke run on a synthetic stream.log produced expected findings (A1, A4, C8) and a clean markdown report
- [ ] Live sandcastle run produces a real `analysis.md` (manual verification on next run)

## Notes

- `.sandcastle/` is excluded from biome by repo config; analyzer code follows local conventions instead.
- `@anthropic-ai/sdk` is added as a runtime dep for the LLM grader.
- The analyzer is best-effort: malformed log lines are skipped, baseline corruption resets, and analyzer failures are non-fatal to sandcastle runs.