### PR TITLE
chore: streamline agent guidance and enforce app→stdlib layering

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-brief.md
+++ b/.github/ISSUE_TEMPLATE/agent-brief.md
@@ -1,0 +1,29 @@
+---
+name: Agent brief
+about: A fully-specified issue ready for an AFK agent (or human) to pick up
+title: ''
+labels: ['needs-triage']
+---
+
+## Context
+
+Background a fresh reader needs. What exists today, where the relevant code lives at a behavioural level (interfaces, types — not file paths or line numbers).
+
+## Problem statement
+
+What is broken, missing, or limiting. Be concrete.
+
+## Solution
+
+What should change. Describe behaviour, not implementation. Name interfaces and types where helpful.
+
+## Acceptance criteria
+
+- [ ] Specific, testable criterion
+- [ ] Specific, testable criterion
+- [ ] `bun run ci` passes
+
+## Out of scope
+
+- Adjacent thing that is NOT being changed
+- Future work tracked elsewhere

--- a/.sandcastle/CLAUDE.md
+++ b/.sandcastle/CLAUDE.md
@@ -1,0 +1,18 @@
+You are running unattended (AFK). No human will answer questions mid-task. Default to the most conservative interpretation of the issue.
+
+Read the root [`CLAUDE.md`](../CLAUDE.md) and [`CODING_STANDARDS.md`](CODING_STANDARDS.md) first — those rules still apply. This file layers AFK-specific rules on top.
+
+## Scope discipline
+
+- One issue per run. Do not fix unrelated bugs you notice — open a new issue or leave a comment.
+- No drive-by refactors, formatting sweeps, or dependency bumps.
+- If the issue is ambiguous, pick the smallest interpretation that satisfies the literal request and note your assumption in the commit message.
+- If you cannot make progress (blocked, ambiguous, missing context), stop and leave a comment on the issue. Do not guess and ship.
+
+## Done
+
+The issue's "Acceptance criteria" checklist defines done. Every box must pass. If the issue has no acceptance criteria, stop and leave a comment asking for them — do not guess. Always: `bun run ci` must pass before you commit.
+
+## Per-task prompts
+
+The implement / review / PR prompts in this directory layer task-specific instructions on top of these rules. If a per-task prompt conflicts with this file, the per-task prompt wins for that task only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,23 +1,30 @@
-## CI Checks
+## Tool discipline
 
-After pushing to a PR branch, verify CI passes before requesting review:
+Prefer dedicated tools over Bash for filesystem ops — `Read` over `cat`, `Glob` over `find`, `Grep` over `grep`/`rg`, `Edit`/`Write` over `sed`/heredocs. Bash is for tests, git, gh, package managers, builds.
+
+## Orientation
+
+Turborepo monorepo (Bun workspaces). See [README.md](README.md) for the app/package table and tech stack.
+
+Coding standards live in [.sandcastle/CODING_STANDARDS.md](.sandcastle/CODING_STANDARDS.md) — they apply to all contributors, not just AFK agents. Read them before writing code.
+
+## Commands
 
 ```bash
-# Check PR status
-gh pr view <number> --json statusCheckRollup --jq '.statusCheckRollup[] | [.name, .conclusion] | @tsv'
-
-# Get failed job logs
-gh run view <run-id> --log-failed | head -60
+bun run dev         # all apps in dev mode (turbo)
+bun run ci          # typecheck + test + biome check — run before pushing
+bun run typecheck   # turbo typecheck
+bun run test        # turbo test (Vitest)
+bun run lint        # biome lint
+bun run format      # biome format --write
 ```
 
-- If CI fails, fix the issue and push again.
-- Run `bun run format:check` and `bun run lint` locally before pushing to catch issues early.
-- Do not request review or mark a PR as ready while CI is failing.
+Run a single test file: `cd packages/<pkg> && bun test path/to/file.test.ts`.
 
-## Versioning & Releases
+## CI
 
-- Semver versioning: vMAJOR.MINOR.PATCH
-- Conventional commits required
-- QA determines release readiness, CTO executes releases
-- GitHub Actions handles build/publish on version tags (v*.*.\*)
-- Never push directly to main — all work via feature branches and PRs
+If CI fails on a pushed branch, fix it before merging.
+
+## Commits
+
+Use conventional commits.

--- a/biome.json
+++ b/biome.json
@@ -91,5 +91,29 @@
         "organizeImports": "on"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["apps/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "@contexture/stdlib": "Apps must import runtime types via @contexture/runtime, not @contexture/stdlib. (Escape hatch: @contexture/stdlib/registry is allowed for editor tooling — see packages/stdlib/src/registry.ts.)",
+                  "@contexture/stdlib/common": "Use @contexture/runtime/common instead.",
+                  "@contexture/stdlib/identity": "Use @contexture/runtime/identity instead.",
+                  "@contexture/stdlib/place": "Use @contexture/runtime/place instead.",
+                  "@contexture/stdlib/money": "Use @contexture/runtime/money instead.",
+                  "@contexture/stdlib/contact": "Use @contexture/runtime/contact instead."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Streamline `CLAUDE.md` to actionable guidance only — drops redundant sections (CI workflow, release boilerplate, layering rules now lint-enforced) and leads with tool discipline (the rule with the highest per-run cost).
- Add `.sandcastle/CLAUDE.md` as an AFK overlay covering scope discipline; "done" now points at the issue's acceptance criteria rather than a global checklist.
- Enforce `apps/* → runtime → stdlib` via Biome `noRestrictedImports` (apps banned from importing the five stdlib namespace subpaths; `@contexture/stdlib/registry` allowed as the documented escape hatch for editor tooling).
- Add `.github/ISSUE_TEMPLATE/agent-brief.md` mirroring the existing AGENT-BRIEF structure used by the triage skill, so manually-filed issues converge on the same shape.

## Test plan

- [ ] `bun run lint` passes (verified locally — 329 files, no violations).
- [ ] `bun run ci` passes (verified locally via pre-commit hook on both commits).
- [ ] CI green on PR.
- [ ] New issue template appears in the GitHub UI under "New issue".