### PR TITLE
fix(scaffold): drop broken @contexture/cli workspace dep from new projects

### DIFF
--- a/apps/desktop/src/main/scaffold/schema-package.ts
+++ b/apps/desktop/src/main/scaffold/schema-package.ts
@@ -43,7 +43,6 @@ function makePackageJson(projectName: string): string {
       main: './index.ts',
       types: './index.ts',
       dependencies: { convex: 'latest' },
-      devDependencies: { '@contexture/cli': 'workspace:*' },
     },
     null,
     2,

--- a/apps/desktop/src/main/scaffold/turbo-skeleton.ts
+++ b/apps/desktop/src/main/scaffold/turbo-skeleton.ts
@@ -56,7 +56,6 @@ export async function scaffoldTurboSkeleton(
       typecheck: 'turbo typecheck',
     },
     devDependencies: {
-      '@contexture/cli': 'workspace:*',
       turbo: 'latest',
     },
   };


### PR DESCRIPTION
## Summary

The project scaffolder wrote \`@contexture/cli: workspace:*\` into both
the root and the schema-package \`package.json\` of newly-created
projects. \`@contexture/cli\` is \`private: true\` in this monorepo
(never published to npm), and the new project has empty \`apps/\` and
\`packages/\` folders, so \`bun install\` fails on first promote-to-project:

\`\`\`
error: Workspace dependency "@contexture/cli" not found.
Searched in "./*"
\`\`\`

Nothing in the scaffolded project consumes the CLI at scaffold time —
no scripts call it, no code imports it. It was an aspirational
dependency. Drop both references.

When/if \`@contexture/cli\` ships to npm, callers can install it on
demand (e.g. as a desktop-app skill, or \`bunx @contexture/cli ...\`); it
doesn't need to be hard-wired into every scaffolded project.

Bug introduced in #210, predates anything on the active feature branch.

## Test plan

- [x] \`bun run ci\` green (typecheck + 837 tests + biome). Existing
  \`scaffold-schema-package\` tests don't pin the dep, so no test churn.
- [ ] Manual: from the desktop app, promote a scratch schema to a new
  project. Expect \`bun install\` in the new project to succeed.