### PR TITLE
chore: slim ci output to errors-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "check": "biome check .",
-    "ci": "turbo typecheck && turbo test && biome check .",
+    "ci": "TURBO_NO_UPDATE_NOTIFIER=1 turbo typecheck test --output-logs=errors-only && biome check .",
     "prepare": "husky",
     "sandcastle": "bun .sandcastle/main.ts",
     "sandcastle:analyze": "bun .sandcastle/analyze.ts",


### PR DESCRIPTION
## Summary
- Combine `turbo typecheck` and `turbo test` into one invocation with `--output-logs=errors-only` so successful tasks stay silent.
- Set `TURBO_NO_UPDATE_NOTIFIER=1` to suppress the duplicate update banner.
- Green `bun run ci` now prints ~10 lines instead of ~150, cutting wasted tokens for AFK agents. Failures still surface normally.

## Test plan
- [x] `bun run ci` passes locally with the slimmed output.