### PR TITLE
docs: backfill 20 architectural decision records

### DIFF
--- a/docs/adr/0001-turborepo-bun-monorepo.md
+++ b/docs/adr/0001-turborepo-bun-monorepo.md
@@ -1,0 +1,28 @@
+# ADR 0001: Turborepo monorepo with Bun workspaces
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+Contexture ships a desktop editor (Electron), a marketing site (Next.js), a curated stdlib of reusable types, a thin runtime re-export package consumed by end users, and a CLI. These pieces share an IR, op vocabulary, and emitter pipeline. They also need to evolve together: an IR change touches core, the desktop renderer, and downstream emitted artefacts in lockstep.
+
+A multi-repo split would force version-pinned releases between every layer, and every refactor that crosses a layer would become a coordinated multi-PR dance.
+
+## Decision
+
+Single repository organised as a Turborepo monorepo on Bun workspaces (`apps/*`, `packages/*`). Turbo orchestrates `dev`/`build`/`typecheck`/`test`; Bun is the package manager and test/script runner.
+
+## Consequences
+
+- Cross-cutting changes land atomically in one PR with one CI run.
+- Turbo caches typecheck and test results per-package, so unrelated packages don't pay for each other's churn.
+- Bun install speed is meaningfully faster than npm/pnpm in cold and warm cases, which matters for AFK Sandcastle runs that bootstrap fresh containers.
+- Cost: contributors need Bun installed (Node 24 alone is not enough). Documented in the README prerequisites.
+- Cost: tooling (some IDE plugins, some publish workflows) assumes npm — occasional friction.
+
+## Alternatives considered
+
+- **Multi-repo + npm/pnpm:** rejected because the IR/op vocabulary is genuinely shared and changes ripple across layers.
+- **pnpm workspaces + Nx:** viable, but Bun is faster for our workload and Turbo's mental model is simpler than Nx's project graph.
+- **npm workspaces + Turbo:** loses Bun's install/run speed without gaining anything.

--- a/docs/adr/0002-stdlib-runtime-package-boundary.md
+++ b/docs/adr/0002-stdlib-runtime-package-boundary.md
@@ -1,0 +1,31 @@
+# ADR 0002: `stdlib` owns implementation; `runtime` is a thin re-export
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+Contexture ships curated reusable types (money, identity, contact, place, common) that end users import into their generated schemas. These types need two lives:
+
+1. Inside Contexture itself (the editor, the emitters, validation, the chat system prompt all reference them).
+2. Outside Contexture, published as `@contexture/runtime` on npm, imported by user projects at runtime.
+
+If both consumers reach into the same package directly, the published surface bloats with editor-only utilities and the editor's import paths leak into user code.
+
+## Decision
+
+`packages/stdlib` owns all implementation — the Zod schemas, IR JSON for each module, registry, and helper data (countries, currencies). `packages/runtime` is a thin re-export layer published to npm. Dependencies flow strictly one way: `apps/* → runtime → stdlib`. Apps never import `stdlib` directly.
+
+This is enforced as a coding standard (`.sandcastle/CODING_STANDARDS.md`) and visible in the package layout — `packages/runtime/src` only re-exports the subset users need.
+
+## Consequences
+
+- The published npm surface is small and intentional; editor-only data (e.g. registry metadata for the chat system prompt) doesn't leak to consumers.
+- Renaming or restructuring inside stdlib is safe — only `runtime`'s re-exports are public API.
+- One extra hop for editor code, but the indirection is mechanical (a re-export line) and pays for itself the first time we add internal-only stdlib utilities.
+
+## Alternatives considered
+
+- **Single package, mark some exports `@internal`:** doesn't actually prevent imports; relies on discipline.
+- **Two parallel packages with no dependency:** would force duplicating the curated types or copy-pasting at build time.
+- **Apps import stdlib directly, runtime is just a publishing alias:** breaks the invariant that the published surface is intentional — anything stdlib exports becomes implicitly public.

--- a/docs/adr/0003-core-package-with-renderer-model-mirror.md
+++ b/docs/adr/0003-core-package-with-renderer-model-mirror.md
@@ -1,0 +1,34 @@
+# ADR 0003: `@contexture/core` as the shared IR kernel, mirrored under `renderer/src/model/`
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+The IR meta-schema, op vocabulary, ops reducer, loader, migrations, paths, and emitters are needed by:
+
+- The Electron main process (IPC layer, MCP op tools, document store, scaffold pipeline).
+- The renderer (Zustand store, validation, on-screen graph rendering, undo).
+- The CLI.
+- Tests.
+
+These are pure modules — no Electron, no DOM. They belong in a workspace package.
+
+But the renderer also wants short, stable import paths (`@renderer/model/ir`) for ergonomics, and historically the IR lived in the renderer before it was extracted. A flag-day rename of every renderer import would create churn without changing behaviour.
+
+## Decision
+
+`packages/core` is the canonical home for the IR/ops/emit kernel. The renderer keeps a `model/` directory whose files re-export from `@contexture/core` (e.g. `renderer/src/model/ir.ts` is a single `export * from '@contexture/core/ir'` line).
+
+New IR/ops code lands in `@contexture/core`. The renderer mirror exists only as an import-path alias and is allowed to add app-specific helpers (e.g. `preflight-error-copy.ts`) that don't belong in the shared kernel.
+
+## Consequences
+
+- Main process, CLI, and tests get the kernel via a normal workspace dep.
+- The renderer keeps short `@renderer/model/...` imports; refactors that move things between core and the renderer mirror are local edits.
+- Cost: two paths to the same symbol. Contributors must know that `@renderer/model/ir` is *not* a different IR — it is the same one. CODING_STANDARDS calls this out.
+
+## Alternatives considered
+
+- **Delete the mirror, import `@contexture/core` everywhere in the renderer:** noisier imports and a large flag-day diff for no behavioural gain.
+- **Keep the IR only in the renderer:** breaks main-process and CLI consumers that need the same code without booting React.

--- a/docs/adr/0004-electron-desktop-not-web.md
+++ b/docs/adr/0004-electron-desktop-not-web.md
@@ -1,0 +1,32 @@
+# ADR 0004: Desktop editor is Electron, not Tauri or browser-only
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+The editor needs:
+
+- Direct filesystem access (read/write a `.contexture.json` bundle, watch sidecars for drift, scaffold a project directory with git init and turbo skeleton).
+- Long-lived process spawning (Claude Agent SDK CLI, Convex emit, scaffold runners).
+- Native menus, window chrome, auto-update, and OS-keychain-style integration for credentials.
+- A graph canvas with React Flow and ELK that benefits from a real Node runtime for layout work.
+
+A pure browser app cannot do filesystem or process spawning without a separate backend. A desktop wrapper is required.
+
+## Decision
+
+Ship the editor as Electron, with React 19 + Vite (`electron-vite`) in the renderer and Node in the main process. Auto-update via `electron-updater`; releases distributed through GitHub Releases on tag.
+
+## Consequences
+
+- One codebase, one binary, one update channel. Sentry wired up for both main and renderer.
+- The Claude Agent SDK runs in main, calling out to the user's local `claude` CLI when no API key is set — possible because we're a real Node process.
+- Cost: bundle size, security model (sandbox: false in webPreferences for IPC ergonomics — accepted because we ship our own renderer code and validate everything that crosses IPC).
+- Cost: cross-platform packaging (electron-builder for win/mac/linux).
+
+## Alternatives considered
+
+- **Tauri:** smaller binary, Rust backend. Rejected because the team's primary language is TypeScript; rewriting the scaffold pipeline, Claude integration, and document store in Rust would dwarf the binary-size win.
+- **Browser app + local backend daemon:** two binaries, two update paths, harder onboarding.
+- **VS Code extension:** ties us to one host editor and limits the canvas UX.

--- a/docs/adr/0005-zod-meta-schema-as-ir.md
+++ b/docs/adr/0005-zod-meta-schema-as-ir.md
@@ -1,0 +1,33 @@
+# ADR 0005: Zod meta-schema is the authoritative IR; TS types via `z.infer`
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+The IR (TypeDef, FieldDef, FieldType, ImportDecl, …) is consumed at three boundaries:
+
+- Loaded from disk (`.contexture.json`), where input may be malformed, partially migrated, or hand-edited.
+- Mutated by the ops reducer, which must reject invalid ops before they corrupt the live store.
+- Sent across IPC and through MCP tool calls, where the input is opaque until validated.
+
+If the IR is described by hand-written TypeScript types alone, every boundary needs a separate runtime validator and the validator can drift from the type. Adding a new `TypeDef` kind becomes synchronised edits across two files.
+
+## Decision
+
+The Zod meta-schema in `packages/core/src/ir.ts` is the single source of truth. TypeScript types are derived via `z.infer<>`. `IRSchema.parse(x)` is the only sanctioned entry point for untrusted input; it returns a typed `Schema` or throws `ZodError` with path-addressable issues.
+
+Adding a new `TypeDef` kind, `FieldType`, or constraint is a single edit to the Zod schema; the type updates automatically.
+
+## Consequences
+
+- Validator and type can never drift.
+- Path-addressable Zod errors map cleanly onto the renderer's field-level validation UI.
+- Recursive types (`array.element` referencing `FieldType`) need `z.lazy` plus a hand-written union type to break the circularity for TypeScript — accepted as a localised workaround in `ir.ts`.
+- One narrow case (`ImportDecl`'s `path: \`@contexture/${string}\``) keeps a hand-written type that is narrower than what Zod infers; the regex enforces the same invariant at runtime.
+
+## Alternatives considered
+
+- **Hand-written TS types + ad-hoc validators at each boundary:** drift risk, duplicated effort, weaker errors.
+- **JSON Schema as source, generate TS:** extra build step, weaker ergonomics, no parsing helper.
+- **TypeBox or Effect Schema:** comparable, but Zod is already in dependencies for end-user emitted code, so reusing it avoids a second schema library in the runtime.

--- a/docs/adr/0006-versioned-ir-with-migration-chain.md
+++ b/docs/adr/0006-versioned-ir-with-migration-chain.md
@@ -1,0 +1,28 @@
+# ADR 0006: Versioned IR with a migration chain, even when empty
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+`.contexture.json` is a user-owned, source-of-truth file checked into the user's repo. It will outlive any specific Contexture release. The IR shape will change: new TypeDef kinds, new field constraints, new import forms. When it does, a user opening an old file in a new editor must succeed.
+
+If we don't bake versioning in from v1, the first breaking change becomes a coordination problem: detect old shape heuristically, branch the loader, communicate the upgrade.
+
+## Decision
+
+Every `.contexture.json` carries `version: '1'`. The loader walks a registered migration chain (`packages/core/src/migrations`) before the Zod meta-schema runs. Each migration declares `from`/`to`/`migrate`/`warning`. The chain is empty at v1 — the scaffold exists so future bumps slot in by appending one entry.
+
+The loader returns warnings alongside the migrated schema so the UI can surface "we upgraded this file" notices.
+
+## Consequences
+
+- Zero work today; future migrations are append-only and isolated.
+- Round-trip is preserved — `save()` always writes the current version, so opening an old file once upgrades it on next save.
+- The version field is asserted by Zod (`z.literal('1')`), so unknown future versions opened in older editors fail loudly with a clear path.
+
+## Alternatives considered
+
+- **No version field, infer shape:** works for one breaking change, then becomes a maze.
+- **SemVer for the IR:** overkill — IR shapes don't have minor/patch distinctions; either it parses or it doesn't.
+- **Migrate lazily during ops:** mixes the responsibilities of "load this file" and "apply this op", and means partial migrations can persist on disk.

--- a/docs/adr/0007-closed-world-op-vocabulary.md
+++ b/docs/adr/0007-closed-world-op-vocabulary.md
@@ -1,0 +1,34 @@
+# ADR 0007: Closed-world schema edited via a small op vocabulary
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+Two channels mutate the IR: the human (clicking, typing, dragging in the renderer) and Claude (chat turns producing structured edits). They must converge on the same model. We need:
+
+- An undo stack that can replay edits.
+- A clear diff Claude can describe in natural language ("I added a `User` class with three fields").
+- A validation surface that can reject bad edits before they corrupt the live store.
+- A persistence story — what gets saved, what gets logged.
+
+Two extreme designs sit at the ends of the spectrum: free-form patches (JSON Patch over the whole IR) or per-field RPCs.
+
+## Decision
+
+Define a closed `Op` discriminated union in `packages/core/src/ops.ts` covering exactly the mutations the editor supports: `add_type`, `update_type`, `rename_type`, `add_field`, `add_import`, `set_table_flag`, `replace_schema`, etc. Every channel — UI, chat IPC, MCP tools, undo — dispatches through `apply(schema, op)`.
+
+Each op mutates one well-defined region. `rename_type` is the deliberate exception because a rename must cascade atomically through local refs and discriminated-union variants.
+
+## Consequences
+
+- Claude's tool surface is the same op set the UI uses — one validator, one replay engine, one audit trail.
+- Undo is "apply the inverse op" rather than "diff and reconstruct".
+- Adding a new editing capability is a single new op variant + reducer case + tool registration — easy to grep for and easy to test.
+- Cost: any edit the user can imagine but the op set doesn't model is a feature request, not a bypass. Accepted — closed-world is the point.
+
+## Alternatives considered
+
+- **JSON Patch:** maximum flexibility, minimum semantics. Claude could produce unintelligible patches; validation becomes whole-IR-shape only; undo is generic but rename-cascade has to be reinvented.
+- **Free-form Claude output ("here's the new IR"):** loses the per-edit granularity needed for animation, undo, and audit.
+- **Per-field RPCs:** hundreds of methods, no discriminated union to grep.

--- a/docs/adr/0008-pure-ops-reducer-no-exceptions.md
+++ b/docs/adr/0008-pure-ops-reducer-no-exceptions.md
@@ -1,0 +1,34 @@
+# ADR 0008: Ops reducer is pure and returns `{schema} | {error}`, never throws
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+The ops reducer (`apply(schema, op)`) is called from many sites with different error-handling needs:
+
+- The Zustand store wants to commit on success and surface a string on failure.
+- The chat IPC bridge wants to send the error back to Claude as a tool result so the model can recover on the next turn.
+- Tests want to assert on outcomes without try/catch noise.
+- The undo stack wants to know whether an op succeeded before pushing it.
+
+If `apply` throws on validation failure, every caller wraps it in try/catch and re-derives the same handling.
+
+## Decision
+
+`apply(schema, op)` is pure: takes the current schema and an op, returns either `{ schema }` (the new IR) or `{ error: string }` (a message safe to surface to the user or to Claude). It never throws for op-validation reasons. Callers branch on the discriminator.
+
+`replace_schema` runs the Zod meta-schema internally; structural failures become `{error}` results, not exceptions. Semantic rules (unresolved refs, duplicate names) live in `services/validation.ts` so the renderer can surface field-level paths after the replacement lands.
+
+## Consequences
+
+- The store is dumb: `if ('schema' in res) set({ schema: res.schema }); return res;` — that's the whole transaction.
+- Chat tool results map directly: success returns the new IR summary, failure returns the error string verbatim for Claude to react to.
+- Undo only pushes successful ops, no try/catch.
+- Cost: the reducer must explicitly handle every failure mode. Accepted — the failure modes are the API.
+
+## Alternatives considered
+
+- **Throw on validation errors:** every caller writes the same try/catch. Errors crossing IPC need re-serialising.
+- **Return `null` on failure, log internally:** loses the error message that needs to reach the user/model.
+- **Result type from a library (neverthrow, fp-ts):** adds a dependency and ceremony for a two-variant union we can write inline.

--- a/docs/adr/0009-file-bundle-and-sidecar-layout.md
+++ b/docs/adr/0009-file-bundle-and-sidecar-layout.md
@@ -1,0 +1,40 @@
+# ADR 0009: `.contexture.json` source-of-truth + `.contexture/` sidecars + emitted `.schema.{ts,json}`
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+A Contexture document needs to persist:
+
+- The IR itself (canonical, hand-readable, diff-friendly).
+- Editor state — graph layout, chat history — that the user shouldn't have to think about.
+- Generated artefacts that downstream code imports — Zod `.schema.ts`, JSON Schema `.schema.json`, Convex schema, a barrel index.
+- A manifest of generated artefacts for drift detection.
+
+Mixing all of this into one file would conflict every time the layout shifts a node. Hiding everything inside an opaque binary blob would defeat git review. Putting the editor state in user-visible files would clutter their tree.
+
+## Decision
+
+For an IR file `Foo.contexture.json` the bundle is:
+
+- `Foo.contexture.json` — the IR. Source of truth. Committed by the user.
+- `.contexture/layout.json` — graph layout sidecar.
+- `.contexture/chat.json` — chat history sidecar.
+- `.contexture/emitted.json` — SHA-256 manifest of generated artefacts (see ADR 0010).
+- `Foo.schema.ts` and `Foo.schema.json` — generated artefacts, written alongside the IR for ergonomic imports.
+
+Path conventions live in `packages/core/src/paths.ts`. The `DocumentStore` (`apps/desktop/src/main/documents/document-store.ts`) writes the whole bundle atomically.
+
+## Consequences
+
+- The user's diff on a typical edit is small and readable: the IR plus, optionally, the emitted artefacts.
+- The `.contexture/` directory is the natural unit to gitignore if a user prefers to regenerate locally.
+- Emitted files sitting next to the IR mean downstream code does `import { Foo } from './Foo.schema'` — no extra path indirection.
+- Cost: five files to manage instead of one. The atomic write in `DocumentStore` exists specifically to keep them coherent.
+
+## Alternatives considered
+
+- **One file with everything embedded:** layout shifts conflict on every save; emitted artefacts can't be imported directly.
+- **Sidecars inside a hidden `.contexture` next to each IR vs a project-wide `.contexture/`:** per-IR keeps the relationship local and simple; project-wide would force a name-mangling scheme.
+- **Emit to a separate `dist/` directory:** breaks the "import the schema next to the source" ergonomic.

--- a/docs/adr/0010-sha256-manifest-for-drift-detection.md
+++ b/docs/adr/0010-sha256-manifest-for-drift-detection.md
@@ -1,0 +1,32 @@
+# ADR 0010: SHA-256 manifest of emitted artefacts for drift detection
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+The emitter pipeline writes generated files (`Foo.schema.ts`, `Foo.schema.json`, the schema-index barrel, the Convex schema) alongside the IR. Users will edit these by hand — sometimes intentionally, often by accident. We need to detect when a generated file no longer matches what the current IR would produce, so the editor can offer to re-emit (or warn before clobbering hand edits).
+
+`mtime` on the filesystem is unreliable: git checkouts touch every file, editor "save all" updates timestamps without changing content, and timestamps don't survive zip/tar round-trips.
+
+## Decision
+
+`runEmitPipeline` (in `packages/core/src/pipeline.ts`) writes a manifest at `.contexture/emitted.json`:
+
+```ts
+{ version: '1', files: { [path]: sha256(content) } }
+```
+
+The drift watcher (`apps/desktop/src/main/documents/drift-watcher.ts`) compares each generated file's current SHA-256 against the manifest entry. A mismatch means the file diverged — either the IR has been edited (re-emit needed) or the generated file was hand-edited (drift to surface to the user).
+
+## Consequences
+
+- Drift detection is content-based and survives any operation that preserves bytes.
+- The manifest is small, deterministic, and diff-friendly — `emitted.json` only changes when an emitted file's content changes.
+- Cost: SHA-256 every emit. Negligible for the file sizes involved.
+
+## Alternatives considered
+
+- **mtime comparison:** unreliable as above.
+- **Re-run the emitter and string-compare in memory:** equivalent for detection, but the manifest doubles as a record of what was emitted, useful for future migrations and for debugging "where did this file come from".
+- **Embed a hash header in each emitted file:** clutters the generated source and breaks if the user reformats the file.

--- a/docs/adr/0011-claude-agent-sdk-with-mcp-op-tools.md
+++ b/docs/adr/0011-claude-agent-sdk-with-mcp-op-tools.md
@@ -1,0 +1,33 @@
+# ADR 0011: Chat→IR channel uses Claude Agent SDK + MCP `op_tools`, not structured output
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+The product premise: a user chats with Claude about their domain, Claude edits the schema, the graph animates per edit. This requires Claude to produce IR mutations that:
+
+- Are validated before they touch the live store.
+- Animate one at a time, so the user sees what changed.
+- Use the same vocabulary the UI uses, so undo and audit are uniform (see ADR 0007).
+- Allow Claude to see the result of each edit and react on the next turn (a failed op should surface a real error message Claude can recover from).
+
+A "produce the new IR as JSON" approach gives an opaque blob with no per-edit granularity, no per-edit validation, and no incremental animation.
+
+## Decision
+
+Use the Claude Agent SDK with an MCP server (`createSdkMcpServer` in `apps/desktop/src/main/ipc/claude.ts`) that registers one tool per supported `Op` kind. Claude calls `add_type`, `add_field`, `rename_type`, etc., as MCP tool calls. Each call dispatches through the same `apply(schema, op)` reducer the UI uses (ADR 0008). The reducer's `{schema} | {error}` result is returned as the tool result.
+
+## Consequences
+
+- Per-edit granularity for free: each tool call is one op, animated independently.
+- Validation, undo, and audit are unified between human and Claude inputs.
+- When an op fails, Claude sees the exact error string and can correct on the next tool call within the same turn.
+- The system prompt advertises the curated stdlib (`SYSTEM_PROMPT_STDLIB`) so Claude can reference shared types instead of redefining them.
+- Cost: tied to the Agent SDK's session lifecycle and tool-call protocol. Accepted — the alternative is reimplementing it.
+
+## Alternatives considered
+
+- **Structured output of the full IR:** loses incremental animation, mixes "describe a change" with "produce a value", weak per-edit error recovery.
+- **Free-form text + a parser:** brittle and unintelligible to the user.
+- **Function calling against the raw store:** would expose internal state shape to the model; ops are the right abstraction.

--- a/docs/adr/0012-claude-cli-detection-for-max-mode.md
+++ b/docs/adr/0012-claude-cli-detection-for-max-mode.md
@@ -1,0 +1,36 @@
+# ADR 0012: Detect a local `claude` CLI to enable Max-mode auth fallback
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+Two kinds of users run the editor:
+
+- API-key users: have an `ANTHROPIC_API_KEY` and want the SDK to use it directly.
+- Claude Max subscribers: pay for a Max plan and authenticate through the local `claude` CLI. They expect the editor to "just work" without pasting an API key.
+
+The Agent SDK shells out to the `claude` CLI when no `ANTHROPIC_API_KEY` is set. In packaged Electron apps the inherited `PATH` often doesn't see `~/.local/bin/claude` or other user-local install locations, so a relative `claude` lookup fails even when the binary is installed.
+
+## Decision
+
+On startup (and when the auth popover opens) the main process probes for a `claude` binary:
+
+- `which claude` (or `where claude` on Windows) via `execFile`.
+- The first hit is cached in `detectedClaudePath` and passed to the Agent SDK as `pathToClaudeCodeExecutable` so packaged apps work regardless of PATH inheritance.
+- The result (`{installed, path}`) is exposed over IPC so the renderer can show a Max-mode-viable indicator before the user starts a turn.
+
+The same detection predicts whether a turn will succeed without an API key, so the UI can fail fast with a clear message instead of waiting for an SDK error.
+
+## Consequences
+
+- Max users get zero-config sign-in if their CLI is installed.
+- API-key users are unaffected — the env var path takes priority.
+- The auth popover can show truthful state ("Max mode available" / "install the Claude CLI").
+- Cost: one OS shell-out at startup. Negligible.
+
+## Alternatives considered
+
+- **Require API key always:** locks out Max subscribers.
+- **Bundle the `claude` CLI:** licensing, update lag, two update channels.
+- **Trust PATH and let the SDK error:** yields opaque failures inside packaged apps.

--- a/docs/adr/0013-biome-over-eslint-prettier.md
+++ b/docs/adr/0013-biome-over-eslint-prettier.md
@@ -1,0 +1,29 @@
+# ADR 0013: Biome instead of ESLint + Prettier
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+Linting and formatting touch every file, every commit, every CI run. Speed matters. Configuration sprawl matters. The traditional ESLint + Prettier + plugins stack is slow on large repos, has overlapping responsibilities (formatting rules in both), and config files multiply across packages.
+
+We also want hard rules — `noExplicitAny` as an error, not a warning — to be enforceable in one place.
+
+## Decision
+
+Use Biome as the single tool for both linting and formatting. One config (`biome.json`) at the repo root. Run via `bun run lint`, `bun run format`, `bun run check`. CI runs `biome check .` as the final step of `bun run ci`.
+
+Hard rules: `noExplicitAny` is an error, `useImportType` is enforced (so `import type` discipline is mechanical, not aspirational). Style: 2-space indent, 100-char line width, single quotes, trailing commas.
+
+## Consequences
+
+- Lint + format completes in a fraction of the time ESLint+Prettier took.
+- One config, one ignore file, one CLI. New contributors don't have to learn two tools.
+- Lint-staged hooks via Husky run `biome check --write` on staged files only.
+- Cost: a few ESLint plugins have no Biome equivalent yet. We've not hit a case that mattered.
+
+## Alternatives considered
+
+- **ESLint + Prettier + typescript-eslint:** slower, more config, two tools.
+- **dprint + ESLint:** dprint is fast but doesn't lint; we'd still need ESLint.
+- **No linter, just `tsc`:** misses style and import-discipline rules that catch real bugs and review churn.

--- a/docs/adr/0014-vitest-not-bun-test.md
+++ b/docs/adr/0014-vitest-not-bun-test.md
@@ -1,0 +1,30 @@
+# ADR 0014: Vitest as the test runner; `bun test` is actively rejected
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+Bun is the package manager and script runner. Bun also ships its own test runner (`bun test`). Mixing test runners across packages would mean inconsistent assertion APIs, inconsistent mocking semantics, and inconsistent watch behaviour.
+
+Vitest matches Jest's API surface, integrates with the Vite-based renderer toolchain, supports DOM testing via jsdom, has first-class TypeScript and ESM support, and works identically in CI and locally.
+
+`bun test` lacks parity with Vitest's mock and DOM stories at the time of writing; tests written against `bun test` would not run under Vitest without rewrites.
+
+## Decision
+
+Vitest is the test runner across the entire repo. `*.test.ts` / `*.test.tsx` in `tests/` per package. Run via `bun run test` (which delegates to `turbo test`, which delegates to `vitest run`). Watch via `bun run test:watch`.
+
+`scripts/reject-bun-test.ts` actively rejects accidental `bun test` invocations, because the binary will silently run a different runner and produce confusing results.
+
+## Consequences
+
+- One assertion API, one mocking API, one watch UX everywhere.
+- The renderer's Vite config is reused for tests — same path aliases, same plugins, same module resolution.
+- Cost: Bun's test runner is faster on raw startup, but `vitest run` with Turbo cache is comparable in practice and the consistency win is worth the tradeoff.
+
+## Alternatives considered
+
+- **`bun test` everywhere:** API gaps for DOM and mocks; would require migration if/when Bun closes them.
+- **Mixed runners (Bun for packages, Vitest for the renderer):** confusing and breaks shared test utilities.
+- **Jest:** slower, separate config from the Vite-based renderer toolchain.

--- a/docs/adr/0015-conventional-commits-one-pr-per-issue.md
+++ b/docs/adr/0015-conventional-commits-one-pr-per-issue.md
@@ -1,0 +1,32 @@
+# ADR 0015: Conventional commits and one PR per issue
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+Two contributor populations work in this repo: humans and Sandcastle's AFK agents. Both need a uniform commit/PR convention so:
+
+- The history is greppable for `feat:` / `fix:` / `chore:` slices.
+- Each merged PR closes exactly one tracked issue, so the issue tracker is the canonical "what did we ship" log.
+- Reviewers can see the full intent of a change in one PR rather than scrolling across stacked PRs that reference each other.
+- Sandcastle's `Closes #N` body parser has a single, deterministic rule for which issue a PR claims (see ADR 0018).
+
+## Decision
+
+- Conventional Commits for commit subjects (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`).
+- One PR per issue. Multiple commits inside the PR are fine and encouraged when they tell a coherent story.
+- No stacked PRs. If a change must depend on another, land the dependency first.
+
+## Consequences
+
+- The git log reads as a stream of intent-tagged units.
+- The issue tracker and the merged-PR list are always in 1:1 correspondence.
+- Sandcastle's eligibility filter (`pickEligible`) can rely on `Closes/Fixes/Resolves #N` parsing to know whether an issue is already claimed.
+- Cost: occasionally a logically-stacked change has to be reordered to land sequentially. Worth it for the simpler review surface.
+
+## Alternatives considered
+
+- **Stacked PRs (Graphite/Pierre style):** powerful but adds tooling cost and complicates the AFK-agent claim model.
+- **Free-form commit messages:** loses the changelog-by-grep benefit.
+- **Squash everything to one commit per PR:** loses the in-PR commit story; some refactor PRs are easier to review as a sequence.

--- a/docs/adr/0016-tdd-behaviour-only-no-internal-mocks.md
+++ b/docs/adr/0016-tdd-behaviour-only-no-internal-mocks.md
@@ -1,0 +1,32 @@
+# ADR 0016: TDD red-green-refactor; tests verify behaviour through public interfaces; mock only at system boundaries
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+Tests have two failure modes. They can fail to catch real regressions (too lax). They can also fail to *survive* refactors — breaking on every internal restructure even though observable behaviour is unchanged (too coupled).
+
+Codebases that mock internal collaborators end up with the second failure mode. Every refactor cascades into test edits. Confidence in the test suite drops because a green run means "the implementation matches the test's wiring", not "the system behaves correctly".
+
+For an editor with a long lifetime, a closed-world op vocabulary, and a Zod-typed IR, tests should be cheap to keep green across refactors and expensive to fool.
+
+## Decision
+
+- TDD red-green-refactor loop: one test → one implementation → repeat. Never write all tests first. Never refactor while red.
+- Tests verify behaviour through public interfaces only. Test names describe **what** the system does, not how.
+- Mock at system boundaries only — external APIs, time, randomness, network, filesystem. Never mock internal modules or classes. If internal mocking feels necessary, the interface needs redesigning.
+- One logical assertion per test. `describe()` blocks per module or component.
+
+## Consequences
+
+- Refactors that preserve behaviour leave the test suite green.
+- The cost of each test is real implementation work, not mock plumbing.
+- Internal interfaces stay clean because hard-to-test code surfaces as hard-to-write tests.
+- Cost: some end-to-end tests are slower than equivalent mock-driven unit tests would have been. Accepted — the boundary tests pay the price; the bulk of the suite is fast unit tests over pure modules (the IR/ops/emitters were designed to be pure precisely so this works, see ADR 0008).
+
+## Alternatives considered
+
+- **Mock-heavy unit tests:** fast, brittle, and silently encode implementation details.
+- **Test-after development:** loses the design pressure TDD applies to keep public interfaces small.
+- **Property-based testing as the default:** valuable for the IR meta-schema and migrations specifically; worth adding selectively but not as the default style.

--- a/docs/adr/0017-sandcastle-deterministic-eligibility-then-llm-subset.md
+++ b/docs/adr/0017-sandcastle-deterministic-eligibility-then-llm-subset.md
@@ -1,0 +1,33 @@
+# ADR 0017: Sandcastle uses deterministic eligibility, then an LLM subset selector only when needed
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+Sandcastle runs an autonomous loop that picks issues from the backlog and ships PRs overnight. Two failure modes are expensive:
+
+- Burning LLM cost on issues that aren't actually pickable (already claimed by an open PR, missing the right label, closed mid-loop).
+- Picking two issues in the same iteration that conflict on overlapping files, producing wasted parallel work and merge churn.
+
+A naive design hands every open issue to an LLM and asks "what should I work on?". This pays an LLM round-trip every iteration, even when the answer is obvious.
+
+## Decision
+
+Two-phase pick:
+
+1. **Eligibility (deterministic).** `pickEligible()` filters open issues by the `Sandcastle` label and excludes any already claimed by an open PR (via `Closes/Fixes/Resolves #N` parsed from PR bodies). Pure code, no LLM.
+2. **Subset selection (LLM, conditional).** When two or more eligible candidates remain, a lightweight subset-selector agent picks a non-conflicting subset for parallel work. Single-candidate iterations skip the LLM round-trip entirely.
+
+## Consequences
+
+- Most iterations of a quiet backlog skip the LLM selector.
+- The eligibility filter is testable as pure code with no model dependency.
+- Reconciliation runs again inside the per-issue pipeline, so issues closed or claimed between picking and starting are caught.
+- Cost: the eligibility rules are explicit (label + claim parsing). New rules require code changes, not prompt edits — accepted because explicit beats prompted for safety-critical filtering.
+
+## Alternatives considered
+
+- **One LLM call to pick everything:** pays full cost every iteration; harder to audit; harder to test.
+- **No subset selector, just take the first eligible:** misses parallelism opportunities and risks file conflicts.
+- **Static "no parallel work" rule:** wastes the AFK window on serial issues.

--- a/docs/adr/0018-docker-sandboxed-afk-with-pr-link-claim.md
+++ b/docs/adr/0018-docker-sandboxed-afk-with-pr-link-claim.md
@@ -1,0 +1,35 @@
+# ADR 0018: AFK agents run in Docker sandboxes on issue branches; PR body links claim issues
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+Sandcastle runs untrusted-by-default LLM agents that write code, run tests, and push branches. They need:
+
+- Strong isolation from the host machine — the orchestrator's secrets, the developer's filesystem, other in-flight agents.
+- A reproducible base image so a green run today is a green run tomorrow.
+- A claim mechanism so two iterations don't duplicate work on the same issue.
+- A handoff mechanism so the human reviewer can see exactly which issue a PR addresses.
+
+Labels and assignees are racy across iterations and easy to forget. A claim model based on git branches alone is hidden from the issue tracker.
+
+## Decision
+
+- **Sandboxing:** each per-issue pipeline runs inside a fresh Docker container created from a pre-built image (`bun run sandcastle:build`). The host filesystem is not mounted; secrets are scoped to the container's environment.
+- **Branching:** one branch per issue, named via the `<plan>` tag contract in `.sandcastle/plan.ts`. Concurrent runs operate on disjoint branches.
+- **Claim:** the PR body must include `Closes #N` (or `Fixes`/`Resolves`). The eligibility filter (ADR 0017) parses this from open PRs to exclude already-claimed issues. The same convention closes the issue automatically when the PR merges.
+- **Retry:** sandbox-creation failures are retried with backoff (`.sandcastle/retry.ts`); concurrency is bounded by `MAX_PARALLEL` (`.sandcastle/concurrency.ts`).
+
+## Consequences
+
+- A misbehaving agent can't touch the host or other agents' work.
+- The issue tracker is the canonical claim ledger — readable by humans and the eligibility filter alike.
+- Merged PRs auto-close issues, so the night-shift output appears as resolved tickets in the day-shift inbox.
+- Cost: Docker is required to run Sandcastle locally. Image rebuilds when the Dockerfile changes.
+
+## Alternatives considered
+
+- **Worktrees instead of containers:** lighter, but no isolation from the host.
+- **Labels/assignees as the claim:** racy, easily forgotten, invisible from the PR side.
+- **GitHub branch protections as the only safety net:** doesn't protect the developer's machine while the agent is running.

--- a/docs/adr/0019-separate-marketing-site-on-vercel.md
+++ b/docs/adr/0019-separate-marketing-site-on-vercel.md
@@ -1,0 +1,28 @@
+# ADR 0019: Marketing site is a separate Next.js app, deployed to Vercel
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+The marketing site and the desktop editor are different products with different release cadences, different deploy targets, and different audiences. The marketing site needs SEO, fast TTFB, and continuous deploy; the editor needs signed binaries on tagged releases.
+
+Coupling them — for example, building the marketing site as part of the Electron bundle, or running marketing pages inside the editor's web stack — creates accidental complexity (one CI failure blocks both, dependency upgrades have to satisfy both).
+
+## Decision
+
+`apps/web` is a standalone Next.js 16 app. Auto-deploys to Vercel on merge to `main`. The desktop app (`apps/desktop`) is independent: tagged releases publish to GitHub Releases via electron-builder.
+
+The two apps share the design tokens defined in `DESIGN.md` (OKLCH palette, Geist typography, shadcn patterns) but each renders them with its own Tailwind config — no shared component library between them. Shared substance (IR, runtime, stdlib) lives in `packages/*`.
+
+## Consequences
+
+- Marketing changes ship in minutes via Vercel preview + merge; editor changes ship on a release cadence.
+- Each app upgrades dependencies on its own schedule.
+- Cost: divergence risk on visual design. Mitigated by `DESIGN.md` being canonical and reviewed when either app changes its tokens.
+
+## Alternatives considered
+
+- **One Next.js app that also hosts the editor as a web build:** loses filesystem and process-spawning capabilities the editor needs (see ADR 0004).
+- **Marketing pages inside the Electron renderer:** users would have to install the editor to read landing copy.
+- **Shared component package between web and desktop:** premature — the two apps' UI surfaces overlap less than expected, and the design tokens are the actual shared substance.

--- a/docs/adr/0020-shadcn-tailwind-v4-oklch.md
+++ b/docs/adr/0020-shadcn-tailwind-v4-oklch.md
@@ -1,0 +1,35 @@
+# ADR 0020: shadcn/ui + Tailwind v4 + OKLCH design tokens
+
+- **Status:** Accepted (backfilled)
+- **Date:** 2026-05-01
+
+## Context
+
+The editor and the marketing site need a shared visual language with serious requirements:
+
+- Light and dark modes that are perceptually balanced — the same UI weight in both.
+- A graph canvas with semantic colours (class node, selected, adjacent, dimmed, three edge kinds) that compose with the rest of the UI.
+- Components we can extend, not fight. shadcn-style "copy the source into your tree" beats opaque component libraries when we need precise control over Radix primitives.
+
+sRGB-named colours (hex, hsl) drift in perceived lightness across the spectrum: a `#FF0000` red and a `#0000FF` blue at the same notional brightness look very different. OKLCH is perceptually uniform — same `L` value reads as the same lightness regardless of hue.
+
+## Decision
+
+- **Design system spec:** `DESIGN.md` is the source of truth. It enumerates every token, every component pattern, every motion duration.
+- **Components:** shadcn/ui copied into each app's tree, extended in place. Prefer existing shadcn components over custom implementations.
+- **Styling:** Tailwind CSS v4 with the new CSS-variable-driven theme. Tokens declared as CSS custom properties (`--background`, `--primary`, etc.) consumable by both apps.
+- **Colour space:** OKLCH for every token. Light and dark modes share the same hue and chroma where possible; only `L` shifts, which keeps the brand consistent across modes.
+- **Graph tokens:** dedicated `--graph-*` namespace for canvas-specific colours, kept separate from the general UI palette so the canvas can be tuned independently.
+
+## Consequences
+
+- Adding a new themeable surface is a token edit, not a component rewrite.
+- Hover states, alpha overlays, and selection tints compose predictably because the lightness scale is uniform.
+- shadcn components live in our tree, so upstream churn doesn't break us; we cherry-pick fixes we want.
+- Cost: OKLCH support requires modern browsers; not a constraint for an Electron renderer or a marketing site we control.
+
+## Alternatives considered
+
+- **MUI / Mantine / Chakra:** opaque components; theming a graph canvas semantic palette through them is awkward.
+- **HSL tokens:** familiar but perceptually non-uniform — dark mode required hand-tuning that OKLCH avoids.
+- **CSS-in-JS (Emotion, vanilla-extract):** loses the Tailwind utility ergonomics we already depend on across both apps.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,35 @@
+# Architectural Decision Records
+
+Load-bearing decisions in Contexture's architecture. New ADRs append; existing ADRs are superseded rather than rewritten.
+
+Format: Context → Decision → Consequences → Alternatives. Status is `Proposed` / `Accepted` / `Superseded by NNNN`.
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-turborepo-bun-monorepo.md) | Turborepo monorepo with Bun workspaces | Accepted |
+| [0002](0002-stdlib-runtime-package-boundary.md) | `stdlib` owns implementation; `runtime` is a thin re-export | Accepted |
+| [0003](0003-core-package-with-renderer-model-mirror.md) | `@contexture/core` as the shared IR kernel, mirrored under `renderer/src/model/` | Accepted |
+| [0004](0004-electron-desktop-not-web.md) | Desktop editor is Electron, not Tauri or browser-only | Accepted |
+| [0005](0005-zod-meta-schema-as-ir.md) | Zod meta-schema is the authoritative IR; TS types via `z.infer` | Accepted |
+| [0006](0006-versioned-ir-with-migration-chain.md) | Versioned IR with a migration chain, even when empty | Accepted |
+| [0007](0007-closed-world-op-vocabulary.md) | Closed-world schema edited via a small op vocabulary | Accepted |
+| [0008](0008-pure-ops-reducer-no-exceptions.md) | Ops reducer is pure and returns `{schema} \| {error}` | Accepted |
+| [0009](0009-file-bundle-and-sidecar-layout.md) | `.contexture.json` + `.contexture/` sidecars + emitted `.schema.{ts,json}` | Accepted |
+| [0010](0010-sha256-manifest-for-drift-detection.md) | SHA-256 manifest of emitted artefacts for drift detection | Accepted |
+| [0011](0011-claude-agent-sdk-with-mcp-op-tools.md) | Chat→IR channel uses Claude Agent SDK + MCP `op_tools` | Accepted |
+| [0012](0012-claude-cli-detection-for-max-mode.md) | Detect a local `claude` CLI to enable Max-mode auth fallback | Accepted |
+| [0013](0013-biome-over-eslint-prettier.md) | Biome instead of ESLint + Prettier | Accepted |
+| [0014](0014-vitest-not-bun-test.md) | Vitest as the test runner; `bun test` rejected | Accepted |
+| [0015](0015-conventional-commits-one-pr-per-issue.md) | Conventional commits and one PR per issue | Accepted |
+| [0016](0016-tdd-behaviour-only-no-internal-mocks.md) | TDD; behaviour-only tests; mock only at system boundaries | Accepted |
+| [0017](0017-sandcastle-deterministic-eligibility-then-llm-subset.md) | Sandcastle: deterministic eligibility, then LLM subset selector | Accepted |
+| [0018](0018-docker-sandboxed-afk-with-pr-link-claim.md) | AFK agents in Docker sandboxes; PR body links claim issues | Accepted |
+| [0019](0019-separate-marketing-site-on-vercel.md) | Marketing site is a separate Next.js app on Vercel | Accepted |
+| [0020](0020-shadcn-tailwind-v4-oklch.md) | shadcn/ui + Tailwind v4 + OKLCH design tokens | Accepted |
+
+## Adding a new ADR
+
+1. Pick the next number.
+2. Use the existing files as a template — Context → Decision → Consequences → Alternatives.
+3. Add a row to the table above.
+4. Reference the ADR from code comments where it's load-bearing (e.g. "see ADR 0007").


### PR DESCRIPTION
## Summary

- Backfills 20 ADRs in `docs/adr/` capturing load-bearing architectural decisions visible in the codebase that a new contributor would otherwise have to reverse-engineer.
- Each ADR follows Context → Decision → Consequences → Alternatives, marked `Accepted (backfilled)`.
- Adds `docs/adr/README.md` as an index with a table of all ADRs and instructions for adding new ones.

## ADRs added

**Architecture & boundaries** — 0001 monorepo, 0002 stdlib/runtime split, 0003 core kernel + renderer mirror, 0004 Electron choice
**IR & data model** — 0005 Zod meta-schema, 0006 versioned migration chain, 0007 closed-world op vocabulary, 0008 pure reducer, 0009 file bundle layout, 0010 SHA-256 drift manifest
**LLM integration** — 0011 Agent SDK + MCP op tools, 0012 Claude CLI detection
**Build, CI, conventions** — 0013 Biome, 0014 Vitest, 0015 conventional commits + one-PR-per-issue, 0016 TDD + behaviour-only tests
**AI night shift** — 0017 deterministic eligibility + LLM subset, 0018 Docker sandbox + PR-link claim
**Web & design** — 0019 separate Vercel marketing site, 0020 shadcn/Tailwind v4/OKLCH

## Test plan

- [ ] Skim `docs/adr/README.md` table renders correctly on GitHub
- [ ] Spot-check 2–3 ADRs for accuracy against the code they describe
- [ ] Confirm no ADR misrepresents a decision (correct any that do before merge)