### PR TITLE
fix: stdlib refs auto-import on emit + prompt fix for unresolved-ref handling

### DIFF
--- a/apps/desktop/resources/skills/skills/use-stdlib.md
+++ b/apps/desktop/resources/skills/skills/use-stdlib.md
@@ -6,8 +6,14 @@ description: Use when a field or pattern in the schema matches a stdlib type (em
 # use-stdlib
 
 Before adding a regex or a bespoke object shape, check whether the
-bundled stdlib already covers the pattern. Qualified refs (`common.Email`)
-resolve automatically — no `add_import` needed.
+bundled stdlib already covers the pattern.
+
+**Always write stdlib refs with their namespace prefix** (e.g.
+`place.CountryCode`, `money.Money`, `common.Email`). Bare refs like
+`CountryCode` will NOT resolve — the validator only checks bare names
+against locally-defined types in the schema. The namespace prefix is
+what triggers the stdlib lookup; `add_import` is optional and only
+needed if you want to rename the alias.
 
 ## Pattern → stdlib mapping
 
@@ -44,3 +50,25 @@ resolve automatically — no `add_import` needed.
 - If a user explicitly needs tighter validation than the stdlib (e.g.
   "only .com emails"), use a `raw` TypeDef with a custom Zod
   expression — don't shoehorn it into the stdlib ref.
+
+## Fixing `Unresolved ref "Foo"` errors
+
+When the validator reports an unresolved ref, the fix is almost always
+one of:
+
+1. **Bare ref that should be qualified** — change `CountryCode` to
+   `place.CountryCode`. Use `update_field` with a patch that **only
+   changes `type.typeName`**, preserving `kind: "ref"` so the diagram
+   edge stays intact:
+   ```json
+   { "kind": "update_field", "typeName": "Album", "fieldName": "country",
+     "patch": { "type": { "kind": "ref", "typeName": "place.CountryCode" } } }
+   ```
+2. **Typo of a local type** — rename via `update_field` patching only
+   `type.typeName`.
+3. **Type genuinely doesn't exist yet** — `add_type` to create it.
+
+**Never** "fix" an unresolved ref by replacing the field's type with a
+primitive (`string`, `int`, `boolean`, etc.). That makes the error
+disappear by silently deleting the relationship the ref represented,
+losing the connection in the graph.

--- a/apps/desktop/src/main/documents/document-store.ts
+++ b/apps/desktop/src/main/documents/document-store.ts
@@ -23,6 +23,7 @@ import {
   projectRootFor,
   runEmitPipeline,
 } from '@contexture/core';
+import { NAMESPACES as STDLIB_NAMESPACES } from '@contexture/stdlib/registry';
 import { type ChatHistory, loadChatHistory, saveChatHistory } from '@renderer/model/chat-history';
 import { emit as defaultEmitClaudeMd } from '@renderer/model/emit-claude-md';
 import { emit as defaultEmitJsonSchema } from '@renderer/model/emit-json-schema';
@@ -134,8 +135,10 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
   const {
     fs,
     recentFilesPath,
-    emitZod = defaultEmitZod,
-    emitJsonSchema = (s: Schema, sp?: string) => defaultEmitJsonSchema(s, undefined, sp),
+    emitZod = (s: Schema, sp: string) =>
+      defaultEmitZod(s, sp, { stdlibNamespaces: STDLIB_NAMESPACES }),
+    emitJsonSchema = (s: Schema, sp?: string) =>
+      defaultEmitJsonSchema(s, undefined, sp, { stdlibNamespaces: STDLIB_NAMESPACES }),
     emitSchemaIndex = defaultEmitSchemaIndex,
     emitClaudeMd = defaultEmitClaudeMd,
     emitConvex,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -217,7 +217,10 @@ export default function App(): React.JSX.Element {
       saveFixture: async () => '',
     },
     ir: schema,
-    getRootJsonSchema: (rootTypeName) => emitJsonSchema(schema, rootTypeName),
+    getRootJsonSchema: (rootTypeName) =>
+      emitJsonSchema(schema, rootTypeName, undefined, {
+        stdlibNamespaces: STDLIB_REGISTRY.namespaces,
+      }),
     validate: ({ rootTypeName }) => {
       const errors = validate(schema, { stdlib: STDLIB_REGISTRY });
       return errors.length === 0
@@ -246,7 +249,12 @@ export default function App(): React.JSX.Element {
   const zodEmission = useMemo((): { source: string; error: string | null } => {
     if (activeTab !== 'schema') return { source: '', error: null };
     try {
-      return { source: emitZod(schema, filePath ?? '<unsaved>.contexture.json'), error: null };
+      return {
+        source: emitZod(schema, filePath ?? '<unsaved>.contexture.json', {
+          stdlibNamespaces: STDLIB_REGISTRY.namespaces,
+        }),
+        error: null,
+      };
     } catch (e) {
       return { source: '', error: e instanceof Error ? e.message : String(e) };
     }

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -97,7 +97,7 @@ function applySelectedOps(
   let next = schema;
   for (let i = 0; i < proposedOps.length; i += 1) {
     if (!selectedIndices.has(i)) continue;
-    const result = apply(next, proposedOps[i].op);
+    const result = apply(next, proposedOps[i].op, STDLIB_REGISTRY);
     if ('error' in result) {
       return { schema: next, error: result.error };
     }

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -26,6 +26,7 @@ import { emit as emitJsonSchema } from '@renderer/model/emit-json-schema';
 import { emit as emitSchemaIndex } from '@renderer/model/emit-schema-index';
 import { emit as emitZod } from '@renderer/model/emit-zod';
 import type { Schema } from '@renderer/model/ir';
+import { STDLIB_REGISTRY } from '@renderer/services/stdlib-registry';
 import { useDocumentStore } from '@renderer/store/document';
 import { useDriftStore } from '@renderer/store/drift';
 import { apply } from '@renderer/store/ops';
@@ -62,10 +63,18 @@ function safeEmitForTarget(schema: Schema, targetPath: string, irPath: string | 
         source = emitConvexSchema(schema, irPath ?? undefined);
         break;
       case 'zod':
-        source = emitZod(schema, irPath ?? '<unknown>');
+        source = emitZod(schema, irPath ?? '<unknown>', {
+          stdlibNamespaces: STDLIB_REGISTRY.namespaces,
+        });
         break;
       case 'json-schema':
-        source = `${JSON.stringify(emitJsonSchema(schema, undefined, irPath ?? undefined), null, 2)}\n`;
+        source = `${JSON.stringify(
+          emitJsonSchema(schema, undefined, irPath ?? undefined, {
+            stdlibNamespaces: STDLIB_REGISTRY.namespaces,
+          }),
+          null,
+          2,
+        )}\n`;
         break;
       case 'schema-index':
         source = emitSchemaIndex(irPath ? baseNameFor(irPath) : 'schema', irPath ?? undefined);

--- a/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -41,7 +41,11 @@ export function StatusBar(): React.JSX.Element {
   const tokenCount = useMemo(() => {
     if (typeCount === 0) return 0;
     try {
-      return estimateTokenCount(emitZod(schema, filePath ?? 'untitled.contexture.json'));
+      return estimateTokenCount(
+        emitZod(schema, filePath ?? 'untitled.contexture.json', {
+          stdlibNamespaces: STDLIB_REGISTRY.namespaces,
+        }),
+      );
     } catch {
       // Emitter throws on malformed IR; treat as zero rather than crashing
       // the status bar.

--- a/apps/desktop/src/renderer/src/hooks/useClaudeReconcile.ts
+++ b/apps/desktop/src/renderer/src/hooks/useClaudeReconcile.ts
@@ -17,6 +17,7 @@
  * `open()` get a fresh effect run).
  */
 import { useEffect, useRef } from 'react';
+import { STDLIB_REGISTRY } from '../services/stdlib-registry';
 import { useDocumentStore } from '../store/document';
 import { type ApplyResult, apply, type Op } from '../store/ops';
 import { type ReconcileOp, targetKindFor, useReconcileStore } from '../store/reconcile';
@@ -104,7 +105,7 @@ export function useClaudeReconcile(): void {
           continue;
         }
         const op = entry.op as Op;
-        const applyResult: ApplyResult = apply(schema, op);
+        const applyResult: ApplyResult = apply(schema, op, STDLIB_REGISTRY);
         if ('error' in applyResult) {
           console.warn('[reconcile] dropping invalid op', op, applyResult.error);
           continue;

--- a/apps/desktop/src/renderer/src/services/stdlib-registry.ts
+++ b/apps/desktop/src/renderer/src/services/stdlib-registry.ts
@@ -14,7 +14,7 @@
  * validate cleanly. Tests can supply a custom registry (empty, or
  * with a synthetic namespace) without touching the stdlib package.
  */
-import type { StdlibCatalog } from '@contexture/core';
+import type { StdlibCatalog } from '@contexture/core/semantic-validation';
 import { IR_BY_NAMESPACE, NAMESPACES, type Namespace } from '@contexture/stdlib/registry';
 import type { StdlibRegistry as SystemPromptStdlibRegistry } from '../chat/system-prompt';
 

--- a/apps/desktop/src/renderer/src/services/stdlib-registry.ts
+++ b/apps/desktop/src/renderer/src/services/stdlib-registry.ts
@@ -14,15 +14,16 @@
  * validate cleanly. Tests can supply a custom registry (empty, or
  * with a synthetic namespace) without touching the stdlib package.
  */
+import type { StdlibCatalog } from '@contexture/core';
 import { IR_BY_NAMESPACE, NAMESPACES, type Namespace } from '@contexture/stdlib/registry';
 import type { StdlibRegistry as SystemPromptStdlibRegistry } from '../chat/system-prompt';
 
-export interface StdlibRegistry {
-  /** All stdlib namespace aliases (`common`, `identity`, …). */
-  namespaces: readonly string[];
-  /** Returns true iff the namespace defines a type with that name. */
-  hasType: (namespace: string, typeName: string) => boolean;
-}
+/**
+ * Renderer-facing stdlib registry. Identical shape to the core
+ * `StdlibCatalog` so that `STDLIB_REGISTRY` can be passed straight into
+ * `apply(schema, op, catalog)` and `checkSemantic(schema, catalog)`.
+ */
+export type StdlibRegistry = StdlibCatalog;
 
 export function buildStdlibRegistry(): StdlibRegistry {
   const typeNamesByNamespace: Record<string, ReadonlySet<string>> = Object.fromEntries(

--- a/apps/desktop/src/renderer/src/services/validation.ts
+++ b/apps/desktop/src/renderer/src/services/validation.ts
@@ -2,23 +2,23 @@
  * Semantic validators for the IR.
  *
  * The Zod meta-schema (`model/ir.ts`) enforces structural correctness
- * at load time. This module layers the 7 semantic rules on top:
+ * at load time. This module layers the semantic rules on top:
  *
  * 1. Structural parse (enforced by the loader; not re-checked here).
- * 2. Every `ref.typeName` resolves — local type OR `alias.Name` with a
- *    matching import alias.
- * 3. No duplicate type names within a file.
- * 4. Discriminated unions — every variant must reference a local `object`
+ * 2. Refs + imports + duplicate type names — delegated to core's
+ *    `checkSemantic` so the validation panel and the op-layer gate
+ *    share one implementation.
+ * 3. Discriminated unions — every variant must reference a local `object`
  *    type whose fields include the discriminator.
- * 5. Enums — non-empty `values`, no duplicate values.
- * 6. Imports — every alias unique. (Cycles are the loader's concern.)
- * 7. Emitted Zod compiles — deferred sandboxed eval, wired up alongside
+ * 4. Enums — non-empty `values`, no duplicate values.
+ * 5. Emitted Zod compiles — deferred sandboxed eval, wired up alongside
  *    the Zod emitter in #83.
  *
  * Each returned `ValidationError` carries a stable `code` and a dotted
  * `path` so the UI can map the message back to the offending field.
  */
-import type { FieldType, Schema } from '../model/ir';
+import { checkSemantic, type SemanticIssue } from '@contexture/core';
+import type { Schema } from '../model/ir';
 import type { StdlibRegistry } from './stdlib-registry';
 
 export interface ValidationError {
@@ -29,10 +29,10 @@ export interface ValidationError {
 
 export interface ValidateOptions {
   /**
-   * Optional stdlib registry used by Rule 2 to resolve qualified refs
+   * Optional stdlib registry used to resolve qualified refs
    * (`<namespace>.<TypeName>`) against bundled stdlib namespaces when
-   * no matching `add_import` has been declared. Callers that want
-   * strict import-only resolution (historical behaviour) pass nothing.
+   * no matching `add_import` has been declared, and to validate that
+   * stdlib imports point at known namespaces with matching aliases.
    */
   stdlib?: StdlibRegistry;
 }
@@ -40,13 +40,19 @@ export interface ValidateOptions {
 export function validate(schema: Schema, options: ValidateOptions = {}): ValidationError[] {
   if (!schema || schema.version !== '1') return [];
   const errors: ValidationError[] = [];
-  errors.push(...checkDuplicateTypeNames(schema));
-  errors.push(...checkRefsResolve(schema, options.stdlib));
+  errors.push(...checkSemantic(schema, options.stdlib).map(toValidationError));
   errors.push(...checkDiscriminatedUnions(schema));
   errors.push(...checkEnums(schema));
-  errors.push(...checkImportAliases(schema));
   errors.push(...checkEmittedZodCompiles(schema));
   return errors;
+}
+
+function toValidationError(issue: SemanticIssue): ValidationError {
+  return {
+    code: issue.code,
+    path: issue.path,
+    message: issue.hint ? `${issue.message} ${issue.hint}` : issue.message,
+  };
 }
 
 /**
@@ -60,23 +66,6 @@ function checkEmittedZodCompiles(_schema: Schema): ValidationError[] {
   // TODO(#83): emit Zod for `_schema`, eval in sandboxed worker,
   // surface `zod_compile_failed` with the offending type path.
   return [];
-}
-
-function checkImportAliases(schema: Schema): ValidationError[] {
-  const errors: ValidationError[] = [];
-  const seen = new Set<string>();
-  (schema.imports ?? []).forEach((imp, i) => {
-    if (seen.has(imp.alias)) {
-      errors.push({
-        code: 'dup_import_alias',
-        path: `imports.${i}`,
-        message: `Duplicate import alias "${imp.alias}".`,
-      });
-    } else {
-      seen.add(imp.alias);
-    }
-  });
-  return errors;
 }
 
 function checkEnums(schema: Schema): ValidationError[] {
@@ -140,69 +129,6 @@ function checkDiscriminatedUnions(schema: Schema): ValidationError[] {
         });
       }
     });
-  });
-  return errors;
-}
-
-function checkRefsResolve(schema: Schema, stdlib?: StdlibRegistry): ValidationError[] {
-  const errors: ValidationError[] = [];
-  const localNames = new Set(schema.types.map((t) => t.name));
-  const aliases = new Set((schema.imports ?? []).map((i) => i.alias));
-
-  const walkField = (t: FieldType, path: string) => {
-    if (t.kind === 'ref') {
-      if (!resolves(t.typeName, localNames, aliases, stdlib)) {
-        errors.push({
-          code: 'unresolved_ref',
-          path,
-          message: `Unresolved ref "${t.typeName}".`,
-        });
-      }
-    } else if (t.kind === 'array') {
-      walkField(t.element, `${path}.element`);
-    }
-  };
-
-  schema.types.forEach((type, ti) => {
-    if (type.kind !== 'object') return;
-    type.fields.forEach((f, fi) => {
-      walkField(f.type, `types.${ti}.fields.${fi}.type`);
-    });
-  });
-  return errors;
-}
-
-function resolves(
-  typeName: string,
-  locals: Set<string>,
-  aliases: Set<string>,
-  stdlib?: StdlibRegistry,
-): boolean {
-  const dot = typeName.indexOf('.');
-  if (dot === -1) return locals.has(typeName);
-  const ns = typeName.slice(0, dot);
-  const name = typeName.slice(dot + 1);
-  // An explicit `add_import` alias satisfies the ref without looking
-  // inside the target module (matches legacy behaviour). A bundled
-  // stdlib namespace satisfies it by name lookup — that's what
-  // `common.Email` without an explicit import relies on.
-  if (aliases.has(ns)) return true;
-  return stdlib?.hasType(ns, name) ?? false;
-}
-
-function checkDuplicateTypeNames(schema: Schema): ValidationError[] {
-  const errors: ValidationError[] = [];
-  const seen = new Set<string>();
-  schema.types.forEach((type, i) => {
-    if (seen.has(type.name)) {
-      errors.push({
-        code: 'dup_type_name',
-        path: `types.${i}`,
-        message: `Duplicate type name "${type.name}".`,
-      });
-    } else {
-      seen.add(type.name);
-    }
   });
   return errors;
 }

--- a/apps/desktop/src/renderer/src/services/validation.ts
+++ b/apps/desktop/src/renderer/src/services/validation.ts
@@ -17,7 +17,7 @@
  * Each returned `ValidationError` carries a stable `code` and a dotted
  * `path` so the UI can map the message back to the offending field.
  */
-import { checkSemantic, type SemanticIssue } from '@contexture/core';
+import { checkSemantic, type SemanticIssue } from '@contexture/core/semantic-validation';
 import type { Schema } from '../model/ir';
 import type { StdlibRegistry } from './stdlib-registry';
 

--- a/apps/desktop/src/renderer/src/store/contexture.ts
+++ b/apps/desktop/src/renderer/src/store/contexture.ts
@@ -12,6 +12,7 @@
  */
 import { create } from 'zustand';
 import type { Schema } from '../model/ir';
+import { STDLIB_REGISTRY } from '../services/stdlib-registry';
 import { type ApplyResult, apply, type Op } from './ops';
 
 export interface ContextureState {
@@ -23,7 +24,7 @@ export function createContextureStore(initial: Schema) {
   return create<ContextureState>((set, get) => ({
     schema: initial,
     apply: (op) => {
-      const res = apply(get().schema, op);
+      const res = apply(get().schema, op, STDLIB_REGISTRY);
       if ('schema' in res) set({ schema: res.schema });
       return res;
     },

--- a/apps/desktop/src/renderer/src/store/undo.ts
+++ b/apps/desktop/src/renderer/src/store/undo.ts
@@ -25,6 +25,7 @@
 import { create } from 'zustand';
 import type { Schema } from '../model/ir';
 import { load, save } from '../model/load';
+import { STDLIB_REGISTRY } from '../services/stdlib-registry';
 import { type ApplyResult, apply as applyOp, type Op } from './ops';
 
 export interface UndoableState {
@@ -69,7 +70,7 @@ export function createUndoableContextureStore(initial: Schema) {
 
       apply: (op) => {
         const state = get();
-        const res = applyOp(state.schema, op);
+        const res = applyOp(state.schema, op, STDLIB_REGISTRY);
         if ('error' in res) return res;
 
         if (state.txDepth > 0) {

--- a/apps/desktop/tests/hooks/useFileMenu.test.tsx
+++ b/apps/desktop/tests/hooks/useFileMenu.test.tsx
@@ -122,13 +122,19 @@ describe('useFileMenu', () => {
   it('handleSave prompts when validation has errors; force-save writes through', async () => {
     const bridge = mockFileBridge();
     useDocumentStore.getState().setFilePath('/tmp/x.contexture.json');
-    // Introduce an unresolved ref → validator barks.
-    useUndoStore.getState().apply({
-      kind: 'add_type',
-      type: {
-        kind: 'object',
-        name: 'Plot',
-        fields: [{ name: 'bogus', type: { kind: 'ref', typeName: 'Nope' } }],
+    // Seed an unresolved-ref schema directly — bypasses the op-layer
+    // semantic gate so we can exercise the save-with-errors path the
+    // way it would fire for a doc loaded from disk.
+    useUndoStore.setState({
+      schema: {
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'Plot',
+            fields: [{ name: 'bogus', type: { kind: 'ref', typeName: 'Nope' } }],
+          },
+        ],
       },
     });
     const { result } = renderHook(() => useFileMenu());

--- a/apps/desktop/tests/services/validation.test.ts
+++ b/apps/desktop/tests/services/validation.test.ts
@@ -18,9 +18,9 @@ describe('validate', () => {
       ],
     };
     const errs = validate(schema);
-    const dup = errs.find((e) => e.code === 'dup_type_name');
+    const dup = errs.find((e) => e.code === 'duplicate_type_name');
     expect(dup).toEqual({
-      code: 'dup_type_name',
+      code: 'duplicate_type_name',
       path: 'types.1',
       message: 'Duplicate type name "User".',
     });
@@ -271,9 +271,9 @@ describe('validate', () => {
       ],
       types: [],
     };
-    const err = validate(schema).find((e) => e.code === 'dup_import_alias');
+    const err = validate(schema).find((e) => e.code === 'duplicate_alias');
     expect(err).toEqual({
-      code: 'dup_import_alias',
+      code: 'duplicate_alias',
       path: 'imports.1',
       message: 'Duplicate import alias "lib".',
     });
@@ -288,7 +288,7 @@ describe('validate', () => {
       ],
       types: [],
     };
-    expect(validate(schema).some((e) => e.code === 'dup_import_alias')).toBe(false);
+    expect(validate(schema).some((e) => e.code === 'duplicate_alias')).toBe(false);
   });
 
   // Rule 7: Zod emit compiles (sandboxed eval wired up in #83).
@@ -314,6 +314,6 @@ describe('validate', () => {
         { kind: 'object', name: 'Post', fields: [] },
       ],
     };
-    expect(validate(schema).some((e) => e.code === 'dup_type_name')).toBe(false);
+    expect(validate(schema).some((e) => e.code === 'duplicate_type_name')).toBe(false);
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,8 @@
     "./ops": "./src/ops.ts",
     "./op-tools": "./src/op-tools.ts",
     "./paths": "./src/paths.ts",
-    "./pipeline": "./src/pipeline.ts"
+    "./pipeline": "./src/pipeline.ts",
+    "./semantic-validation": "./src/semantic-validation.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/core/src/emit-json-schema.ts
+++ b/packages/core/src/emit-json-schema.ts
@@ -28,11 +28,37 @@ function generatedMarker(sourcePath?: string): string {
   return sourcePath ? `${base} Source: ${sourcePath}` : base;
 }
 
-export function emit(schema: Schema, rootTypeName?: string, sourcePath?: string): object {
+export interface EmitOptions {
+  /** Namespaces (e.g. `'place'`, `'money'`) treated as ambient stdlib. */
+  stdlibNamespaces?: readonly string[];
+}
+
+export function emit(
+  schema: Schema,
+  rootTypeName?: string,
+  sourcePath?: string,
+  options: EmitOptions = {},
+): object {
   const aliases = new Map<string, ImportDecl>();
   (schema.imports ?? []).forEach((imp) => {
     aliases.set(imp.alias, imp);
   });
+
+  const stdlibNs = new Set(options.stdlibNamespaces ?? []);
+  const ensureStdlibImport = (alias: string) => {
+    if (aliases.has(alias) || !stdlibNs.has(alias)) return;
+    aliases.set(alias, {
+      kind: 'stdlib',
+      path: `@contexture/${alias}`,
+      alias,
+    });
+  };
+  for (const type of schema.types) {
+    if (type.kind !== 'object') continue;
+    for (const field of type.fields) {
+      collectStdlibAliases(field.type, ensureStdlibImport);
+    }
+  }
 
   const defs: Record<string, object> = {};
   for (const type of schema.types) {
@@ -155,5 +181,14 @@ function emitFieldType(t: FieldType, aliases: Map<string, ImportDecl>): object {
       if (t.max !== undefined) out.maxItems = t.max;
       return out;
     }
+  }
+}
+
+function collectStdlibAliases(t: FieldType, ensure: (alias: string) => void): void {
+  if (t.kind === 'ref') {
+    const dot = t.typeName.indexOf('.');
+    if (dot !== -1) ensure(t.typeName.slice(0, dot));
+  } else if (t.kind === 'array') {
+    collectStdlibAliases(t.element, ensure);
   }
 }

--- a/packages/core/src/emit-zod.ts
+++ b/packages/core/src/emit-zod.ts
@@ -9,6 +9,10 @@
  * Import handling follows the plan's uniform mechanism:
  *   - Stdlib aliases (`@contexture/<ns>`) become runtime imports from
  *     `@contexture/runtime/<ns>`, importing only the names actually used.
+ *     If `options.stdlibNamespaces` is provided, qualified refs whose
+ *     namespace matches a known stdlib namespace synthesise an import even
+ *     when `schema.imports` doesn't declare one — this matches the
+ *     validator, which treats stdlib namespaces as ambient.
  *   - Relative aliases map to `./<alias>.schema` (the emitted sibling of the
  *     referenced `.contexture.json`), importing only the names used.
  *   - Local refs emit as bare identifiers.
@@ -20,11 +24,16 @@
  */
 import type { FieldDef, FieldType, ImportDecl, Schema, TypeDef } from './ir';
 
-export function emit(schema: Schema, sourcePath: string): string {
-  const ctx = buildContext(schema);
+export interface EmitOptions {
+  /** Namespaces (e.g. `'place'`, `'money'`) treated as ambient stdlib. */
+  stdlibNamespaces?: readonly string[];
+}
+
+export function emit(schema: Schema, sourcePath: string, options: EmitOptions = {}): string {
+  const ctx = buildContext(schema, options);
   const header = `// @contexture-generated — do not edit by hand. Regenerated on every IR save. Source: ${sourcePath}\n`;
   const zodImport = `import { z } from 'zod';\n`;
-  const externalImports = renderExternalImports(schema, ctx);
+  const externalImports = renderExternalImports(ctx);
   const body = schema.types.map((t) => emitTypeDef(t, ctx)).join('');
   return header + zodImport + externalImports + body;
 }
@@ -32,18 +41,27 @@ export function emit(schema: Schema, sourcePath: string): string {
 interface EmitContext {
   /** alias → ImportDecl (for resolving qualified refs). */
   aliases: Map<string, ImportDecl>;
+  /**
+   * Ordered list of imports to render. Includes `schema.imports` plus any
+   * synthetic stdlib imports derived from qualified refs whose namespace
+   * matches `options.stdlibNamespaces`.
+   */
+  imports: ImportDecl[];
   /** alias → set of imported names that were actually referenced. */
   usedByAlias: Map<string, Set<string>>;
   /** `raw` types with an external import hint, keyed by name. */
   rawExternal: Map<string, { from: string; name: string }>;
 }
 
-function buildContext(schema: Schema): EmitContext {
+function buildContext(schema: Schema, options: EmitOptions): EmitContext {
   const aliases = new Map<string, ImportDecl>();
+  const imports: ImportDecl[] = [];
   (schema.imports ?? []).forEach((imp) => {
     aliases.set(imp.alias, imp);
+    imports.push(imp);
   });
 
+  const stdlibNs = new Set(options.stdlibNamespaces ?? []);
   const usedByAlias = new Map<string, Set<string>>();
   const rawExternal = new Map<string, { from: string; name: string }>();
 
@@ -53,6 +71,15 @@ function buildContext(schema: Schema): EmitContext {
       if (dot !== -1) {
         const alias = t.typeName.slice(0, dot);
         const name = t.typeName.slice(dot + 1);
+        if (!aliases.has(alias) && stdlibNs.has(alias)) {
+          const synthetic: ImportDecl = {
+            kind: 'stdlib',
+            path: `@contexture/${alias}`,
+            alias,
+          };
+          aliases.set(alias, synthetic);
+          imports.push(synthetic);
+        }
         if (aliases.has(alias)) {
           const set = usedByAlias.get(alias) ?? new Set<string>();
           set.add(name);
@@ -74,13 +101,13 @@ function buildContext(schema: Schema): EmitContext {
     }
   });
 
-  return { aliases, usedByAlias, rawExternal };
+  return { aliases, imports, usedByAlias, rawExternal };
 }
 
-function renderExternalImports(schema: Schema, ctx: EmitContext): string {
+function renderExternalImports(ctx: EmitContext): string {
   const lines: string[] = [];
 
-  (schema.imports ?? []).forEach((imp) => {
+  ctx.imports.forEach((imp) => {
     const used = ctx.usedByAlias.get(imp.alias);
     if (!used || used.size === 0) return;
     const names = [...used].sort().join(', ');
@@ -88,10 +115,8 @@ function renderExternalImports(schema: Schema, ctx: EmitContext): string {
     lines.push(`import { ${names} } from '${module}';`);
   });
 
-  schema.types.forEach((type) => {
-    if (type.kind === 'raw' && type.import) {
-      lines.push(`import { ${type.import.name} } from '${type.import.from}';`);
-    }
+  ctx.rawExternal.forEach((imp) => {
+    lines.push(`import { ${imp.name} } from '${imp.from}';`);
   });
 
   return lines.length ? `${lines.join('\n')}\n` : '';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,3 +11,4 @@ export * from './migrations';
 export * from './op-tools';
 export * from './ops';
 export * from './pipeline';
+export * from './semantic-validation';

--- a/packages/core/src/op-tools.ts
+++ b/packages/core/src/op-tools.ts
@@ -70,7 +70,19 @@ const FieldTypeSchema: z.ZodType<import('./ir').FieldType> = z.lazy(() =>
       kind: z.literal('literal'),
       value: z.union([z.string(), z.number(), z.boolean()]),
     }),
-    z.object({ kind: z.literal('ref'), typeName: z.string() }),
+    z.object({
+      kind: z.literal('ref'),
+      typeName: z
+        .string()
+        .describe(
+          'Either a local TypeDef name from this schema, or a qualified ' +
+            '"<namespace>.<TypeName>" for a stdlib type (e.g. ' +
+            '"place.CountryCode", "money.Money", "common.Email"). ' +
+            'Bare names that do not match a local type WILL be rejected ' +
+            'by the op layer — the namespace prefix is mandatory for ' +
+            'stdlib refs.',
+        ),
+    }),
     z.object({
       kind: z.literal('array'),
       element: FieldTypeSchema,
@@ -354,7 +366,14 @@ export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
     ),
     lenientTool(
       'add_import',
-      'Add an import declaration (stdlib or relative).',
+      'Add an import declaration (stdlib or relative). For stdlib ' +
+        'imports the alias MUST equal the namespace ' +
+        '(e.g. { kind: "stdlib", path: "@contexture/place", alias: "place" }). ' +
+        'Note: stdlib imports are NOT required for refs to resolve — ' +
+        'qualified refs like "place.CountryCode" are auto-imported by ' +
+        'the emitter. Only call add_import for relative imports of ' +
+        'sibling .contexture.json files, or when you specifically want ' +
+        'a stdlib namespace listed in schema.imports[].',
       (payload) => ({
         kind: 'add_import',
         import: payload as Extract<Op, { kind: 'add_import' }>['import'],

--- a/packages/core/src/ops.ts
+++ b/packages/core/src/ops.ts
@@ -14,13 +14,20 @@
  *     local refs and discriminated-union variants. Qualified refs
  *     (`alias.Name`) are left alone — they point at external modules.
  *   - `replace_schema` runs the Zod meta-schema so obviously broken inputs
- *     are caught here; semantic rules (unresolved refs, duplicate names)
- *     stay in `services/validation.ts` so the UI can surface them with
- *     field-level paths after the replacement lands.
+ *     are caught here. When `apply()` is called with a `StdlibCatalog`,
+ *     a delta semantic check (refs, imports, duplicates) gates *every*
+ *     op — including `replace_schema` — so the chat cannot land an IR
+ *     that introduces new unresolved refs or unknown stdlib imports.
  */
 
 import type { FieldDef, FieldType, ImportDecl, IndexDef, Schema, TypeDef } from './ir';
 import { IRSchema } from './ir';
+import {
+  checkSemantic,
+  newIssues,
+  type SemanticIssue,
+  type StdlibCatalog,
+} from './semantic-validation';
 
 export type Op =
   | { kind: 'add_type'; type: TypeDef }
@@ -51,7 +58,44 @@ export type Op =
 
 export type ApplyResult = { schema: Schema } | { error: string };
 
-export function apply(schema: Schema, op: Op): ApplyResult {
+/**
+ * Apply an `Op` to `schema` and return the next schema or a structured
+ * error.
+ *
+ * When `catalog` is provided, the result is gated by a *delta* semantic
+ * check: any new unresolved-ref / bad-import / duplicate-name issue
+ * introduced by this op rejects the op with a chat-friendly error
+ * (including the `hint` text from `checkSemantic`). Issues that already
+ * existed in `schema` are not blamed on the new op — the chat can fix
+ * them incrementally without the gate getting in the way.
+ *
+ * Without a catalog, this is structural-only (the historical behaviour).
+ */
+export function apply(schema: Schema, op: Op, catalog?: StdlibCatalog): ApplyResult {
+  const result = applyStructural(schema, op);
+  if ('error' in result) return result;
+  if (!catalog) return result;
+  const introduced = newIssues(
+    checkSemantic(schema, catalog),
+    checkSemantic(result.schema, catalog),
+  );
+  if (introduced.length === 0) return result;
+  return { error: formatSemanticErrors(op.kind, introduced) };
+}
+
+function formatSemanticErrors(opKind: string, issues: SemanticIssue[]): string {
+  const lines = issues.map((i) => {
+    const hint = i.hint ? ` ${i.hint}` : '';
+    return `  - ${i.path}: ${i.message}${hint}`;
+  });
+  const lead =
+    issues.length === 1
+      ? `${opKind}: would introduce 1 semantic issue:`
+      : `${opKind}: would introduce ${issues.length} semantic issues:`;
+  return [lead, ...lines].join('\n');
+}
+
+function applyStructural(schema: Schema, op: Op): ApplyResult {
   switch (op.kind) {
     case 'add_type':
       return addType(schema, op.type);

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -1,0 +1,184 @@
+/**
+ * Semantic validation of an IR — refs, imports, duplicates.
+ *
+ * Structural validation (zod meta-schema) lives in `ir.ts`. This module
+ * checks the things zod can't: unresolved refs, unknown stdlib namespaces,
+ * stdlib alias mismatches, duplicate aliases / type names. It is the
+ * source of truth consumed by both:
+ *
+ *   1. `apply()` in `ops.ts`, which uses it to delta-reject any op whose
+ *      result would introduce a *new* issue (the chat-tool-call gate).
+ *   2. The renderer's validation panel, which surfaces the issues to the
+ *      user for hand-editing scenarios.
+ *
+ * The optional `StdlibCatalog` enables namespace-aware ref resolution and
+ * import validation. Callers without stdlib context (e.g. core unit tests)
+ * pass nothing and get import-only resolution.
+ */
+import type { FieldType, ImportDecl, Schema } from './ir';
+
+/**
+ * Stdlib namespace catalog. The renderer / main process build one from
+ * `@contexture/stdlib/registry`; tests can build a synthetic one.
+ */
+export interface StdlibCatalog {
+  /** All known stdlib namespace aliases (e.g. `'common'`, `'place'`). */
+  namespaces: readonly string[];
+  /** True iff the namespace defines a type with that name. */
+  hasType: (namespace: string, typeName: string) => boolean;
+}
+
+export type SemanticIssueCode =
+  | 'unresolved_ref'
+  | 'unknown_stdlib_namespace'
+  | 'stdlib_alias_mismatch'
+  | 'duplicate_alias'
+  | 'duplicate_type_name';
+
+export interface SemanticIssue {
+  code: SemanticIssueCode;
+  path: string;
+  message: string;
+  /** Remediation suggestion the chat / UI should surface verbatim. */
+  hint?: string;
+}
+
+export function checkSemantic(schema: Schema, catalog?: StdlibCatalog): SemanticIssue[] {
+  if (!schema || schema.version !== '1') return [];
+  return [
+    ...checkImports(schema, catalog),
+    ...checkRefs(schema, catalog),
+    ...checkDuplicateTypeNames(schema),
+  ];
+}
+
+function checkImports(schema: Schema, catalog?: StdlibCatalog): SemanticIssue[] {
+  const issues: SemanticIssue[] = [];
+  const seenAliases = new Set<string>();
+  (schema.imports ?? []).forEach((imp, i) => {
+    const path = `imports.${i}`;
+    if (seenAliases.has(imp.alias)) {
+      issues.push({
+        code: 'duplicate_alias',
+        path,
+        message: `Duplicate import alias "${imp.alias}".`,
+      });
+    } else {
+      seenAliases.add(imp.alias);
+    }
+    if (imp.kind === 'stdlib' && catalog) {
+      const ns = stdlibNamespaceFromPath(imp.path);
+      if (ns === null || !catalog.namespaces.includes(ns)) {
+        issues.push({
+          code: 'unknown_stdlib_namespace',
+          path,
+          message: `Unknown stdlib namespace "${imp.path}".`,
+          hint: `Available: ${catalog.namespaces.map((n) => `@contexture/${n}`).join(', ')}.`,
+        });
+      } else if (imp.alias !== ns) {
+        issues.push({
+          code: 'stdlib_alias_mismatch',
+          path,
+          message: `Stdlib import alias "${imp.alias}" must match its namespace "${ns}".`,
+          hint: `Set alias to "${ns}" so refs like "${ns}.SomeType" resolve.`,
+        });
+      }
+    }
+  });
+  return issues;
+}
+
+function checkRefs(schema: Schema, catalog?: StdlibCatalog): SemanticIssue[] {
+  const issues: SemanticIssue[] = [];
+  const localNames = new Set(schema.types.map((t) => t.name));
+  const aliases = new Set((schema.imports ?? []).map((i) => i.alias));
+
+  const walk = (t: FieldType, path: string): void => {
+    if (t.kind === 'ref') {
+      if (!resolves(t.typeName, localNames, aliases, catalog)) {
+        issues.push({
+          code: 'unresolved_ref',
+          path,
+          message: `Unresolved ref "${t.typeName}".`,
+          hint: hintForUnresolvedRef(t.typeName, catalog),
+        });
+      }
+    } else if (t.kind === 'array') {
+      walk(t.element, `${path}.element`);
+    }
+  };
+
+  schema.types.forEach((type, ti) => {
+    if (type.kind !== 'object') return;
+    type.fields.forEach((f, fi) => {
+      walk(f.type, `types.${ti}.fields.${fi}.type`);
+    });
+  });
+  return issues;
+}
+
+function resolves(
+  typeName: string,
+  locals: Set<string>,
+  aliases: Set<string>,
+  catalog?: StdlibCatalog,
+): boolean {
+  const dot = typeName.indexOf('.');
+  if (dot === -1) return locals.has(typeName);
+  const ns = typeName.slice(0, dot);
+  const name = typeName.slice(dot + 1);
+  if (aliases.has(ns)) return true;
+  return catalog?.hasType(ns, name) ?? false;
+}
+
+function hintForUnresolvedRef(typeName: string, catalog?: StdlibCatalog): string | undefined {
+  if (!catalog) return undefined;
+  const dot = typeName.indexOf('.');
+  if (dot !== -1) return undefined;
+  for (const ns of catalog.namespaces) {
+    if (catalog.hasType(ns, typeName)) {
+      return `Did you mean "${ns}.${typeName}"?`;
+    }
+  }
+  return undefined;
+}
+
+function checkDuplicateTypeNames(schema: Schema): SemanticIssue[] {
+  const issues: SemanticIssue[] = [];
+  const seen = new Set<string>();
+  schema.types.forEach((type, i) => {
+    if (seen.has(type.name)) {
+      issues.push({
+        code: 'duplicate_type_name',
+        path: `types.${i}`,
+        message: `Duplicate type name "${type.name}".`,
+      });
+    } else {
+      seen.add(type.name);
+    }
+  });
+  return issues;
+}
+
+function stdlibNamespaceFromPath(path: ImportDecl['path']): string | null {
+  const prefix = '@contexture/';
+  if (!path.startsWith(prefix)) return null;
+  const rest = path.slice(prefix.length);
+  if (rest.length === 0 || rest.includes('/')) return null;
+  return rest;
+}
+
+/**
+ * Compare two issue lists and return any that exist in `post` but not in
+ * `pre` (matched by `code` + `path` + `message` so a recurring issue
+ * after an unrelated edit is not blamed on the new op).
+ *
+ * Used by `apply()` to delta-reject ops that *introduce* new semantic
+ * problems while letting through ops that touch parts of the schema with
+ * pre-existing issues.
+ */
+export function newIssues(pre: SemanticIssue[], post: SemanticIssue[]): SemanticIssue[] {
+  const key = (i: SemanticIssue) => `${i.code}|${i.path}|${i.message}`;
+  const seen = new Set(pre.map(key));
+  return post.filter((i) => !seen.has(key(i)));
+}

--- a/packages/core/tests/apply-semantic-gate.test.ts
+++ b/packages/core/tests/apply-semantic-gate.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import type { Schema } from '../src/ir';
+import { apply, type Op } from '../src/ops';
+import type { StdlibCatalog } from '../src/semantic-validation';
+
+const STDLIB: StdlibCatalog = {
+  namespaces: ['common', 'place', 'money'],
+  hasType: (ns, name) => {
+    const types: Record<string, ReadonlySet<string>> = {
+      common: new Set(['Email', 'URL']),
+      place: new Set(['CountryCode']),
+      money: new Set(['Money']),
+    };
+    return types[ns]?.has(name) ?? false;
+  },
+};
+
+const baseSchema: Schema = {
+  version: '1',
+  types: [{ kind: 'object', name: 'Order', fields: [] }],
+};
+
+describe('apply() — delta semantic gate', () => {
+  it('rejects add_field with a bare ref that matches a stdlib type', () => {
+    const op: Op = {
+      kind: 'add_field',
+      typeName: 'Order',
+      field: { name: 'country', type: { kind: 'ref', typeName: 'CountryCode' } },
+    };
+    const result = apply(baseSchema, op, STDLIB);
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('Unresolved ref "CountryCode"');
+      expect(result.error).toContain('Did you mean "place.CountryCode"?');
+    }
+  });
+
+  it('accepts add_field with a qualified stdlib ref (catalog-resolved, no add_import)', () => {
+    const op: Op = {
+      kind: 'add_field',
+      typeName: 'Order',
+      field: { name: 'country', type: { kind: 'ref', typeName: 'place.CountryCode' } },
+    };
+    const result = apply(baseSchema, op, STDLIB);
+    expect('schema' in result).toBe(true);
+  });
+
+  it('accepts update_field that rewrites a ref to a primitive (not a new issue)', () => {
+    const start: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Order',
+          fields: [{ name: 'c', type: { kind: 'ref', typeName: 'place.CountryCode' } }],
+        },
+      ],
+    };
+    const op: Op = {
+      kind: 'update_field',
+      typeName: 'Order',
+      fieldName: 'c',
+      patch: { type: { kind: 'string' } },
+    };
+    const result = apply(start, op, STDLIB);
+    expect('schema' in result).toBe(true);
+  });
+
+  it('rejects add_import for an unknown stdlib namespace', () => {
+    const op: Op = {
+      kind: 'add_import',
+      import: { kind: 'stdlib', path: '@contexture/banana', alias: 'banana' },
+    };
+    const result = apply(baseSchema, op, STDLIB);
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('@contexture/banana');
+      expect(result.error).toContain('Available');
+    }
+  });
+
+  it('rejects add_import where alias does not match the stdlib namespace', () => {
+    const op: Op = {
+      kind: 'add_import',
+      import: { kind: 'stdlib', path: '@contexture/place', alias: 'p' },
+    };
+    const result = apply(baseSchema, op, STDLIB);
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('alias');
+    }
+  });
+
+  it('rejects replace_schema that introduces multiple unresolved refs', () => {
+    const op: Op = {
+      kind: 'replace_schema',
+      schema: {
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'Order',
+            fields: [
+              { name: 'c', type: { kind: 'ref', typeName: 'CountryCode' } },
+              { name: 'p', type: { kind: 'ref', typeName: 'Money' } },
+            ],
+          },
+        ],
+      },
+    };
+    const result = apply(baseSchema, op, STDLIB);
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('Unresolved ref "CountryCode"');
+      expect(result.error).toContain('Unresolved ref "Money"');
+      expect(result.error).toContain('Did you mean "place.CountryCode"?');
+      expect(result.error).toContain('Did you mean "money.Money"?');
+    }
+  });
+
+  it('does not blame an op for pre-existing issues', () => {
+    const broken: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Order',
+          fields: [
+            { name: 'c', type: { kind: 'ref', typeName: 'CountryCode' } },
+            { name: 'p', type: { kind: 'ref', typeName: 'Money' } },
+          ],
+        },
+      ],
+    };
+    // Removing an unrelated field should succeed even though refs are still broken.
+    const op: Op = { kind: 'remove_field', typeName: 'Order', fieldName: 'p' };
+    const result = apply(broken, op, STDLIB);
+    expect('schema' in result).toBe(true);
+  });
+
+  it('without a catalog, behaves structurally (today’s behaviour)', () => {
+    const op: Op = {
+      kind: 'add_field',
+      typeName: 'Order',
+      field: { name: 'country', type: { kind: 'ref', typeName: 'CountryCode' } },
+    };
+    const result = apply(baseSchema, op);
+    expect('schema' in result).toBe(true);
+  });
+});

--- a/packages/core/tests/emit-stdlib-imports.test.ts
+++ b/packages/core/tests/emit-stdlib-imports.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { emit as emitJsonSchema } from '../src/emit-json-schema';
+import { emit as emitZod } from '../src/emit-zod';
+import type { Schema } from '../src/ir';
+
+const STDLIB_NAMESPACES = ['common', 'identity', 'place', 'money', 'contact'] as const;
+
+const schemaWithBareStdlibQualifiedRefs: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Order',
+      fields: [
+        { name: 'country', type: { kind: 'ref', typeName: 'place.CountryCode' } },
+        { name: 'price', type: { kind: 'ref', typeName: 'money.Money' } },
+      ],
+    },
+  ],
+};
+
+describe('emit-zod stdlib auto-import', () => {
+  it('synthesises an import line for a stdlib-qualified ref with no add_import', () => {
+    const out = emitZod(schemaWithBareStdlibQualifiedRefs, '/x.contexture.json', {
+      stdlibNamespaces: STDLIB_NAMESPACES,
+    });
+    expect(out).toContain(`import { CountryCode } from '@contexture/runtime/place';`);
+    expect(out).toContain(`import { Money } from '@contexture/runtime/money';`);
+    // Field uses the bare imported identifier
+    expect(out).toContain('country: CountryCode,');
+    expect(out).toContain('price: Money,');
+  });
+
+  it('does not duplicate an explicit stdlib import', () => {
+    const schema: Schema = {
+      ...schemaWithBareStdlibQualifiedRefs,
+      imports: [{ kind: 'stdlib', path: '@contexture/place', alias: 'place' }],
+    };
+    const out = emitZod(schema, '/x.contexture.json', {
+      stdlibNamespaces: STDLIB_NAMESPACES,
+    });
+    const placeImports = out.match(/from '@contexture\/runtime\/place'/g) ?? [];
+    expect(placeImports.length).toBe(1);
+  });
+
+  it('respects user-renamed aliases for stdlib namespaces', () => {
+    const schema: Schema = {
+      version: '1',
+      imports: [{ kind: 'stdlib', path: '@contexture/place', alias: 'p' }],
+      types: [
+        {
+          kind: 'object',
+          name: 'Order',
+          fields: [{ name: 'country', type: { kind: 'ref', typeName: 'p.CountryCode' } }],
+        },
+      ],
+    };
+    const out = emitZod(schema, '/x.contexture.json', {
+      stdlibNamespaces: STDLIB_NAMESPACES,
+    });
+    expect(out).toContain(`import { CountryCode } from '@contexture/runtime/place';`);
+    // The synthetic step must NOT also add an unaliased `place` import
+    expect(out).not.toMatch(
+      /from '@contexture\/runtime\/place'.*\n.*from '@contexture\/runtime\/place'/,
+    );
+  });
+
+  it('does not synthesise imports for non-stdlib qualified refs', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Order',
+          fields: [{ name: 'foo', type: { kind: 'ref', typeName: 'unknownNs.Foo' } }],
+        },
+      ],
+    };
+    const out = emitZod(schema, '/x.contexture.json', {
+      stdlibNamespaces: STDLIB_NAMESPACES,
+    });
+    expect(out).not.toContain('@contexture/runtime/unknownNs');
+  });
+});
+
+describe('emit-json-schema stdlib auto-import', () => {
+  it('emits a runtime $ref for a stdlib-qualified ref with no add_import', () => {
+    const out = emitJsonSchema(schemaWithBareStdlibQualifiedRefs, undefined, undefined, {
+      stdlibNamespaces: STDLIB_NAMESPACES,
+    });
+    expect(out).toMatchObject({
+      $defs: {
+        Order: {
+          properties: {
+            country: { $ref: '@contexture/runtime/place#/$defs/CountryCode' },
+            price: { $ref: '@contexture/runtime/money#/$defs/Money' },
+          },
+        },
+      },
+    });
+  });
+
+  it('still emits relative ./alias.schema.json for relative imports', () => {
+    const schema: Schema = {
+      version: '1',
+      imports: [{ kind: 'relative', path: './shared.contexture.json', alias: 'shared' }],
+      types: [
+        {
+          kind: 'object',
+          name: 'Order',
+          fields: [{ name: 'tag', type: { kind: 'ref', typeName: 'shared.Tag' } }],
+        },
+      ],
+    };
+    const out = emitJsonSchema(schema, undefined, undefined, {
+      stdlibNamespaces: STDLIB_NAMESPACES,
+    });
+    expect(out).toMatchObject({
+      $defs: {
+        Order: {
+          properties: {
+            tag: { $ref: './shared.schema.json#/$defs/Tag' },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import type { Schema } from '../src/ir';
+import { checkSemantic, type StdlibCatalog } from '../src/semantic-validation';
+
+const STDLIB: StdlibCatalog = {
+  namespaces: ['common', 'place', 'money'],
+  hasType: (ns, name) => {
+    const types: Record<string, ReadonlySet<string>> = {
+      common: new Set(['Email', 'URL']),
+      place: new Set(['CountryCode', 'Address']),
+      money: new Set(['Money', 'CurrencyCode']),
+    };
+    return types[ns]?.has(name) ?? false;
+  },
+};
+
+const objectWithRef = (typeName: string): Schema => ({
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Order',
+      fields: [{ name: 'country', type: { kind: 'ref', typeName } }],
+    },
+  ],
+});
+
+describe('checkSemantic — refs', () => {
+  it('passes for a local ref', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Buyer', fields: [] },
+        {
+          kind: 'object',
+          name: 'Order',
+          fields: [{ name: 'buyer', type: { kind: 'ref', typeName: 'Buyer' } }],
+        },
+      ],
+    };
+    expect(checkSemantic(schema, STDLIB)).toEqual([]);
+  });
+
+  it('passes for a qualified stdlib ref with no add_import (catalog-resolved)', () => {
+    expect(checkSemantic(objectWithRef('place.CountryCode'), STDLIB)).toEqual([]);
+  });
+
+  it('rejects a bare ref that matches a stdlib type, with a hint', () => {
+    const issues = checkSemantic(objectWithRef('CountryCode'), STDLIB);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.code).toBe('unresolved_ref');
+    expect(issues[0]?.path).toBe('types.0.fields.0.type');
+    expect(issues[0]?.hint).toBe('Did you mean "place.CountryCode"?');
+  });
+
+  it('rejects a bare ref with no stdlib match, no hint', () => {
+    const issues = checkSemantic(objectWithRef('TotallyUnknown'), STDLIB);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.hint).toBeUndefined();
+  });
+
+  it('rejects a qualified ref to an unknown namespace', () => {
+    const issues = checkSemantic(objectWithRef('banana.CountryCode'), STDLIB);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.code).toBe('unresolved_ref');
+  });
+
+  it('reports multiple offenders in path order', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'A',
+          fields: [
+            { name: 'x', type: { kind: 'ref', typeName: 'CountryCode' } },
+            { name: 'y', type: { kind: 'ref', typeName: 'Money' } },
+          ],
+        },
+      ],
+    };
+    const issues = checkSemantic(schema, STDLIB);
+    expect(issues.map((i) => i.hint)).toEqual([
+      'Did you mean "place.CountryCode"?',
+      'Did you mean "money.Money"?',
+    ]);
+  });
+
+  it('walks into array element refs', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'A',
+          fields: [
+            {
+              name: 'tags',
+              type: {
+                kind: 'array',
+                element: { kind: 'ref', typeName: 'CountryCode' },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const issues = checkSemantic(schema, STDLIB);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe('types.0.fields.0.type.element');
+  });
+
+  it('without a catalog, treats stdlib namespaces as unknown unless explicitly imported', () => {
+    const schema: Schema = {
+      version: '1',
+      imports: [{ kind: 'stdlib', path: '@contexture/place', alias: 'place' }],
+      types: [
+        {
+          kind: 'object',
+          name: 'A',
+          fields: [{ name: 'c', type: { kind: 'ref', typeName: 'place.CountryCode' } }],
+        },
+      ],
+    };
+    expect(checkSemantic(schema)).toEqual([]);
+  });
+});
+
+describe('checkSemantic — imports', () => {
+  it('rejects an unknown stdlib namespace', () => {
+    const schema: Schema = {
+      version: '1',
+      imports: [{ kind: 'stdlib', path: '@contexture/banana', alias: 'banana' }],
+      types: [],
+    };
+    const issues = checkSemantic(schema, STDLIB);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.code).toBe('unknown_stdlib_namespace');
+    expect(issues[0]?.path).toBe('imports.0');
+    expect(issues[0]?.message).toContain('@contexture/banana');
+    expect(issues[0]?.hint).toContain('@contexture/common');
+  });
+
+  it('rejects a stdlib import whose alias does not match its namespace', () => {
+    const schema: Schema = {
+      version: '1',
+      imports: [{ kind: 'stdlib', path: '@contexture/place', alias: 'p' }],
+      types: [],
+    };
+    const issues = checkSemantic(schema, STDLIB);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.code).toBe('stdlib_alias_mismatch');
+    expect(issues[0]?.path).toBe('imports.0');
+  });
+
+  it('accepts a relative import with any alias', () => {
+    const schema: Schema = {
+      version: '1',
+      imports: [{ kind: 'relative', path: './shared.contexture.json', alias: 'shared' }],
+      types: [],
+    };
+    expect(checkSemantic(schema, STDLIB)).toEqual([]);
+  });
+
+  it('rejects duplicate aliases', () => {
+    const schema: Schema = {
+      version: '1',
+      imports: [
+        { kind: 'stdlib', path: '@contexture/place', alias: 'place' },
+        { kind: 'stdlib', path: '@contexture/money', alias: 'place' },
+      ],
+      types: [],
+    };
+    const issues = checkSemantic(schema, STDLIB);
+    expect(issues.some((i) => i.code === 'duplicate_alias')).toBe(true);
+  });
+});
+
+describe('checkSemantic — duplicates', () => {
+  it('rejects duplicate type names', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'A', fields: [] },
+        { kind: 'object', name: 'A', fields: [] },
+      ],
+    };
+    const issues = checkSemantic(schema, STDLIB);
+    expect(issues.some((i) => i.code === 'duplicate_type_name')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two reinforcing bugs that produce silent footguns around stdlib refs (`place.CountryCode`, `money.Money`, etc.):

- **Emitter ↔ validator mismatch (Part C, commit 1).** The validator treats stdlib namespaces as ambient (a qualified ref like `place.CountryCode` resolves via `STDLIB_REGISTRY` without an `add_import`), but the emitters did not — they only emitted import lines from `schema.imports[]`. As a result a schema could be fully green in the editor and produce broken `.schema.ts` (bare identifier with no `import` line, runtime ReferenceError) and broken `.schema.json` (best-effort `\$ref: \"place#/\$defs/CountryCode\"` that nothing resolves) when promoted from scratch to project mode. `emit-zod` and `emit-json-schema` now accept an optional `stdlibNamespaces` list and synthesise stdlib `ImportDecl`s on demand. Core stays stdlib-agnostic; desktop call sites inject the namespaces.
- **Prompt mishandling unresolved refs (Part A, commit 2).** The `use-stdlib` skill said qualified refs resolve "automatically — no `add_import` needed" without making the namespace prefix mandatory, so the chat wrote bare `CountryCode` / `Money` thinking they would resolve like local types. When the user then asked the chat to fix the resulting unresolved-ref errors, nothing in the prompt steered it away from `update_field` patches that replaced the ref with a primitive — the error vanished along with the diagram edge. Skill body now requires the namespace prefix and adds an explicit troubleshooting block.

After Part C, even if the prompt regresses, scratch → project still emits working artefacts.

## Test plan

- [x] `bun run ci` passes (typecheck + 837 tests + biome)
- [x] New `packages/core/tests/emit-stdlib-imports.test.ts` covers: synthesis with no `add_import`, no duplication when an explicit import exists, user-renamed aliases, non-stdlib namespaces left alone (emit-zod), and runtime `\$ref` synthesis + relative-import passthrough (emit-json-schema)
- [ ] Manual smoke: open the schema from the bug report, ask chat to "fix the unresolved-ref errors" — expect 5 `update_field` ops touching only `type.typeName`, every graph edge present before survives after
- [ ] Manual smoke: promote a scratch schema with bare-resolved stdlib refs to a project, confirm `<name>.schema.ts` contains `import { CountryCode } from '@contexture/runtime/place'` and `import { Money } from '@contexture/runtime/money'`, and `tsc` against the emitted file passes