### PR TITLE
chore(sandcastle): wire gh auth setup-git so git push works in sandbox

### DIFF
--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -33,7 +33,13 @@ const COPY_TO_WORKTREE: readonly string[] = ["apps/desktop/.env", "apps/web/.env
 // 0 even when individual extractions are mangled, so we follow with `turbo
 // typecheck`, which resolves and loads imports across every workspace and
 // fails loudly if a package's main entry is missing.
-const INSTALL_AND_VERIFY = "bun install && bun run typecheck";
+//
+// `gh auth setup-git` wires git to use the gh CLI as a credential helper.
+// gh is already authed via $GH_TOKEN (injected by sandcastle), but git
+// itself has no helper configured — without this, `git push` from the
+// pr-opener phase fails and the agent burns ~10 calls discovering a
+// workable credential scheme.
+const INSTALL_AND_VERIFY = "gh auth setup-git && bun install && bun run typecheck";
 
 // ---------- Agent specs ----------
 


### PR DESCRIPTION
## Summary

The pr-opener phase was burning ~10 tool calls per run rediscovering how to authenticate `git push` inside the sandbox. `GH_TOKEN` is in the container env, so `gh` is authed — but git itself has no credential helper configured, so pushes fail silently and the agent flails through credential schemes until something sticks.

Running `gh auth setup-git` once at sandbox start configures git to use gh as its credential helper. One-line change to the `onSandboxReady` hook command.

Surfaced by the harness analyzer (run `2026-04-30T15-08-18-640Z-76426`), which flagged "3× duplicate `gh pr create`" — but reading the full pr-opener log showed the duplicates were a downstream symptom of the underlying push-credential problem.

## Test plan

- [ ] Next sandcastle run: pr-opener completes without git-credential debugging tool calls
- [ ] `git push` from inside the container succeeds on first attempt