### PR TITLE
IMPLEMENT: Add /changelog page that renders GitHub releases (#227)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,8 @@
     "posthog-js": "^1.364.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.1",
     "shiki": "^4.0.2",
     "tailwind-merge": "^3.5.0",

--- a/apps/web/src/app/brand/page.tsx
+++ b/apps/web/src/app/brand/page.tsx
@@ -647,10 +647,7 @@ export default function BrandPage() {
             >
               GitHub
             </a>
-            <a
-              href="https://github.com/applification/contexture/releases"
-              className="hover:text-foreground transition-colors"
-            >
+            <a href="/changelog" className="hover:text-foreground transition-colors">
               Changelog
             </a>
           </div>

--- a/apps/web/src/app/changelog/page.tsx
+++ b/apps/web/src/app/changelog/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { AnimatedThemeToggler } from '@/components/ui/animated-theme-toggler';
 import { fetchReleases } from '@/lib/changelog';
 
@@ -107,8 +109,71 @@ export default async function ChangelogPage() {
                   </time>
                 </header>
                 {release.body && (
-                  <div className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
-                    {release.body}
+                  <div className="text-sm text-muted-foreground leading-relaxed">
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      components={{
+                        h1: ({ children }) => (
+                          <h3 className="text-lg font-semibold text-foreground mt-6 mb-3">
+                            {children}
+                          </h3>
+                        ),
+                        h2: ({ children }) => (
+                          <h3 className="text-lg font-semibold text-foreground mt-6 mb-3">
+                            {children}
+                          </h3>
+                        ),
+                        h3: ({ children }) => (
+                          <h4 className="text-base font-semibold text-foreground mt-5 mb-2">
+                            {children}
+                          </h4>
+                        ),
+                        h4: ({ children }) => (
+                          <h5 className="text-sm font-semibold text-foreground mt-4 mb-2">
+                            {children}
+                          </h5>
+                        ),
+                        p: ({ children }) => <p className="mb-3">{children}</p>,
+                        ul: ({ children }) => (
+                          <ul className="list-disc pl-6 mb-3 space-y-1">{children}</ul>
+                        ),
+                        ol: ({ children }) => (
+                          <ol className="list-decimal pl-6 mb-3 space-y-1">{children}</ol>
+                        ),
+                        li: ({ children }) => <li>{children}</li>,
+                        a: ({ href, children }) => (
+                          <a
+                            href={href}
+                            className="text-accent hover:underline"
+                            target={href?.startsWith('http') ? '_blank' : undefined}
+                            rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
+                          >
+                            {children}
+                          </a>
+                        ),
+                        code: ({ children }) => (
+                          <code className="px-1.5 py-0.5 rounded bg-muted text-foreground font-mono text-xs">
+                            {children}
+                          </code>
+                        ),
+                        pre: ({ children }) => (
+                          <pre className="p-3 rounded-md bg-muted text-foreground font-mono text-xs overflow-x-auto mb-3">
+                            {children}
+                          </pre>
+                        ),
+                        blockquote: ({ children }) => (
+                          <blockquote className="border-l-2 border-border pl-4 italic mb-3">
+                            {children}
+                          </blockquote>
+                        ),
+                        hr: () => <hr className="my-4 border-border/50" />,
+                        strong: ({ children }) => (
+                          <strong className="font-semibold text-foreground">{children}</strong>
+                        ),
+                      }}
+                    >
+                      {release.body}
+                    </ReactMarkdown>
                   </div>
                 )}
               </article>

--- a/apps/web/src/app/changelog/page.tsx
+++ b/apps/web/src/app/changelog/page.tsx
@@ -1,0 +1,142 @@
+import type { Metadata } from 'next';
+import { AnimatedThemeToggler } from '@/components/ui/animated-theme-toggler';
+import { fetchReleases } from '@/lib/changelog';
+
+export const metadata: Metadata = {
+  title: 'Changelog — Contexture',
+  description: 'Release history and what has changed in each version of Contexture.',
+};
+
+function LogoMark({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 32 32" fill="none" aria-hidden="true">
+      <line
+        x1="8"
+        y1="24"
+        x2="24"
+        y2="24"
+        stroke="var(--primary)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <line
+        x1="8"
+        y1="24"
+        x2="16"
+        y2="8"
+        stroke="var(--primary)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <line
+        x1="24"
+        y1="24"
+        x2="16"
+        y2="8"
+        stroke="var(--primary)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <circle cx="16" cy="8" r="3.5" fill="var(--primary)" />
+      <circle cx="8" cy="24" r="3.5" fill="var(--primary)" />
+      <circle cx="24" cy="24" r="3.5" fill="var(--accent)" />
+    </svg>
+  );
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default async function ChangelogPage() {
+  const releases = await fetchReleases();
+
+  return (
+    <div className="min-h-screen">
+      {/* Nav */}
+      <nav className="fixed top-0 w-full z-50 border-b border-border/50 bg-background/80 backdrop-blur-md">
+        <div className="max-w-5xl mx-auto px-8 h-16 flex items-center justify-between">
+          <a href="/" className="flex items-center gap-2 text-lg font-semibold tracking-tight">
+            <LogoMark className="size-6" />
+            Contexture
+          </a>
+          <div className="flex items-center gap-4">
+            <span className="text-sm text-muted-foreground">Changelog</span>
+            <AnimatedThemeToggler className="size-9 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground transition-colors [&_svg]:size-4" />
+          </div>
+        </div>
+      </nav>
+
+      <div className="max-w-5xl mx-auto px-8 pt-32 pb-20">
+        {/* Hero */}
+        <header className="pb-16 border-b border-border/30">
+          <p className="text-sm text-accent font-medium tracking-widest uppercase mb-4">
+            Release History
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-bold tracking-tight mb-6">Changelog</h1>
+          <p className="text-lg text-muted-foreground max-w-2xl leading-relaxed">
+            What&apos;s new in each version of Contexture.
+          </p>
+        </header>
+
+        {/* Releases */}
+        {releases.length === 0 ? (
+          <div className="py-20 text-center text-muted-foreground">
+            <p>No releases found.</p>
+          </div>
+        ) : (
+          <div className="divide-y divide-border/30">
+            {releases.map((release) => (
+              <article key={release.tag_name} className="py-12">
+                <header className="mb-6">
+                  <div className="flex flex-wrap items-baseline gap-4 mb-2">
+                    <h2 className="text-2xl font-bold tracking-tight">{release.tag_name}</h2>
+                    {release.name && release.name !== release.tag_name && (
+                      <span className="text-lg text-muted-foreground">{release.name}</span>
+                    )}
+                  </div>
+                  <time
+                    dateTime={release.published_at}
+                    className="text-sm text-muted-foreground font-mono"
+                  >
+                    {formatDate(release.published_at)}
+                  </time>
+                </header>
+                {release.body && (
+                  <div className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
+                    {release.body}
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Footer */}
+      <footer className="border-t border-border/30 py-10 px-8">
+        <div className="max-w-5xl mx-auto flex items-center justify-between text-sm text-muted-foreground">
+          <a href="/" className="flex items-center gap-2 hover:text-foreground transition-colors">
+            <LogoMark className="size-4" />
+            Contexture
+          </a>
+          <div className="flex items-center gap-6">
+            <a
+              href="https://github.com/applification/contexture"
+              className="hover:text-foreground transition-colors"
+            >
+              GitHub
+            </a>
+            <a href="/changelog" className="hover:text-foreground transition-colors">
+              Changelog
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -438,10 +438,7 @@ export default function Home() {
             >
               GitHub
             </a>
-            <a
-              href="https://github.com/applification/contexture/releases"
-              className="hover:text-foreground transition-colors"
-            >
+            <a href="/changelog" className="hover:text-foreground transition-colors">
               Changelog
             </a>
           </div>

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -1,0 +1,24 @@
+const GITHUB_RELEASES_API = 'https://api.github.com/repos/applification/contexture/releases';
+
+export interface GitHubRelease {
+  tag_name: string;
+  name: string;
+  body: string;
+  published_at: string;
+  draft: boolean;
+  prerelease: boolean;
+}
+
+export async function fetchReleases(): Promise<GitHubRelease[]> {
+  try {
+    const res = await fetch(GITHUB_RELEASES_API, {
+      headers: { Accept: 'application/vnd.github+json' },
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as GitHubRelease[];
+    return data.filter((r) => !r.draft && !r.prerelease);
+  } catch {
+    return [];
+  }
+}

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -2,8 +2,8 @@ const GITHUB_RELEASES_API = 'https://api.github.com/repos/applification/contextu
 
 export interface GitHubRelease {
   tag_name: string;
-  name: string;
-  body: string;
+  name: string | null;
+  body: string | null;
   published_at: string;
   draft: boolean;
   prerelease: boolean;

--- a/apps/web/tests/lib/changelog.test.ts
+++ b/apps/web/tests/lib/changelog.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchReleases } from '@/lib/changelog';
+
+const SAMPLE_RELEASES = [
+  {
+    tag_name: 'v1.2.0',
+    name: 'v1.2.0',
+    body: '## What changed\n\n- Added new feature\n- Fixed a bug',
+    published_at: '2024-03-01T00:00:00Z',
+    draft: false,
+    prerelease: false,
+  },
+  {
+    tag_name: 'v1.1.0',
+    name: 'v1.1.0',
+    body: '## Changes\n\n- Initial release',
+    published_at: '2024-02-01T00:00:00Z',
+    draft: false,
+    prerelease: false,
+  },
+  {
+    tag_name: 'v1.1.1-beta',
+    name: 'v1.1.1-beta',
+    body: 'Beta release',
+    published_at: '2024-02-15T00:00:00Z',
+    draft: false,
+    prerelease: true,
+  },
+  {
+    tag_name: 'v1.2.1-draft',
+    name: 'v1.2.1-draft',
+    body: 'Draft release',
+    published_at: '2024-03-15T00:00:00Z',
+    draft: true,
+    prerelease: false,
+  },
+];
+
+describe('fetchReleases', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns stable releases from GitHub', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => SAMPLE_RELEASES,
+    } as Response);
+
+    const releases = await fetchReleases();
+
+    expect(releases).toHaveLength(2);
+    expect(releases[0].tag_name).toBe('v1.2.0');
+    expect(releases[1].tag_name).toBe('v1.1.0');
+  });
+
+  it('filters out prerelease entries', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => SAMPLE_RELEASES,
+    } as Response);
+
+    const releases = await fetchReleases();
+
+    expect(releases.every((r) => !r.prerelease)).toBe(true);
+  });
+
+  it('filters out draft entries', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => SAMPLE_RELEASES,
+    } as Response);
+
+    const releases = await fetchReleases();
+
+    expect(releases.every((r) => !r.draft)).toBe(true);
+  });
+
+  it('returns empty array when GitHub API returns non-ok response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+    } as Response);
+
+    const releases = await fetchReleases();
+
+    expect(releases).toEqual([]);
+  });
+
+  it('returns empty array when fetch throws', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+    const releases = await fetchReleases();
+
+    expect(releases).toEqual([]);
+  });
+});

--- a/apps/web/tests/lib/changelog.test.ts
+++ b/apps/web/tests/lib/changelog.test.ts
@@ -98,4 +98,74 @@ describe('fetchReleases', () => {
 
     expect(releases).toEqual([]);
   });
+
+  it('returns empty array when all releases are drafts or prereleases', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          tag_name: 'v2.0.0-rc',
+          name: 'v2.0.0-rc',
+          body: null,
+          published_at: '2024-04-01T00:00:00Z',
+          draft: false,
+          prerelease: true,
+        },
+        {
+          tag_name: 'v2.0.0-draft',
+          name: null,
+          body: null,
+          published_at: '2024-04-02T00:00:00Z',
+          draft: true,
+          prerelease: false,
+        },
+      ],
+    } as Response);
+
+    const releases = await fetchReleases();
+
+    expect(releases).toEqual([]);
+  });
+
+  it('returns releases with null body without throwing', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          tag_name: 'v1.0.0',
+          name: 'v1.0.0',
+          body: null,
+          published_at: '2024-01-01T00:00:00Z',
+          draft: false,
+          prerelease: false,
+        },
+      ],
+    } as Response);
+
+    const releases = await fetchReleases();
+
+    expect(releases).toHaveLength(1);
+    expect(releases[0].body).toBeNull();
+  });
+
+  it('returns releases with null name without throwing', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          tag_name: 'v1.0.0',
+          name: null,
+          body: 'Some changes',
+          published_at: '2024-01-01T00:00:00Z',
+          draft: false,
+          prerelease: false,
+        },
+      ],
+    } as Response);
+
+    const releases = await fetchReleases();
+
+    expect(releases).toHaveLength(1);
+    expect(releases[0].name).toBeNull();
+  });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -104,6 +104,8 @@
         "posthog-js": "^1.364.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "shadcn": "^4.1.1",
         "shiki": "^4.0.2",
         "tailwind-merge": "^3.5.0",
@@ -2532,6 +2534,8 @@
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 


### PR DESCRIPTION
## Summary

- IMPLEMENT: Add /changelog page that renders GitHub releases (#227)
- REVIEW: tighten GitHubRelease types and add edge-case tests

Closes #227