### PR TITLE
docs(claude): add applification-vault skill for Obsidian vault access

### DIFF
--- a/.claude/skills/applification-vault/SKILL.md
+++ b/.claude/skills/applification-vault/SKILL.md
@@ -1,19 +1,34 @@
 ---
 name: applification-vault
-description: Read and write the Applification Ltd Obsidian vault via the local obsidian CLI. Use when planning architecture, recalling prior product/business decisions, or recording an architectural decision worth preserving for Contexture. Read-first; writes restricted to Products/Contexture/ and log.md.
+description: Read and write the Applification Ltd Obsidian vault via the obsidian CLI. Use when planning architecture, recalling prior product/business decisions, or recording an architectural decision worth preserving for Contexture. Read-first; writes restricted to Products/Contexture/ and log.md.
 ---
 
 # Applification vault
 
-Contexture is one product within Applification Ltd. The company's curated knowledge — AI engineering research, business/marketing/product thinking, and per-product strategy — lives in an Obsidian vault. This skill is the protocol for accessing it from the Contexture repo.
+Contexture is one product within Applification Ltd. The company's curated knowledge — AI engineering research, business/marketing/product thinking, and per-product strategy — lives in an Obsidian vault named `Applification Ltd`. This skill is the protocol for accessing it from the Contexture repo.
 
 ## The vault
 
-- **Name**: `Applification Ltd` (single vault on this machine — no need to pass `vault=`)
-- **Path**: `/Users/rufus/Documents/Applification Ltd`
-- **CLI**: `/usr/local/bin/obsidian` — invoked via `Bash` as `obsidian <command> …`. Run `obsidian help` or `obsidian help <command>` for the full surface.
+- **Name**: `Applification Ltd` — referenced by name, never by hardcoded path.
+- **CLI**: `obsidian` (resolved via `PATH`). Run `obsidian help` or `obsidian help <command>` for the full surface.
+- **Prerequisite check**: at the start of any session that needs the vault, confirm the CLI is installed and the vault is registered:
+  ```bash
+  command -v obsidian >/dev/null && obsidian vaults | grep -Fxq "Applification Ltd"
+  ```
+  If either fails, tell the user and stop — don't guess paths or proceed without the vault.
 
-Top-level layout:
+### Discovering the vault path
+
+The `obsidian` CLI takes **vault-relative paths** for `append`, `create`, `files`, `search`, `outline`, etc. — so most operations don't need the absolute path. The absolute path is only needed for `Read`/`Edit` on disk.
+
+When you need it, discover it dynamically — never hardcode:
+```bash
+VAULT_PATH="$(obsidian vault info=path)"
+```
+
+For multi-vault machines, pass `vault="Applification Ltd"` to disambiguate (e.g. `obsidian vault=... vault info=path`); on single-vault machines it's optional.
+
+## Top-level layout
 
 - `index.md` — curated catalog. **Always read this first** when answering "what do we know about X?"
 - `log.md` — append-only chronological record (`## [YYYY-MM-DD] <op> | <title>`)
@@ -35,14 +50,18 @@ Top-level layout:
 
 ## Read protocol
 
-1. **`index.md` first**: `Read /Users/rufus/Documents/Applification Ltd/index.md`. It's the human-curated catalog grouped by Knowledge sub-folder + tag cluster, with hub notes and Dataview blocks.
-2. **Contexture-specific context**: `Read /Users/rufus/Documents/Applification Ltd/Products/Contexture/<file>.md`. As of writing: `Contexture Future Direction.md`, `Pivot.md` — but list the folder first to catch new files: `obsidian files folder="Products/Contexture"`.
-3. **Drill into Knowledge notes** referenced by index/Contexture docs. Files are on the local filesystem at the vault path — prefer `Read` with the absolute path over `obsidian` for plain file reads (faster, no CLI overhead).
-4. **Search as fallback**, not as the first move. When you do search, prefer `search:context` over `search`:
+1. **`index.md` first**: read the curated catalog. Either via CLI-relative read or with `Read "$VAULT_PATH/index.md"` once you've resolved `VAULT_PATH`. It's grouped by Knowledge sub-folder + tag cluster, with hub notes and Dataview blocks.
+2. **Contexture-specific context**: list the folder first to catch new files, then read what's relevant:
+   ```bash
+   obsidian files folder="Products/Contexture"
+   Read "$VAULT_PATH/Products/Contexture/Contexture Future Direction.md"
+   ```
+3. **Drill into Knowledge notes** referenced by index/Contexture docs. Prefer `Read "$VAULT_PATH/<rel>"` for plain file reads (faster than CLI round-trips).
+4. **Search as fallback**, not as the first move. Prefer `search:context` over `search`:
    ```bash
    obsidian search:context query="schema designer" path=Products/Contexture limit=10
    ```
-5. **Other useful read commands** (`Bash` → `obsidian …`):
+5. **Other useful read commands** (all take vault-relative paths):
    - `obsidian files folder=<path>` — list files in a folder
    - `obsidian backlinks file="<name>"` — what links to this note
    - `obsidian links file="<name>"` — what this note links to
@@ -58,17 +77,24 @@ Top-level layout:
 
 ### Default: append to an existing direction doc
 
-When the decision extends or refines existing strategy, append a dated section to the relevant doc — usually `Products/Contexture/Contexture Future Direction.md`:
+When the decision extends or refines existing strategy, append a dated section to the relevant doc — usually `Products/Contexture/Contexture Future Direction.md`. Paths are vault-relative, so this is machine-independent:
 
 ```bash
-obsidian append path="Products/Contexture/Contexture Future Direction.md" content="\n\n## [2026-05-13] Decision: <slug>\n\n<one-paragraph summary of the decision and the why>.\n\nRelated: [[<knowledge-or-product-note>]]"
+obsidian append path="Products/Contexture/Contexture Future Direction.md" content="\n\n## [<YYYY-MM-DD>] Decision: <slug>\n\n<one-paragraph summary of the decision and the why>.\n\nRelated: [[<knowledge-or-product-note>]]"
 ```
 
 Note: the CLI converts `\n` to newlines in `content`. Quote the whole value.
 
 ### In-place edits to existing `Products/Contexture/` docs
 
-When the user wants to **revise** existing content (not just append) — e.g. updating a section in `Contexture Future Direction.md` because the direction has shifted — use `Read` + `Edit` on the absolute path: `/Users/rufus/Documents/Applification Ltd/Products/Contexture/<file>.md`. Obsidian's file watcher picks up external disk changes automatically.
+When the user wants to **revise** existing content (not just append), use `Read` + `Edit` against the resolved vault path:
+
+```bash
+VAULT_PATH="$(obsidian vault info=path)"
+# then Read "$VAULT_PATH/Products/Contexture/<file>.md" and Edit it
+```
+
+Obsidian's file watcher picks up external disk changes automatically.
 
 Reserve `obsidian append` for genuine appends and `obsidian create` for new files. Even on in-place edits: bump the `updated:` frontmatter date, append a one-liner to `log.md` summarising the change, and confirm the proposed edit with the user before writing.
 
@@ -77,15 +103,15 @@ Reserve `obsidian append` for genuine appends and `obsidian create` for new file
 Create a new file in `Products/Contexture/` when the decision is substantial and self-contained enough that it deserves its own page (e.g. a major architectural pivot, a new pricing model, a competitive positioning note). Choose a descriptive kebab-case filename, not a date-prefixed ADR slug.
 
 ```bash
-obsidian create path="Products/Contexture/<descriptive-slug>.md" content="---\ntitle: <Title>\ncreated: 2026-05-13\nupdated: 2026-05-13\ncreated-by: agent:claude-code\n---\n\n# <Title>\n\n<body, using [[wikilinks]] to related notes>"
+obsidian create path="Products/Contexture/<descriptive-slug>.md" content="---\ntitle: <Title>\ncreated: <YYYY-MM-DD>\nupdated: <YYYY-MM-DD>\ncreated-by: agent:claude-code\n---\n\n# <Title>\n\n<body, using [[wikilinks]] to related notes>"
 ```
 
 ### Always: append a one-liner to `log.md`
 
-Whether you appended or created, also append to `log.md` matching the vault's existing format:
+Whether you appended, edited, or created, also append to `log.md` matching the vault's existing format:
 
 ```bash
-obsidian append path=log.md content="\n## [2026-05-13] decision | <slug>\n\n<one-sentence summary>. See [[<note-name-without-md>]]."
+obsidian append path=log.md content="\n## [<YYYY-MM-DD>] decision | <slug>\n\n<one-sentence summary>. See [[<note-name-without-md>]]."
 ```
 
 ### Frontmatter convention for new files
@@ -107,7 +133,7 @@ Use `[[wikilinks]]` for all internal references (Obsidian convention). Link to r
 
 ## Verification after a write
 
-After any write, `Read` the target file (absolute path) to confirm the content landed correctly. The `obsidian` CLI does not always surface errors loudly.
+After any write, `Read "$VAULT_PATH/<rel>"` to confirm the content landed correctly. The `obsidian` CLI does not always surface errors loudly.
 
 ## What this skill does NOT do
 

--- a/.claude/skills/applification-vault/SKILL.md
+++ b/.claude/skills/applification-vault/SKILL.md
@@ -66,6 +66,12 @@ obsidian append path="Products/Contexture/Contexture Future Direction.md" conten
 
 Note: the CLI converts `\n` to newlines in `content`. Quote the whole value.
 
+### In-place edits to existing `Products/Contexture/` docs
+
+When the user wants to **revise** existing content (not just append) — e.g. updating a section in `Contexture Future Direction.md` because the direction has shifted — use `Read` + `Edit` on the absolute path: `/Users/rufus/Documents/Applification Ltd/Products/Contexture/<file>.md`. Obsidian's file watcher picks up external disk changes automatically.
+
+Reserve `obsidian append` for genuine appends and `obsidian create` for new files. Even on in-place edits: bump the `updated:` frontmatter date, append a one-liner to `log.md` summarising the change, and confirm the proposed edit with the user before writing.
+
 ### When to create a new file instead
 
 Create a new file in `Products/Contexture/` when the decision is substantial and self-contained enough that it deserves its own page (e.g. a major architectural pivot, a new pricing model, a competitive positioning note). Choose a descriptive kebab-case filename, not a date-prefixed ADR slug.

--- a/.claude/skills/applification-vault/SKILL.md
+++ b/.claude/skills/applification-vault/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: applification-vault
+description: Read and write the Applification Ltd Obsidian vault via the local obsidian CLI. Use when planning architecture, recalling prior product/business decisions, or recording an architectural decision worth preserving for Contexture. Read-first; writes restricted to Products/Contexture/ and log.md.
+---
+
+# Applification vault
+
+Contexture is one product within Applification Ltd. The company's curated knowledge — AI engineering research, business/marketing/product thinking, and per-product strategy — lives in an Obsidian vault. This skill is the protocol for accessing it from the Contexture repo.
+
+## The vault
+
+- **Name**: `Applification Ltd` (single vault on this machine — no need to pass `vault=`)
+- **Path**: `/Users/rufus/Documents/Applification Ltd`
+- **CLI**: `/usr/local/bin/obsidian` — invoked via `Bash` as `obsidian <command> …`. Run `obsidian help` or `obsidian help <command>` for the full surface.
+
+Top-level layout:
+
+- `index.md` — curated catalog. **Always read this first** when answering "what do we know about X?"
+- `log.md` — append-only chronological record (`## [YYYY-MM-DD] <op> | <title>`)
+- `Knowledge/{AI Engineering,Business,Engineering,Marketing,Product}/` — synthesised wiki layer
+- `Products/<Product>/` — per-product strategy & direction (Contexture, Plantry, Allotment, Ontograph, Contract Finder, Scarlett Hudson)
+- `Clippings/`, `Marketing/`, `Minutes/`, `TaxCredits/`, `Tech Stack/` — operational notes
+
+## When to use this skill
+
+**Read** before:
+- Architectural or product decisions for Contexture
+- Planning a feature that touches the product's direction
+- The user references prior thinking, a pivot, "what we decided", or vault content
+- Drafting docs/ADRs that should be informed by business context
+
+**Write** when (and only when):
+- The user has explicitly agreed an architectural decision is worth recording in the vault
+- The decision is about Contexture (not generic engineering knowledge — that's vault-curator territory)
+
+## Read protocol
+
+1. **`index.md` first**: `Read /Users/rufus/Documents/Applification Ltd/index.md`. It's the human-curated catalog grouped by Knowledge sub-folder + tag cluster, with hub notes and Dataview blocks.
+2. **Contexture-specific context**: `Read /Users/rufus/Documents/Applification Ltd/Products/Contexture/<file>.md`. As of writing: `Contexture Future Direction.md`, `Pivot.md` — but list the folder first to catch new files: `obsidian files folder="Products/Contexture"`.
+3. **Drill into Knowledge notes** referenced by index/Contexture docs. Files are on the local filesystem at the vault path — prefer `Read` with the absolute path over `obsidian` for plain file reads (faster, no CLI overhead).
+4. **Search as fallback**, not as the first move. When you do search, prefer `search:context` over `search`:
+   ```bash
+   obsidian search:context query="schema designer" path=Products/Contexture limit=10
+   ```
+5. **Other useful read commands** (`Bash` → `obsidian …`):
+   - `obsidian files folder=<path>` — list files in a folder
+   - `obsidian backlinks file="<name>"` — what links to this note
+   - `obsidian links file="<name>"` — what this note links to
+   - `obsidian outline path=<path>` — heading tree
+   - `obsidian tags sort=count` — tag frequency
+   - `obsidian tag name=<tag> verbose` — files carrying a tag
+
+## Write protocol
+
+**Scope guardrail**: writes are limited to `Products/Contexture/` and `log.md`. Touching `Knowledge/`, `Marketing/`, `Minutes/`, `Clippings/`, `.obsidian/`, or other `Products/<Product>/` folders requires the user to explicitly ask. Refuse silently-broadening the scope.
+
+**Confirm before writing**: surface the proposed content and target path to the user; get a go-ahead before running any `obsidian append`, `obsidian create`, `obsidian move`, or `obsidian delete`.
+
+### Default: append to an existing direction doc
+
+When the decision extends or refines existing strategy, append a dated section to the relevant doc — usually `Products/Contexture/Contexture Future Direction.md`:
+
+```bash
+obsidian append path="Products/Contexture/Contexture Future Direction.md" content="\n\n## [2026-05-13] Decision: <slug>\n\n<one-paragraph summary of the decision and the why>.\n\nRelated: [[<knowledge-or-product-note>]]"
+```
+
+Note: the CLI converts `\n` to newlines in `content`. Quote the whole value.
+
+### When to create a new file instead
+
+Create a new file in `Products/Contexture/` when the decision is substantial and self-contained enough that it deserves its own page (e.g. a major architectural pivot, a new pricing model, a competitive positioning note). Choose a descriptive kebab-case filename, not a date-prefixed ADR slug.
+
+```bash
+obsidian create path="Products/Contexture/<descriptive-slug>.md" content="---\ntitle: <Title>\ncreated: 2026-05-13\nupdated: 2026-05-13\ncreated-by: agent:claude-code\n---\n\n# <Title>\n\n<body, using [[wikilinks]] to related notes>"
+```
+
+### Always: append a one-liner to `log.md`
+
+Whether you appended or created, also append to `log.md` matching the vault's existing format:
+
+```bash
+obsidian append path=log.md content="\n## [2026-05-13] decision | <slug>\n\n<one-sentence summary>. See [[<note-name-without-md>]]."
+```
+
+### Frontmatter convention for new files
+
+```yaml
+---
+title: <Title>
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+created-by: agent:claude-code
+---
+```
+
+When editing an existing file you created, bump `updated:`.
+
+### Linking
+
+Use `[[wikilinks]]` for all internal references (Obsidian convention). Link to relevant `Knowledge/` notes and hub notes (e.g. `[[Agent Harness]]`, `[[Compound Engineering]]`) where the decision draws on them — those backlinks are how the vault compounds value over time.
+
+## Verification after a write
+
+After any write, `Read` the target file (absolute path) to confirm the content landed correctly. The `obsidian` CLI does not always surface errors loudly.
+
+## What this skill does NOT do
+
+- Curate clippings into Knowledge notes (that's the vault's own `/clippings-curator` skill, run from inside the vault).
+- Lint the vault (vault's `/vault-lint` skill).
+- Mirror this repo's `docs/adr/` ADRs into the vault — code-level ADRs stay in-repo; product-level decisions go to the vault.
+- Touch `.obsidian/`. Ever.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Turborepo monorepo (Bun workspaces). See [README.md](README.md) for the app/pack
 
 Coding standards live in [.sandcastle/CODING_STANDARDS.md](.sandcastle/CODING_STANDARDS.md) — they apply to all contributors, not just AFK agents. Read them before writing code.
 
+## Business context (Obsidian vault)
+
+Contexture is one product within Applification Ltd. Strategic direction, prior decisions, and curated business/engineering knowledge live in the Obsidian vault at `/Users/rufus/Documents/Applification Ltd` (single vault, name `Applification Ltd`). Access it via the local `obsidian` CLI through the [`applification-vault`](.claude/skills/applification-vault/SKILL.md) skill — read first before product/architecture planning; write only to `Products/Contexture/` and `log.md`, and only after the user has agreed a decision should be recorded.
+
 **No lint suppressions.** Never write `biome-ignore` or `eslint-disable`. If a rule fires, fix the underlying code. `bun run ci` enforces this with the `check:no-suppressions` script in [package.json](package.json).
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Coding standards live in [.sandcastle/CODING_STANDARDS.md](.sandcastle/CODING_ST
 
 ## Business context (Obsidian vault)
 
-Contexture is one product within Applification Ltd. Strategic direction, prior decisions, and curated business/engineering knowledge live in the Obsidian vault at `/Users/rufus/Documents/Applification Ltd` (single vault, name `Applification Ltd`). Access it via the local `obsidian` CLI through the [`applification-vault`](.claude/skills/applification-vault/SKILL.md) skill — read first before product/architecture planning; write only to `Products/Contexture/` and `log.md`, and only after the user has agreed a decision should be recorded.
+Contexture is one product within Applification Ltd. Strategic direction, prior decisions, and curated business/engineering knowledge live in an Obsidian vault named `Applification Ltd`. Access it through the [`applification-vault`](.claude/skills/applification-vault/SKILL.md) skill, which uses the `obsidian` CLI (resolved via `PATH`) and discovers the vault path dynamically with `obsidian vault info=path` — no machine-specific paths. Read first before product/architecture planning; write only to `Products/Contexture/` and `log.md`, and only after the user has agreed a decision should be recorded. If the CLI or vault isn't available on this machine, the skill stops and tells you.
 
 **No lint suppressions.** Never write `biome-ignore` or `eslint-disable`. If a rule fires, fix the underlying code. `bun run ci` enforces this with the `check:no-suppressions` script in [package.json](package.json).
 


### PR DESCRIPTION
## Summary

- Adds a new `applification-vault` skill at `.claude/skills/applification-vault/SKILL.md` defining how Claude reads and writes the Applification Ltd Obsidian vault via the local `obsidian` CLI.
- Read-first protocol: `index.md` → `Products/Contexture/` → drill into `Knowledge/` → `obsidian search:context` only as a fallback.
- Write scope is tight: `Products/Contexture/` and `log.md` only, and only after the user has agreed a decision is worth recording. Default is appending to existing direction docs (e.g. `Contexture Future Direction.md`); new files allowed in `Products/Contexture/` when the decision is substantial. `log.md` always gets a one-liner.
- Adds a "Business context (Obsidian vault)" section to the repo's `CLAUDE.md` pointing at the skill so future Claude sessions discover it before product/architecture planning.

Rationale: Contexture is one product within Applification Ltd, and strategic direction / prior decisions live in the vault. Giving Claude a documented, scoped path to that context makes architectural discussions better-informed without risking writes to curated `Knowledge/` notes or other products.

## Test plan

- [ ] Open a fresh Claude session in this repo and ask "what does the vault say about Contexture's direction?" — confirm the skill triggers, `index.md` is read first, then `Products/Contexture/Contexture Future Direction.md`.
- [ ] Confirm `obsidian vault` returns `Applification Ltd` and `obsidian files folder="Products/Contexture"` lists the existing files.
- [ ] Dry-run a write: when a decision is agreed in a real session, confirm Claude proposes the append + `log.md` entry and asks for go-ahead before running `obsidian append`.
- [ ] Confirm Claude refuses to write to `Knowledge/`, `Marketing/`, or other `Products/<X>/` folders without explicit prompting.