### PR TITLE
feat(sandcastle): install agent-browser for browser-observable AC verification

### DIFF
--- a/.sandcastle/CLAUDE.md
+++ b/.sandcastle/CLAUDE.md
@@ -13,6 +13,22 @@ Read the root [`CLAUDE.md`](../CLAUDE.md) and [`CODING_STANDARDS.md`](CODING_STA
 
 The issue's "Acceptance criteria" checklist defines done. Every box must pass. If the issue has no acceptance criteria, stop and leave a comment asking for them — do not guess. Always: `bun run ci` must pass before you commit.
 
+## Browser skill (agent-browser)
+
+`agent-browser` is pre-installed and registered as a Claude Code skill. Use it to verify browser-observable acceptance criteria — UI flows, redirects, analytics events, rendered output — that unit tests and Playwright e2e tests cannot cover.
+
+**When to use:** the issue acceptance criteria require observing browser state (e.g. "visiting `/download` redirects to the right asset", "clicking the Download CTA fires the PostHog event", "the editor renders X after Y").
+
+**How to invoke:** use the `agent-browser` skill from within a Claude Code session. Key actions: `navigate`, `click`, `fill`, `screenshot`, `accessibility-snapshot`, `evaluate`.
+
+**Sandbox guardrails:**
+- Only connect to `localhost` and `127.0.0.1` (the local dev server). Do not make real network calls to external services unless the issue explicitly allows a specific domain.
+- No logins to third-party services (GitHub, PostHog, Stripe, etc.).
+- State files (sessions, cookies, screenshots) must be written under `/tmp`, not into the worktree. Do not commit browser artefacts.
+- Chrome runs headless by default; headed mode works under `xvfb` if needed.
+
+**Do not use** agent-browser to replace existing Playwright e2e tests — those stay as-is.
+
 ## Per-task prompts
 
 The implement / review / PR prompts in this directory layer task-specific instructions on top of these rules. If a per-task prompt conflicts with this file, the per-task prompt wins for that task only.

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -48,6 +48,9 @@ RUN apt-get update && apt-get install -y \
 # Install turbo globally
 RUN bun install -g turbo
 
+# Install agent-browser CLI globally (root so it lands on the system PATH)
+RUN npm install -g agent-browser
+
 # The oven/bun image already has a "bun" user (UID 1000).
 RUN usermod -d /home/agent -m -l agent bun
 # oven/bun's home dir is mode 700 (vs 755 on node:slim). Sandcastle runs the
@@ -60,6 +63,14 @@ USER agent
 
 # Install Claude Code CLI
 RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Pre-fetch Chrome for Testing into the image so AFK sessions don't need
+# network access for the browser binary at runtime.
+RUN agent-browser install
+
+# Register agent-browser as a Claude Code skill so AFK sessions can invoke
+# browser actions (navigate, click, screenshot, etc.) without further setup.
+RUN npx --yes skills add https://github.com/vercel-labs/agent-browser --skill agent-browser
 
 # Claude Code's install creates ~/.claude, ~/.claude.json, and ~/.cache
 # owned by UID 1000. Sandcastle runs the container as the host UID, so


### PR DESCRIPTION
## Summary

- Install agent-browser CLI globally so AFK agents can use browser automation skills
- Pre-fetch Chrome for Testing during image build for zero-network runtime setup
- Register Claude Code skill in image so browser interaction (navigate/click/screenshot/evaluate) is available without per-session setup

Closes #222