### PR TITLE
Add Codex schema-agent provider runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ This is a Turborepo monorepo:
 # Install dependencies
 bun install
 
-# Run all apps in dev mode
+# Run the desktop app in dev mode
 bun run dev
+
+# Run every app in dev mode
+bun run dev:all
 
 # Build all apps
 bun run build

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,6 +14,7 @@ import { registerDriftIpc } from './ipc/drift';
 import { registerFileIpc } from './ipc/file';
 import { registerProjectIpc } from './ipc/project';
 import { registerScaffoldIpc } from './ipc/scaffold';
+import { registerSchemaAgentIpc } from './ipc/schema-agent';
 import { registerShellIpc } from './ipc/shell';
 import { registerUpdateIpc } from './ipc/update';
 import { createMenu } from './menu';
@@ -78,6 +79,7 @@ app.whenReady().then(() => {
   registerScaffoldIpc(mainWindow);
   registerShellIpc();
   registerProjectIpc();
+  registerSchemaAgentIpc(mainWindow);
   registerClaudeIpc(mainWindow);
   registerDriftIpc(mainWindow);
 

--- a/apps/desktop/src/main/ipc/claude.ts
+++ b/apps/desktop/src/main/ipc/claude.ts
@@ -28,7 +28,7 @@ import {
   TurnContext,
 } from './claude-bridge';
 import { ChatCancelledError } from './claude-errors';
-import { invokeOpHandler } from './op-tool-bridge';
+import { invokeOpHandler, normalizeOpToolArgs } from './op-tool-bridge';
 
 const execFileAsync = promisify(execFile);
 
@@ -70,12 +70,13 @@ type ChatAuth = { mode: 'max' } | { mode: 'api-key'; key: string };
 let currentAuth: ChatAuth = { mode: 'max' };
 
 type ModelId = 'claude-haiku-4-5-20251001' | 'claude-sonnet-4-6' | 'claude-opus-4-6';
-type ThinkingBudget = 'auto' | 'low' | 'med' | 'high';
+type ThinkingBudget = 'auto' | 'low' | 'med' | 'high' | 'xhigh';
 const THINKING_TOKENS: Record<ThinkingBudget, number | undefined> = {
   auto: undefined,
   low: 2048,
   med: 8192,
   high: 16000,
+  xhigh: 32000,
 };
 let currentModel: ModelId = 'claude-sonnet-4-6';
 let currentThinkingBudget: ThinkingBudget = 'auto';
@@ -474,7 +475,10 @@ function resolveSkillsPluginPath(): string | null {
 
 function toSdkTool(descriptor: OpToolDescriptor) {
   return tool(descriptor.name, descriptor.description, descriptor.inputSchema, (args) =>
-    invokeOpHandler(descriptor.handler, args as Record<string, unknown>),
+    invokeOpHandler(
+      descriptor.handler,
+      normalizeOpToolArgs(descriptor, args as Record<string, unknown>),
+    ),
   );
 }
 

--- a/apps/desktop/src/main/ipc/op-tool-bridge.ts
+++ b/apps/desktop/src/main/ipc/op-tool-bridge.ts
@@ -66,3 +66,51 @@ export async function invokeOpHandler(
     };
   }
 }
+
+/**
+ * Claude's Agent SDK/MCP bridge can hand tool args to local tools in a
+ * slightly flatter shape than our op descriptors advertise. Type-level
+ * Contexture tools intentionally expose `{ payload: unknown }`; when the
+ * SDK gives us `{ name: "SaleLineItem" }` for `delete_type`, normalize it
+ * back to `{ payload: { name: "SaleLineItem" } }` before the op handler
+ * validates it. Keep strict field-level tools untouched.
+ */
+export function normalizeOpToolArgs(
+  descriptor: OpToolDescriptor,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  if ('payload' in args) {
+    const payload = args.payload;
+    if (isPayloadOnlyTool(descriptor) && isRecord(payload) && 'payload' in payload) {
+      return { payload: payload.payload };
+    }
+    if (descriptor.name === 'replace_schema' && isRecord(payload) && 'schema' in payload) {
+      return { schema: payload.schema };
+    }
+    if (descriptor.name === 'replace_schema' && isSchemaLike(payload)) {
+      return { schema: payload };
+    }
+    return args;
+  }
+
+  if (isPayloadOnlyTool(descriptor) && Object.keys(args).length > 0) {
+    return { payload: args };
+  }
+  if (descriptor.name === 'replace_schema' && isSchemaLike(args)) {
+    return { schema: args };
+  }
+  return args;
+}
+
+function isPayloadOnlyTool(descriptor: OpToolDescriptor): boolean {
+  const keys = Object.keys(descriptor.inputSchema);
+  return keys.length === 1 && keys[0] === 'payload';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isSchemaLike(value: unknown): boolean {
+  return isRecord(value) && value.version === '1' && Array.isArray(value.types);
+}

--- a/apps/desktop/src/main/ipc/schema-agent.ts
+++ b/apps/desktop/src/main/ipc/schema-agent.ts
@@ -2,8 +2,14 @@ import type { Schema } from '@renderer/model/ir';
 import type { BrowserWindow } from 'electron';
 import { ipcMain } from 'electron';
 import { createOpTools } from '../ops';
+import { ClaudeProviderRuntime } from '../providers/claude/runtime';
 import { CodexProviderRuntime } from '../providers/codex/runtime';
-import type { ProviderRuntime, ProviderThreadRef } from '../providers/runtime';
+import type {
+  ModelOptions,
+  ProviderKind,
+  ProviderRuntime,
+  ProviderThreadRef,
+} from '../providers/runtime';
 import {
   SCHEMA_AGENT_ASSISTANT_DELTA,
   SCHEMA_AGENT_ASSISTANT_FINAL,
@@ -37,10 +43,21 @@ export function registerSchemaAgentIpc(mainWindow: BrowserWindow): SchemaAgentIp
 
   const forwardOp = makeIpcForwardOp(toolTransport);
   const opToolDescriptors = createOpTools(forwardOp);
-  const runtime = new CodexProviderRuntime({ opToolDescriptors });
+  const runtimes: Record<ProviderKind, ProviderRuntime> = {
+    codex: new CodexProviderRuntime({ opToolDescriptors }),
+    claude: new ClaudeProviderRuntime({ opToolDescriptors }),
+  };
+  let currentProvider: ProviderKind = 'codex';
+  const activeRuntime = (): ProviderRuntime => runtimes[currentProvider];
+  const runtimeForProvider = (provider: unknown): ProviderRuntime | null => {
+    if (provider !== 'codex' && provider !== 'claude') return null;
+    return runtimes[provider];
+  };
   const turnContext = new TurnContext();
-  let currentThread: ProviderThreadRef | undefined;
-  let currentModelOptions: { model?: string; effort?: string } = {};
+  const currentThreads: Partial<Record<ProviderKind, ProviderThreadRef>> = {};
+  const currentModelOptions: Partial<
+    Record<ProviderKind, { model?: string; effort?: string; options?: ModelOptions }>
+  > = {};
   const desyncedThreads = new Set<string>();
 
   const turnController = new ChatTurnController({
@@ -48,20 +65,20 @@ export function registerSchemaAgentIpc(mainWindow: BrowserWindow): SchemaAgentIp
   });
 
   const driver = new SchemaAgentDriver({
-    runtime,
+    getRuntime: activeRuntime,
     turnController,
     transport: {
       send: (channel, payload) => mainWindow.webContents.send(channel, payload),
     },
     getCurrentIR: () => turnContext.current(),
-    getThreadRef: () => currentThread,
+    getThreadRef: () => currentThreads[currentProvider],
     setThreadRef: (thread) => {
-      currentThread = thread;
+      currentThreads[currentProvider] = thread;
     },
     markThreadDesynced: (thread) => {
-      desyncedThreads.add(thread.threadId);
+      desyncedThreads.add(threadKey(thread));
     },
-    getModelOptions: () => currentModelOptions,
+    getModelOptions: () => currentModelOptions[currentProvider] ?? {},
   });
 
   ipcMain.on('schema-agent:set-ir', (_evt, ir: Schema) => {
@@ -79,9 +96,10 @@ export function registerSchemaAgentIpc(mainWindow: BrowserWindow): SchemaAgentIp
   });
 
   ipcMain.handle('schema-agent:abort', async () => {
+    const currentThread = currentThreads[currentProvider];
     if (!currentThread) return { ok: false, error: 'no active schema-agent thread' };
     try {
-      await runtime.interruptTurn({ thread: currentThread });
+      await activeRuntime().interruptTurn({ thread: currentThread });
       return { ok: true };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -89,64 +107,74 @@ export function registerSchemaAgentIpc(mainWindow: BrowserWindow): SchemaAgentIp
     }
   });
 
-  ipcMain.handle('schema-agent:get-status', () => runtime.getStatus());
-  ipcMain.handle('schema-agent:list-models', () => runtime.listModels());
+  ipcMain.handle('schema-agent:get-status', () => activeRuntime().getStatus());
+  ipcMain.handle('schema-agent:list-models', (_evt, provider?: unknown) => {
+    const runtime = provider ? runtimeForProvider(provider) : activeRuntime();
+    if (!runtime) return [];
+    return runtime.listModels();
+  });
   ipcMain.handle('schema-agent:set-provider', (_evt, provider: unknown) => {
-    if (provider !== 'codex') {
-      return { ok: false, error: 'Only the Codex schema-agent provider is available' };
+    if (provider !== 'codex' && provider !== 'claude') {
+      return { ok: false, error: 'Unsupported schema-agent provider' };
     }
-    currentThread = undefined;
+    currentProvider = provider;
     return { ok: true };
   });
   ipcMain.handle(
     'schema-agent:set-model-options',
-    (_evt, options: { model?: string; effort?: string }) => {
-      currentModelOptions = {
+    (_evt, options: { model?: string; effort?: string; options?: ModelOptions }) => {
+      currentModelOptions[currentProvider] = {
         ...(options.model ? { model: options.model } : {}),
         ...(options.effort ? { effort: options.effort } : {}),
+        ...(options.options ? { options: options.options } : {}),
       };
       return { ok: true };
     },
   );
   ipcMain.handle(
     'schema-agent:start-login',
-    (_evt, input: { mode: 'chatgpt' | 'api-key'; apiKey?: string }) => runtime.startLogin(input),
+    (_evt, input: { mode: 'chatgpt' | 'api-key' | 'cli-session'; apiKey?: string }) =>
+      activeRuntime().startLogin(input),
   );
   ipcMain.handle('schema-agent:cancel-login', (_evt, input: { flowId: string }) =>
-    runtime.cancelLogin(input),
+    activeRuntime().cancelLogin(input),
   );
-  ipcMain.handle('schema-agent:logout', () => runtime.logout());
+  ipcMain.handle('schema-agent:logout', () => activeRuntime().logout());
   ipcMain.handle('schema-agent:thread-clear', () => {
-    currentThread = undefined;
+    currentThreads[currentProvider] = undefined;
     return { ok: true };
   });
   ipcMain.handle('schema-agent:thread-set', async (_evt, thread: ProviderThreadRef) => {
-    if (desyncedThreads.has(thread.threadId)) {
+    const runtime = runtimes[thread.provider] ?? activeRuntime();
+    currentProvider = runtime.provider;
+    if (desyncedThreads.has(threadKey(thread))) {
       mainWindow.webContents.send(SCHEMA_AGENT_THREAD_DESYNCED, {
         thread,
         reason: 'thread was previously marked desynced',
       });
-      currentThread = undefined;
+      currentThreads[currentProvider] = undefined;
       return { ok: false, error: 'thread was previously marked desynced' };
     }
 
     try {
-      currentThread = runtime.capabilities.supportsThreadResume
-        ? await runtime.resumeThread({ thread, ...currentModelOptions })
+      currentThreads[currentProvider] = runtime.capabilities.supportsThreadResume
+        ? await runtime.resumeThread({ thread, ...(currentModelOptions[currentProvider] ?? {}) })
         : thread;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
-      desyncedThreads.add(thread.threadId);
-      currentThread = undefined;
+      desyncedThreads.add(threadKey(thread));
+      currentThreads[currentProvider] = undefined;
       mainWindow.webContents.send(SCHEMA_AGENT_THREAD_DESYNCED, { thread, reason });
       return { ok: false, error: reason };
     }
 
-    mainWindow.webContents.send(SCHEMA_AGENT_THREAD_UPDATED, { thread: currentThread });
+    mainWindow.webContents.send(SCHEMA_AGENT_THREAD_UPDATED, {
+      thread: currentThreads[currentProvider],
+    });
     return { ok: true };
   });
 
-  void runtime
+  void activeRuntime()
     .getStatus()
     .then((status) => {
       mainWindow.webContents.send(SCHEMA_AGENT_STATUS_CHANGED, status);
@@ -156,7 +184,11 @@ export function registerSchemaAgentIpc(mainWindow: BrowserWindow): SchemaAgentIp
       mainWindow.webContents.send(SCHEMA_AGENT_ERROR, { message });
     });
 
-  return { runtime, driver, turnContext };
+  return { runtime: activeRuntime(), driver, turnContext };
+}
+
+function threadKey(thread: ProviderThreadRef): string {
+  return `${thread.provider}:${thread.threadId}`;
 }
 
 export const SCHEMA_AGENT_CHANNELS = {

--- a/apps/desktop/src/main/ipc/schema-agent.ts
+++ b/apps/desktop/src/main/ipc/schema-agent.ts
@@ -1,0 +1,171 @@
+import type { Schema } from '@renderer/model/ir';
+import type { BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
+import { createOpTools } from '../ops';
+import { CodexProviderRuntime } from '../providers/codex/runtime';
+import type { ProviderRuntime, ProviderThreadRef } from '../providers/runtime';
+import {
+  SCHEMA_AGENT_ASSISTANT_DELTA,
+  SCHEMA_AGENT_ASSISTANT_FINAL,
+  SCHEMA_AGENT_ERROR,
+  SCHEMA_AGENT_STATUS_CHANGED,
+  SCHEMA_AGENT_THREAD_DESYNCED,
+  SCHEMA_AGENT_THREAD_UPDATED,
+  SCHEMA_AGENT_TOOL_CALL_FINISHED,
+  SCHEMA_AGENT_TOOL_CALL_STARTED,
+  SchemaAgentDriver,
+} from '../providers/schema-agent-driver';
+import { ChatTurnController } from './chat-turn';
+import { type BridgeTransport, makeIpcForwardOp, TurnContext } from './claude-bridge';
+
+export interface SchemaAgentIpc {
+  runtime: ProviderRuntime;
+  driver: SchemaAgentDriver;
+  turnContext: TurnContext;
+}
+
+export function registerSchemaAgentIpc(mainWindow: BrowserWindow): SchemaAgentIpc {
+  const toolTransport: BridgeTransport = {
+    send: (id, payload) => {
+      mainWindow.webContents.send('schema-agent:tool-request', { id, op: payload });
+    },
+  };
+
+  ipcMain.on('schema-agent:tool-reply', (_evt, message: { id: string; result: unknown }) => {
+    toolTransport.onReply?.(message.id, message.result);
+  });
+
+  const forwardOp = makeIpcForwardOp(toolTransport);
+  const opToolDescriptors = createOpTools(forwardOp);
+  const runtime = new CodexProviderRuntime({ opToolDescriptors });
+  const turnContext = new TurnContext();
+  let currentThread: ProviderThreadRef | undefined;
+  let currentModelOptions: { model?: string; effort?: string } = {};
+  const desyncedThreads = new Set<string>();
+
+  const turnController = new ChatTurnController({
+    send: (channel, payload) => mainWindow.webContents.send(channel, payload),
+  });
+
+  const driver = new SchemaAgentDriver({
+    runtime,
+    turnController,
+    transport: {
+      send: (channel, payload) => mainWindow.webContents.send(channel, payload),
+    },
+    getCurrentIR: () => turnContext.current(),
+    getThreadRef: () => currentThread,
+    setThreadRef: (thread) => {
+      currentThread = thread;
+    },
+    markThreadDesynced: (thread) => {
+      desyncedThreads.add(thread.threadId);
+    },
+    getModelOptions: () => currentModelOptions,
+  });
+
+  ipcMain.on('schema-agent:set-ir', (_evt, ir: Schema) => {
+    turnContext.pushIR(ir);
+  });
+
+  ipcMain.handle('schema-agent:send', async (_evt, userMessage: string) => {
+    try {
+      await driver.send(userMessage);
+      return { ok: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message };
+    }
+  });
+
+  ipcMain.handle('schema-agent:abort', async () => {
+    if (!currentThread) return { ok: false, error: 'no active schema-agent thread' };
+    try {
+      await runtime.interruptTurn({ thread: currentThread });
+      return { ok: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message };
+    }
+  });
+
+  ipcMain.handle('schema-agent:get-status', () => runtime.getStatus());
+  ipcMain.handle('schema-agent:list-models', () => runtime.listModels());
+  ipcMain.handle('schema-agent:set-provider', (_evt, provider: unknown) => {
+    if (provider !== 'codex') {
+      return { ok: false, error: 'Only the Codex schema-agent provider is available' };
+    }
+    currentThread = undefined;
+    return { ok: true };
+  });
+  ipcMain.handle(
+    'schema-agent:set-model-options',
+    (_evt, options: { model?: string; effort?: string }) => {
+      currentModelOptions = {
+        ...(options.model ? { model: options.model } : {}),
+        ...(options.effort ? { effort: options.effort } : {}),
+      };
+      return { ok: true };
+    },
+  );
+  ipcMain.handle(
+    'schema-agent:start-login',
+    (_evt, input: { mode: 'chatgpt' | 'api-key'; apiKey?: string }) => runtime.startLogin(input),
+  );
+  ipcMain.handle('schema-agent:cancel-login', (_evt, input: { flowId: string }) =>
+    runtime.cancelLogin(input),
+  );
+  ipcMain.handle('schema-agent:logout', () => runtime.logout());
+  ipcMain.handle('schema-agent:thread-clear', () => {
+    currentThread = undefined;
+    return { ok: true };
+  });
+  ipcMain.handle('schema-agent:thread-set', async (_evt, thread: ProviderThreadRef) => {
+    if (desyncedThreads.has(thread.threadId)) {
+      mainWindow.webContents.send(SCHEMA_AGENT_THREAD_DESYNCED, {
+        thread,
+        reason: 'thread was previously marked desynced',
+      });
+      currentThread = undefined;
+      return { ok: false, error: 'thread was previously marked desynced' };
+    }
+
+    try {
+      currentThread = runtime.capabilities.supportsThreadResume
+        ? await runtime.resumeThread({ thread, ...currentModelOptions })
+        : thread;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      desyncedThreads.add(thread.threadId);
+      currentThread = undefined;
+      mainWindow.webContents.send(SCHEMA_AGENT_THREAD_DESYNCED, { thread, reason });
+      return { ok: false, error: reason };
+    }
+
+    mainWindow.webContents.send(SCHEMA_AGENT_THREAD_UPDATED, { thread: currentThread });
+    return { ok: true };
+  });
+
+  void runtime
+    .getStatus()
+    .then((status) => {
+      mainWindow.webContents.send(SCHEMA_AGENT_STATUS_CHANGED, status);
+    })
+    .catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      mainWindow.webContents.send(SCHEMA_AGENT_ERROR, { message });
+    });
+
+  return { runtime, driver, turnContext };
+}
+
+export const SCHEMA_AGENT_CHANNELS = {
+  assistantDelta: SCHEMA_AGENT_ASSISTANT_DELTA,
+  assistantFinal: SCHEMA_AGENT_ASSISTANT_FINAL,
+  toolCallStarted: SCHEMA_AGENT_TOOL_CALL_STARTED,
+  toolCallFinished: SCHEMA_AGENT_TOOL_CALL_FINISHED,
+  error: SCHEMA_AGENT_ERROR,
+  statusChanged: SCHEMA_AGENT_STATUS_CHANGED,
+  threadUpdated: SCHEMA_AGENT_THREAD_UPDATED,
+  threadDesynced: SCHEMA_AGENT_THREAD_DESYNCED,
+} as const;

--- a/apps/desktop/src/main/providers/claude/cli.ts
+++ b/apps/desktop/src/main/providers/claude/cli.ts
@@ -1,0 +1,49 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { ProviderStatus } from '../runtime';
+
+export interface ClaudeCliInfo {
+  installed: boolean;
+  path: string | null;
+}
+
+export type ExecFileFn = (
+  file: string,
+  args: string[],
+) => Promise<{ stdout: string; stderr?: string }>;
+
+const execFileAsync = promisify(execFile);
+
+export async function detectClaudeCli(exec: ExecFileFn = nodeExecFile): Promise<ClaudeCliInfo> {
+  try {
+    const command = process.platform === 'win32' ? 'where' : 'which';
+    const { stdout } = await exec(command, ['claude']);
+    const path = stdout.trim().split('\n')[0] || null;
+    return { installed: path !== null, path };
+  } catch {
+    return { installed: false, path: null };
+  }
+}
+
+export function claudeCliInfoToStatus(info: ClaudeCliInfo): ProviderStatus {
+  if (!info.installed) {
+    return {
+      provider: 'claude',
+      readiness: 'cli_missing',
+      detail: 'Claude CLI is not detected.',
+    };
+  }
+  return {
+    provider: 'claude',
+    readiness: 'authenticated_cli',
+    detail: 'Claude CLI session available.',
+  };
+}
+
+async function nodeExecFile(
+  file: string,
+  args: string[],
+): Promise<{ stdout: string; stderr?: string }> {
+  const { stdout, stderr } = await execFileAsync(file, args);
+  return { stdout, stderr };
+}

--- a/apps/desktop/src/main/providers/claude/runtime.ts
+++ b/apps/desktop/src/main/providers/claude/runtime.ts
@@ -1,0 +1,414 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createSdkMcpServer, query, tool } from '@anthropic-ai/claude-agent-sdk';
+import { buildSystemPromptAppend } from '@renderer/chat/system-prompt';
+import { SYSTEM_PROMPT_STDLIB } from '@renderer/services/stdlib-registry';
+import { app } from 'electron';
+import { ChatCancelledError } from '../../ipc/claude-errors';
+import { invokeOpHandler, normalizeOpToolArgs } from '../../ipc/op-tool-bridge';
+import type { OpToolDescriptor } from '../../ops';
+import { CLAUDE_FALLBACK_MODELS, claudeModelFromSdk } from '../model-registry';
+import type {
+  CancelLoginInput,
+  InterruptTurnInput,
+  LoginFlow,
+  ModelInfo,
+  ProviderCapabilities,
+  ProviderRuntime,
+  ProviderRuntimeEvent,
+  ProviderStatus,
+  ProviderThreadRef,
+  ResumeThreadInput,
+  RollbackThreadInput,
+  SendTurnInput,
+  StartLoginInput,
+  StartThreadInput,
+} from '../runtime';
+import { claudeCliInfoToStatus, detectClaudeCli, type ExecFileFn } from './cli';
+
+export const CLAUDE_PROVIDER_CAPABILITIES: ProviderCapabilities = {
+  authModes: ['cli-session', 'api-key'],
+  modelSource: 'static',
+  supportsThreadResume: true,
+  supportsThreadRollback: false,
+  supportsDynamicTools: false,
+  supportsMcpTools: true,
+  supportsInterrupt: true,
+  supportsRateLimitStatus: false,
+  supportsReasoningEffort: true,
+  supportsSchemaOnlyMode: true,
+};
+
+const THINKING_TOKENS: Record<string, number | undefined> = {
+  auto: undefined,
+  low: 2048,
+  med: 8192,
+  medium: 8192,
+  high: 16000,
+  xhigh: 32000,
+  max: 32000,
+  ultrathink: 32000,
+};
+
+type ClaudeEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+const DISALLOWED_BUILTINS = [
+  'Read',
+  'Edit',
+  'Write',
+  'Bash',
+  'Glob',
+  'Grep',
+  'Agent',
+  'NotebookEdit',
+  'WebFetch',
+  'WebSearch',
+];
+
+type ClaudeQuery = typeof query;
+
+export interface ClaudeProviderRuntimeOptions {
+  execFile?: ExecFileFn;
+  queryFn?: ClaudeQuery;
+  opToolDescriptors?: OpToolDescriptor[];
+  skillsPluginPath?: string | null;
+}
+
+type ClaudeAuth =
+  | { mode: 'cli-session'; cliPath?: string | null }
+  | { mode: 'api-key'; key: string };
+
+export class ClaudeProviderRuntime implements ProviderRuntime {
+  readonly provider = 'claude' as const;
+  readonly capabilities = CLAUDE_PROVIDER_CAPABILITIES;
+  readonly #execFile?: ExecFileFn;
+  readonly #query: ClaudeQuery;
+  readonly #opToolDescriptors: OpToolDescriptor[];
+  readonly #mcpServer: ReturnType<typeof createSdkMcpServer>;
+  readonly #allowedTools: string[];
+  readonly #skillsPluginPath: string | null;
+  #auth: ClaudeAuth = { mode: 'cli-session' };
+  #currentQuery: { interrupt(): Promise<void> } | null = null;
+  #cancelRequested = false;
+
+  constructor(options: ClaudeProviderRuntimeOptions = {}) {
+    this.#execFile = options.execFile;
+    this.#query = options.queryFn ?? query;
+    this.#opToolDescriptors = options.opToolDescriptors ?? [];
+    this.#mcpServer = createSdkMcpServer({
+      name: 'contexture-ops',
+      version: '1.0.0',
+      tools: this.#opToolDescriptors.map(toSdkTool),
+    });
+    this.#allowedTools = this.#opToolDescriptors.map((tool) => `mcp__contexture-ops__${tool.name}`);
+    this.#skillsPluginPath =
+      'skillsPluginPath' in options
+        ? (options.skillsPluginPath ?? null)
+        : resolveSkillsPluginPath();
+  }
+
+  async getStatus(): Promise<ProviderStatus> {
+    if (this.#auth.mode === 'api-key') {
+      return { provider: 'claude', readiness: 'authenticated_api_key' };
+    }
+    const cli = await detectClaudeCli(this.#execFile);
+    if (cli.installed) this.#auth = { mode: 'cli-session', cliPath: cli.path };
+    return claudeCliInfoToStatus(cli);
+  }
+
+  async listModels(): Promise<ModelInfo[]> {
+    try {
+      const iterator = this.#query({
+        prompt: emptyPrompt(),
+        options: this.#baseQueryOptions(),
+      });
+      try {
+        const models = (await iterator.supportedModels())
+          .map(claudeModelFromSdk)
+          .filter((model): model is ModelInfo => model !== null);
+        return models.length > 0 ? models : CLAUDE_FALLBACK_MODELS;
+      } finally {
+        iterator.close?.();
+      }
+    } catch {
+      return CLAUDE_FALLBACK_MODELS;
+    }
+  }
+
+  async startThread(_input: StartThreadInput): Promise<ProviderThreadRef> {
+    return {
+      provider: 'claude',
+      threadId: cryptoRandomId(),
+      opaque: {},
+    };
+  }
+
+  async resumeThread(input: ResumeThreadInput): Promise<ProviderThreadRef> {
+    return input.thread;
+  }
+
+  async *sendTurn(input: SendTurnInput): AsyncIterable<ProviderRuntimeEvent> {
+    const resume = readSessionId(input.thread);
+    let finalAssistant = '';
+    this.#cancelRequested = false;
+
+    yield { type: 'turn_started', thread: input.thread };
+
+    try {
+      const thinking = claudeThinkingConfig(input.options);
+      const effort = claudeEffort(input.options, input.effort);
+      const fastMode = readBooleanOption(input.options, 'fastMode');
+      const model = claudeModelWithContext(
+        input.model ?? CLAUDE_FALLBACK_MODELS[0].id,
+        input.options,
+      );
+      const iterator = this.#query({
+        prompt: input.message,
+        options: {
+          ...this.#baseQueryOptions(),
+          allowedTools: this.#allowedTools,
+          disallowedTools: DISALLOWED_BUILTINS,
+          model,
+          ...(thinking ? { thinking } : {}),
+          ...(effort ? { effort } : {}),
+          ...(fastMode !== null ? { settings: { fastMode, fastModePerSessionOptIn: true } } : {}),
+          mcpServers: { 'contexture-ops': this.#mcpServer },
+          ...(resume ? { resume } : {}),
+        },
+      });
+      this.#currentQuery = iterator;
+
+      for await (const message of iterator) {
+        const sessionId = extractSessionId(message);
+        if (sessionId) {
+          writeSessionId(input.thread, sessionId);
+          yield { type: 'thread_resumed', thread: input.thread };
+        }
+
+        const event = mapClaudeMessage(message);
+        if (!event) continue;
+        if (event.type === 'assistant_delta') finalAssistant += event.text;
+        yield event;
+        if (event.type === 'turn_failed') return;
+      }
+
+      if (this.#cancelRequested) throw new ChatCancelledError();
+      yield { type: 'turn_completed' };
+      if (finalAssistant.trim()) yield { type: 'assistant_final', text: finalAssistant };
+    } catch (err) {
+      if (err instanceof ChatCancelledError) {
+        yield { type: 'turn_interrupted', message: err.message };
+        return;
+      }
+      yield { type: 'turn_failed', message: err instanceof Error ? err.message : String(err) };
+    } finally {
+      this.#cancelRequested = false;
+      this.#currentQuery = null;
+    }
+  }
+
+  async interruptTurn(_input: InterruptTurnInput): Promise<void> {
+    if (!this.#currentQuery) throw new Error('no active Claude query');
+    this.#cancelRequested = true;
+    await this.#currentQuery.interrupt();
+  }
+
+  async rollbackThread(_input: RollbackThreadInput): Promise<void> {
+    throw new Error('Claude provider does not support thread rollback');
+  }
+
+  async startLogin(input: StartLoginInput): Promise<LoginFlow> {
+    if (input.mode === 'api-key') {
+      if (!input.apiKey) throw new Error('API key is required for Claude API-key login');
+      this.#auth = { mode: 'api-key', key: input.apiKey };
+      return { id: 'api-key', mode: 'api-key' };
+    }
+    if (input.mode !== 'cli-session') {
+      throw new Error(`Claude does not support ${input.mode} login`);
+    }
+    const cli = await detectClaudeCli(this.#execFile);
+    if (!cli.installed) throw new Error('Claude CLI is not detected');
+    this.#auth = { mode: 'cli-session', cliPath: cli.path };
+    return { id: cli.path ?? 'claude', mode: 'cli-session' };
+  }
+
+  async cancelLogin(_input: CancelLoginInput): Promise<void> {
+    return undefined;
+  }
+
+  async logout(): Promise<void> {
+    this.#auth = { mode: 'cli-session' };
+  }
+
+  #baseQueryOptions(): Parameters<ClaudeQuery>[0]['options'] {
+    return {
+      systemPrompt: {
+        type: 'preset',
+        preset: 'claude_code',
+        append: buildSystemPromptAppend({ stdlibRegistry: SYSTEM_PROMPT_STDLIB }),
+      },
+      pathToClaudeCodeExecutable:
+        this.#auth.mode === 'cli-session' ? (this.#auth.cliPath ?? 'claude') : 'claude',
+      ...(this.#skillsPluginPath
+        ? { plugins: [{ type: 'local' as const, path: this.#skillsPluginPath }] }
+        : {}),
+      ...(this.#auth.mode === 'api-key' ? { env: { ANTHROPIC_API_KEY: this.#auth.key } } : {}),
+    };
+  }
+}
+
+async function* emptyPrompt(): AsyncIterable<never> {}
+
+function toSdkTool(descriptor: OpToolDescriptor) {
+  return tool(descriptor.name, descriptor.description, descriptor.inputSchema, (args) =>
+    invokeOpHandler(
+      descriptor.handler,
+      normalizeOpToolArgs(descriptor, args as Record<string, unknown>),
+    ),
+  );
+}
+
+function mapClaudeMessage(message: unknown): ProviderRuntimeEvent | null {
+  if (!message || typeof message !== 'object') return null;
+  const msg = message as {
+    type?: unknown;
+    message?: { content?: unknown };
+    subtype?: unknown;
+    is_error?: unknown;
+    result?: unknown;
+  };
+  if (msg.type === 'assistant') {
+    const content = Array.isArray(msg.message?.content) ? msg.message.content : [];
+    const textParts = content.filter(isTextPart).map((part) => part.text);
+    if (textParts.length > 0) return { type: 'assistant_delta', text: textParts.join('') };
+    const toolUse = content.find(isToolUsePart);
+    if (toolUse) {
+      return {
+        type: 'tool_call_started',
+        id: toolUse.id ?? toolUse.name,
+        name: toolUse.name,
+        input: toolUse.input,
+      };
+    }
+  }
+  if (msg.type === 'result' && (msg.subtype !== 'success' || msg.is_error === true)) {
+    return {
+      type: 'turn_failed',
+      message: typeof msg.result === 'string' ? msg.result : 'Claude turn failed',
+    };
+  }
+  return null;
+}
+
+function isTextPart(part: unknown): part is { type: 'text'; text: string } {
+  return (
+    !!part &&
+    typeof part === 'object' &&
+    (part as { type?: unknown }).type === 'text' &&
+    typeof (part as { text?: unknown }).text === 'string'
+  );
+}
+
+function isToolUsePart(
+  part: unknown,
+): part is { type: 'tool_use'; id?: string; name: string; input: unknown } {
+  return (
+    !!part &&
+    typeof part === 'object' &&
+    (part as { type?: unknown }).type === 'tool_use' &&
+    typeof (part as { name?: unknown }).name === 'string'
+  );
+}
+
+function extractSessionId(message: unknown): string | null {
+  if (!message || typeof message !== 'object') return null;
+  const msg = message as { type?: unknown; subtype?: unknown; session_id?: unknown };
+  if (msg.type !== 'system' || msg.subtype !== 'init') return null;
+  return typeof msg.session_id === 'string' && msg.session_id.length > 0 ? msg.session_id : null;
+}
+
+function readSessionId(thread: ProviderThreadRef): string | undefined {
+  if (!thread.opaque || typeof thread.opaque !== 'object') return undefined;
+  const sessionId = (thread.opaque as { sessionId?: unknown }).sessionId;
+  return typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : undefined;
+}
+
+function claudeThinkingConfig(
+  options: Record<string, string | boolean> | undefined,
+): { type: 'adaptive' } | { type: 'disabled' } | undefined {
+  if (options?.thinking === false) return { type: 'disabled' };
+  if (options?.thinking === true) return { type: 'adaptive' };
+  return undefined;
+}
+
+function claudeEffort(
+  options: Record<string, string | boolean> | undefined,
+  fallbackEffort: string | undefined,
+): ClaudeEffort | undefined {
+  const effort =
+    readStringOption(options, 'reasoningEffort') ??
+    readStringOption(options, 'effort') ??
+    fallbackEffort;
+  if (effort === 'ultrathink') return 'xhigh';
+  if (
+    effort === 'low' ||
+    effort === 'medium' ||
+    effort === 'high' ||
+    effort === 'xhigh' ||
+    effort === 'max'
+  ) {
+    return effort;
+  }
+  if (effort && THINKING_TOKENS[effort] !== undefined) return effort === 'med' ? 'medium' : 'high';
+  return undefined;
+}
+
+function readStringOption(
+  options: Record<string, string | boolean> | undefined,
+  key: string,
+): string | null {
+  const value = options?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readBooleanOption(
+  options: Record<string, string | boolean> | undefined,
+  key: string,
+): boolean | null {
+  const value = options?.[key];
+  return typeof value === 'boolean' ? value : null;
+}
+
+function claudeModelWithContext(
+  model: string,
+  options: Record<string, string | boolean> | undefined,
+): string {
+  const contextWindow = readStringOption(options, 'contextWindow');
+  if (contextWindow === '1m' && !model.toLowerCase().includes('[1m]')) return `${model}[1m]`;
+  if (contextWindow === '200k') return model.replace(/\[1m\]/gi, '');
+  return model;
+}
+
+function writeSessionId(thread: ProviderThreadRef, sessionId: string): void {
+  const opaque = thread.opaque && typeof thread.opaque === 'object' ? thread.opaque : {};
+  thread.opaque = { ...opaque, sessionId };
+  thread.threadId = sessionId;
+}
+
+function resolveSkillsPluginPath(): string | null {
+  const candidates = [
+    join(process.resourcesPath ?? '', 'skills'),
+    join(app.getAppPath(), 'resources', 'skills'),
+  ];
+  for (const candidate of candidates) {
+    if (candidate && existsSync(join(candidate, '.claude-plugin', 'plugin.json'))) return candidate;
+  }
+  return null;
+}
+
+function cryptoRandomId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  return c?.randomUUID
+    ? c.randomUUID()
+    : `claude-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+}

--- a/apps/desktop/src/main/providers/codex/app-server.ts
+++ b/apps/desktop/src/main/providers/codex/app-server.ts
@@ -1,0 +1,51 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import { CodexJsonRpcClient } from './json-rpc';
+
+export type SpawnCodexAppServerFn = (
+  command: string,
+  args: string[],
+  options: { stdio: 'pipe'; env: NodeJS.ProcessEnv },
+) => ChildProcessWithoutNullStreams;
+
+export interface CodexAppServerOptions {
+  codexPath?: string;
+  spawnFn?: SpawnCodexAppServerFn;
+  env?: NodeJS.ProcessEnv;
+  onExit?: (code: number | null, signal: NodeJS.Signals | null) => void;
+}
+
+export interface CodexAppServerConnection {
+  process: ChildProcessWithoutNullStreams;
+  client: CodexJsonRpcClient;
+  dispose: () => void;
+}
+
+export function startCodexAppServer({
+  codexPath = 'codex',
+  spawnFn = spawn,
+  env = process.env,
+  onExit,
+}: CodexAppServerOptions = {}): CodexAppServerConnection {
+  const child = spawnFn(codexPath, ['app-server', '--listen', 'stdio://'], {
+    stdio: 'pipe',
+    env,
+  });
+  const client = new CodexJsonRpcClient({
+    input: child.stdout,
+    output: child.stdin,
+  });
+  child.once('exit', (code, signal) => {
+    client.dispose();
+    onExit?.(code, signal);
+  });
+
+  return {
+    process: child,
+    client,
+    dispose: () => {
+      client.dispose();
+      if (!child.killed) child.kill();
+    },
+  };
+}

--- a/apps/desktop/src/main/providers/codex/cli.ts
+++ b/apps/desktop/src/main/providers/codex/cli.ts
@@ -1,0 +1,96 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { ProviderStatus } from '../runtime';
+import { CODEX_PROVIDER_MIN_CLI_VERSION } from './version';
+
+export interface CodexCliInfo {
+  installed: boolean;
+  path: string | null;
+  version: string | null;
+  supported: boolean;
+}
+
+export type ExecFileFn = (
+  file: string,
+  args: string[],
+) => Promise<{ stdout: string; stderr?: string }>;
+
+const execFileAsync = promisify(execFile);
+
+export async function detectCodexCli(exec: ExecFileFn = nodeExecFile): Promise<CodexCliInfo> {
+  const path = await findCodexPath(exec);
+  if (!path) {
+    return { installed: false, path: null, version: null, supported: false };
+  }
+
+  try {
+    const { stdout } = await exec(path, ['--version']);
+    const version = parseCodexVersion(stdout);
+    return {
+      installed: true,
+      path,
+      version,
+      supported: version !== null && compareSemver(version, CODEX_PROVIDER_MIN_CLI_VERSION) >= 0,
+    };
+  } catch {
+    return { installed: true, path, version: null, supported: false };
+  }
+}
+
+export function codexCliInfoToStatus(info: CodexCliInfo): ProviderStatus {
+  if (!info.installed) {
+    return {
+      provider: 'codex',
+      readiness: 'cli_missing',
+      minimumCliVersion: CODEX_PROVIDER_MIN_CLI_VERSION,
+    };
+  }
+  if (!info.supported) {
+    return {
+      provider: 'codex',
+      readiness: 'cli_outdated',
+      cliVersion: info.version ?? undefined,
+      minimumCliVersion: CODEX_PROVIDER_MIN_CLI_VERSION,
+    };
+  }
+  return {
+    provider: 'codex',
+    readiness: 'app_server_unavailable',
+    detail: 'Codex CLI is available; app-server connection is not initialized yet.',
+    cliVersion: info.version ?? undefined,
+    minimumCliVersion: CODEX_PROVIDER_MIN_CLI_VERSION,
+  };
+}
+
+export function parseCodexVersion(output: string): string | null {
+  const match = output.match(/codex-cli\s+(\d+\.\d+\.\d+)/);
+  return match?.[1] ?? null;
+}
+
+export function compareSemver(a: string, b: string): number {
+  const left = a.split('.').map((part) => Number.parseInt(part, 10));
+  const right = b.split('.').map((part) => Number.parseInt(part, 10));
+  for (let i = 0; i < 3; i += 1) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+async function findCodexPath(exec: ExecFileFn): Promise<string | null> {
+  try {
+    const command = process.platform === 'win32' ? 'where' : 'which';
+    const { stdout } = await exec(command, ['codex']);
+    return stdout.trim().split('\n')[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+async function nodeExecFile(
+  file: string,
+  args: string[],
+): Promise<{ stdout: string; stderr?: string }> {
+  const { stdout, stderr } = await execFileAsync(file, args);
+  return { stdout, stderr };
+}

--- a/apps/desktop/src/main/providers/codex/json-rpc.ts
+++ b/apps/desktop/src/main/providers/codex/json-rpc.ts
@@ -1,0 +1,165 @@
+import { createInterface, type Interface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+
+type JsonRpcId = number | string;
+
+export interface JsonRpcRequestMessage {
+  jsonrpc: '2.0';
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcNotificationMessage {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcResponseMessage {
+  jsonrpc: '2.0';
+  id: JsonRpcId;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export type JsonRpcIncomingMessage =
+  | JsonRpcRequestMessage
+  | JsonRpcNotificationMessage
+  | JsonRpcResponseMessage;
+
+export interface CodexJsonRpcClientOptions {
+  input: Readable;
+  output: Writable;
+  onNotification?: (message: JsonRpcNotificationMessage) => void;
+  onServerRequest?: (message: JsonRpcRequestMessage, client: CodexJsonRpcClient) => void;
+}
+
+export class CodexJsonRpcClient {
+  readonly #output: Writable;
+  readonly #notificationListeners = new Set<(message: JsonRpcNotificationMessage) => void>();
+  readonly #serverRequestListeners = new Set<
+    (message: JsonRpcRequestMessage, client: CodexJsonRpcClient) => boolean | undefined
+  >();
+  readonly #reader: Interface;
+  readonly #pending = new Map<
+    JsonRpcId,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+  #nextId = 1;
+
+  constructor({ input, output, onNotification, onServerRequest }: CodexJsonRpcClientOptions) {
+    this.#output = output;
+    if (onNotification) this.#notificationListeners.add(onNotification);
+    if (onServerRequest) {
+      this.#serverRequestListeners.add((message, client) => {
+        onServerRequest(message, client);
+        return true;
+      });
+    }
+    this.#reader = createInterface({ input });
+    this.#reader.on('line', (line) => this.#handleLine(line));
+    this.#reader.on('close', () =>
+      this.#rejectAll(new Error('Codex app-server connection closed')),
+    );
+  }
+
+  onNotification(listener: (message: JsonRpcNotificationMessage) => void): () => void {
+    this.#notificationListeners.add(listener);
+    return () => this.#notificationListeners.delete(listener);
+  }
+
+  onServerRequest(
+    listener: (message: JsonRpcRequestMessage, client: CodexJsonRpcClient) => boolean | undefined,
+  ): () => void {
+    this.#serverRequestListeners.add(listener);
+    return () => this.#serverRequestListeners.delete(listener);
+  }
+
+  request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    const id = this.#nextId;
+    this.#nextId += 1;
+    const message: JsonRpcRequestMessage = { jsonrpc: '2.0', id, method, params };
+    return new Promise<T>((resolve, reject) => {
+      this.#pending.set(id, {
+        resolve: (value) => resolve(value as T),
+        reject,
+      });
+      this.#write(message);
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    this.#write({ jsonrpc: '2.0', method, params });
+  }
+
+  respond(id: JsonRpcId, result: unknown): void {
+    this.#write({ jsonrpc: '2.0', id, result });
+  }
+
+  respondError(id: JsonRpcId, code: number, message: string, data?: unknown): void {
+    this.#write({ jsonrpc: '2.0', id, error: { code, message, data } });
+  }
+
+  dispose(): void {
+    this.#reader.close();
+    this.#rejectAll(new Error('Codex app-server connection disposed'));
+  }
+
+  #handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let parsed: JsonRpcIncomingMessage;
+    try {
+      parsed = JSON.parse(trimmed) as JsonRpcIncomingMessage;
+    } catch {
+      return;
+    }
+
+    if ('id' in parsed && !('method' in parsed)) {
+      this.#handleResponse(parsed);
+      return;
+    }
+
+    if ('id' in parsed && 'method' in parsed) {
+      let handled = false;
+      for (const listener of this.#serverRequestListeners) {
+        if (listener(parsed, this) === true) {
+          handled = true;
+          break;
+        }
+      }
+      if (!handled)
+        this.respondError(parsed.id, -32601, `Unhandled server request: ${parsed.method}`);
+      return;
+    }
+
+    if ('method' in parsed) {
+      for (const listener of this.#notificationListeners) listener(parsed);
+    }
+  }
+
+  #handleResponse(message: JsonRpcResponseMessage): void {
+    const pending = this.#pending.get(message.id);
+    if (!pending) return;
+    this.#pending.delete(message.id);
+    if (message.error) {
+      pending.reject(new Error(message.error.message));
+      return;
+    }
+    pending.resolve(message.result);
+  }
+
+  #write(
+    message: JsonRpcRequestMessage | JsonRpcNotificationMessage | JsonRpcResponseMessage,
+  ): void {
+    this.#output.write(`${JSON.stringify(message)}\n`);
+  }
+
+  #rejectAll(error: Error): void {
+    for (const pending of this.#pending.values()) {
+      pending.reject(error);
+    }
+    this.#pending.clear();
+  }
+}

--- a/apps/desktop/src/main/providers/codex/runtime.ts
+++ b/apps/desktop/src/main/providers/codex/runtime.ts
@@ -1,0 +1,618 @@
+import { tmpdir } from 'node:os';
+import type { OpToolDescriptor } from '../../ops';
+import type {
+  CancelLoginInput,
+  InterruptTurnInput,
+  LoginFlow,
+  ModelInfo,
+  ProviderCapabilities,
+  ProviderRuntime,
+  ProviderRuntimeEvent,
+  ProviderStatus,
+  ProviderThreadRef,
+  ResumeThreadInput,
+  RollbackThreadInput,
+  SendTurnInput,
+  StartLoginInput,
+  StartThreadInput,
+} from '../runtime';
+import { type CodexAppServerConnection, startCodexAppServer } from './app-server';
+import { codexCliInfoToStatus, detectCodexCli, type ExecFileFn } from './cli';
+import { handleCodexDynamicToolCall, toCodexDynamicTools } from './tools';
+import type {
+  AccountRateLimitsUpdatedNotification,
+  AccountUpdatedNotification,
+  AgentMessageDeltaNotification,
+  AskForApproval,
+  CancelLoginAccountResponse,
+  DynamicToolCallItem,
+  DynamicToolCallParams,
+  ErrorNotification,
+  GetAccountRateLimitsResponse,
+  GetAccountResponse,
+  InitializeResponse,
+  ItemNotification,
+  LoginAccountResponse,
+  LogoutAccountResponse,
+  ModelListResponse,
+  RateLimitSnapshot,
+  ServerNotification,
+  ServerRequest,
+  ThreadResumeResponse,
+  ThreadRollbackResponse,
+  ThreadStartResponse,
+  TurnCompletedNotification,
+  TurnInterruptResponse,
+  TurnStartResponse,
+} from './types';
+
+export const CODEX_PROVIDER_CAPABILITIES: ProviderCapabilities = {
+  authModes: ['chatgpt', 'api-key'],
+  modelSource: 'runtime',
+  supportsThreadResume: true,
+  supportsThreadRollback: true,
+  supportsDynamicTools: true,
+  supportsMcpTools: false,
+  supportsInterrupt: true,
+  supportsRateLimitStatus: true,
+  supportsReasoningEffort: true,
+  supportsSchemaOnlyMode: true,
+};
+
+const SCHEMA_AGENT_CODEX_CWD = tmpdir();
+const SCHEMA_AGENT_APPROVAL_POLICY: AskForApproval = {
+  granular: {
+    sandbox_approval: true,
+    rules: true,
+    skill_approval: true,
+    request_permissions: true,
+    mcp_elicitations: true,
+  },
+};
+
+export interface CodexProviderRuntimeOptions {
+  execFile?: ExecFileFn;
+  appServerFactory?: (codexPath?: string) => CodexAppServerConnection;
+  opToolDescriptors?: OpToolDescriptor[];
+}
+
+export class CodexProviderRuntime implements ProviderRuntime {
+  readonly provider = 'codex' as const;
+  readonly capabilities = CODEX_PROVIDER_CAPABILITIES;
+  readonly #execFile?: ExecFileFn;
+  readonly #appServerFactory: (codexPath?: string) => CodexAppServerConnection;
+  readonly #opToolDescriptors: OpToolDescriptor[];
+  #connection: CodexAppServerConnection | null = null;
+  #initializePromise: Promise<InitializeResponse> | null = null;
+  #lastAuthenticatedReadiness: ProviderStatus['readiness'] = 'not_signed_in';
+
+  constructor(options: CodexProviderRuntimeOptions = {}) {
+    this.#execFile = options.execFile;
+    this.#appServerFactory =
+      options.appServerFactory ?? ((codexPath) => startCodexAppServer({ codexPath }));
+    this.#opToolDescriptors = options.opToolDescriptors ?? [];
+  }
+
+  async getStatus(): Promise<ProviderStatus> {
+    const cli = await detectCodexCli(this.#execFile);
+    const cliStatus = codexCliInfoToStatus(cli);
+    if (!cli.installed || !cli.supported) return cliStatus;
+
+    try {
+      const connection = await this.#ensureConnection(cli.path ?? undefined);
+      const response = await connection.client.request<GetAccountResponse>('account/read', {});
+      if (response.account?.type === 'chatgpt' || response.account?.type === 'apiKey') {
+        const readiness =
+          response.account.type === 'chatgpt' ? 'authenticated_chatgpt' : 'authenticated_api_key';
+        this.#lastAuthenticatedReadiness = readiness;
+        const status: ProviderStatus = {
+          provider: 'codex',
+          readiness,
+          cliVersion: cli.version ?? undefined,
+          minimumCliVersion: cliStatus.minimumCliVersion,
+        };
+        return (await this.#readRateLimitStatus(status)) ?? status;
+      }
+      this.#lastAuthenticatedReadiness = 'not_signed_in';
+      return {
+        provider: 'codex',
+        readiness: 'not_signed_in',
+        cliVersion: cli.version ?? undefined,
+        minimumCliVersion: cliStatus.minimumCliVersion,
+      };
+    } catch (err) {
+      return {
+        ...cliStatus,
+        detail: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  async listModels(): Promise<ModelInfo[]> {
+    const connection = await this.#ensureConnection();
+    const models: ModelInfo[] = [];
+    let cursor: string | null = null;
+
+    do {
+      const response = await connection.client.request<ModelListResponse>('model/list', {
+        cursor,
+        includeHidden: false,
+      });
+      for (const model of response.data) {
+        models.push({
+          id: model.model || model.id,
+          label: model.displayName || model.model || model.id,
+          supportsReasoningEffort: model.supportedReasoningEfforts.length > 0,
+        });
+      }
+      cursor = response.nextCursor;
+    } while (cursor);
+
+    return models;
+  }
+
+  async startThread(input: StartThreadInput): Promise<ProviderThreadRef> {
+    const connection = await this.#ensureConnection();
+    const response = await connection.client.request<ThreadStartResponse>('thread/start', {
+      model: input.model ?? null,
+      cwd: SCHEMA_AGENT_CODEX_CWD,
+      approvalPolicy: SCHEMA_AGENT_APPROVAL_POLICY,
+      sandbox: 'read-only',
+      environments: [],
+      config: {
+        web_search: 'disabled',
+        tools: { view_image: false },
+      },
+      developerInstructions: buildSchemaOnlyInstructions(),
+      dynamicTools: toCodexDynamicTools(this.#opToolDescriptors),
+      experimentalRawEvents: false,
+      persistExtendedHistory: false,
+    });
+    return {
+      provider: 'codex',
+      threadId: response.thread.id,
+      opaque: { thread: response.thread },
+    };
+  }
+
+  async resumeThread(input: ResumeThreadInput): Promise<ProviderThreadRef> {
+    const connection = await this.#ensureConnection();
+    const response = await connection.client.request<ThreadResumeResponse>('thread/resume', {
+      threadId: input.thread.threadId,
+      model: input.model ?? null,
+      cwd: SCHEMA_AGENT_CODEX_CWD,
+      approvalPolicy: SCHEMA_AGENT_APPROVAL_POLICY,
+      sandbox: 'read-only',
+      config: {
+        web_search: 'disabled',
+        tools: { view_image: false },
+      },
+      developerInstructions: buildSchemaOnlyInstructions(),
+      excludeTurns: true,
+      persistExtendedHistory: false,
+    });
+    return {
+      provider: 'codex',
+      threadId: response.thread.id,
+      opaque: { thread: response.thread },
+    };
+  }
+
+  async *sendTurn(input: SendTurnInput): AsyncIterable<ProviderRuntimeEvent> {
+    const connection = await this.#ensureConnection();
+    const queue = new AsyncEventQueue<ProviderRuntimeEvent>();
+    let turnId: string | null = null;
+    let finalAssistant = '';
+
+    const offNotification = connection.client.onNotification((message) => {
+      const statusEvent = this.#mapStatusNotification(message as ServerNotification);
+      if (statusEvent) {
+        queue.push(statusEvent);
+        return;
+      }
+      const event = mapCodexNotification(message as ServerNotification, input.thread, turnId);
+      if (!event) return;
+      if (event.type === 'assistant_delta') finalAssistant += event.text;
+      queue.push(event);
+      if (
+        event.type === 'turn_completed' ||
+        event.type === 'turn_failed' ||
+        event.type === 'turn_interrupted'
+      ) {
+        if (finalAssistant.trim()) queue.push({ type: 'assistant_final', text: finalAssistant });
+        queue.close();
+      }
+    });
+
+    const offServerRequest = connection.client.onServerRequest((message, client) => {
+      const request = message as ServerRequest;
+      const requestThreadId = readServerRequestThreadId(request);
+      if (requestThreadId && requestThreadId !== input.thread.threadId) return false;
+      const requestTurnId = readServerRequestTurnId(request);
+      if (turnId && requestTurnId && requestTurnId !== turnId) return false;
+      const forbidden = forbiddenServerRequestMessage(request);
+      if (forbidden) {
+        client.respondError(request.id, -32000, forbidden);
+        queue.push({ type: 'turn_failed', message: forbidden });
+        queue.close();
+        return true;
+      }
+      if (request.method !== 'item/tool/call') return false;
+      const params = request.params as DynamicToolCallParams;
+      if (params.threadId !== input.thread.threadId) return false;
+      handleCodexDynamicToolCall(params, this.#opToolDescriptors)
+        .then((result) => client.respond(request.id, result))
+        .catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          client.respondError(request.id, -32000, message);
+        });
+      return true;
+    });
+
+    try {
+      const response = await connection.client.request<TurnStartResponse>('turn/start', {
+        threadId: input.thread.threadId,
+        input: [{ type: 'text', text: input.message, text_elements: [] }],
+        environments: [],
+        cwd: SCHEMA_AGENT_CODEX_CWD,
+        approvalPolicy: SCHEMA_AGENT_APPROVAL_POLICY,
+        sandboxPolicy: { type: 'readOnly', networkAccess: false },
+        model: input.model ?? null,
+        effort: input.effort ?? null,
+      });
+      turnId = response.turn.id;
+      writeCurrentTurnId(input.thread, turnId);
+      yield { type: 'turn_started', thread: input.thread };
+
+      for await (const event of queue) {
+        yield event;
+      }
+    } finally {
+      offNotification();
+      offServerRequest();
+    }
+  }
+
+  async interruptTurn(input: InterruptTurnInput): Promise<void> {
+    const turnId = readCurrentTurnId(input.thread);
+    if (!turnId) throw new Error('Cannot interrupt Codex turn before a turn id is known');
+    const connection = await this.#ensureConnection();
+    await connection.client.request<TurnInterruptResponse>('turn/interrupt', {
+      threadId: input.thread.threadId,
+      turnId,
+    });
+  }
+
+  async rollbackThread(input: RollbackThreadInput): Promise<void> {
+    const connection = await this.#ensureConnection();
+    await connection.client.request<ThreadRollbackResponse>('thread/rollback', {
+      threadId: input.thread.threadId,
+      numTurns: input.turns,
+    });
+  }
+
+  async startLogin(input: StartLoginInput): Promise<LoginFlow> {
+    const connection = await this.#ensureConnection();
+    if (input.mode === 'api-key') {
+      if (!input.apiKey) throw new Error('API key is required for Codex API-key login');
+      await connection.client.request<LoginAccountResponse>('account/login/start', {
+        type: 'apiKey',
+        apiKey: input.apiKey,
+      });
+      return { id: 'api-key', mode: 'api-key' };
+    }
+
+    const response = await connection.client.request<LoginAccountResponse>('account/login/start', {
+      type: 'chatgpt',
+      codexStreamlinedLogin: true,
+    });
+    if (response.type !== 'chatgpt' || !response.loginId) {
+      throw new Error(`Unexpected Codex login response: ${response.type}`);
+    }
+    return { id: response.loginId, mode: 'chatgpt', url: response.authUrl };
+  }
+
+  async cancelLogin(input: CancelLoginInput): Promise<void> {
+    const connection = await this.#ensureConnection();
+    await connection.client.request<CancelLoginAccountResponse>('account/login/cancel', {
+      loginId: input.flowId,
+    });
+  }
+
+  async logout(): Promise<void> {
+    const connection = await this.#ensureConnection();
+    await connection.client.request<LogoutAccountResponse>('account/logout', undefined);
+  }
+
+  async #readRateLimitStatus(baseStatus: ProviderStatus): Promise<ProviderStatus | null> {
+    try {
+      const connection = await this.#ensureConnection();
+      const response =
+        await connection.client.request<GetAccountRateLimitsResponse>('account/rateLimits/read');
+      const snapshot = pickCodexRateLimitSnapshot(response);
+      if (!isRateLimited(snapshot)) return null;
+      return {
+        ...baseStatus,
+        readiness: 'rate_limited',
+        detail: rateLimitDetail(snapshot),
+      };
+    } catch (err) {
+      return {
+        ...baseStatus,
+        detail: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  #mapStatusNotification(message: ServerNotification): ProviderRuntimeEvent | null {
+    if (message.method === 'account/rateLimits/updated') {
+      const snapshot = (message as AccountRateLimitsUpdatedNotification).params.rateLimits;
+      if (isRateLimited(snapshot)) {
+        return {
+          type: 'status_changed',
+          status: {
+            provider: 'codex',
+            readiness: 'rate_limited',
+            detail: rateLimitDetail(snapshot),
+          },
+        };
+      }
+      return {
+        type: 'status_changed',
+        status: {
+          provider: 'codex',
+          readiness: this.#lastAuthenticatedReadiness,
+        },
+      };
+    }
+
+    if (message.method === 'account/updated') {
+      const { authMode } = (message as AccountUpdatedNotification).params;
+      if (authMode === 'chatgpt' || authMode === 'chatgptAuthTokens') {
+        this.#lastAuthenticatedReadiness = 'authenticated_chatgpt';
+      } else if (authMode === 'apikey') {
+        this.#lastAuthenticatedReadiness = 'authenticated_api_key';
+      } else {
+        this.#lastAuthenticatedReadiness = 'not_signed_in';
+      }
+      return {
+        type: 'auth_changed',
+        status: {
+          provider: 'codex',
+          readiness: this.#lastAuthenticatedReadiness,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  async #ensureConnection(codexPath?: string): Promise<CodexAppServerConnection> {
+    if (this.#connection && this.#initializePromise) {
+      await this.#initializePromise;
+      return this.#connection;
+    }
+
+    const cli = codexPath ? null : await detectCodexCli(this.#execFile);
+    if (cli && !cli.installed) throw new Error('Codex CLI is not installed');
+    if (cli && !cli.supported) throw new Error('Codex CLI version is not supported');
+
+    const connection = this.#appServerFactory(codexPath ?? cli?.path ?? undefined);
+    this.#connection = connection;
+    connection.process.once('exit', () => {
+      if (this.#connection === connection) {
+        this.#connection = null;
+        this.#initializePromise = null;
+      }
+    });
+    this.#initializePromise = connection.client.request<InitializeResponse>('initialize', {
+      clientInfo: {
+        name: 'contexture',
+        title: 'Contexture',
+        version: '0.14.0',
+      },
+      capabilities: {
+        experimentalApi: true,
+      },
+    });
+    try {
+      await this.#initializePromise;
+      return connection;
+    } catch (err) {
+      if (this.#connection === connection) {
+        this.#connection = null;
+        this.#initializePromise = null;
+      }
+      throw err;
+    }
+  }
+}
+
+function buildSchemaOnlyInstructions(): string {
+  return [
+    'You are Contexture schema chat.',
+    'Use only the Contexture schema tools provided by this client.',
+    'Do not read files, write files, run shell commands, browse, or mutate a repository.',
+    'Treat the current Contexture IR in the user message as authoritative.',
+  ].join('\n');
+}
+
+function readCurrentTurnId(thread: ProviderThreadRef): string | null {
+  if (!thread.opaque || typeof thread.opaque !== 'object') return null;
+  const currentTurnId = (thread.opaque as { currentTurnId?: unknown }).currentTurnId;
+  return typeof currentTurnId === 'string' && currentTurnId.length > 0 ? currentTurnId : null;
+}
+
+function writeCurrentTurnId(thread: ProviderThreadRef, turnId: string): void {
+  const opaque = thread.opaque && typeof thread.opaque === 'object' ? thread.opaque : {};
+  thread.opaque = { ...opaque, currentTurnId: turnId };
+}
+
+function mapCodexNotification(
+  message: ServerNotification,
+  thread: ProviderThreadRef,
+  currentTurnId: string | null,
+): ProviderRuntimeEvent | null {
+  const params = 'params' in message ? message.params : null;
+  if (!params || typeof params !== 'object') return null;
+  const threadId = (params as { threadId?: unknown }).threadId;
+  if (threadId !== thread.threadId) return null;
+  const turnId = (params as { turnId?: unknown }).turnId;
+  if (currentTurnId && typeof turnId === 'string' && turnId !== currentTurnId) return null;
+
+  switch (message.method) {
+    case 'item/agentMessage/delta':
+      return {
+        type: 'assistant_delta',
+        text: (message as AgentMessageDeltaNotification).params.delta,
+      };
+    case 'item/started': {
+      const item = (message as ItemNotification).params.item;
+      const forbidden = forbiddenThreadItemMessage(item);
+      if (forbidden) return { type: 'turn_failed', message: forbidden };
+      if (item.type !== 'dynamicToolCall') return null;
+      const toolCall = item as unknown as DynamicToolCallItem;
+      return {
+        type: 'tool_call_started',
+        id: toolCall.id,
+        name: toolCall.tool,
+        input: toolCall.arguments,
+      };
+    }
+    case 'item/completed': {
+      const item = (message as ItemNotification).params.item;
+      const forbidden = forbiddenThreadItemMessage(item);
+      if (forbidden) return { type: 'turn_failed', message: forbidden };
+      if (item.type !== 'dynamicToolCall') return null;
+      const toolCall = item as unknown as DynamicToolCallItem;
+      return {
+        type: 'tool_call_finished',
+        id: toolCall.id,
+        name: toolCall.tool,
+        ok: toolCall.success === true,
+        result: toolCall.contentItems,
+      };
+    }
+    case 'turn/completed':
+      return mapTurnCompleted(message.params as TurnCompletedNotification);
+    case 'error': {
+      const params = (message as ErrorNotification).params;
+      if (params.willRetry) return null;
+      return {
+        type: 'turn_failed',
+        message: params.error.message,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function mapTurnCompleted(notification: TurnCompletedNotification): ProviderRuntimeEvent {
+  const { turn } = notification;
+  if (turn.status === 'completed') return { type: 'turn_completed' };
+  if (turn.status === 'interrupted') return { type: 'turn_interrupted' };
+  return {
+    type: 'turn_failed',
+    message: turn.error?.message ?? `Codex turn ended with status ${turn.status}`,
+  };
+}
+
+function forbiddenServerRequestMessage(request: ServerRequest): string | null {
+  const method = request.method as string;
+  if (
+    method.startsWith('command/') ||
+    method.startsWith('fs/') ||
+    method === 'thread/shellCommand'
+  ) {
+    return `Codex requested forbidden schema-chat capability: ${method}`;
+  }
+
+  const forbiddenMethods = new Set([
+    'item/commandExecution/requestApproval',
+    'item/fileChange/requestApproval',
+    'item/permissions/requestApproval',
+    'item/tool/requestUserInput',
+    'mcpServer/elicitation/request',
+    'applyPatchApproval',
+    'execCommandApproval',
+  ]);
+  if (!forbiddenMethods.has(method)) return null;
+  return `Codex requested forbidden schema-chat capability: ${method}`;
+}
+
+function forbiddenThreadItemMessage(item: { type: string }): string | null {
+  const forbiddenTypes = new Set([
+    'commandExecution',
+    'fileChange',
+    'mcpToolCall',
+    'webSearch',
+    'collabAgentToolCall',
+  ]);
+  if (!forbiddenTypes.has(item.type)) return null;
+  return `Codex attempted forbidden schema-chat item: ${item.type}`;
+}
+
+function pickCodexRateLimitSnapshot(
+  response: GetAccountRateLimitsResponse,
+): RateLimitSnapshot | null {
+  return response.rateLimitsByLimitId?.codex ?? response.rateLimits;
+}
+
+function isRateLimited(snapshot: RateLimitSnapshot | null): boolean {
+  if (!snapshot) return false;
+  if (snapshot.rateLimitReachedType) return true;
+  return false;
+}
+
+function rateLimitDetail(snapshot: RateLimitSnapshot | null): string | undefined {
+  if (!snapshot) return undefined;
+  if (snapshot.rateLimitReachedType) return snapshot.rateLimitReachedType.replaceAll('_', ' ');
+  return undefined;
+}
+
+function readServerRequestThreadId(request: ServerRequest): string | null {
+  const params = 'params' in request ? request.params : null;
+  if (!params || typeof params !== 'object') return null;
+  const threadId = (params as { threadId?: unknown }).threadId;
+  return typeof threadId === 'string' ? threadId : null;
+}
+
+function readServerRequestTurnId(request: ServerRequest): string | null {
+  const params = 'params' in request ? request.params : null;
+  if (!params || typeof params !== 'object') return null;
+  const turnId = (params as { turnId?: unknown }).turnId;
+  return typeof turnId === 'string' ? turnId : null;
+}
+
+class AsyncEventQueue<T> implements AsyncIterable<T> {
+  readonly #values: T[] = [];
+  readonly #waiters: Array<(result: IteratorResult<T>) => void> = [];
+  #closed = false;
+
+  push(value: T): void {
+    if (this.#closed) return;
+    const waiter = this.#waiters.shift();
+    if (waiter) waiter({ value, done: false });
+    else this.#values.push(value);
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const waiter of this.#waiters.splice(0)) {
+      waiter({ value: undefined, done: true });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () => {
+        const value = this.#values.shift();
+        if (value) return Promise.resolve({ value, done: false });
+        if (this.#closed) return Promise.resolve({ value: undefined, done: true });
+        return new Promise<IteratorResult<T>>((resolve) => this.#waiters.push(resolve));
+      },
+    };
+  }
+}

--- a/apps/desktop/src/main/providers/codex/runtime.ts
+++ b/apps/desktop/src/main/providers/codex/runtime.ts
@@ -1,10 +1,12 @@
 import { tmpdir } from 'node:os';
 import type { OpToolDescriptor } from '../../ops';
+import { overlayModelOptions } from '../model-registry';
 import type {
   CancelLoginInput,
   InterruptTurnInput,
   LoginFlow,
   ModelInfo,
+  ModelOptionDescriptor,
   ProviderCapabilities,
   ProviderRuntime,
   ProviderRuntimeEvent,
@@ -139,11 +141,18 @@ export class CodexProviderRuntime implements ProviderRuntime {
         includeHidden: false,
       });
       for (const model of response.data) {
-        models.push({
-          id: model.model || model.id,
-          label: model.displayName || model.model || model.id,
-          supportsReasoningEffort: model.supportedReasoningEfforts.length > 0,
-        });
+        models.push(
+          overlayModelOptions('codex', {
+            id: model.model || model.id,
+            label: codexModelLabel(model.displayName || model.model || model.id),
+            supportsReasoningEffort: model.supportedReasoningEfforts.length > 0,
+            optionDescriptors: codexOptionDescriptors(
+              model.supportedReasoningEfforts,
+              model.defaultReasoningEffort,
+              model.serviceTiers,
+            ),
+          }),
+        );
       }
       cursor = response.nextCursor;
     } while (cursor);
@@ -155,6 +164,7 @@ export class CodexProviderRuntime implements ProviderRuntime {
     const connection = await this.#ensureConnection();
     const response = await connection.client.request<ThreadStartResponse>('thread/start', {
       model: input.model ?? null,
+      serviceTier: codexServiceTier(input.options),
       cwd: SCHEMA_AGENT_CODEX_CWD,
       approvalPolicy: SCHEMA_AGENT_APPROVAL_POLICY,
       sandbox: 'read-only',
@@ -180,6 +190,7 @@ export class CodexProviderRuntime implements ProviderRuntime {
     const response = await connection.client.request<ThreadResumeResponse>('thread/resume', {
       threadId: input.thread.threadId,
       model: input.model ?? null,
+      serviceTier: codexServiceTier(input.options),
       cwd: SCHEMA_AGENT_CODEX_CWD,
       approvalPolicy: SCHEMA_AGENT_APPROVAL_POLICY,
       sandbox: 'read-only',
@@ -259,7 +270,8 @@ export class CodexProviderRuntime implements ProviderRuntime {
         approvalPolicy: SCHEMA_AGENT_APPROVAL_POLICY,
         sandboxPolicy: { type: 'readOnly', networkAccess: false },
         model: input.model ?? null,
-        effort: input.effort ?? null,
+        serviceTier: codexServiceTier(input.options),
+        effort: readStringOption(input.options, 'reasoningEffort') ?? input.effort ?? null,
       });
       turnId = response.turn.id;
       writeCurrentTurnId(input.thread, turnId);
@@ -429,6 +441,67 @@ export class CodexProviderRuntime implements ProviderRuntime {
   }
 }
 
+const CODEX_REASONING_LABELS: Record<string, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'Extra High',
+};
+
+function codexOptionDescriptors(
+  supportedReasoningEfforts: unknown[],
+  defaultReasoningEffort?: string | null,
+  serviceTiers: Array<{ id: string; name: string; description: string }> = [],
+): ModelOptionDescriptor[] {
+  const options = supportedReasoningEfforts
+    .map(readReasoningEffortOption)
+    .filter((option): option is { id: string; label: string } => option !== null);
+  const descriptors: ModelOptionDescriptor[] = [];
+
+  const defaultId =
+    typeof defaultReasoningEffort === 'string' &&
+    options.some((option) => option.id === defaultReasoningEffort)
+      ? defaultReasoningEffort
+      : options.some((option) => option.id === 'high')
+        ? 'high'
+        : options[0]?.id;
+
+  if (options.length > 0) {
+    descriptors.push({
+      id: 'reasoningEffort',
+      type: 'select',
+      label: 'Effort',
+      options: options.map((option) => ({
+        ...option,
+        ...(option.id === defaultId ? { isDefault: true } : {}),
+      })),
+    });
+  }
+
+  if (serviceTiers.some((tier) => tier.id === 'priority')) {
+    descriptors.push({ id: 'fastMode', type: 'boolean', label: 'Fast', defaultValue: false });
+  }
+
+  return descriptors;
+}
+
+function readReasoningEffortOption(value: unknown): { id: string; label: string } | null {
+  if (typeof value === 'string' && value.trim()) {
+    const id = value.trim();
+    return { id, label: CODEX_REASONING_LABELS[id] ?? id };
+  }
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const rawId = record.reasoningEffort ?? record.id ?? record.value;
+  if (typeof rawId !== 'string' || !rawId.trim()) return null;
+  const id = rawId.trim();
+  return { id, label: CODEX_REASONING_LABELS[id] ?? id };
+}
+
+function codexModelLabel(label: string): string {
+  return label.replace(/^gpt-/i, 'GPT-');
+}
+
 function buildSchemaOnlyInstructions(): string {
   return [
     'You are Contexture schema chat.',
@@ -593,6 +666,18 @@ function readServerRequestTurnId(request: ServerRequest): string | null {
   if (!params || typeof params !== 'object') return null;
   const turnId = (params as { turnId?: unknown }).turnId;
   return typeof turnId === 'string' ? turnId : null;
+}
+
+function readStringOption(
+  options: Record<string, string | boolean> | undefined,
+  key: string,
+): string | null {
+  const value = options?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function codexServiceTier(options: Record<string, string | boolean> | undefined): string | null {
+  return options?.fastMode === true ? 'priority' : null;
 }
 
 class AsyncEventQueue<T> implements AsyncIterable<T> {

--- a/apps/desktop/src/main/providers/codex/runtime.ts
+++ b/apps/desktop/src/main/providers/codex/runtime.ts
@@ -188,6 +188,7 @@ export class CodexProviderRuntime implements ProviderRuntime {
         tools: { view_image: false },
       },
       developerInstructions: buildSchemaOnlyInstructions(),
+      dynamicTools: toCodexDynamicTools(this.#opToolDescriptors),
       excludeTurns: true,
       persistExtendedHistory: false,
     });
@@ -457,8 +458,8 @@ function mapCodexNotification(
   if (!params || typeof params !== 'object') return null;
   const threadId = (params as { threadId?: unknown }).threadId;
   if (threadId !== thread.threadId) return null;
-  const turnId = (params as { turnId?: unknown }).turnId;
-  if (currentTurnId && typeof turnId === 'string' && turnId !== currentTurnId) return null;
+  const turnId = readNotificationTurnId(params);
+  if (currentTurnId && turnId && turnId !== currentTurnId) return null;
 
   switch (message.method) {
     case 'item/agentMessage/delta':
@@ -506,6 +507,15 @@ function mapCodexNotification(
     default:
       return null;
   }
+}
+
+function readNotificationTurnId(params: object): string | null {
+  const turnId = (params as { turnId?: unknown }).turnId;
+  if (typeof turnId === 'string') return turnId;
+  const turn = (params as { turn?: unknown }).turn;
+  if (!turn || typeof turn !== 'object') return null;
+  const nestedTurnId = (turn as { id?: unknown }).id;
+  return typeof nestedTurnId === 'string' ? nestedTurnId : null;
 }
 
 function mapTurnCompleted(notification: TurnCompletedNotification): ProviderRuntimeEvent {

--- a/apps/desktop/src/main/providers/codex/tools.ts
+++ b/apps/desktop/src/main/providers/codex/tools.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import type { OpToolDescriptor } from '../../ops';
+import type {
+  DynamicToolCallParams,
+  DynamicToolCallResponse,
+  DynamicToolSpec,
+  JsonValue,
+} from './types';
+
+export const CODEX_CONTEXTURE_TOOL_NAMESPACE = 'contexture';
+
+export function toCodexDynamicTools(descriptors: OpToolDescriptor[]): DynamicToolSpec[] {
+  return descriptors.map((descriptor) => ({
+    namespace: CODEX_CONTEXTURE_TOOL_NAMESPACE,
+    name: descriptor.name,
+    description: descriptor.description,
+    inputSchema: z.toJSONSchema(z.object(descriptor.inputSchema)) as JsonValue,
+  }));
+}
+
+export async function handleCodexDynamicToolCall(
+  params: DynamicToolCallParams,
+  descriptors: OpToolDescriptor[],
+): Promise<DynamicToolCallResponse> {
+  if (params.namespace !== CODEX_CONTEXTURE_TOOL_NAMESPACE) {
+    return failure(`Unsupported tool namespace: ${params.namespace ?? '(none)'}`);
+  }
+
+  const descriptor = descriptors.find((tool) => tool.name === params.tool);
+  if (!descriptor) return failure(`Unknown Contexture tool: ${params.tool}`);
+
+  try {
+    const args = params.arguments;
+    if (!args || typeof args !== 'object' || Array.isArray(args)) {
+      return failure(`Tool arguments for ${params.tool} must be an object`);
+    }
+    const result = await descriptor.handler(args as Record<string, unknown>);
+    return {
+      success: !('error' in result),
+      contentItems: [{ type: 'inputText', text: JSON.stringify(result) }],
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return failure(message);
+  }
+}
+
+function failure(message: string): DynamicToolCallResponse {
+  return {
+    success: false,
+    contentItems: [{ type: 'inputText', text: message }],
+  };
+}

--- a/apps/desktop/src/main/providers/codex/types.ts
+++ b/apps/desktop/src/main/providers/codex/types.ts
@@ -81,6 +81,10 @@ export interface ModelListResponse {
     model?: string | null;
     displayName?: string | null;
     supportedReasoningEfforts: unknown[];
+    defaultReasoningEffort?: string | null;
+    serviceTiers?: Array<{ id: string; name: string; description: string }>;
+    additionalSpeedTiers?: string[];
+    isDefault?: boolean;
   }>;
   nextCursor: string | null;
 }
@@ -92,10 +96,16 @@ export interface CodexThread {
 
 export interface ThreadStartResponse {
   thread: CodexThread;
+  model?: string;
+  modelProvider?: string;
+  serviceTier?: string | null;
 }
 
 export interface ThreadResumeResponse {
   thread: CodexThread;
+  model?: string;
+  modelProvider?: string;
+  serviceTier?: string | null;
 }
 
 export interface Turn {

--- a/apps/desktop/src/main/providers/codex/types.ts
+++ b/apps/desktop/src/main/providers/codex/types.ts
@@ -1,0 +1,189 @@
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue | undefined };
+
+export type AskForApproval =
+  | 'untrusted'
+  | 'on-failure'
+  | 'on-request'
+  | 'never'
+  | {
+      granular: {
+        sandbox_approval: boolean;
+        rules: boolean;
+        skill_approval: boolean;
+        request_permissions: boolean;
+        mcp_elicitations: boolean;
+      };
+    };
+
+export interface InitializeResponse {
+  userAgent?: string;
+  codexHome?: string;
+  platformFamily?: string;
+  platformOs?: string;
+}
+
+export type Account =
+  | { type: 'chatgpt'; email?: string | null; planType?: string | null }
+  | { type: 'apiKey' };
+
+export interface GetAccountResponse {
+  account: Account | null;
+  requiresOpenaiAuth?: boolean;
+}
+
+export interface LoginAccountResponse {
+  type: 'chatgpt' | 'apiKey';
+  loginId: string;
+  authUrl?: string;
+}
+
+export type CancelLoginAccountResponse = Record<string, never>;
+export type LogoutAccountResponse = Record<string, never>;
+export type ThreadRollbackResponse = Record<string, never>;
+export type TurnInterruptResponse = Record<string, never>;
+
+export interface RateLimitWindow {
+  usedPercent: number;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+}
+
+export interface RateLimitSnapshot {
+  limitId: string | null;
+  limitName: string | null;
+  primary: RateLimitWindow | null;
+  secondary: RateLimitWindow | null;
+  credits: { hasCredits: boolean; unlimited: boolean; balance: string | null } | null;
+  planType: string | null;
+  rateLimitReachedType:
+    | 'rate_limit_reached'
+    | 'workspace_owner_credits_depleted'
+    | 'workspace_member_credits_depleted'
+    | 'workspace_owner_usage_limit_reached'
+    | 'workspace_member_usage_limit_reached'
+    | null;
+}
+
+export interface GetAccountRateLimitsResponse {
+  rateLimits: RateLimitSnapshot;
+  rateLimitsByLimitId: Record<string, RateLimitSnapshot | undefined> | null;
+}
+
+export interface ModelListResponse {
+  data: Array<{
+    id: string;
+    model?: string | null;
+    displayName?: string | null;
+    supportedReasoningEfforts: unknown[];
+  }>;
+  nextCursor: string | null;
+}
+
+export interface CodexThread {
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface ThreadStartResponse {
+  thread: CodexThread;
+}
+
+export interface ThreadResumeResponse {
+  thread: CodexThread;
+}
+
+export interface Turn {
+  id: string;
+  status: 'inProgress' | 'completed' | 'failed' | 'interrupted' | 'cancelled' | 'pending' | string;
+  error?: { message?: string | null } | null;
+}
+
+export interface TurnStartResponse {
+  turn: Turn;
+}
+
+export interface TurnCompletedNotification {
+  threadId: string;
+  turn: Turn;
+}
+
+export interface DynamicToolSpec {
+  namespace?: string;
+  name: string;
+  description: string;
+  inputSchema: JsonValue;
+  deferLoading?: boolean;
+}
+
+export interface DynamicToolCallParams {
+  threadId: string;
+  turnId: string;
+  callId: string;
+  namespace: string | null;
+  tool: string;
+  arguments: JsonValue;
+}
+
+export interface DynamicToolCallResponse {
+  contentItems: Array<{ type: 'inputText'; text: string }>;
+  success: boolean;
+}
+
+export type ServerRequest = {
+  jsonrpc?: '2.0';
+  id: number | string;
+  method: string;
+  params?: unknown;
+};
+
+export interface ServerNotification {
+  method: string;
+  params?: unknown;
+}
+
+export interface AccountRateLimitsUpdatedNotification extends ServerNotification {
+  method: 'account/rateLimits/updated';
+  params: { rateLimits: RateLimitSnapshot };
+}
+
+export interface AccountUpdatedNotification extends ServerNotification {
+  method: 'account/updated';
+  params: { authMode: string | null };
+}
+
+export interface AgentMessageDeltaNotification extends ServerNotification {
+  method: 'item/agentMessage/delta';
+  params: { threadId: string; turnId?: string; delta: string };
+}
+
+export interface ItemNotification extends ServerNotification {
+  method: 'item/started' | 'item/completed';
+  params: { threadId: string; turnId?: string; item: ThreadItem };
+}
+
+export interface ErrorNotification extends ServerNotification {
+  method: 'error';
+  params: { willRetry?: boolean; error: { message: string } };
+}
+
+export interface DynamicToolCallItem {
+  type: 'dynamicToolCall';
+  id: string;
+  namespace: string | null;
+  tool: string;
+  arguments: JsonValue;
+  success: boolean | null;
+  contentItems?: unknown;
+}
+
+export interface ThreadItem {
+  type: string;
+  id?: string;
+  [key: string]: unknown;
+}

--- a/apps/desktop/src/main/providers/codex/version.ts
+++ b/apps/desktop/src/main/providers/codex/version.ts
@@ -1,0 +1,1 @@
+export const CODEX_PROVIDER_MIN_CLI_VERSION = '0.130.0';

--- a/apps/desktop/src/main/providers/model-registry.ts
+++ b/apps/desktop/src/main/providers/model-registry.ts
@@ -1,0 +1,195 @@
+import type { ModelInfo, ModelOptionDescriptor, ProviderKind } from './runtime';
+
+type SelectDescriptor = Extract<ModelOptionDescriptor, { type: 'select' }>;
+
+const LOW_MED_HIGH_MAX_ULTRA = [
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium', isDefault: true },
+  { id: 'high', label: 'High' },
+  { id: 'max', label: 'Max' },
+  { id: 'xhigh', label: 'Ultrathink' },
+];
+
+const LOW_MED_HIGH_ULTRA = [
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium', isDefault: true },
+  { id: 'high', label: 'High' },
+  { id: 'xhigh', label: 'Ultrathink' },
+];
+
+function contextWindow(currentValue?: string): SelectDescriptor {
+  return {
+    id: 'contextWindow',
+    type: 'select',
+    label: 'Context',
+    options: [
+      { id: '200k', label: '200K', isDefault: true },
+      { id: '1m', label: '1M' },
+    ],
+    ...(currentValue ? { currentValue } : {}),
+  };
+}
+
+const FAST_MODE: ModelOptionDescriptor = {
+  id: 'fastMode',
+  type: 'boolean',
+  label: 'Fast',
+  defaultValue: false,
+};
+
+const THINKING: ModelOptionDescriptor = {
+  id: 'thinking',
+  type: 'boolean',
+  label: 'Think',
+  defaultValue: false,
+};
+
+export const CLAUDE_FALLBACK_MODELS: ModelInfo[] = [
+  {
+    id: 'default',
+    label: 'Default',
+    optionDescriptors: [reasoning(LOW_MED_HIGH_MAX_ULTRA), FAST_MODE, contextWindow()],
+  },
+  {
+    id: 'haiku',
+    label: 'Haiku',
+    optionDescriptors: [THINKING],
+  },
+  {
+    id: 'sonnet',
+    label: 'Sonnet',
+    optionDescriptors: [reasoning(LOW_MED_HIGH_ULTRA), contextWindow()],
+  },
+  {
+    id: 'opus',
+    label: 'Opus',
+    optionDescriptors: [reasoning(LOW_MED_HIGH_MAX_ULTRA), FAST_MODE, contextWindow()],
+  },
+];
+
+const CODEX_MODEL_OVERLAYS: Array<{
+  provider: ProviderKind;
+  matches: string[];
+  optionDescriptors: ModelOptionDescriptor[];
+}> = [
+  {
+    provider: 'codex',
+    matches: ['gpt-5.5', 'gpt-5.4'],
+    optionDescriptors: [FAST_MODE],
+  },
+];
+
+export function overlayModelOptions(provider: ProviderKind, model: ModelInfo): ModelInfo {
+  const overlays = CODEX_MODEL_OVERLAYS.filter(
+    (entry) =>
+      entry.provider === provider &&
+      entry.matches.some((match) => model.id.toLowerCase() === match.toLowerCase()),
+  );
+  if (overlays.length === 0) return model;
+  return {
+    ...model,
+    optionDescriptors: mergeOptionDescriptors([
+      ...(model.optionDescriptors ?? []),
+      ...overlays.flatMap((entry) => entry.optionDescriptors),
+    ]),
+  };
+}
+
+export function claudeModelFromSdk(value: unknown): ModelInfo | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const id = typeof record.value === 'string' ? record.value : null;
+  if (!id) return null;
+  const displayName = typeof record.displayName === 'string' ? record.displayName : id;
+  const description = typeof record.description === 'string' ? record.description : '';
+  const supportsEffort = record.supportsEffort === true;
+  const supportsAdaptiveThinking = record.supportsAdaptiveThinking === true;
+  const supportsFastMode = record.supportsFastMode === true;
+  const effortLevels = Array.isArray(record.supportedEffortLevels)
+    ? record.supportedEffortLevels.filter((level): level is string => typeof level === 'string')
+    : [];
+  const optionDescriptors: ModelOptionDescriptor[] = [];
+  if (supportsEffort && effortLevels.length > 0) {
+    optionDescriptors.push(reasoning(effortOptions(effortLevels)));
+  }
+  if (supportsAdaptiveThinking && !supportsEffort) optionDescriptors.push(THINKING);
+  if (supportsFastMode) optionDescriptors.push(FAST_MODE);
+  return {
+    id,
+    label: claudeDisplayLabel(displayName, description),
+    optionDescriptors: mergeOptionDescriptors([
+      ...knownClaudeModelOptions(id, displayName, description),
+      ...optionDescriptors,
+    ]),
+  };
+}
+
+function reasoning(options: SelectDescriptor['options']): SelectDescriptor {
+  return {
+    id: 'reasoningEffort',
+    type: 'select',
+    label: 'Reasoning',
+    options,
+  };
+}
+
+function effortOptions(levels: string[]): SelectDescriptor['options'] {
+  const labels: Record<string, string> = {
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    xhigh: 'Ultrathink',
+    max: 'Max',
+    ultrathink: 'Ultrathink',
+  };
+  return levels.map((id) => ({
+    id,
+    label: labels[id] ?? id,
+    ...(id === 'medium' ? { isDefault: true } : {}),
+  }));
+}
+
+function claudeDisplayLabel(displayName: string, description: string): string {
+  if (displayName === 'Default (recommended)') {
+    const match = description.match(/^(Opus [^·]+)/);
+    return match ? `Default (${match[1].trim()})` : 'Default';
+  }
+  if (displayName === 'Sonnet (1M context)') return 'Sonnet 1M';
+  return displayName;
+}
+
+function knownClaudeModelOptions(
+  id: string,
+  displayName: string,
+  description: string,
+): ModelOptionDescriptor[] {
+  const key = `${id} ${displayName} ${description}`.toLowerCase();
+  const isOneMillion = key.includes('1m') || key.includes('1m context');
+  if (key.includes('haiku')) return [THINKING];
+  if (key.includes('sonnet')) {
+    return [reasoning(LOW_MED_HIGH_ULTRA), contextWindow(isOneMillion ? '1m' : undefined)];
+  }
+  if (key.includes('opus')) {
+    const effort = key.includes('4.5')
+      ? reasoning(effortOptions(['low', 'medium', 'high', 'max']))
+      : reasoning(LOW_MED_HIGH_MAX_ULTRA);
+    const descriptors: ModelOptionDescriptor[] = [effort, FAST_MODE];
+    if (!key.includes('4.5')) descriptors.push(contextWindow(isOneMillion ? '1m' : undefined));
+    return descriptors;
+  }
+  if (displayName === 'Default (recommended)') {
+    return [reasoning(LOW_MED_HIGH_MAX_ULTRA), FAST_MODE, contextWindow()];
+  }
+  return [];
+}
+
+function mergeOptionDescriptors(descriptors: ModelOptionDescriptor[]): ModelOptionDescriptor[] {
+  const seen = new Set<string>();
+  const merged: ModelOptionDescriptor[] = [];
+  for (const descriptor of descriptors) {
+    if (seen.has(descriptor.id)) continue;
+    seen.add(descriptor.id);
+    merged.push(descriptor);
+  }
+  return merged;
+}

--- a/apps/desktop/src/main/providers/runtime.ts
+++ b/apps/desktop/src/main/providers/runtime.ts
@@ -22,6 +22,7 @@ export type ProviderReadiness =
   | 'cli_outdated'
   | 'app_server_unavailable'
   | 'not_signed_in'
+  | 'authenticated_cli'
   | 'authenticated_chatgpt'
   | 'authenticated_api_key'
   | 'rate_limited'
@@ -39,7 +40,27 @@ export interface ModelInfo {
   id: string;
   label: string;
   supportsReasoningEffort?: boolean;
+  optionDescriptors?: ModelOptionDescriptor[];
 }
+
+export type ModelOptionValue = string | boolean;
+export type ModelOptions = Record<string, ModelOptionValue>;
+
+export type ModelOptionDescriptor =
+  | {
+      id: string;
+      type: 'select';
+      label: string;
+      options: Array<{ id: string; label: string; isDefault?: boolean }>;
+      currentValue?: string;
+    }
+  | {
+      id: string;
+      type: 'boolean';
+      label: string;
+      defaultValue?: boolean;
+      currentValue?: boolean;
+    };
 
 export interface ProviderThreadRef {
   provider: ProviderKind;
@@ -50,6 +71,7 @@ export interface ProviderThreadRef {
 export interface StartThreadInput {
   model?: string;
   effort?: string;
+  options?: ModelOptions;
   schema: Schema;
 }
 
@@ -59,12 +81,14 @@ export interface SendTurnInput {
   schema: Schema;
   model?: string;
   effort?: string;
+  options?: ModelOptions;
 }
 
 export interface ResumeThreadInput {
   thread: ProviderThreadRef;
   model?: string;
   effort?: string;
+  options?: ModelOptions;
 }
 
 export interface InterruptTurnInput {
@@ -77,7 +101,7 @@ export interface RollbackThreadInput {
 }
 
 export interface StartLoginInput {
-  mode: Extract<ProviderAuthMode, 'chatgpt' | 'api-key'>;
+  mode: Extract<ProviderAuthMode, 'chatgpt' | 'api-key' | 'cli-session'>;
   apiKey?: string;
 }
 

--- a/apps/desktop/src/main/providers/runtime.ts
+++ b/apps/desktop/src/main/providers/runtime.ts
@@ -1,0 +1,125 @@
+import type { Schema } from '@renderer/model/ir';
+
+export type ProviderKind = 'codex' | 'claude';
+
+export type ProviderAuthMode = 'chatgpt' | 'api-key' | 'cli-session' | 'none';
+
+export interface ProviderCapabilities {
+  authModes: ProviderAuthMode[];
+  modelSource: 'runtime' | 'static';
+  supportsThreadResume: boolean;
+  supportsThreadRollback: boolean;
+  supportsDynamicTools: boolean;
+  supportsMcpTools: boolean;
+  supportsInterrupt: boolean;
+  supportsRateLimitStatus: boolean;
+  supportsReasoningEffort: boolean;
+  supportsSchemaOnlyMode: boolean;
+}
+
+export type ProviderReadiness =
+  | 'cli_missing'
+  | 'cli_outdated'
+  | 'app_server_unavailable'
+  | 'not_signed_in'
+  | 'authenticated_chatgpt'
+  | 'authenticated_api_key'
+  | 'rate_limited'
+  | 'desynced';
+
+export interface ProviderStatus {
+  provider: ProviderKind;
+  readiness: ProviderReadiness;
+  detail?: string;
+  cliVersion?: string;
+  minimumCliVersion?: string;
+}
+
+export interface ModelInfo {
+  id: string;
+  label: string;
+  supportsReasoningEffort?: boolean;
+}
+
+export interface ProviderThreadRef {
+  provider: ProviderKind;
+  threadId: string;
+  opaque?: unknown;
+}
+
+export interface StartThreadInput {
+  model?: string;
+  effort?: string;
+  schema: Schema;
+}
+
+export interface SendTurnInput {
+  thread: ProviderThreadRef;
+  message: string;
+  schema: Schema;
+  model?: string;
+  effort?: string;
+}
+
+export interface ResumeThreadInput {
+  thread: ProviderThreadRef;
+  model?: string;
+  effort?: string;
+}
+
+export interface InterruptTurnInput {
+  thread: ProviderThreadRef;
+}
+
+export interface RollbackThreadInput {
+  thread: ProviderThreadRef;
+  turns: number;
+}
+
+export interface StartLoginInput {
+  mode: Extract<ProviderAuthMode, 'chatgpt' | 'api-key'>;
+  apiKey?: string;
+}
+
+export interface CancelLoginInput {
+  flowId: string;
+}
+
+export interface LoginFlow {
+  id: string;
+  mode: ProviderAuthMode;
+  url?: string;
+}
+
+export type ProviderRuntimeEvent =
+  | { type: 'status_changed'; status: ProviderStatus }
+  | { type: 'auth_changed'; status: ProviderStatus }
+  | { type: 'thread_started'; thread: ProviderThreadRef }
+  | { type: 'thread_resumed'; thread: ProviderThreadRef }
+  | { type: 'turn_started'; thread: ProviderThreadRef }
+  | { type: 'assistant_delta'; text: string }
+  | { type: 'assistant_final'; text: string }
+  | { type: 'tool_call_started'; id: string; name: string; input?: unknown }
+  | { type: 'tool_call_finished'; id: string; name: string; ok: boolean; result?: unknown }
+  | { type: 'turn_completed' }
+  | { type: 'turn_failed'; message: string }
+  | { type: 'turn_interrupted'; message?: string }
+  | { type: 'thread_desynced'; thread: ProviderThreadRef; reason: string };
+
+export interface ProviderRuntime {
+  provider: ProviderKind;
+  capabilities: ProviderCapabilities;
+
+  getStatus(): Promise<ProviderStatus>;
+  listModels(): Promise<ModelInfo[]>;
+
+  startThread(input: StartThreadInput): Promise<ProviderThreadRef>;
+  resumeThread(input: ResumeThreadInput): Promise<ProviderThreadRef>;
+  sendTurn(input: SendTurnInput): AsyncIterable<ProviderRuntimeEvent>;
+  interruptTurn(input: InterruptTurnInput): Promise<void>;
+  rollbackThread(input: RollbackThreadInput): Promise<void>;
+
+  startLogin(input: StartLoginInput): Promise<LoginFlow>;
+  cancelLogin(input: CancelLoginInput): Promise<void>;
+  logout(): Promise<void>;
+}

--- a/apps/desktop/src/main/providers/schema-agent-driver.ts
+++ b/apps/desktop/src/main/providers/schema-agent-driver.ts
@@ -1,0 +1,170 @@
+import { buildUserMessage } from '@renderer/chat/system-prompt';
+import type { Schema } from '@renderer/model/ir';
+import type { ChatTurnController } from '../ipc/chat-turn';
+import type { ProviderRuntime, ProviderRuntimeEvent, ProviderThreadRef } from './runtime';
+
+export const SCHEMA_AGENT_ASSISTANT_DELTA = 'schema-agent:assistant-delta' as const;
+export const SCHEMA_AGENT_ASSISTANT_FINAL = 'schema-agent:assistant-final' as const;
+export const SCHEMA_AGENT_TOOL_CALL_STARTED = 'schema-agent:tool-call-started' as const;
+export const SCHEMA_AGENT_TOOL_CALL_FINISHED = 'schema-agent:tool-call-finished' as const;
+export const SCHEMA_AGENT_ERROR = 'schema-agent:error' as const;
+export const SCHEMA_AGENT_STATUS_CHANGED = 'schema-agent:status-changed' as const;
+export const SCHEMA_AGENT_THREAD_UPDATED = 'schema-agent:thread-updated' as const;
+export const SCHEMA_AGENT_THREAD_DESYNCED = 'schema-agent:thread-desynced' as const;
+
+export interface SchemaAgentTransport {
+  send: (channel: string, payload: unknown) => void;
+}
+
+export interface SchemaAgentDriverDeps {
+  runtime: ProviderRuntime;
+  transport: SchemaAgentTransport;
+  turnController: ChatTurnController;
+  getCurrentIR: () => Schema | null;
+  getThreadRef: () => ProviderThreadRef | undefined;
+  setThreadRef: (thread: ProviderThreadRef) => void;
+  markThreadDesynced: (thread: ProviderThreadRef, reason: string) => void;
+  getModelOptions?: () => { model?: string; effort?: string };
+}
+
+export class SchemaAgentDriver {
+  readonly #deps: SchemaAgentDriverDeps;
+
+  constructor(deps: SchemaAgentDriverDeps) {
+    this.#deps = deps;
+  }
+
+  async send(userMessage: string): Promise<void> {
+    const {
+      runtime,
+      transport,
+      turnController,
+      getCurrentIR,
+      getThreadRef,
+      setThreadRef,
+      markThreadDesynced,
+      getModelOptions,
+    } = this.#deps;
+    const schema = getCurrentIR() ?? { version: '1', types: [] };
+    const modelOptions = getModelOptions?.() ?? {};
+    let thread = getThreadRef();
+    if (!thread) {
+      thread = await runtime.startThread({ schema, ...modelOptions });
+      setThreadRef(thread);
+      transport.send(SCHEMA_AGENT_THREAD_UPDATED, { thread });
+    }
+
+    try {
+      await turnController.run(async () => {
+        for await (const event of runtime.sendTurn({
+          thread,
+          schema,
+          message: buildUserMessage({ ir: schema, userMessage }),
+          ...modelOptions,
+        })) {
+          handleRuntimeEvent(event, transport, setThreadRef);
+          if (event.type === 'turn_failed') {
+            throw new Error(event.message);
+          }
+          if (event.type === 'turn_interrupted') {
+            throw new Error(event.message ?? 'turn interrupted');
+          }
+        }
+      });
+    } catch (err) {
+      await rollbackProviderThread({
+        err,
+        thread,
+        runtime,
+        transport,
+        markThreadDesynced,
+      });
+      throw err;
+    }
+  }
+}
+
+function handleRuntimeEvent(
+  event: ProviderRuntimeEvent,
+  transport: SchemaAgentTransport,
+  setThreadRef: (thread: ProviderThreadRef) => void,
+): void {
+  switch (event.type) {
+    case 'status_changed':
+    case 'auth_changed':
+      transport.send(SCHEMA_AGENT_STATUS_CHANGED, event.status);
+      return;
+    case 'thread_started':
+    case 'thread_resumed':
+      setThreadRef(event.thread);
+      transport.send(SCHEMA_AGENT_THREAD_UPDATED, { thread: event.thread });
+      return;
+    case 'assistant_delta':
+      transport.send(SCHEMA_AGENT_ASSISTANT_DELTA, { text: event.text });
+      return;
+    case 'assistant_final':
+      transport.send(SCHEMA_AGENT_ASSISTANT_FINAL, { text: event.text });
+      return;
+    case 'tool_call_started':
+      transport.send(SCHEMA_AGENT_TOOL_CALL_STARTED, {
+        id: event.id,
+        name: event.name,
+        input: event.input,
+      });
+      return;
+    case 'tool_call_finished':
+      transport.send(SCHEMA_AGENT_TOOL_CALL_FINISHED, {
+        id: event.id,
+        name: event.name,
+        ok: event.ok,
+        result: event.result,
+      });
+      return;
+    case 'turn_failed':
+      return;
+    case 'turn_interrupted':
+      return;
+    case 'thread_desynced':
+      transport.send(SCHEMA_AGENT_THREAD_DESYNCED, {
+        thread: event.thread,
+        reason: event.reason,
+      });
+      return;
+    case 'turn_started':
+    case 'turn_completed':
+      return;
+  }
+}
+
+async function rollbackProviderThread({
+  err,
+  thread,
+  runtime,
+  transport,
+  markThreadDesynced,
+}: {
+  err: unknown;
+  thread: ProviderThreadRef;
+  runtime: ProviderRuntime;
+  transport: SchemaAgentTransport;
+  markThreadDesynced: (thread: ProviderThreadRef, reason: string) => void;
+}): Promise<void> {
+  if (!runtime.capabilities.supportsThreadRollback) {
+    const reason = 'provider does not support thread rollback';
+    markThreadDesynced(thread, reason);
+    transport.send(SCHEMA_AGENT_THREAD_DESYNCED, { thread, reason });
+    return;
+  }
+
+  try {
+    await runtime.rollbackThread({ thread, turns: 1 });
+  } catch (rollbackErr) {
+    const reason = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+    markThreadDesynced(thread, reason);
+    transport.send(SCHEMA_AGENT_THREAD_DESYNCED, { thread, reason });
+  }
+
+  if (err instanceof Error) {
+    transport.send(SCHEMA_AGENT_ERROR, { message: err.message });
+  }
+}

--- a/apps/desktop/src/main/providers/schema-agent-driver.ts
+++ b/apps/desktop/src/main/providers/schema-agent-driver.ts
@@ -1,7 +1,12 @@
 import { buildUserMessage } from '@renderer/chat/system-prompt';
 import type { Schema } from '@renderer/model/ir';
 import type { ChatTurnController } from '../ipc/chat-turn';
-import type { ProviderRuntime, ProviderRuntimeEvent, ProviderThreadRef } from './runtime';
+import type {
+  ModelOptions,
+  ProviderRuntime,
+  ProviderRuntimeEvent,
+  ProviderThreadRef,
+} from './runtime';
 
 export const SCHEMA_AGENT_ASSISTANT_DELTA = 'schema-agent:assistant-delta' as const;
 export const SCHEMA_AGENT_ASSISTANT_FINAL = 'schema-agent:assistant-final' as const;
@@ -17,14 +22,15 @@ export interface SchemaAgentTransport {
 }
 
 export interface SchemaAgentDriverDeps {
-  runtime: ProviderRuntime;
+  runtime?: ProviderRuntime;
+  getRuntime?: () => ProviderRuntime;
   transport: SchemaAgentTransport;
   turnController: ChatTurnController;
   getCurrentIR: () => Schema | null;
   getThreadRef: () => ProviderThreadRef | undefined;
   setThreadRef: (thread: ProviderThreadRef) => void;
   markThreadDesynced: (thread: ProviderThreadRef, reason: string) => void;
-  getModelOptions?: () => { model?: string; effort?: string };
+  getModelOptions?: () => { model?: string; effort?: string; options?: ModelOptions };
 }
 
 export class SchemaAgentDriver {
@@ -36,7 +42,8 @@ export class SchemaAgentDriver {
 
   async send(userMessage: string): Promise<void> {
     const {
-      runtime,
+      runtime: staticRuntime,
+      getRuntime,
       transport,
       turnController,
       getCurrentIR,
@@ -45,6 +52,8 @@ export class SchemaAgentDriver {
       markThreadDesynced,
       getModelOptions,
     } = this.#deps;
+    const runtime = getRuntime?.() ?? staticRuntime;
+    if (!runtime) throw new Error('No schema-agent provider runtime configured');
     const schema = getCurrentIR() ?? { version: '1', types: [] };
     const modelOptions = getModelOptions?.() ?? {};
     let thread = getThreadRef();

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -49,7 +49,7 @@ export interface ContextureChatAPI {
   ) => Promise<{ ok: boolean; error?: string }>;
   setModelOptions: (opts: {
     model?: string;
-    thinkingBudget?: 'auto' | 'low' | 'med' | 'high';
+    thinkingBudget?: 'auto' | 'low' | 'med' | 'high' | 'xhigh';
   }) => Promise<{ ok: boolean }>;
   abort: () => Promise<{ ok: boolean; error?: string }>;
   onAssistant: (listener: (payload: { text: string }) => void) => Unsubscribe;
@@ -73,13 +73,17 @@ export interface ContextureSchemaAgentAPI {
   setIR: (ir: unknown) => void;
   abort: () => Promise<{ ok: boolean; error?: string }>;
   getStatus: () => Promise<unknown>;
-  listModels: () => Promise<unknown>;
+  listModels: (provider?: 'codex' | 'claude') => Promise<unknown>;
   setProvider: (provider: 'codex' | 'claude') => Promise<{ ok: boolean; error?: string }>;
-  setModelOptions: (options: { model?: string; effort?: string }) => Promise<{ ok: boolean }>;
+  setModelOptions: (options: {
+    model?: string;
+    effort?: string;
+    options?: Record<string, string | boolean>;
+  }) => Promise<{ ok: boolean }>;
   startLogin: (input: {
-    mode: 'chatgpt' | 'api-key';
+    mode: 'chatgpt' | 'api-key' | 'cli-session';
     apiKey?: string;
-  }) => Promise<{ id: string; mode: 'chatgpt' | 'api-key'; url?: string }>;
+  }) => Promise<{ id: string; mode: 'chatgpt' | 'api-key' | 'cli-session'; url?: string }>;
   cancelLogin: (input: { flowId: string }) => Promise<void>;
   logout: () => Promise<void>;
   threadSet: (thread: unknown) => Promise<{ ok: boolean }>;

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -68,6 +68,43 @@ export interface ContextureChatAPI {
   clearSession: () => Promise<{ ok: boolean }>;
 }
 
+export interface ContextureSchemaAgentAPI {
+  send: (message: string) => Promise<{ ok: boolean; error?: string }>;
+  setIR: (ir: unknown) => void;
+  abort: () => Promise<{ ok: boolean; error?: string }>;
+  getStatus: () => Promise<unknown>;
+  listModels: () => Promise<unknown>;
+  setProvider: (provider: 'codex' | 'claude') => Promise<{ ok: boolean; error?: string }>;
+  setModelOptions: (options: { model?: string; effort?: string }) => Promise<{ ok: boolean }>;
+  startLogin: (input: {
+    mode: 'chatgpt' | 'api-key';
+    apiKey?: string;
+  }) => Promise<{ id: string; mode: 'chatgpt' | 'api-key'; url?: string }>;
+  cancelLogin: (input: { flowId: string }) => Promise<void>;
+  logout: () => Promise<void>;
+  threadSet: (thread: unknown) => Promise<{ ok: boolean }>;
+  threadClear: () => Promise<{ ok: boolean }>;
+  replyTool: (id: string, result: unknown) => void;
+  onAssistantDelta: (listener: (payload: { text: string }) => void) => Unsubscribe;
+  onAssistantFinal: (listener: (payload: { text: string }) => void) => Unsubscribe;
+  onToolCallStarted: (
+    listener: (payload: { id: string; name: string; input?: unknown }) => void,
+  ) => Unsubscribe;
+  onToolCallFinished: (
+    listener: (payload: { id: string; name: string; ok: boolean; result?: unknown }) => void,
+  ) => Unsubscribe;
+  onError: (listener: (payload: { message: string }) => void) => Unsubscribe;
+  onStatusChanged: (listener: (payload: unknown) => void) => Unsubscribe;
+  onThreadUpdated: (listener: (payload: { thread: unknown }) => void) => Unsubscribe;
+  onThreadDesynced: (
+    listener: (payload: { thread: unknown; reason: string }) => void,
+  ) => Unsubscribe;
+  onToolRequest: (listener: (payload: { id: string; op: unknown }) => void) => Unsubscribe;
+  onTurnBegin: (listener: () => void) => Unsubscribe;
+  onTurnCommit: (listener: () => void) => Unsubscribe;
+  onTurnRollback: (listener: () => void) => Unsubscribe;
+}
+
 export interface OpenWarning {
   message: string;
   severity: 'warning' | 'error';
@@ -93,6 +130,10 @@ export interface OpenedDocument {
       content: string;
       createdAt: number;
     }>;
+    provider?: 'codex' | 'claude';
+    providerThreadRef?: unknown;
+    model?: string;
+    effort?: string;
     sessionId?: string;
   };
   /** Sidecar warnings (not IR — those come from renderer-side `load()`). */
@@ -195,6 +236,7 @@ export interface ContextureReconcileAPI {
 
 export interface ContextureAPI {
   chat: ContextureChatAPI;
+  schemaAgent: ContextureSchemaAgentAPI;
   file: ContextureFileAPI;
   scaffold: ContextureScaffoldAPI;
   shell: ContextureShellAPI;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -45,7 +45,7 @@ const chat = {
   /** Update the model + thinking-effort used by the next SDK query. */
   setModelOptions: (opts: {
     model?: string;
-    thinkingBudget?: 'auto' | 'low' | 'med' | 'high';
+    thinkingBudget?: 'auto' | 'low' | 'med' | 'high' | 'xhigh';
   }): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('claude:set-model-options', opts) as Promise<{ ok: boolean }>,
   /** Interrupt the in-flight query (stop button). */
@@ -94,15 +94,20 @@ const schemaAgent = {
   abort: (): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('schema-agent:abort') as Promise<{ ok: boolean; error?: string }>,
   getStatus: () => ipcRenderer.invoke('schema-agent:get-status'),
-  listModels: () => ipcRenderer.invoke('schema-agent:list-models'),
+  listModels: (provider?: 'codex' | 'claude') =>
+    ipcRenderer.invoke('schema-agent:list-models', provider),
   setProvider: (provider: 'codex' | 'claude'): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('schema-agent:set-provider', provider) as Promise<{
       ok: boolean;
       error?: string;
     }>,
-  setModelOptions: (options: { model?: string; effort?: string }): Promise<{ ok: boolean }> =>
+  setModelOptions: (options: {
+    model?: string;
+    effort?: string;
+    options?: Record<string, string | boolean>;
+  }): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('schema-agent:set-model-options', options) as Promise<{ ok: boolean }>,
-  startLogin: (input: { mode: 'chatgpt' | 'api-key'; apiKey?: string }) =>
+  startLogin: (input: { mode: 'chatgpt' | 'api-key' | 'cli-session'; apiKey?: string }) =>
     ipcRenderer.invoke('schema-agent:start-login', input),
   cancelLogin: (input: { flowId: string }): Promise<void> =>
     ipcRenderer.invoke('schema-agent:cancel-login', input) as Promise<void>,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -87,6 +87,56 @@ const chat = {
     ipcRenderer.invoke('chat:clear-session') as Promise<{ ok: boolean }>,
 };
 
+const schemaAgent = {
+  send: (message: string) =>
+    ipcRenderer.invoke('schema-agent:send', message) as Promise<{ ok: boolean; error?: string }>,
+  setIR: (ir: unknown) => ipcRenderer.send('schema-agent:set-ir', ir),
+  abort: (): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('schema-agent:abort') as Promise<{ ok: boolean; error?: string }>,
+  getStatus: () => ipcRenderer.invoke('schema-agent:get-status'),
+  listModels: () => ipcRenderer.invoke('schema-agent:list-models'),
+  setProvider: (provider: 'codex' | 'claude'): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('schema-agent:set-provider', provider) as Promise<{
+      ok: boolean;
+      error?: string;
+    }>,
+  setModelOptions: (options: { model?: string; effort?: string }): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('schema-agent:set-model-options', options) as Promise<{ ok: boolean }>,
+  startLogin: (input: { mode: 'chatgpt' | 'api-key'; apiKey?: string }) =>
+    ipcRenderer.invoke('schema-agent:start-login', input),
+  cancelLogin: (input: { flowId: string }): Promise<void> =>
+    ipcRenderer.invoke('schema-agent:cancel-login', input) as Promise<void>,
+  logout: (): Promise<void> => ipcRenderer.invoke('schema-agent:logout') as Promise<void>,
+  threadSet: (thread: unknown): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('schema-agent:thread-set', thread) as Promise<{ ok: boolean }>,
+  threadClear: (): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('schema-agent:thread-clear') as Promise<{ ok: boolean }>,
+  replyTool: (id: string, result: unknown) =>
+    ipcRenderer.send('schema-agent:tool-reply', { id, result }),
+  onAssistantDelta: (listener: (payload: { text: string }) => void) =>
+    subscribe('schema-agent:assistant-delta', listener as (p: unknown) => void),
+  onAssistantFinal: (listener: (payload: { text: string }) => void) =>
+    subscribe('schema-agent:assistant-final', listener as (p: unknown) => void),
+  onToolCallStarted: (listener: (payload: { id: string; name: string; input?: unknown }) => void) =>
+    subscribe('schema-agent:tool-call-started', listener as (p: unknown) => void),
+  onToolCallFinished: (
+    listener: (payload: { id: string; name: string; ok: boolean; result?: unknown }) => void,
+  ) => subscribe('schema-agent:tool-call-finished', listener as (p: unknown) => void),
+  onError: (listener: (payload: { message: string }) => void) =>
+    subscribe('schema-agent:error', listener as (p: unknown) => void),
+  onStatusChanged: (listener: (payload: unknown) => void) =>
+    subscribe('schema-agent:status-changed', listener),
+  onThreadUpdated: (listener: (payload: { thread: unknown }) => void) =>
+    subscribe('schema-agent:thread-updated', listener as (p: unknown) => void),
+  onThreadDesynced: (listener: (payload: { thread: unknown; reason: string }) => void) =>
+    subscribe('schema-agent:thread-desynced', listener as (p: unknown) => void),
+  onToolRequest: (listener: (payload: { id: string; op: unknown }) => void) =>
+    subscribe('schema-agent:tool-request', listener as (p: unknown) => void),
+  onTurnBegin: (listener: () => void) => subscribe('turn:begin', listener),
+  onTurnCommit: (listener: () => void) => subscribe('turn:commit', listener),
+  onTurnRollback: (listener: () => void) => subscribe('turn:rollback', listener),
+};
+
 // Open results carry the full bundle (IR raw text + parsed sidecars).
 // The `.d.ts` declares the canonical `OpenedDocument` shape; here we
 // pass the IPC value through unchanged — the renderer sees the typed
@@ -193,7 +243,7 @@ const reconcile = {
     }>,
 };
 
-const contexture = { chat, file, scaffold, shell, project, drift, reconcile };
+const contexture = { chat, schemaAgent, file, scaffold, shell, project, drift, reconcile };
 
 /**
  * Legacy surface. Sidecar reads/writes use the preload process's

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -179,19 +179,17 @@ export default function App(): React.JSX.Element {
     getChat: () => ({
       version: '1',
       messages: chatMessagesRef.current,
-      provider: 'providerLabel' in chat ? 'codex' : 'claude',
+      provider: readProviderProp(chat),
       ...(readStringProp(chat, 'model') ? { model: readStringProp(chat, 'model') } : {}),
       ...(readStringProp(chat, 'effort') ? { effort: readStringProp(chat, 'effort') } : {}),
+      ...(readModelOptionsProp(chat) ? { modelOptions: readModelOptionsProp(chat) } : {}),
       ...('providerThreadRef' in chat && chat.providerThreadRef
         ? { providerThreadRef: chat.providerThreadRef }
         : {}),
     }),
     onBundleLoaded: ({ layout, chat: loadedChat }) => {
       setPositions(layout.positions);
-      const modelSetter = (chat as { setModel?: unknown }).setModel;
-      if (loadedChat.model && typeof modelSetter === 'function') modelSetter(loadedChat.model);
-      const effortSetter = (chat as { setEffort?: unknown }).setEffort;
-      if (loadedChat.effort && typeof effortSetter === 'function') effortSetter(loadedChat.effort);
+      restoreChatSettings(chat, loadedChat);
       chatHydrateRef.current(loadedChat.messages);
       if (loadedChat.sessionId) {
         void window.contexture?.chat.setSessionId(loadedChat.sessionId);
@@ -233,9 +231,10 @@ export default function App(): React.JSX.Element {
     getChat: () => ({
       version: '1',
       messages: chatMessagesRef.current,
-      provider: 'providerLabel' in chat ? 'codex' : 'claude',
+      provider: readProviderProp(chat),
       ...(readStringProp(chat, 'model') ? { model: readStringProp(chat, 'model') } : {}),
       ...(readStringProp(chat, 'effort') ? { effort: readStringProp(chat, 'effort') } : {}),
+      ...(readModelOptionsProp(chat) ? { modelOptions: readModelOptionsProp(chat) } : {}),
       ...('providerThreadRef' in chat && chat.providerThreadRef
         ? { providerThreadRef: chat.providerThreadRef }
         : {}),
@@ -395,7 +394,7 @@ export default function App(): React.JSX.Element {
                   onOpenRecent={fileMenu.handleOpenPath}
                   isNewProject={documentMode === 'project'}
                   projectName={filePath?.split('/').at(-1)?.replace('.contexture.json', '') ?? null}
-                  providerLabel={schemaAgentAvailable ? 'Codex' : 'Claude'}
+                  providerLabel={schemaAgentAvailable ? readProviderLabelProp(chat) : 'Claude'}
                 />
               )}
             </div>
@@ -562,6 +561,57 @@ function readStringProp(value: unknown, key: string): string | undefined {
   if (!value || typeof value !== 'object') return undefined;
   const prop = (value as Record<string, unknown>)[key];
   return typeof prop === 'string' && prop.length > 0 ? prop : undefined;
+}
+
+function readProviderProp(value: unknown): 'codex' | 'claude' {
+  if (!value || typeof value !== 'object') return 'claude';
+  const provider = (value as { provider?: unknown }).provider;
+  return provider === 'codex' || provider === 'claude' ? provider : 'claude';
+}
+
+function readModelOptionsProp(value: unknown): Record<string, string | boolean> | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const modelOptions = (value as { modelOptions?: unknown }).modelOptions;
+  if (!modelOptions || typeof modelOptions !== 'object' || Array.isArray(modelOptions)) {
+    return undefined;
+  }
+  const entries = Object.entries(modelOptions as Record<string, unknown>).filter(
+    (entry): entry is [string, string | boolean] =>
+      typeof entry[1] === 'string' || typeof entry[1] === 'boolean',
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function readProviderLabelProp(value: unknown): 'Codex' | 'Claude' {
+  if (!value || typeof value !== 'object') return 'Claude';
+  const providerLabel = (value as { providerLabel?: unknown }).providerLabel;
+  return providerLabel === 'Codex' || providerLabel === 'Claude' ? providerLabel : 'Claude';
+}
+
+function restoreChatSettings(
+  chat: unknown,
+  loadedChat: {
+    provider?: 'codex' | 'claude';
+    model?: string;
+    effort?: string;
+    modelOptions?: Record<string, string | boolean>;
+  },
+): void {
+  const restorer = (chat as { restoreSettings?: unknown }).restoreSettings;
+  if (typeof restorer === 'function') {
+    restorer({
+      provider: loadedChat.provider,
+      model: loadedChat.model,
+      effort: loadedChat.effort,
+      modelOptions: loadedChat.modelOptions,
+    });
+    return;
+  }
+
+  const modelSetter = (chat as { setModel?: unknown }).setModel;
+  if (loadedChat.model && typeof modelSetter === 'function') modelSetter(loadedChat.model);
+  const effortSetter = (chat as { setEffort?: unknown }).setEffort;
+  if (loadedChat.effort && typeof effortSetter === 'function') effortSetter(loadedChat.effort);
 }
 
 function noopChatApi() {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -25,6 +25,7 @@ import type { PanelImperativeHandle } from 'react-resizable-panels';
 import { evalRootCandidates } from './chat/eval-prompt';
 import { useClaudeEval } from './chat/useClaudeEval';
 import { useClaudeSchemaChat } from './chat/useClaudeSchemaChat';
+import { useSchemaAgentChat } from './chat/useSchemaAgentChat';
 import { ActivityBar } from './components/activity-bar/ActivityBar';
 import { ChatPanel } from './components/chat/ChatPanel';
 import { DetailPanel } from './components/detail/DetailPanel';
@@ -136,12 +137,24 @@ export default function App(): React.JSX.Element {
       .apply({ kind: 'replace_schema', schema: allotment as unknown as never });
   }, []);
 
-  const chat = useClaudeSchemaChat({
-    api:
-      typeof window !== 'undefined' && window.contexture?.chat
+  const schemaAgentAvailable = typeof window !== 'undefined' && !!window.contexture?.schemaAgent;
+  const schemaAgentApi = useMemo(
+    () =>
+      typeof window !== 'undefined' && window.contexture?.schemaAgent
+        ? window.contexture.schemaAgent
+        : noopSchemaAgentApi(),
+    [],
+  );
+  const chatApi = useMemo(
+    () =>
+      !schemaAgentAvailable && typeof window !== 'undefined' && window.contexture?.chat
         ? window.contexture.chat
         : noopChatApi(),
-  });
+    [schemaAgentAvailable],
+  );
+  const codexChat = useSchemaAgentChat({ api: schemaAgentApi });
+  const claudeChat = useClaudeSchemaChat({ api: chatApi });
+  const chat = schemaAgentAvailable ? codexChat : claudeChat;
 
   // Track positions + chat in refs so `useFileMenu` getters can read
   // the live values on save without re-subscribing on every change.
@@ -163,14 +176,37 @@ export default function App(): React.JSX.Element {
 
   const fileMenu = useFileMenu({
     getLayout: () => ({ version: '1', positions: positionsRef.current }),
-    getChat: () => ({ version: '1', messages: chatMessagesRef.current }),
+    getChat: () => ({
+      version: '1',
+      messages: chatMessagesRef.current,
+      provider: 'providerLabel' in chat ? 'codex' : 'claude',
+      ...(readStringProp(chat, 'model') ? { model: readStringProp(chat, 'model') } : {}),
+      ...(readStringProp(chat, 'effort') ? { effort: readStringProp(chat, 'effort') } : {}),
+      ...('providerThreadRef' in chat && chat.providerThreadRef
+        ? { providerThreadRef: chat.providerThreadRef }
+        : {}),
+    }),
     onBundleLoaded: ({ layout, chat: loadedChat }) => {
       setPositions(layout.positions);
+      const modelSetter = (chat as { setModel?: unknown }).setModel;
+      if (loadedChat.model && typeof modelSetter === 'function') modelSetter(loadedChat.model);
+      const effortSetter = (chat as { setEffort?: unknown }).setEffort;
+      if (loadedChat.effort && typeof effortSetter === 'function') effortSetter(loadedChat.effort);
       chatHydrateRef.current(loadedChat.messages);
       if (loadedChat.sessionId) {
         void window.contexture?.chat.setSessionId(loadedChat.sessionId);
+        if (loadedChat.providerThreadRef) {
+          void window.contexture?.schemaAgent?.threadSet(loadedChat.providerThreadRef);
+        } else {
+          void window.contexture?.schemaAgent?.threadClear();
+        }
       } else {
         void window.contexture?.chat.clearSession();
+        if (loadedChat.providerThreadRef) {
+          void window.contexture?.schemaAgent?.threadSet(loadedChat.providerThreadRef);
+        } else {
+          void window.contexture?.schemaAgent?.threadClear();
+        }
       }
       // Capture a seeded first message for auto-send (set by onOpenProject).
       const first = loadedChat.messages[0];
@@ -188,12 +224,22 @@ export default function App(): React.JSX.Element {
       setPositions({});
       chatHydrateRef.current([]);
       void window.contexture?.chat.clearSession();
+      void window.contexture?.schemaAgent?.threadClear();
     },
   });
 
   useProjectAutoSave({
     getLayout: () => ({ version: '1', positions: positionsRef.current }),
-    getChat: () => ({ version: '1', messages: chatMessagesRef.current }),
+    getChat: () => ({
+      version: '1',
+      messages: chatMessagesRef.current,
+      provider: 'providerLabel' in chat ? 'codex' : 'claude',
+      ...(readStringProp(chat, 'model') ? { model: readStringProp(chat, 'model') } : {}),
+      ...(readStringProp(chat, 'effort') ? { effort: readStringProp(chat, 'effort') } : {}),
+      ...('providerThreadRef' in chat && chat.providerThreadRef
+        ? { providerThreadRef: chat.providerThreadRef }
+        : {}),
+    }),
   });
 
   const sessionLayout = useMemo<Layout>(() => ({ version: '1', positions }), [positions]);
@@ -349,6 +395,7 @@ export default function App(): React.JSX.Element {
                   onOpenRecent={fileMenu.handleOpenPath}
                   isNewProject={documentMode === 'project'}
                   projectName={filePath?.split('/').at(-1)?.replace('.contexture.json', '') ?? null}
+                  providerLabel={schemaAgentAvailable ? 'Codex' : 'Claude'}
                 />
               )}
             </div>
@@ -437,12 +484,14 @@ function EmptyState({
   onOpenRecent,
   isNewProject = false,
   projectName = null,
+  providerLabel,
 }: {
   onLoadSample: () => void;
   recentFiles: string[];
   onOpenRecent: (path: string) => void;
   isNewProject?: boolean;
   projectName?: string | null;
+  providerLabel: 'Codex' | 'Claude';
 }): React.JSX.Element {
   return (
     <div
@@ -456,8 +505,8 @@ function EmptyState({
             {projectName ?? 'New project'}
           </h1>
           <p className="text-sm">
-            Your project has been scaffolded. Claude is building your schema in the chat panel —
-            types will appear here as they're created.
+            Your project has been scaffolded. {providerLabel} is building your schema in the chat
+            panel — types will appear here as they're created.
           </p>
           <p className="text-xs text-muted-foreground/60">
             You can iterate on the schema by continuing the conversation, or edit types directly
@@ -470,7 +519,7 @@ function EmptyState({
           <p className="text-xs text-muted-foreground/70 mb-3">Visual Zod schema editor</p>
           <p className="text-sm mb-4">
             Open a <code className="text-xs">.contexture.json</code> file or start chatting with
-            Claude to create one.
+            {` ${providerLabel}`} to create one.
           </p>
           <Button onClick={onLoadSample}>Load allotment sample</Button>
 
@@ -509,6 +558,12 @@ function copyToClipboard(text: string): void {
   navigator.clipboard?.writeText(text).catch(() => undefined);
 }
 
+function readStringProp(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const prop = (value as Record<string, unknown>)[key];
+  return typeof prop === 'string' && prop.length > 0 ? prop : undefined;
+}
+
 function noopChatApi() {
   const unsub = () => undefined;
   return {
@@ -531,5 +586,36 @@ function noopChatApi() {
     onSession: () => unsub,
     setSessionId: async () => ({ ok: false }),
     clearSession: async () => ({ ok: false }),
+  };
+}
+
+function noopSchemaAgentApi() {
+  const unsub = () => undefined;
+  return {
+    send: async () => ({ ok: false, error: 'schema agent unavailable (no preload bridge)' }),
+    setIR: () => undefined,
+    abort: async () => ({ ok: false, error: 'schema agent unavailable' }),
+    getStatus: async () => ({ provider: 'codex', readiness: 'app_server_unavailable' }),
+    listModels: async () => [],
+    setProvider: async () => ({ ok: false, error: 'schema agent unavailable' }),
+    setModelOptions: async () => ({ ok: false }),
+    startLogin: async () => ({ id: '', mode: 'chatgpt' as const }),
+    cancelLogin: async () => undefined,
+    logout: async () => undefined,
+    threadSet: async () => ({ ok: false }),
+    threadClear: async () => ({ ok: false }),
+    replyTool: () => undefined,
+    onAssistantDelta: () => unsub,
+    onAssistantFinal: () => unsub,
+    onToolCallStarted: () => unsub,
+    onToolCallFinished: () => unsub,
+    onError: () => unsub,
+    onStatusChanged: () => unsub,
+    onThreadUpdated: () => unsub,
+    onThreadDesynced: () => unsub,
+    onToolRequest: () => unsub,
+    onTurnBegin: () => unsub,
+    onTurnCommit: () => unsub,
+    onTurnRollback: () => unsub,
   };
 }

--- a/apps/desktop/src/renderer/src/chat/useChatThreads.ts
+++ b/apps/desktop/src/renderer/src/chat/useChatThreads.ts
@@ -28,6 +28,7 @@ export interface ChatThread {
   messages: ChatMessage[];
   model?: string;
   effort?: string;
+  modelOptions?: Record<string, string | boolean>;
   filePath: string | null;
   providerThreadRef?: unknown;
   /** Agent SDK session id — set after the first turn. Undefined on a fresh thread. */
@@ -90,6 +91,7 @@ export interface UseChatThreadsReturn {
     provider: ProviderKind;
     model?: string;
     effort?: string;
+    modelOptions?: Record<string, string | boolean>;
     filePath: string | null;
   }) => string;
   /** All threads for a given file, newest-first. */
@@ -98,6 +100,15 @@ export interface UseChatThreadsReturn {
   switchThread: (id: string) => ChatThread | undefined;
   deleteThread: (id: string) => void;
   updateThreadMessages: (id: string, messages: ChatMessage[]) => void;
+  updateThreadSettings: (
+    id: string,
+    settings: {
+      provider: ProviderKind;
+      model?: string;
+      effort?: string;
+      modelOptions?: Record<string, string | boolean>;
+    },
+  ) => void;
   updateThreadSessionId: (id: string, sessionId: string) => void;
   updateThreadProviderRef: (id: string, providerThreadRef: unknown) => void;
   markThreadDesynced: (id: string) => void;
@@ -127,6 +138,7 @@ export function useChatThreads(): UseChatThreadsReturn {
       provider: ProviderKind;
       model?: string;
       effort?: string;
+      modelOptions?: Record<string, string | boolean>;
       filePath: string | null;
     }): string => {
       const id = generateId();
@@ -137,6 +149,7 @@ export function useChatThreads(): UseChatThreadsReturn {
         messages: [],
         model: input.model,
         effort: input.effort,
+        modelOptions: input.modelOptions,
         filePath: input.filePath,
         createdAt: Date.now(),
         updatedAt: Date.now(),
@@ -183,6 +196,34 @@ export function useChatThreads(): UseChatThreadsReturn {
       }),
     );
   }, []);
+
+  const updateThreadSettings = useCallback(
+    (
+      id: string,
+      settings: {
+        provider: ProviderKind;
+        model?: string;
+        effort?: string;
+        modelOptions?: Record<string, string | boolean>;
+      },
+    ) => {
+      setThreads((prev) =>
+        prev.map((t) => {
+          if (t.id !== id) return t;
+          if (
+            t.provider === settings.provider &&
+            t.model === settings.model &&
+            t.effort === settings.effort &&
+            modelOptionsEqual(t.modelOptions, settings.modelOptions)
+          ) {
+            return t;
+          }
+          return { ...t, ...settings, updatedAt: Date.now() };
+        }),
+      );
+    },
+    [],
+  );
 
   const updateThreadSessionId = useCallback((id: string, sessionId: string) => {
     setThreads((prev) =>
@@ -233,6 +274,7 @@ export function useChatThreads(): UseChatThreadsReturn {
     switchThread,
     deleteThread,
     updateThreadMessages,
+    updateThreadSettings,
     updateThreadSessionId,
     updateThreadProviderRef,
     markThreadDesynced,
@@ -240,4 +282,15 @@ export function useChatThreads(): UseChatThreadsReturn {
     setActiveThreadId,
     threadsForFile,
   };
+}
+
+function modelOptionsEqual(
+  left: Record<string, string | boolean> | undefined,
+  right: Record<string, string | boolean> | undefined,
+): boolean {
+  if (left === right) return true;
+  const leftEntries = Object.entries(left ?? {});
+  const rightEntries = Object.entries(right ?? {});
+  if (leftEntries.length !== rightEntries.length) return false;
+  return leftEntries.every(([key, value]) => right?.[key] === value);
 }

--- a/apps/desktop/src/renderer/src/chat/useChatThreads.ts
+++ b/apps/desktop/src/renderer/src/chat/useChatThreads.ts
@@ -19,16 +19,20 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { ChatMessage } from '../model/chat-history';
 
-export type ModelId = 'claude-haiku-4-5-20251001' | 'claude-sonnet-4-6' | 'claude-opus-4-6';
+export type ProviderKind = 'codex' | 'claude';
 
 export interface ChatThread {
   id: string;
+  provider: ProviderKind;
   title: string;
   messages: ChatMessage[];
-  model: ModelId;
+  model?: string;
+  effort?: string;
   filePath: string | null;
+  providerThreadRef?: unknown;
   /** Agent SDK session id — set after the first turn. Undefined on a fresh thread. */
   sessionId?: string;
+  desynced?: boolean;
   createdAt: number;
   updatedAt: number;
 }
@@ -47,6 +51,7 @@ function loadThreads(): ChatThread[] {
     const threads: ChatThread[] = raw ? JSON.parse(raw) : [];
     // Defensive: older stored threads may be missing optional fields.
     for (const t of threads) {
+      if (t.provider === undefined) t.provider = 'claude';
       if (t.filePath === undefined) t.filePath = null;
       if (!Array.isArray(t.messages)) t.messages = [];
     }
@@ -81,7 +86,12 @@ export interface UseChatThreadsReturn {
   showThreadList: boolean;
   setShowThreadList: (show: boolean) => void;
   /** Create a new thread; returns the id. Sets it as active. */
-  createThread: (model: ModelId, filePath: string | null) => string;
+  createThread: (input: {
+    provider: ProviderKind;
+    model?: string;
+    effort?: string;
+    filePath: string | null;
+  }) => string;
   /** All threads for a given file, newest-first. */
   threadsForFile: (filePath: string | null) => ChatThread[];
   /** Switch active thread. Returns the newly-active thread for convenience. */
@@ -89,6 +99,8 @@ export interface UseChatThreadsReturn {
   deleteThread: (id: string) => void;
   updateThreadMessages: (id: string, messages: ChatMessage[]) => void;
   updateThreadSessionId: (id: string, sessionId: string) => void;
+  updateThreadProviderRef: (id: string, providerThreadRef: unknown) => void;
+  markThreadDesynced: (id: string) => void;
   getActiveThread: () => ChatThread | undefined;
   setActiveThreadId: (id: string | null) => void;
 }
@@ -111,14 +123,21 @@ export function useChatThreads(): UseChatThreadsReturn {
   }, []);
 
   const createThread = useCallback(
-    (model: ModelId, filePath: string | null): string => {
+    (input: {
+      provider: ProviderKind;
+      model?: string;
+      effort?: string;
+      filePath: string | null;
+    }): string => {
       const id = generateId();
       const thread: ChatThread = {
         id,
+        provider: input.provider,
         title: 'New chat',
         messages: [],
-        model,
-        filePath,
+        model: input.model,
+        effort: input.effort,
+        filePath: input.filePath,
         createdAt: Date.now(),
         updatedAt: Date.now(),
       };
@@ -168,8 +187,26 @@ export function useChatThreads(): UseChatThreadsReturn {
   const updateThreadSessionId = useCallback((id: string, sessionId: string) => {
     setThreads((prev) =>
       prev.map((t) =>
-        t.id === id && t.sessionId !== sessionId ? { ...t, sessionId, updatedAt: Date.now() } : t,
+        t.id === id && t.sessionId !== sessionId
+          ? { ...t, provider: 'claude', sessionId, updatedAt: Date.now() }
+          : t,
       ),
+    );
+  }, []);
+
+  const updateThreadProviderRef = useCallback((id: string, providerThreadRef: unknown) => {
+    setThreads((prev) =>
+      prev.map((t) =>
+        t.id === id && t.providerThreadRef !== providerThreadRef
+          ? { ...t, providerThreadRef, updatedAt: Date.now() }
+          : t,
+      ),
+    );
+  }, []);
+
+  const markThreadDesynced = useCallback((id: string) => {
+    setThreads((prev) =>
+      prev.map((t) => (t.id === id && !t.desynced ? { ...t, desynced: true } : t)),
     );
   }, []);
 
@@ -197,6 +234,8 @@ export function useChatThreads(): UseChatThreadsReturn {
     deleteThread,
     updateThreadMessages,
     updateThreadSessionId,
+    updateThreadProviderRef,
+    markThreadDesynced,
     getActiveThread,
     setActiveThreadId,
     threadsForFile,

--- a/apps/desktop/src/renderer/src/chat/useClaude.ts
+++ b/apps/desktop/src/renderer/src/chat/useClaude.ts
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type AuthMode = 'max' | 'api-key';
 export type ModelId = 'claude-haiku-4-5-20251001' | 'claude-sonnet-4-6' | 'claude-opus-4-6';
-export type ThinkingBudget = 'auto' | 'low' | 'med' | 'high';
+export type ThinkingBudget = 'auto' | 'low' | 'med' | 'high' | 'xhigh';
 
 interface UseClaudeReturn {
   authMode: AuthMode;

--- a/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
+++ b/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import type { ContextureSchemaAgentAPI } from '../../../preload/index.d';
 import type { ChatMessage, ChatRole } from '../model/chat-history';
 import { useChatComposerStore } from '../store/chat-composer';
@@ -6,11 +6,45 @@ import type { ApplyResult, Op } from '../store/ops';
 import { useUndoStore } from '../store/undo';
 import { bindTurnToUndo, type IpcSubscriber } from './turn-binder';
 
+export type SchemaAgentProvider = 'codex' | 'claude';
+export const SCHEMA_AGENT_PROVIDER_CHANGED = 'contexture-schema-agent-provider-changed';
+export type SchemaAgentModelOptions = Record<string, string | boolean>;
+
+export type SchemaAgentModelOptionDescriptor =
+  | {
+      id: string;
+      type: 'select';
+      label: string;
+      options: Array<{ id: string; label: string; isDefault?: boolean }>;
+      currentValue?: string;
+    }
+  | {
+      id: string;
+      type: 'boolean';
+      label: string;
+      defaultValue?: boolean;
+      currentValue?: boolean;
+    };
+
+export interface SchemaAgentModelInfo {
+  id: string;
+  label: string;
+  supportsReasoningEffort?: boolean;
+  optionDescriptors?: SchemaAgentModelOptionDescriptor[];
+}
+
 export interface SchemaAgentChatState {
-  providerLabel: 'Codex';
-  models: Array<{ id: string; label: string; supportsReasoningEffort?: boolean }>;
+  provider: SchemaAgentProvider;
+  providerLabel: 'Codex' | 'Claude';
+  setProvider: (provider: SchemaAgentProvider) => void;
+  restoreSettings: (settings: SchemaAgentModelSettings) => void;
+  models: SchemaAgentModelInfo[];
+  modelsLoading: boolean;
+  modelsUnavailable: boolean;
   model: string;
   setModel: (model: string) => void;
+  modelOptions: SchemaAgentModelOptions;
+  setModelOption: (id: string, value: string | boolean) => void;
   effort: string;
   setEffort: (effort: string) => void;
   messages: ChatMessage[];
@@ -26,6 +60,13 @@ export interface SchemaAgentChatState {
   abort: () => Promise<void>;
   hydrate: (messages: ChatMessage[]) => void;
   clear: () => void;
+}
+
+export interface SchemaAgentModelSettings {
+  provider?: SchemaAgentProvider;
+  model?: string;
+  effort?: string;
+  modelOptions?: SchemaAgentModelOptions;
 }
 
 export interface UseSchemaAgentChatOptions {
@@ -54,15 +95,24 @@ export function useSchemaAgentChat({
   const [unavailableMessage, setUnavailableMessage] = useState<string | null>(null);
   const [providerThreadRef, setProviderThreadRef] = useState<unknown>(undefined);
   const [desynced, setDesynced] = useState(false);
-  const [models, setModels] = useState<
-    Array<{ id: string; label: string; supportsReasoningEffort?: boolean }>
-  >([]);
+  const [provider, setProviderState] = useState<SchemaAgentProvider>(
+    () =>
+      (localStorage.getItem('contexture-schema-agent-provider') as SchemaAgentProvider | null) ??
+      'codex',
+  );
+  const [models, setModels] = useState<SchemaAgentModelInfo[]>([]);
+  const [modelsProvider, setModelsProvider] = useState<SchemaAgentProvider | null>(null);
+  const [modelListState, setModelListState] = useState<'idle' | 'loading' | 'loaded' | 'error'>(
+    'idle',
+  );
   const [model, setModelState] = useState(
-    () => localStorage.getItem('contexture-codex-model') ?? '',
+    () => localStorage.getItem(modelStorageKey(provider)) ?? '',
   );
-  const [effort, setEffortState] = useState(
-    () => localStorage.getItem('contexture-codex-effort') ?? 'high',
+  const [modelOptions, setModelOptionsState] = useState<SchemaAgentModelOptions>(() =>
+    readStoredModelOptions(provider),
   );
+  const [effort, setEffortState] = useState(() => readStoredEffort(provider));
+  const providerRef = useRef(provider);
   const schema = useSyncExternalStore(useUndoStore.subscribe, () => useUndoStore.getState().schema);
   const persistenceEnabled = useChatComposerStore((s) => s.chatHistoryPersistence);
   const assistantBufferRef = useRef('');
@@ -103,10 +153,64 @@ export function useSchemaAgentChat({
     [persistenceEnabled, onMessagePersisted],
   );
 
+  const visibleModels = useMemo(
+    () => (modelsProvider === provider ? models : []),
+    [modelsProvider, provider, models],
+  );
+  const selectedModel = useMemo(
+    () =>
+      model && visibleModels.some((option) => option.id === model)
+        ? model
+        : visibleModels[0]?.id || model,
+    [model, visibleModels],
+  );
+  const selectedModelInfo = useMemo(
+    () => visibleModels.find((option) => option.id === selectedModel),
+    [selectedModel, visibleModels],
+  );
+  const selectedModelOptions = useMemo(
+    () => normalizeModelOptions(provider, modelOptions, selectedModelInfo, effort),
+    [provider, modelOptions, selectedModelInfo, effort],
+  );
+  const selectedEffort = useMemo(
+    () => readEffortFromOptions(provider, selectedModelOptions, selectedModelInfo, effort),
+    [provider, selectedModelOptions, selectedModelInfo, effort],
+  );
+  const modelsLoading = modelListState === 'loading' || modelListState === 'idle';
+  const modelsUnavailable = modelListState === 'loaded' && visibleModels.length === 0;
+
+  useEffect(() => {
+    providerRef.current = provider;
+  }, [provider]);
+
+  useEffect(() => {
+    const listener = (event: Event) => {
+      const detail = (event as CustomEvent<{ provider?: unknown }>).detail;
+      const next = detail?.provider;
+      if (next !== 'codex' && next !== 'claude') return;
+      if (next === providerRef.current) return;
+      setProviderState(next);
+      const nextModel = localStorage.getItem(modelStorageKey(next)) ?? '';
+      const nextEffort = readStoredEffort(next);
+      const nextOptions = readStoredModelOptions(next);
+      setModels([]);
+      setModelsProvider(null);
+      setModelListState('idle');
+      setModelState(nextModel);
+      setEffortState(nextEffort);
+      setModelOptionsState(nextOptions);
+      setProviderThreadRef(undefined);
+      setDesynced(false);
+    };
+    window.addEventListener(SCHEMA_AGENT_PROVIDER_CHANGED, listener);
+    return () => window.removeEventListener(SCHEMA_AGENT_PROVIDER_CHANGED, listener);
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     api
-      .getStatus()
+      .setProvider(provider)
+      .then(() => api.getStatus())
       .then((status) => {
         if (cancelled) return;
         applyStatus(status, setReady, setUnavailableMessage);
@@ -119,42 +223,92 @@ export function useSchemaAgentChat({
     return () => {
       cancelled = true;
     };
-  }, [api]);
+  }, [api, provider]);
 
   useEffect(() => {
     let cancelled = false;
+    setModels([]);
+    setModelsProvider(null);
+    setModelListState('loading');
     api
-      .listModels()
+      .setProvider(provider)
+      .then(() => api.listModels(provider))
       .then((result) => {
-        if (cancelled || !Array.isArray(result)) return;
+        if (cancelled) return;
+        if (!Array.isArray(result)) {
+          setModelListState('error');
+          return;
+        }
         const parsed = result
-          .filter((m): m is { id: string; label: string; supportsReasoningEffort?: boolean } => {
+          .filter((m): m is Record<string, unknown> & { id: string; label: string } => {
             if (!m || typeof m !== 'object') return false;
             const candidate = m as { id?: unknown; label?: unknown };
             return typeof candidate.id === 'string' && typeof candidate.label === 'string';
           })
-          .map((m) => ({
-            id: m.id,
-            label: m.label,
-            supportsReasoningEffort: m.supportsReasoningEffort,
-          }));
+          .map((m) => {
+            const optionDescriptors = parseModelOptionDescriptors(m.optionDescriptors);
+            return {
+              id: m.id,
+              label: m.label,
+              ...(typeof m.supportsReasoningEffort === 'boolean'
+                ? { supportsReasoningEffort: m.supportsReasoningEffort }
+                : {}),
+              ...(optionDescriptors ? { optionDescriptors } : {}),
+            };
+          });
         setModels(parsed);
-        if (!model && parsed[0]) {
-          setModelState(parsed[0].id);
-          localStorage.setItem('contexture-codex-model', parsed[0].id);
-          api.setModelOptions({ model: parsed[0].id, effort }).catch(() => undefined);
+        setModelsProvider(provider);
+        setModelListState('loaded');
+        if (parsed.length === 0) {
+          setModelState('');
+          return;
+        }
+        const storedModel = localStorage.getItem(modelStorageKey(provider)) ?? '';
+        const storedOptions = readStoredModelOptions(provider);
+        const storedEffortRaw = localStorage.getItem(effortStorageKey(provider));
+        const storedEffort = normalizeEffort(provider, storedEffortRaw);
+        const nextModel =
+          storedModel && parsed.some((option) => option.id === storedModel)
+            ? storedModel
+            : parsed[0]?.id;
+        const modelInfo = parsed.find((option) => option.id === nextModel);
+        const nextOptions = normalizeModelOptions(
+          provider,
+          storedOptions,
+          modelInfo,
+          storedEffortRaw === null ? undefined : storedEffort,
+        );
+        const nextEffort = readEffortFromOptions(provider, nextOptions, modelInfo);
+        if (nextModel) {
+          setModelState(nextModel);
+          localStorage.setItem(modelStorageKey(provider), nextModel);
+          setModelOptionsState(nextOptions);
+          localStorage.setItem(modelOptionsStorageKey(provider), JSON.stringify(nextOptions));
+          if (nextEffort && nextEffort !== storedEffort) setEffortState(nextEffort);
+          if (nextEffort) localStorage.setItem(effortStorageKey(provider), nextEffort);
+          api
+            .setModelOptions({ model: nextModel, effort: nextEffort, options: nextOptions })
+            .catch(() => undefined);
         }
       })
-      .catch(() => undefined);
+      .catch(() => {
+        if (!cancelled) setModelListState('error');
+      });
     return () => {
       cancelled = true;
     };
-  }, [api, effort, model]);
+  }, [api, provider]);
 
   useEffect(() => {
-    if (!model) return;
-    api.setModelOptions({ model, effort }).catch(() => undefined);
-  }, [api, model, effort]);
+    if (!selectedModel) return;
+    api
+      .setModelOptions({
+        model: selectedModel,
+        effort: selectedEffort,
+        options: selectedModelOptions,
+      })
+      .catch(() => undefined);
+  }, [api, selectedEffort, selectedModel, selectedModelOptions]);
 
   useEffect(() => {
     return api.onStatusChanged((status) => {
@@ -234,6 +388,26 @@ export function useSchemaAgentChat({
     async (text: string) => {
       const trimmed = text.trim();
       if (!trimmed || isStreaming || !isReady) return;
+      if (!selectedModel) {
+        setUnavailableMessage('No model is available for the selected provider.');
+        return;
+      }
+      const modelResult: { ok: boolean; error?: string } = await api
+        .setModelOptions({
+          model: selectedModel,
+          effort: selectedEffort,
+          options: selectedModelOptions,
+        })
+        .catch((err) => ({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        }));
+      if (!modelResult.ok) {
+        const message = modelResult.error ?? 'Failed to select model for this turn.';
+        setUnavailableMessage(message);
+        appendMessage(mkMessage('assistant', `Error: ${message}`));
+        return;
+      }
       appendMessage(mkMessage('user', trimmed));
       setStreaming(true);
       setLiveAssistant('');
@@ -248,22 +422,140 @@ export function useSchemaAgentChat({
         if (isAuthMessage(message)) setAuthRequired(true);
       }
     },
-    [api, appendMessage, isReady, isStreaming, schema],
+    [
+      api,
+      appendMessage,
+      isReady,
+      isStreaming,
+      schema,
+      selectedEffort,
+      selectedModel,
+      selectedModelOptions,
+    ],
   );
 
   const abort = useCallback(async () => {
     await api.abort();
   }, [api]);
 
-  const setModel = useCallback((next: string) => {
-    setModelState(next);
-    localStorage.setItem('contexture-codex-model', next);
-  }, []);
+  const restoreSettings = useCallback(
+    (settings: SchemaAgentModelSettings) => {
+      const nextProvider = settings.provider ?? provider;
+      providerRef.current = nextProvider;
+      setProviderState(nextProvider);
+      localStorage.setItem('contexture-schema-agent-provider', nextProvider);
 
-  const setEffort = useCallback((next: string) => {
-    setEffortState(next);
-    localStorage.setItem('contexture-codex-effort', next);
-  }, []);
+      const nextModel =
+        settings.model !== undefined
+          ? settings.model
+          : (localStorage.getItem(modelStorageKey(nextProvider)) ?? '');
+      const nextEffort = normalizeEffort(
+        nextProvider,
+        settings.effort ?? localStorage.getItem(effortStorageKey(nextProvider)),
+      );
+      const nextOptions = settings.modelOptions ?? readStoredModelOptions(nextProvider);
+
+      setModels([]);
+      setModelsProvider(null);
+      setModelListState('idle');
+      setModelState(nextModel);
+      setEffortState(nextEffort);
+      setModelOptionsState(nextOptions);
+      setProviderThreadRef(undefined);
+      setDesynced(false);
+
+      localStorage.setItem(modelStorageKey(nextProvider), nextModel);
+      localStorage.setItem(effortStorageKey(nextProvider), nextEffort);
+      localStorage.setItem(modelOptionsStorageKey(nextProvider), JSON.stringify(nextOptions));
+      api.setProvider(nextProvider).catch(() => undefined);
+      window.dispatchEvent(
+        new CustomEvent(SCHEMA_AGENT_PROVIDER_CHANGED, { detail: { provider: nextProvider } }),
+      );
+    },
+    [api, provider],
+  );
+
+  const setProvider = useCallback(
+    (next: SchemaAgentProvider) => {
+      if (next === provider) {
+        localStorage.setItem('contexture-schema-agent-provider', next);
+        api.setProvider(next).catch(() => undefined);
+        return;
+      }
+      providerRef.current = next;
+      setProviderState(next);
+      localStorage.setItem('contexture-schema-agent-provider', next);
+      const nextModel = localStorage.getItem(modelStorageKey(next)) ?? '';
+      const nextEffort = readStoredEffort(next);
+      const nextOptions = readStoredModelOptions(next);
+      setModels([]);
+      setModelsProvider(null);
+      setModelListState('idle');
+      setModelState(nextModel);
+      setEffortState(nextEffort);
+      setModelOptionsState(nextOptions);
+      setProviderThreadRef(undefined);
+      setDesynced(false);
+      api.setProvider(next).catch(() => undefined);
+      window.dispatchEvent(
+        new CustomEvent(SCHEMA_AGENT_PROVIDER_CHANGED, { detail: { provider: next } }),
+      );
+    },
+    [api, provider],
+  );
+
+  const setModel = useCallback(
+    (next: string) => {
+      setModelState(next);
+      localStorage.setItem(modelStorageKey(provider), next);
+      const modelInfo = models.find((option) => option.id === next);
+      const nextOptions = normalizeModelOptions(provider, modelOptions, modelInfo);
+      const nextEffort = readEffortFromOptions(provider, nextOptions, modelInfo);
+      setModelOptionsState(nextOptions);
+      localStorage.setItem(modelOptionsStorageKey(provider), JSON.stringify(nextOptions));
+      if (nextEffort && nextEffort !== effort) {
+        setEffortState(nextEffort);
+        localStorage.setItem(effortStorageKey(provider), nextEffort);
+      }
+    },
+    [effort, modelOptions, models, provider],
+  );
+
+  const setEffort = useCallback(
+    (next: string) => {
+      const activeModel = models.find((option) => option.id === model);
+      const descriptor = findEffortDescriptor(activeModel);
+      const normalized = descriptor
+        ? normalizeModelOptionValue(
+            descriptor,
+            provider === 'codex' && next === 'med' ? 'medium' : next,
+          )
+        : normalizeEffort(provider, next);
+      const nextOptions = descriptor
+        ? { ...modelOptions, [descriptor.id]: normalized }
+        : modelOptions;
+      setModelOptionsState(nextOptions);
+      setEffortState(normalized);
+      localStorage.setItem(modelOptionsStorageKey(provider), JSON.stringify(nextOptions));
+      localStorage.setItem(effortStorageKey(provider), normalized);
+    },
+    [model, modelOptions, models, provider],
+  );
+
+  const setModelOption = useCallback(
+    (id: string, value: string | boolean) => {
+      const nextOptions = { ...modelOptions, [id]: value };
+      const activeModel = models.find((option) => option.id === model);
+      const nextEffort = readEffortFromOptions(provider, nextOptions, activeModel);
+      setModelOptionsState(nextOptions);
+      localStorage.setItem(modelOptionsStorageKey(provider), JSON.stringify(nextOptions));
+      if (nextEffort) {
+        setEffortState(nextEffort);
+        localStorage.setItem(effortStorageKey(provider), nextEffort);
+      }
+    },
+    [model, modelOptions, models, provider],
+  );
 
   const hydrate = useCallback((next: ChatMessage[]) => setMessages(next), []);
   const clear = useCallback(() => {
@@ -275,11 +567,18 @@ export function useSchemaAgentChat({
   const clearAuthRequired = useCallback(() => setAuthRequired(false), []);
 
   return {
-    providerLabel: 'Codex',
-    models,
-    model,
+    provider,
+    providerLabel: provider === 'codex' ? 'Codex' : 'Claude',
+    setProvider,
+    restoreSettings,
+    models: visibleModels,
+    modelsLoading,
+    modelsUnavailable,
+    model: selectedModel,
     setModel,
-    effort,
+    modelOptions: selectedModelOptions,
+    setModelOption,
+    effort: selectedEffort,
     setEffort,
     messages,
     isStreaming,
@@ -309,20 +608,227 @@ function applyStatus(
     setUnavailableMessage(null);
     return;
   }
+  if (readiness === 'authenticated_cli') {
+    setReady(true);
+    setUnavailableMessage(null);
+    return;
+  }
   setReady(false);
-  setUnavailableMessage(readinessToMessage(readiness));
+  const provider =
+    status && typeof status === 'object' ? (status as { provider?: unknown }).provider : null;
+  setUnavailableMessage(readinessToMessage(readiness, provider));
 }
 
-function readinessToMessage(readiness: unknown): string {
-  if (readiness === 'cli_missing') return 'Codex CLI not detected.';
-  if (readiness === 'cli_outdated') return 'Codex CLI is outdated.';
-  if (readiness === 'app_server_unavailable') return 'Codex app-server is unavailable.';
-  if (readiness === 'not_signed_in') return 'Sign in to Codex to start chatting.';
-  if (readiness === 'rate_limited') return 'Codex is currently rate-limited.';
-  if (readiness === 'desynced') return 'Codex thread is desynced. Start a new chat.';
-  return 'Codex is not ready.';
+function readinessToMessage(readiness: unknown, provider: unknown): string {
+  const label = provider === 'claude' ? 'Claude' : 'Codex';
+  if (readiness === 'cli_missing') return `${label} CLI not detected.`;
+  if (readiness === 'cli_outdated') return `${label} CLI is outdated.`;
+  if (readiness === 'app_server_unavailable') return `${label} app-server is unavailable.`;
+  if (readiness === 'not_signed_in') return `Sign in to ${label} to start chatting.`;
+  if (readiness === 'rate_limited') return `${label} is currently rate-limited.`;
+  if (readiness === 'desynced') return `${label} thread is desynced. Start a new chat.`;
+  return `${label} is not ready.`;
 }
 
 function isAuthMessage(message: string): boolean {
   return /auth|sign.?in|unauthori[sz]ed|api key/i.test(message);
+}
+
+function modelStorageKey(provider: SchemaAgentProvider): string {
+  return `contexture-schema-agent-${provider}-model`;
+}
+
+function effortStorageKey(provider: SchemaAgentProvider): string {
+  return `contexture-schema-agent-${provider}-effort`;
+}
+
+function modelOptionsStorageKey(provider: SchemaAgentProvider): string {
+  return `contexture-schema-agent-${provider}-model-options`;
+}
+
+function readStoredModelOptions(provider: SchemaAgentProvider): SchemaAgentModelOptions {
+  try {
+    const raw = localStorage.getItem(modelOptionsStorageKey(provider));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).filter(
+        (entry): entry is [string, string | boolean] =>
+          typeof entry[1] === 'string' || typeof entry[1] === 'boolean',
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function readStoredEffort(provider: SchemaAgentProvider): string {
+  return normalizeEffort(provider, localStorage.getItem(effortStorageKey(provider)));
+}
+
+function defaultEffort(provider: SchemaAgentProvider): string {
+  return provider === 'codex' ? 'high' : 'auto';
+}
+
+function normalizeEffort(provider: SchemaAgentProvider, effort: unknown): string {
+  if (provider === 'codex') {
+    if (effort === 'med') return 'medium';
+    if (effort === 'low' || effort === 'medium' || effort === 'high' || effort === 'xhigh') {
+      return effort;
+    }
+    return 'high';
+  }
+  if (effort === 'medium') return 'med';
+  if (
+    effort === 'auto' ||
+    effort === 'low' ||
+    effort === 'med' ||
+    effort === 'high' ||
+    effort === 'xhigh'
+  ) {
+    return effort;
+  }
+  return 'auto';
+}
+
+function normalizeEffortForModel(
+  provider: SchemaAgentProvider,
+  effort: unknown,
+  model?: SchemaAgentModelInfo,
+): string {
+  const descriptor = findEffortDescriptor(model);
+  if (descriptor) {
+    const raw = typeof effort === 'string' ? effort : null;
+    const alias = provider === 'codex' && raw === 'med' ? 'medium' : raw;
+    if (alias && descriptor.options.some((option) => option.id === alias)) return alias;
+    return (
+      descriptor.options.find((option) => option.isDefault)?.id ??
+      descriptor.options[0]?.id ??
+      defaultEffort(provider)
+    );
+  }
+  return normalizeEffort(provider, effort);
+}
+
+function normalizeModelOptions(
+  provider: SchemaAgentProvider,
+  options: SchemaAgentModelOptions,
+  model?: SchemaAgentModelInfo,
+  effort?: string,
+): SchemaAgentModelOptions {
+  const descriptors = model?.optionDescriptors ?? [];
+  if (descriptors.length === 0) return options;
+  const normalized: SchemaAgentModelOptions = {};
+  for (const descriptor of descriptors) {
+    if (descriptor.type === 'select') {
+      const rawValue =
+        options[descriptor.id] ??
+        (isEffortDescriptor(descriptor) ? effort : undefined) ??
+        descriptor.currentValue;
+      normalized[descriptor.id] = normalizeModelOptionValue(
+        descriptor,
+        provider === 'codex' && rawValue === 'med' ? 'medium' : rawValue,
+      );
+    } else {
+      const rawValue = options[descriptor.id] ?? descriptor.currentValue ?? descriptor.defaultValue;
+      normalized[descriptor.id] = typeof rawValue === 'boolean' ? rawValue : false;
+    }
+  }
+  return normalized;
+}
+
+function normalizeModelOptionValue(
+  descriptor: Extract<SchemaAgentModelOptionDescriptor, { type: 'select' }>,
+  value: unknown,
+): string {
+  if (typeof value === 'string' && descriptor.options.some((option) => option.id === value)) {
+    return value;
+  }
+  return (
+    descriptor.options.find((option) => option.isDefault)?.id ?? descriptor.options[0]?.id ?? ''
+  );
+}
+
+function readEffortFromOptions(
+  provider: SchemaAgentProvider,
+  options: SchemaAgentModelOptions,
+  model?: SchemaAgentModelInfo,
+  fallbackEffort?: string,
+): string {
+  const descriptor = findEffortDescriptor(model);
+  const value = descriptor ? options[descriptor.id] : undefined;
+  if (typeof value === 'string' && value.length > 0) return value;
+  return normalizeEffortForModel(provider, fallbackEffort, model);
+}
+
+function findEffortDescriptor(
+  model?: SchemaAgentModelInfo,
+): Extract<SchemaAgentModelOptionDescriptor, { type: 'select' }> | null {
+  const descriptor = model?.optionDescriptors?.find(
+    (candidate) => candidate.type === 'select' && isEffortDescriptor(candidate),
+  );
+  return descriptor?.type === 'select' ? descriptor : null;
+}
+
+function isEffortDescriptor(descriptor: SchemaAgentModelOptionDescriptor): boolean {
+  return descriptor.id === 'effort' || descriptor.id === 'reasoningEffort';
+}
+
+function parseModelOptionDescriptors(
+  value: unknown,
+): SchemaAgentModelOptionDescriptor[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parsed = value
+    .map(parseModelOptionDescriptor)
+    .filter((descriptor): descriptor is SchemaAgentModelOptionDescriptor => descriptor !== null);
+  return parsed.length > 0 ? parsed : undefined;
+}
+
+function parseModelOptionDescriptor(value: unknown): SchemaAgentModelOptionDescriptor | null {
+  if (!value || typeof value !== 'object') return null;
+  const descriptor = value as Record<string, unknown>;
+  if (typeof descriptor.id !== 'string' || typeof descriptor.label !== 'string') return null;
+  if (descriptor.type === 'boolean') {
+    return {
+      id: descriptor.id,
+      type: 'boolean',
+      label: descriptor.label,
+      ...(typeof descriptor.defaultValue === 'boolean'
+        ? { defaultValue: descriptor.defaultValue }
+        : {}),
+      ...(typeof descriptor.currentValue === 'boolean'
+        ? { currentValue: descriptor.currentValue }
+        : {}),
+    };
+  }
+  if (descriptor.type !== 'select' || !Array.isArray(descriptor.options)) return null;
+  const options = descriptor.options
+    .map(parseSelectOption)
+    .filter(
+      (option): option is { id: string; label: string; isDefault?: boolean } => option !== null,
+    );
+  if (options.length === 0) return null;
+  return {
+    id: descriptor.id,
+    type: 'select',
+    label: descriptor.label,
+    options,
+    ...(typeof descriptor.currentValue === 'string'
+      ? { currentValue: descriptor.currentValue }
+      : {}),
+  };
+}
+
+function parseSelectOption(
+  value: unknown,
+): { id: string; label: string; isDefault?: boolean } | null {
+  if (!value || typeof value !== 'object') return null;
+  const option = value as Record<string, unknown>;
+  if (typeof option.id !== 'string' || typeof option.label !== 'string') return null;
+  return {
+    id: option.id,
+    label: option.label,
+    ...(option.isDefault === true ? { isDefault: true } : {}),
+  };
 }

--- a/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
+++ b/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
@@ -1,0 +1,328 @@
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import type { ContextureSchemaAgentAPI } from '../../../preload/index.d';
+import type { ChatMessage, ChatRole } from '../model/chat-history';
+import { useChatComposerStore } from '../store/chat-composer';
+import type { ApplyResult, Op } from '../store/ops';
+import { useUndoStore } from '../store/undo';
+import { bindTurnToUndo, type IpcSubscriber } from './turn-binder';
+
+export interface SchemaAgentChatState {
+  providerLabel: 'Codex';
+  models: Array<{ id: string; label: string; supportsReasoningEffort?: boolean }>;
+  model: string;
+  setModel: (model: string) => void;
+  effort: string;
+  setEffort: (effort: string) => void;
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  liveAssistant: string;
+  authRequired: boolean;
+  isReady: boolean;
+  unavailableMessage: string | null;
+  providerThreadRef: unknown;
+  desynced: boolean;
+  clearAuthRequired: () => void;
+  send: (text: string) => Promise<void>;
+  abort: () => Promise<void>;
+  hydrate: (messages: ChatMessage[]) => void;
+  clear: () => void;
+}
+
+export interface UseSchemaAgentChatOptions {
+  api: ContextureSchemaAgentAPI;
+  onMessagePersisted?: (message: ChatMessage) => void;
+}
+
+function mkId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  return c?.randomUUID ? c.randomUUID() : `id-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+}
+
+function mkMessage(role: ChatRole, content: string): ChatMessage {
+  return { id: mkId(), role, content, createdAt: Date.now() };
+}
+
+export function useSchemaAgentChat({
+  api,
+  onMessagePersisted,
+}: UseSchemaAgentChatOptions): SchemaAgentChatState {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isStreaming, setStreaming] = useState(false);
+  const [liveAssistant, setLiveAssistant] = useState('');
+  const [authRequired, setAuthRequired] = useState(false);
+  const [isReady, setReady] = useState(false);
+  const [unavailableMessage, setUnavailableMessage] = useState<string | null>(null);
+  const [providerThreadRef, setProviderThreadRef] = useState<unknown>(undefined);
+  const [desynced, setDesynced] = useState(false);
+  const [models, setModels] = useState<
+    Array<{ id: string; label: string; supportsReasoningEffort?: boolean }>
+  >([]);
+  const [model, setModelState] = useState(
+    () => localStorage.getItem('contexture-codex-model') ?? '',
+  );
+  const [effort, setEffortState] = useState(
+    () => localStorage.getItem('contexture-codex-effort') ?? 'high',
+  );
+  const schema = useSyncExternalStore(useUndoStore.subscribe, () => useUndoStore.getState().schema);
+  const persistenceEnabled = useChatComposerStore((s) => s.chatHistoryPersistence);
+  const assistantBufferRef = useRef('');
+  const rafHandleRef = useRef<number | null>(null);
+
+  const flushLiveAssistant = useCallback(() => {
+    rafHandleRef.current = null;
+    setLiveAssistant(assistantBufferRef.current);
+  }, []);
+
+  const scheduleLiveFlush = useCallback(() => {
+    if (rafHandleRef.current !== null) return;
+    const raf =
+      typeof requestAnimationFrame === 'function'
+        ? requestAnimationFrame
+        : (cb: FrameRequestCallback) =>
+            setTimeout(() => cb(performance.now()), 16) as unknown as number;
+    rafHandleRef.current = -1;
+    const handle = raf(flushLiveAssistant);
+    if (rafHandleRef.current === -1) rafHandleRef.current = handle;
+  }, [flushLiveAssistant]);
+
+  const cancelLiveFlush = useCallback(() => {
+    if (rafHandleRef.current === null) return;
+    const caf =
+      typeof cancelAnimationFrame === 'function'
+        ? cancelAnimationFrame
+        : (id: number) => clearTimeout(id as unknown as ReturnType<typeof setTimeout>);
+    caf(rafHandleRef.current);
+    rafHandleRef.current = null;
+  }, []);
+
+  const appendMessage = useCallback(
+    (message: ChatMessage) => {
+      setMessages((prev) => [...prev, message]);
+      if (persistenceEnabled) onMessagePersisted?.(message);
+    },
+    [persistenceEnabled, onMessagePersisted],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getStatus()
+      .then((status) => {
+        if (cancelled) return;
+        applyStatus(status, setReady, setUnavailableMessage);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setReady(false);
+        setUnavailableMessage(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listModels()
+      .then((result) => {
+        if (cancelled || !Array.isArray(result)) return;
+        const parsed = result
+          .filter((m): m is { id: string; label: string; supportsReasoningEffort?: boolean } => {
+            if (!m || typeof m !== 'object') return false;
+            const candidate = m as { id?: unknown; label?: unknown };
+            return typeof candidate.id === 'string' && typeof candidate.label === 'string';
+          })
+          .map((m) => ({
+            id: m.id,
+            label: m.label,
+            supportsReasoningEffort: m.supportsReasoningEffort,
+          }));
+        setModels(parsed);
+        if (!model && parsed[0]) {
+          setModelState(parsed[0].id);
+          localStorage.setItem('contexture-codex-model', parsed[0].id);
+          api.setModelOptions({ model: parsed[0].id, effort }).catch(() => undefined);
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [api, effort, model]);
+
+  useEffect(() => {
+    if (!model) return;
+    api.setModelOptions({ model, effort }).catch(() => undefined);
+  }, [api, model, effort]);
+
+  useEffect(() => {
+    return api.onStatusChanged((status) => {
+      applyStatus(status, setReady, setUnavailableMessage);
+    });
+  }, [api]);
+
+  useEffect(() => {
+    return api.onToolRequest(({ id, op }) => {
+      const result: ApplyResult = useUndoStore.getState().apply(op as Op);
+      api.replyTool(id, result);
+    });
+  }, [api]);
+
+  useEffect(() => {
+    return api.onThreadUpdated(({ thread }) => {
+      setProviderThreadRef(thread);
+      setDesynced(false);
+    });
+  }, [api]);
+
+  useEffect(() => {
+    return api.onThreadDesynced(({ thread }) => {
+      setProviderThreadRef(thread);
+      setDesynced(true);
+    });
+  }, [api]);
+
+  useEffect(() => {
+    return api.onAssistantDelta(({ text }) => {
+      assistantBufferRef.current += text;
+      scheduleLiveFlush();
+    });
+  }, [api, scheduleLiveFlush]);
+
+  useEffect(() => {
+    return api.onToolCallStarted(({ name }) => {
+      appendMessage(mkMessage('assistant', `\`${name}\``));
+    });
+  }, [api, appendMessage]);
+
+  useEffect(() => {
+    return api.onAssistantFinal(({ text }) => {
+      cancelLiveFlush();
+      assistantBufferRef.current = '';
+      setLiveAssistant('');
+      const trimmed = text.trim();
+      if (trimmed) appendMessage(mkMessage('assistant', trimmed));
+      setStreaming(false);
+    });
+  }, [api, appendMessage, cancelLiveFlush]);
+
+  useEffect(() => {
+    return api.onError(({ message }) => {
+      cancelLiveFlush();
+      assistantBufferRef.current = '';
+      setLiveAssistant('');
+      appendMessage(mkMessage('assistant', `Error: ${message}`));
+      setStreaming(false);
+      if (isAuthMessage(message)) setAuthRequired(true);
+    });
+  }, [api, appendMessage, cancelLiveFlush]);
+
+  useEffect(() => {
+    const subscriber: IpcSubscriber = {
+      on: (channel, listener) => {
+        if (channel === 'turn:begin') return api.onTurnBegin(listener);
+        if (channel === 'turn:commit') return api.onTurnCommit(listener);
+        if (channel === 'turn:rollback') return api.onTurnRollback(listener);
+        return () => undefined;
+      },
+    };
+    return bindTurnToUndo(subscriber, useUndoStore.getState());
+  }, [api]);
+
+  const send = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || isStreaming || !isReady) return;
+      appendMessage(mkMessage('user', trimmed));
+      setStreaming(true);
+      setLiveAssistant('');
+      assistantBufferRef.current = '';
+      setAuthRequired(false);
+      api.setIR(schema);
+      const result = await api.send(trimmed);
+      if (!result.ok) {
+        const message = result.error ?? 'Schema-agent send failed';
+        appendMessage(mkMessage('assistant', `Error: ${message}`));
+        setStreaming(false);
+        if (isAuthMessage(message)) setAuthRequired(true);
+      }
+    },
+    [api, appendMessage, isReady, isStreaming, schema],
+  );
+
+  const abort = useCallback(async () => {
+    await api.abort();
+  }, [api]);
+
+  const setModel = useCallback((next: string) => {
+    setModelState(next);
+    localStorage.setItem('contexture-codex-model', next);
+  }, []);
+
+  const setEffort = useCallback((next: string) => {
+    setEffortState(next);
+    localStorage.setItem('contexture-codex-effort', next);
+  }, []);
+
+  const hydrate = useCallback((next: ChatMessage[]) => setMessages(next), []);
+  const clear = useCallback(() => {
+    setMessages([]);
+    cancelLiveFlush();
+    assistantBufferRef.current = '';
+    setLiveAssistant('');
+  }, [cancelLiveFlush]);
+  const clearAuthRequired = useCallback(() => setAuthRequired(false), []);
+
+  return {
+    providerLabel: 'Codex',
+    models,
+    model,
+    setModel,
+    effort,
+    setEffort,
+    messages,
+    isStreaming,
+    liveAssistant,
+    authRequired,
+    isReady,
+    unavailableMessage,
+    providerThreadRef,
+    desynced,
+    clearAuthRequired,
+    send,
+    abort,
+    hydrate,
+    clear,
+  };
+}
+
+function applyStatus(
+  status: unknown,
+  setReady: (ready: boolean) => void,
+  setUnavailableMessage: (message: string | null) => void,
+): void {
+  const readiness =
+    status && typeof status === 'object' ? (status as { readiness?: unknown }).readiness : null;
+  if (readiness === 'authenticated_chatgpt' || readiness === 'authenticated_api_key') {
+    setReady(true);
+    setUnavailableMessage(null);
+    return;
+  }
+  setReady(false);
+  setUnavailableMessage(readinessToMessage(readiness));
+}
+
+function readinessToMessage(readiness: unknown): string {
+  if (readiness === 'cli_missing') return 'Codex CLI not detected.';
+  if (readiness === 'cli_outdated') return 'Codex CLI is outdated.';
+  if (readiness === 'app_server_unavailable') return 'Codex app-server is unavailable.';
+  if (readiness === 'not_signed_in') return 'Sign in to Codex to start chatting.';
+  if (readiness === 'rate_limited') return 'Codex is currently rate-limited.';
+  if (readiness === 'desynced') return 'Codex thread is desynced. Start a new chat.';
+  return 'Codex is not ready.';
+}
+
+function isAuthMessage(message: string): boolean {
+  return /auth|sign.?in|unauthori[sz]ed|api key/i.test(message);
+}

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -23,10 +23,14 @@
  * live in `useClaude`. The panel stitches them together.
  */
 
-import { useChatThreads } from '@renderer/chat/useChatThreads';
+import { type ChatThread, useChatThreads } from '@renderer/chat/useChatThreads';
 import { type ModelId, type ThinkingBudget, useClaude } from '@renderer/chat/useClaude';
 import type { ClaudeSchemaChatState } from '@renderer/chat/useClaudeSchemaChat';
-import type { SchemaAgentChatState } from '@renderer/chat/useSchemaAgentChat';
+import type {
+  SchemaAgentChatState,
+  SchemaAgentModelInfo,
+  SchemaAgentModelOptionDescriptor,
+} from '@renderer/chat/useSchemaAgentChat';
 import type { ChatMessage } from '@renderer/model/chat-history';
 import { useDocumentStore } from '@renderer/store/document';
 import { code } from '@streamdown/code';
@@ -34,6 +38,7 @@ import { ArrowUp, BotMessageSquare, List, Square, SquarePen } from 'lucide-react
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Streamdown } from 'streamdown';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Empty,
   EmptyDescription,
@@ -69,21 +74,34 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     hydrate,
   } = chat;
   const claude = useClaude();
-  const providerLabel = 'providerLabel' in chat ? chat.providerLabel : 'Claude';
-  const provider = providerLabel === 'Codex' ? 'codex' : 'claude';
-  const isCodex = provider === 'codex';
+  const isSchemaAgent = 'provider' in chat;
+  const providerLabel = isSchemaAgent ? chat.providerLabel : 'Claude';
+  const provider = isSchemaAgent ? chat.provider : 'claude';
   const authMode = claude.authMode;
-  const isReady = 'isReady' in chat ? chat.isReady : claude.isReady;
-  const model = isCodex && 'model' in chat ? chat.model : claude.model;
-  const setModel = isCodex && 'setModel' in chat ? chat.setModel : claude.setModel;
-  const thinkingBudget = isCodex && 'effort' in chat ? chat.effort : claude.thinkingBudget;
-  const setThinkingBudget =
-    isCodex && 'setEffort' in chat ? chat.setEffort : claude.setThinkingBudget;
-  const codexModels = isCodex && 'models' in chat ? chat.models : [];
-  const modelSelectValue = isCodex ? model || codexModels[0]?.id || 'models-unavailable' : model;
+  const isReady = isSchemaAgent ? chat.isReady : claude.isReady;
+  const model = isSchemaAgent ? chat.model : claude.model;
+  const setModel = isSchemaAgent ? chat.setModel : claude.setModel;
+  const thinkingBudget = isSchemaAgent ? chat.effort : claude.thinkingBudget;
+  const providerModels = isSchemaAgent ? chat.models : [];
+  const modelsLoading = isSchemaAgent ? chat.modelsLoading : false;
+  const modelsUnavailable = isSchemaAgent ? chat.modelsUnavailable : false;
+  const modelSelectValue = isSchemaAgent
+    ? model || providerModels[0]?.id || (modelsLoading ? 'models-loading' : 'models-unavailable')
+    : model;
+  const activeModel = isSchemaAgent
+    ? providerModels.find((option) => option.id === modelSelectValue)
+    : legacyClaudeModelInfo(model);
+  const modelOptionDescriptors = activeModel?.optionDescriptors ?? [];
+  const modelOptionValues = isSchemaAgent ? chat.modelOptions : { effort: thinkingBudget };
+  const currentModelOptions = isSchemaAgent ? chat.modelOptions : undefined;
+  const restoreSchemaAgentSettings = isSchemaAgent ? chat.restoreSettings : undefined;
   const unavailableMessage = 'unavailableMessage' in chat ? chat.unavailableMessage : null;
   const providerThreadRef = 'providerThreadRef' in chat ? chat.providerThreadRef : undefined;
   const desynced = 'desynced' in chat ? chat.desynced : false;
+  const hasUsableModel =
+    !isSchemaAgent || providerModels.some((option) => option.id === modelSelectValue);
+  const canCompose =
+    isReady && !isStreaming && hasUsableModel && !modelsLoading && !modelsUnavailable;
 
   const filePath = useDocumentStore((s) => s.filePath);
   const history = useChatThreads();
@@ -99,14 +117,32 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   // trigger a spurious update).
   const prevMessagesRef = useRef<ChatMessage[] | null>(null);
 
+  const restoreThreadSettings = useCallback(
+    (thread: ChatThread) => {
+      if (restoreSchemaAgentSettings) {
+        restoreSchemaAgentSettings({
+          provider: thread.provider,
+          model: thread.model,
+          effort: thread.effort,
+          modelOptions: thread.modelOptions,
+        });
+        return;
+      }
+      if (thread.model) claude.setModel(thread.model as ModelId);
+      if (thread.effort) claude.setThinkingBudget(thread.effort as ThinkingBudget);
+    },
+    [claude.setModel, claude.setThinkingBudget, restoreSchemaAgentSettings],
+  );
+
   // Restore the active thread's messages on first mount.
   const restoredRef = useRef(false);
   useEffect(() => {
     if (restoredRef.current) return;
     restoredRef.current = true;
     const thread = history.getActiveThread();
-    if (thread && thread.messages.length > 0) {
-      hydrate(thread.messages);
+    if (thread) {
+      if (thread.messages.length > 0) hydrate(thread.messages);
+      restoreThreadSettings(thread);
       // Push the stored session id into main so the next turn resumes
       // this thread's prior SDK context.
       if (thread.sessionId) {
@@ -119,7 +155,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       else void window.contexture?.schemaAgent?.threadClear();
     }
     prevMessagesRef.current = thread?.messages ?? [];
-  }, [history, hydrate]);
+  }, [history, hydrate, restoreThreadSettings]);
 
   // On schema-file change, switch to the most recent thread for that
   // file — or clear the transcript and the SDK session if this file
@@ -138,6 +174,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       const latest = fileThreads[0];
       history.switchThread(latest.id);
       hydrate(latest.messages);
+      restoreThreadSettings(latest);
       prevMessagesRef.current = latest.messages;
       if (latest.sessionId) {
         void window.contexture?.chat?.setSessionId?.(latest.sessionId);
@@ -156,7 +193,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       void window.contexture?.chat?.clearSession?.();
       void window.contexture?.schemaAgent?.threadClear();
     }
-  }, [filePath, history, hydrate, clear]);
+  }, [filePath, history, hydrate, clear, restoreThreadSettings]);
 
   // Persist messages into the active thread whenever they change.
   useEffect(() => {
@@ -170,11 +207,34 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   // Auto-create a thread on the first appended message if none active.
   useEffect(() => {
     if (!history.activeThreadId && messages.length > 0) {
-      const id = history.createThread({ provider, model, effort: thinkingBudget, filePath });
+      const id = history.createThread({
+        provider,
+        model,
+        effort: thinkingBudget,
+        modelOptions: currentModelOptions,
+        filePath,
+      });
       history.updateThreadMessages(id, messages);
       prevMessagesRef.current = messages;
     }
-  }, [messages, history, model, thinkingBudget, filePath, provider]);
+  }, [messages, history, model, thinkingBudget, filePath, provider, currentModelOptions]);
+
+  useEffect(() => {
+    if (!history.activeThreadId) return;
+    history.updateThreadSettings(history.activeThreadId, {
+      provider,
+      model,
+      effort: thinkingBudget,
+      modelOptions: currentModelOptions,
+    });
+  }, [
+    history.activeThreadId,
+    history.updateThreadSettings,
+    provider,
+    model,
+    thinkingBudget,
+    currentModelOptions,
+  ]);
 
   // Stamp the active thread with the SDK session id as it streams in.
   useEffect(() => {
@@ -218,7 +278,13 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     if (history.activeThreadId && messages.length === 0) {
       history.deleteThread(history.activeThreadId);
     }
-    history.createThread({ provider, model, effort: thinkingBudget, filePath });
+    history.createThread({
+      provider,
+      model,
+      effort: thinkingBudget,
+      modelOptions: currentModelOptions,
+      filePath,
+    });
     clear();
     setInput('');
     prevMessagesRef.current = [];
@@ -227,7 +293,16 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     void window.contexture?.chat?.clearSession?.();
     void window.contexture?.schemaAgent?.threadClear();
     history.setShowThreadList(false);
-  }, [history, messages.length, provider, model, thinkingBudget, filePath, clear]);
+  }, [
+    history,
+    messages.length,
+    provider,
+    model,
+    thinkingBudget,
+    filePath,
+    clear,
+    currentModelOptions,
+  ]);
 
   const handleSwitchThread = useCallback(
     (id: string) => {
@@ -235,6 +310,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       if (!thread) return;
       history.switchThread(id);
       hydrate(thread.messages);
+      restoreThreadSettings(thread);
       prevMessagesRef.current = thread.messages;
       if (thread.sessionId) {
         void window.contexture?.chat?.setSessionId?.(thread.sessionId);
@@ -245,7 +321,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
         void window.contexture?.schemaAgent?.threadSet(thread.providerThreadRef);
       else void window.contexture?.schemaAgent?.threadClear();
     },
-    [history, hydrate],
+    [history, hydrate, restoreThreadSettings],
   );
 
   const handleDeleteThread = useCallback(
@@ -259,6 +335,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       if (remaining.length > 0) {
         const next = remaining[0];
         hydrate(next.messages);
+        restoreThreadSettings(next);
         history.setActiveThreadId(next.id);
         prevMessagesRef.current = next.messages;
         if (next.sessionId) void window.contexture?.chat?.setSessionId?.(next.sessionId);
@@ -273,18 +350,18 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
         void window.contexture?.schemaAgent?.threadClear();
       }
     },
-    [history, filePath, hydrate, clear],
+    [history, filePath, hydrate, clear, restoreThreadSettings],
   );
 
   const handleSubmit = useCallback(
     async (ev?: React.FormEvent) => {
       ev?.preventDefault();
       const text = input.trim();
-      if (!text || isStreaming || !isReady) return;
+      if (!text || !canCompose) return;
       setInput('');
       await send(text);
     },
-    [input, isStreaming, isReady, send],
+    [canCompose, input, send],
   );
 
   const handleKeyDown = useCallback(
@@ -347,15 +424,25 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
                   </EmptyMedia>
                 )}
                 <EmptyTitle className="text-sm font-medium">
-                  {isReady ? 'Start a conversation' : 'Not connected'}
+                  {isReady
+                    ? modelsLoading
+                      ? 'Loading models'
+                      : modelsUnavailable
+                        ? 'No model available'
+                        : 'Start a conversation'
+                    : 'Not connected'}
                 </EmptyTitle>
                 <EmptyDescription className="text-xs">
-                  {isReady
-                    ? `Describe the schema you want and ${providerLabel} will build it on the canvas.`
-                    : (unavailableMessage ??
-                      (authMode === 'max'
-                        ? 'Claude CLI not detected. Configure in toolbar.'
-                        : 'Set your API key in the toolbar to start chatting.'))}
+                  {isReady && modelsLoading
+                    ? `Loading ${providerLabel} models.`
+                    : isReady && modelsUnavailable
+                      ? `${providerLabel} did not return any models for this session.`
+                      : isReady
+                        ? `Describe the schema you want and ${providerLabel} will build it on the canvas.`
+                        : (unavailableMessage ??
+                          (authMode === 'max'
+                            ? 'Claude CLI not detected. Configure in toolbar.'
+                            : 'Set your API key in the toolbar to start chatting.'))}
                 </EmptyDescription>
               </EmptyHeader>
             </Empty>
@@ -409,7 +496,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
             onChange={(ev) => setInput(ev.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={isReady ? 'Ask anything…' : 'Configure auth first…'}
-            disabled={!isReady || isStreaming}
+            disabled={!canCompose}
             rows={1}
             className={cn(
               'w-full resize-none bg-transparent px-3 pt-3 pb-2 text-sm leading-5',
@@ -427,9 +514,13 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
               <SelectContent>
                 <SelectGroup>
                   <SelectLabel>Model</SelectLabel>
-                  {isCodex ? (
-                    codexModels.length > 0 ? (
-                      codexModels.map((option) => (
+                  {isSchemaAgent ? (
+                    modelsLoading ? (
+                      <SelectItem value="models-loading" disabled>
+                        Loading models
+                      </SelectItem>
+                    ) : providerModels.length > 0 ? (
+                      providerModels.map((option) => (
                         <SelectItem key={option.id} value={option.id}>
                           {option.label}
                         </SelectItem>
@@ -449,25 +540,63 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
                 </SelectGroup>
               </SelectContent>
             </Select>
-            <Select
-              value={thinkingBudget}
-              onValueChange={(v) => setThinkingBudget(v as ThinkingBudget)}
-            >
-              <SelectTrigger className="w-20 h-7 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectLabel>Effort</SelectLabel>
-                  {!isCodex && <SelectItem value="auto">Auto</SelectItem>}
-                  <SelectItem value="low">Low</SelectItem>
-                  <SelectItem value={isCodex ? 'medium' : 'med'}>
-                    {isCodex ? 'Medium' : 'Med'}
-                  </SelectItem>
-                  <SelectItem value="high">High</SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
+            {modelOptionDescriptors.map((descriptor) =>
+              descriptor.type === 'select' ? (
+                <Select
+                  key={descriptor.id}
+                  value={resolveSelectValue(
+                    descriptor.options,
+                    readStringOption(modelOptionValues, descriptor.id),
+                  )}
+                  onValueChange={(value) => {
+                    if (isSchemaAgent) chat.setModelOption(descriptor.id, value);
+                    else claude.setThinkingBudget(value as ThinkingBudget);
+                  }}
+                >
+                  <SelectTrigger
+                    aria-label={descriptor.label}
+                    title={descriptor.label}
+                    className={cn(
+                      'h-7 shrink-0 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5',
+                      descriptor.id === 'contextWindow' ? 'w-16' : 'w-20',
+                    )}
+                    data-testid={
+                      isEffortDescriptor(descriptor)
+                        ? 'chat-effort-select'
+                        : `chat-model-option-${descriptor.id}`
+                    }
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>{descriptor.label}</SelectLabel>
+                      {descriptor.options.map((option) => (
+                        <SelectItem key={option.id} value={option.id}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              ) : (
+                <div
+                  key={descriptor.id}
+                  className="flex h-7 shrink-0 items-center gap-1.5 px-1.5 text-xs text-muted-foreground"
+                  data-testid={`chat-model-option-${descriptor.id}`}
+                >
+                  <Checkbox
+                    aria-label={descriptor.label}
+                    className="size-3.5"
+                    checked={readBooleanOption(modelOptionValues, descriptor.id, descriptor)}
+                    onCheckedChange={(value) => {
+                      if (isSchemaAgent) chat.setModelOption(descriptor.id, value === true);
+                    }}
+                  />
+                  {descriptor.label}
+                </div>
+              ),
+            )}
             <div className="ml-auto">
               {isStreaming ? (
                 <button
@@ -481,10 +610,10 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
               ) : (
                 <button
                   type="submit"
-                  disabled={!isReady || !input.trim()}
+                  disabled={!canCompose || !input.trim()}
                   className={cn(
                     'size-7 rounded-lg flex items-center justify-center transition-colors',
-                    isReady && input.trim()
+                    canCompose && input.trim()
                       ? 'bg-primary text-primary-foreground hover:bg-primary/90'
                       : 'bg-muted text-muted-foreground cursor-not-allowed',
                   )}
@@ -535,4 +664,56 @@ function MessageBubble({ message }: { message: ChatMessage }): React.JSX.Element
       <Streamdown plugins={{ code }}>{message.content}</Streamdown>
     </div>
   );
+}
+
+const LEGACY_CLAUDE_EFFORT_DESCRIPTOR: Extract<
+  SchemaAgentModelOptionDescriptor,
+  { type: 'select' }
+> = {
+  id: 'effort',
+  type: 'select',
+  label: 'Effort',
+  options: [
+    { id: 'auto', label: 'Auto', isDefault: true },
+    { id: 'low', label: 'Low' },
+    { id: 'med', label: 'Medium' },
+    { id: 'high', label: 'High' },
+    { id: 'xhigh', label: 'Extra High' },
+  ],
+};
+
+function legacyClaudeModelInfo(model: string): SchemaAgentModelInfo {
+  return {
+    id: model,
+    label: model,
+    optionDescriptors: [LEGACY_CLAUDE_EFFORT_DESCRIPTOR],
+  };
+}
+
+function resolveSelectValue(
+  options: Array<{ id: string; label: string; isDefault?: boolean }>,
+  value: string,
+): string {
+  if (options.some((option) => option.id === value)) return value;
+  return options.find((option) => option.isDefault)?.id ?? options[0]?.id ?? '';
+}
+
+function isEffortDescriptor(descriptor: SchemaAgentModelOptionDescriptor): boolean {
+  return descriptor.id === 'effort' || descriptor.id === 'reasoningEffort';
+}
+
+function readStringOption(options: Record<string, string | boolean>, key: string): string {
+  const value = options[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function readBooleanOption(
+  options: Record<string, string | boolean>,
+  key: string,
+  descriptor: Extract<SchemaAgentModelOptionDescriptor, { type: 'boolean' }>,
+): boolean {
+  const value = options[key];
+  return typeof value === 'boolean'
+    ? value
+    : (descriptor.currentValue ?? descriptor.defaultValue ?? false);
 }

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -26,6 +26,7 @@
 import { useChatThreads } from '@renderer/chat/useChatThreads';
 import { type ModelId, type ThinkingBudget, useClaude } from '@renderer/chat/useClaude';
 import type { ClaudeSchemaChatState } from '@renderer/chat/useClaudeSchemaChat';
+import type { SchemaAgentChatState } from '@renderer/chat/useSchemaAgentChat';
 import type { ChatMessage } from '@renderer/model/chat-history';
 import { useDocumentStore } from '@renderer/store/document';
 import { code } from '@streamdown/code';
@@ -53,7 +54,7 @@ import { cn } from '@/lib/utils';
 import { ChatThreadList } from './ChatThreadList';
 
 export interface ChatPanelProps {
-  chat: ClaudeSchemaChatState;
+  chat: ClaudeSchemaChatState | SchemaAgentChatState;
 }
 
 export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
@@ -67,7 +68,22 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     clear,
     hydrate,
   } = chat;
-  const { authMode, isReady, model, setModel, thinkingBudget, setThinkingBudget } = useClaude();
+  const claude = useClaude();
+  const providerLabel = 'providerLabel' in chat ? chat.providerLabel : 'Claude';
+  const provider = providerLabel === 'Codex' ? 'codex' : 'claude';
+  const isCodex = provider === 'codex';
+  const authMode = claude.authMode;
+  const isReady = 'isReady' in chat ? chat.isReady : claude.isReady;
+  const model = isCodex && 'model' in chat ? chat.model : claude.model;
+  const setModel = isCodex && 'setModel' in chat ? chat.setModel : claude.setModel;
+  const thinkingBudget = isCodex && 'effort' in chat ? chat.effort : claude.thinkingBudget;
+  const setThinkingBudget =
+    isCodex && 'setEffort' in chat ? chat.setEffort : claude.setThinkingBudget;
+  const codexModels = isCodex && 'models' in chat ? chat.models : [];
+  const modelSelectValue = isCodex ? model || codexModels[0]?.id || 'models-unavailable' : model;
+  const unavailableMessage = 'unavailableMessage' in chat ? chat.unavailableMessage : null;
+  const providerThreadRef = 'providerThreadRef' in chat ? chat.providerThreadRef : undefined;
+  const desynced = 'desynced' in chat ? chat.desynced : false;
 
   const filePath = useDocumentStore((s) => s.filePath);
   const history = useChatThreads();
@@ -98,6 +114,9 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       } else {
         void window.contexture?.chat?.clearSession?.();
       }
+      if (thread.providerThreadRef)
+        void window.contexture?.schemaAgent?.threadSet(thread.providerThreadRef);
+      else void window.contexture?.schemaAgent?.threadClear();
     }
     prevMessagesRef.current = thread?.messages ?? [];
   }, [history, hydrate]);
@@ -125,11 +144,17 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       } else {
         void window.contexture?.chat?.clearSession?.();
       }
+      if (latest.providerThreadRef) {
+        void window.contexture?.schemaAgent?.threadSet(latest.providerThreadRef);
+      } else {
+        void window.contexture?.schemaAgent?.threadClear();
+      }
     } else {
       history.setActiveThreadId(null);
       clear();
       prevMessagesRef.current = [];
       void window.contexture?.chat?.clearSession?.();
+      void window.contexture?.schemaAgent?.threadClear();
     }
   }, [filePath, history, hydrate, clear]);
 
@@ -145,11 +170,11 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   // Auto-create a thread on the first appended message if none active.
   useEffect(() => {
     if (!history.activeThreadId && messages.length > 0) {
-      const id = history.createThread(model, filePath);
+      const id = history.createThread({ provider, model, effort: thinkingBudget, filePath });
       history.updateThreadMessages(id, messages);
       prevMessagesRef.current = messages;
     }
-  }, [messages, history, model, filePath]);
+  }, [messages, history, model, thinkingBudget, filePath, provider]);
 
   // Stamp the active thread with the SDK session id as it streams in.
   useEffect(() => {
@@ -161,6 +186,16 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       if (id) history.updateThreadSessionId(id, sessionId);
     });
   }, [history.activeThreadId, history.updateThreadSessionId]);
+
+  useEffect(() => {
+    if (!providerThreadRef || !history.activeThreadId) return;
+    history.updateThreadProviderRef(history.activeThreadId, providerThreadRef);
+  }, [providerThreadRef, history.activeThreadId, history.updateThreadProviderRef]);
+
+  useEffect(() => {
+    if (!desynced || !history.activeThreadId) return;
+    history.markThreadDesynced(history.activeThreadId);
+  }, [desynced, history.activeThreadId, history.markThreadDesynced]);
 
   const messageCount = messages.length;
   useEffect(() => {
@@ -175,7 +210,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
 
   const activeThread = history.getActiveThread();
   const headerTitle =
-    activeThread && activeThread.title !== 'New chat' ? activeThread.title : 'Claude';
+    activeThread && activeThread.title !== 'New chat' ? activeThread.title : providerLabel;
 
   const handleNewChat = useCallback(() => {
     // Don't save empty threads — recycle an already-empty one instead
@@ -183,15 +218,16 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     if (history.activeThreadId && messages.length === 0) {
       history.deleteThread(history.activeThreadId);
     }
-    history.createThread(model, filePath);
+    history.createThread({ provider, model, effort: thinkingBudget, filePath });
     clear();
     setInput('');
     prevMessagesRef.current = [];
     // Drop main's resume id so the SDK starts a brand-new session on
     // the next turn.
     void window.contexture?.chat?.clearSession?.();
+    void window.contexture?.schemaAgent?.threadClear();
     history.setShowThreadList(false);
-  }, [history, messages.length, model, filePath, clear]);
+  }, [history, messages.length, provider, model, thinkingBudget, filePath, clear]);
 
   const handleSwitchThread = useCallback(
     (id: string) => {
@@ -205,6 +241,9 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       } else {
         void window.contexture?.chat?.clearSession?.();
       }
+      if (thread.providerThreadRef)
+        void window.contexture?.schemaAgent?.threadSet(thread.providerThreadRef);
+      else void window.contexture?.schemaAgent?.threadClear();
     },
     [history, hydrate],
   );
@@ -224,10 +263,14 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
         prevMessagesRef.current = next.messages;
         if (next.sessionId) void window.contexture?.chat?.setSessionId?.(next.sessionId);
         else void window.contexture?.chat?.clearSession?.();
+        if (next.providerThreadRef)
+          void window.contexture?.schemaAgent?.threadSet(next.providerThreadRef);
+        else void window.contexture?.schemaAgent?.threadClear();
       } else {
         clear();
         prevMessagesRef.current = [];
         void window.contexture?.chat?.clearSession?.();
+        void window.contexture?.schemaAgent?.threadClear();
       }
     },
     [history, filePath, hydrate, clear],
@@ -255,8 +298,9 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   );
 
   const handleAbort = useCallback(() => {
-    void window.contexture?.chat?.abort?.();
-  }, []);
+    if ('abort' in chat) void chat.abort();
+    else void window.contexture?.chat?.abort?.();
+  }, [chat]);
 
   return (
     <div className="flex-1 flex flex-col min-h-0" data-testid="chat-panel">
@@ -307,10 +351,11 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
                 </EmptyTitle>
                 <EmptyDescription className="text-xs">
                   {isReady
-                    ? 'Describe the schema you want — "add a Plot type with a name and location" — and Claude will build it on the canvas.'
-                    : authMode === 'max'
-                      ? 'Claude CLI not detected. Configure in toolbar.'
-                      : 'Set your API key in the toolbar to start chatting.'}
+                    ? `Describe the schema you want and ${providerLabel} will build it on the canvas.`
+                    : (unavailableMessage ??
+                      (authMode === 'max'
+                        ? 'Claude CLI not detected. Configure in toolbar.'
+                        : 'Set your API key in the toolbar to start chatting.'))}
                 </EmptyDescription>
               </EmptyHeader>
             </Empty>
@@ -329,7 +374,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
           {isStreaming && (
             <div className="flex gap-1 items-center text-xs text-muted-foreground">
               <span className="animate-pulse">●</span>
-              <span>Claude is thinking…</span>
+              <span>{providerLabel} is thinking…</span>
             </div>
           )}
           {authRequired && (
@@ -375,16 +420,32 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
             data-testid="chat-input"
           />
           <div className="flex items-center gap-1.5 px-2 pb-2">
-            <Select value={model} onValueChange={(v) => setModel(v as ModelId)}>
+            <Select value={modelSelectValue} onValueChange={(v) => setModel(v as ModelId)}>
               <SelectTrigger className="w-24 h-7 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
                 <SelectGroup>
                   <SelectLabel>Model</SelectLabel>
-                  <SelectItem value="claude-haiku-4-5-20251001">Haiku</SelectItem>
-                  <SelectItem value="claude-sonnet-4-6">Sonnet</SelectItem>
-                  <SelectItem value="claude-opus-4-6">Opus</SelectItem>
+                  {isCodex ? (
+                    codexModels.length > 0 ? (
+                      codexModels.map((option) => (
+                        <SelectItem key={option.id} value={option.id}>
+                          {option.label}
+                        </SelectItem>
+                      ))
+                    ) : (
+                      <SelectItem value="models-unavailable" disabled>
+                        Models unavailable
+                      </SelectItem>
+                    )
+                  ) : (
+                    <>
+                      <SelectItem value="claude-haiku-4-5-20251001">Haiku</SelectItem>
+                      <SelectItem value="claude-sonnet-4-6">Sonnet</SelectItem>
+                      <SelectItem value="claude-opus-4-6">Opus</SelectItem>
+                    </>
+                  )}
                 </SelectGroup>
               </SelectContent>
             </Select>
@@ -398,9 +459,11 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
               <SelectContent>
                 <SelectGroup>
                   <SelectLabel>Effort</SelectLabel>
-                  <SelectItem value="auto">Auto</SelectItem>
+                  {!isCodex && <SelectItem value="auto">Auto</SelectItem>}
                   <SelectItem value="low">Low</SelectItem>
-                  <SelectItem value="med">Med</SelectItem>
+                  <SelectItem value={isCodex ? 'medium' : 'med'}>
+                    {isCodex ? 'Medium' : 'Med'}
+                  </SelectItem>
                   <SelectItem value="high">High</SelectItem>
                 </SelectGroup>
               </SelectContent>

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -223,7 +223,12 @@ export function ReconcileModal(): React.JSX.Element {
       '```',
     ].join('\n');
 
-    const threadId = history.createThread('claude-sonnet-4-6', filePath);
+    const provider = window.contexture?.schemaAgent ? 'codex' : 'claude';
+    const threadId = history.createThread({
+      provider,
+      ...(provider === 'claude' ? { model: 'claude-sonnet-4-6' } : {}),
+      filePath,
+    });
     history.updateThreadMessages(threadId, [
       {
         id: crypto.randomUUID(),

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -223,7 +223,13 @@ export function ReconcileModal(): React.JSX.Element {
       '```',
     ].join('\n');
 
-    const provider = window.contexture?.schemaAgent ? 'codex' : 'claude';
+    const storedProvider = localStorage.getItem('contexture-schema-agent-provider');
+    const provider =
+      window.contexture?.schemaAgent && (storedProvider === 'codex' || storedProvider === 'claude')
+        ? storedProvider
+        : window.contexture?.schemaAgent
+          ? 'codex'
+          : 'claude';
     const threadId = history.createThread({
       provider,
       ...(provider === 'claude' ? { model: 'claude-sonnet-4-6' } : {}),

--- a/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
@@ -12,6 +12,7 @@ import { useClaude } from '@renderer/chat/useClaude';
 import { useDocumentStore } from '@renderer/store/document';
 import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import { Bot, ChevronDown, Code, Moon, PanelRight, Sun } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -25,12 +26,63 @@ export function Toolbar(): React.JSX.Element {
   const sidebarVisible = useUIChromeStore((s) => s.sidebarVisible);
   const toggleSidebar = useUIChromeStore((s) => s.toggleSidebar);
   const { authMode, setAuthMode, apiKey, setApiKey, cliDetected, isReady } = useClaude();
+  const schemaAgentAvailable = typeof window !== 'undefined' && !!window.contexture?.schemaAgent;
+  const [codexReady, setCodexReady] = useState(false);
+  const [codexStatus, setCodexStatus] = useState('Codex status unknown.');
+  const [codexApiKey, setCodexApiKey] = useState('');
+  const [providerPopoverOpen, setProviderPopoverOpen] = useState(false);
   const filePath = useDocumentStore((s) => s.filePath);
   const documentMode = useDocumentStore((s) => s.mode);
 
   // Project root is two dirs above the IR path (packages/contexture/<name>.contexture.json).
   const projectRoot =
     filePath && documentMode === 'project' ? filePath.split('/').slice(0, -3).join('/') : null;
+
+  const applyCodexStatus = useCallback((status: unknown): void => {
+    const readiness =
+      status && typeof status === 'object' ? (status as { readiness?: unknown }).readiness : null;
+    setCodexReady(readiness === 'authenticated_chatgpt' || readiness === 'authenticated_api_key');
+    setCodexStatus(codexStatusCopy(readiness));
+  }, []);
+
+  const refreshCodexStatus = useCallback(async (): Promise<void> => {
+    if (!schemaAgentAvailable) return;
+    const status = await window.contexture.schemaAgent.getStatus();
+    applyCodexStatus(status);
+  }, [schemaAgentAvailable, applyCodexStatus]);
+
+  useEffect(() => {
+    if (!schemaAgentAvailable) return;
+    let cancelled = false;
+    window.contexture.schemaAgent
+      .getStatus()
+      .then((status) => {
+        if (!cancelled) applyCodexStatus(status);
+      })
+      .catch((err) => {
+        if (!cancelled) setCodexStatus(err instanceof Error ? err.message : String(err));
+      });
+    const unsubscribe = window.contexture.schemaAgent.onStatusChanged(applyCodexStatus);
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [schemaAgentAvailable, applyCodexStatus]);
+
+  const handleCodexChatGptLogin = async (): Promise<void> => {
+    const flow = await window.contexture.schemaAgent.startLogin({ mode: 'chatgpt' });
+    if (flow.url) window.open(flow.url, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleCodexApiKeyLogin = async (): Promise<void> => {
+    await window.contexture.schemaAgent.startLogin({ mode: 'api-key', apiKey: codexApiKey });
+    await refreshCodexStatus();
+  };
+
+  const handleCodexLogout = async (): Promise<void> => {
+    await window.contexture.schemaAgent.logout();
+    await refreshCodexStatus();
+  };
 
   return (
     <div
@@ -65,66 +117,126 @@ export function Toolbar(): React.JSX.Element {
         {theme === 'dark' ? <Sun /> : <Moon />}
       </Button>
 
-      <Popover>
+      <Popover
+        open={providerPopoverOpen}
+        onOpenChange={(open) => {
+          setProviderPopoverOpen(open);
+          if (open) void refreshCodexStatus();
+        }}
+      >
         <PopoverTrigger asChild>
           <Button
             variant="ghost"
             className="h-8 px-2 gap-1.5 text-muted-foreground hover:bg-icon-btn-hover"
-            title="Claude settings"
+            title={schemaAgentAvailable ? 'Codex settings' : 'Claude settings'}
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
           >
             <Bot className="size-4" />
             <span
               className={cn(
                 'size-1.5 rounded-full',
-                isReady ? 'bg-success' : 'bg-muted-foreground/40',
+                (schemaAgentAvailable ? codexReady : isReady)
+                  ? 'bg-success'
+                  : 'bg-muted-foreground/40',
               )}
-              title={isReady ? 'Claude ready' : 'Claude not configured'}
+              title={
+                schemaAgentAvailable
+                  ? codexReady
+                    ? 'Codex ready'
+                    : 'Codex not configured'
+                  : isReady
+                    ? 'Claude ready'
+                    : 'Claude not configured'
+              }
             />
             <ChevronDown className="size-3" />
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-64 p-3 space-y-2" align="end">
-          <div className="flex gap-1">
-            <Button
-              size="sm"
-              variant={authMode === 'max' ? 'default' : 'secondary'}
-              onClick={() => setAuthMode('max')}
-              className="text-xs h-7 flex-1"
-            >
-              Claude Max
-            </Button>
-            <Button
-              size="sm"
-              variant={authMode === 'api-key' ? 'default' : 'secondary'}
-              onClick={() => setAuthMode('api-key')}
-              className="text-xs h-7 flex-1"
-            >
-              API Key
-            </Button>
-          </div>
+          {schemaAgentAvailable ? (
+            <>
+              <p className="text-xs text-muted-foreground">{codexStatus}</p>
+              <div className="flex gap-1">
+                <Button
+                  size="sm"
+                  variant="default"
+                  onClick={() => void handleCodexChatGptLogin()}
+                  className="text-xs h-7 flex-1"
+                >
+                  ChatGPT
+                </Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => void handleCodexLogout()}
+                  className="text-xs h-7 flex-1"
+                >
+                  Logout
+                </Button>
+              </div>
+              <div className="space-y-1.5">
+                <Input
+                  type="password"
+                  value={codexApiKey}
+                  onChange={(e) => setCodexApiKey(e.target.value)}
+                  placeholder="OPENAI_API_KEY"
+                  className="h-8 text-xs font-mono"
+                />
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={!codexApiKey.trim()}
+                  onClick={() => void handleCodexApiKeyLogin()}
+                  className="text-xs h-7 w-full"
+                >
+                  Use API key
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex gap-1">
+                <Button
+                  size="sm"
+                  variant={authMode === 'max' ? 'default' : 'secondary'}
+                  onClick={() => setAuthMode('max')}
+                  className="text-xs h-7 flex-1"
+                >
+                  Claude Max
+                </Button>
+                <Button
+                  size="sm"
+                  variant={authMode === 'api-key' ? 'default' : 'secondary'}
+                  onClick={() => setAuthMode('api-key')}
+                  className="text-xs h-7 flex-1"
+                >
+                  API Key
+                </Button>
+              </div>
 
-          {authMode === 'max' && (
-            <p className="text-xs text-muted-foreground">
-              {cliDetected
-                ? '✓ Claude CLI detected. Using your Max subscription.'
-                : '✗ Claude CLI not found. Install Claude Code and log in.'}
-            </p>
-          )}
+              {authMode === 'max' && (
+                <p className="text-xs text-muted-foreground">
+                  {cliDetected
+                    ? '✓ Claude CLI detected. Using your Max subscription.'
+                    : '✗ Claude CLI not found. Install Claude Code and log in.'}
+                </p>
+              )}
 
-          {authMode === 'api-key' && (
-            <div className="space-y-1.5">
-              <Input
-                type="password"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder="sk-ant-..."
-                className="h-8 text-xs font-mono"
-              />
-              <p className="text-[10px] text-muted-foreground">
-                Stored locally. Used to call the Claude API directly.
-              </p>
-            </div>
+              {authMode === 'api-key' && (
+                <div className="space-y-1.5">
+                  <Input
+                    type="password"
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder="sk-ant-..."
+                    className="h-8 text-xs font-mono"
+                  />
+                  <p className="text-[10px] text-muted-foreground">
+                    Stored locally. Used to call the Claude API directly.
+                  </p>
+                </div>
+              )}
+            </>
           )}
         </PopoverContent>
       </Popover>
@@ -142,4 +254,15 @@ export function Toolbar(): React.JSX.Element {
       </Button>
     </div>
   );
+}
+
+function codexStatusCopy(readiness: unknown): string {
+  if (readiness === 'authenticated_chatgpt') return 'Codex authenticated with ChatGPT.';
+  if (readiness === 'authenticated_api_key') return 'Codex authenticated with API key.';
+  if (readiness === 'cli_missing') return 'Codex CLI not detected.';
+  if (readiness === 'cli_outdated') return 'Codex CLI is outdated.';
+  if (readiness === 'not_signed_in') return 'Codex is not signed in.';
+  if (readiness === 'rate_limited') return 'Codex is rate-limited.';
+  if (readiness === 'app_server_unavailable') return 'Codex app-server is unavailable.';
+  return 'Codex is not ready.';
 }

--- a/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
@@ -9,6 +9,10 @@
  */
 
 import { useClaude } from '@renderer/chat/useClaude';
+import {
+  SCHEMA_AGENT_PROVIDER_CHANGED,
+  type SchemaAgentProvider,
+} from '@renderer/chat/useSchemaAgentChat';
 import { useDocumentStore } from '@renderer/store/document';
 import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import { Bot, ChevronDown, Code, Moon, PanelRight, Sun } from 'lucide-react';
@@ -27,9 +31,14 @@ export function Toolbar(): React.JSX.Element {
   const toggleSidebar = useUIChromeStore((s) => s.toggleSidebar);
   const { authMode, setAuthMode, apiKey, setApiKey, cliDetected, isReady } = useClaude();
   const schemaAgentAvailable = typeof window !== 'undefined' && !!window.contexture?.schemaAgent;
-  const [codexReady, setCodexReady] = useState(false);
-  const [codexStatus, setCodexStatus] = useState('Codex status unknown.');
-  const [codexApiKey, setCodexApiKey] = useState('');
+  const [provider, setProviderState] = useState<SchemaAgentProvider>(
+    () =>
+      (localStorage.getItem('contexture-schema-agent-provider') as SchemaAgentProvider | null) ??
+      'codex',
+  );
+  const [providerReady, setProviderReady] = useState(false);
+  const [providerStatus, setProviderStatus] = useState('Provider status unknown.');
+  const [providerApiKey, setProviderApiKey] = useState('');
   const [providerPopoverOpen, setProviderPopoverOpen] = useState(false);
   const filePath = useDocumentStore((s) => s.filePath);
   const documentMode = useDocumentStore((s) => s.mode);
@@ -38,50 +47,95 @@ export function Toolbar(): React.JSX.Element {
   const projectRoot =
     filePath && documentMode === 'project' ? filePath.split('/').slice(0, -3).join('/') : null;
 
-  const applyCodexStatus = useCallback((status: unknown): void => {
-    const readiness =
-      status && typeof status === 'object' ? (status as { readiness?: unknown }).readiness : null;
-    setCodexReady(readiness === 'authenticated_chatgpt' || readiness === 'authenticated_api_key');
-    setCodexStatus(codexStatusCopy(readiness));
+  const providerLabel = provider === 'codex' ? 'Codex' : 'Claude';
+
+  useEffect(() => {
+    const listener = (event: Event) => {
+      const next = (event as CustomEvent<{ provider?: unknown }>).detail?.provider;
+      if (next !== 'codex' && next !== 'claude') return;
+      setProviderState(next);
+      localStorage.setItem('contexture-schema-agent-provider', next);
+    };
+    window.addEventListener(SCHEMA_AGENT_PROVIDER_CHANGED, listener);
+    return () => window.removeEventListener(SCHEMA_AGENT_PROVIDER_CHANGED, listener);
   }, []);
 
-  const refreshCodexStatus = useCallback(async (): Promise<void> => {
+  const applyProviderStatus = useCallback(
+    (status: unknown): void => {
+      const readiness =
+        status && typeof status === 'object' ? (status as { readiness?: unknown }).readiness : null;
+      setProviderReady(
+        readiness === 'authenticated_chatgpt' ||
+          readiness === 'authenticated_api_key' ||
+          readiness === 'authenticated_cli',
+      );
+      setProviderStatus(providerStatusCopy(provider, readiness));
+    },
+    [provider],
+  );
+
+  const refreshProviderStatus = useCallback(async (): Promise<void> => {
     if (!schemaAgentAvailable) return;
+    await window.contexture.schemaAgent.setProvider(provider);
     const status = await window.contexture.schemaAgent.getStatus();
-    applyCodexStatus(status);
-  }, [schemaAgentAvailable, applyCodexStatus]);
+    applyProviderStatus(status);
+  }, [schemaAgentAvailable, provider, applyProviderStatus]);
 
   useEffect(() => {
     if (!schemaAgentAvailable) return;
     let cancelled = false;
     window.contexture.schemaAgent
-      .getStatus()
+      .setProvider(provider)
+      .then(() => window.contexture.schemaAgent.getStatus())
       .then((status) => {
-        if (!cancelled) applyCodexStatus(status);
+        if (!cancelled) applyProviderStatus(status);
       })
       .catch((err) => {
-        if (!cancelled) setCodexStatus(err instanceof Error ? err.message : String(err));
+        if (!cancelled) setProviderStatus(err instanceof Error ? err.message : String(err));
       });
-    const unsubscribe = window.contexture.schemaAgent.onStatusChanged(applyCodexStatus);
+    const unsubscribe = window.contexture.schemaAgent.onStatusChanged(applyProviderStatus);
     return () => {
       cancelled = true;
       unsubscribe();
     };
-  }, [schemaAgentAvailable, applyCodexStatus]);
+  }, [schemaAgentAvailable, provider, applyProviderStatus]);
 
-  const handleCodexChatGptLogin = async (): Promise<void> => {
+  const handleProviderChange = async (next: SchemaAgentProvider): Promise<void> => {
+    setProviderState(next);
+    localStorage.setItem('contexture-schema-agent-provider', next);
+    window.dispatchEvent(
+      new CustomEvent(SCHEMA_AGENT_PROVIDER_CHANGED, { detail: { provider: next } }),
+    );
+    await window.contexture.schemaAgent.setProvider(next);
+    const status = await window.contexture.schemaAgent.getStatus();
+    const readiness =
+      status && typeof status === 'object' ? (status as { readiness?: unknown }).readiness : null;
+    setProviderReady(
+      readiness === 'authenticated_chatgpt' ||
+        readiness === 'authenticated_api_key' ||
+        readiness === 'authenticated_cli',
+    );
+    setProviderStatus(providerStatusCopy(next, readiness));
+  };
+
+  const handleChatGptLogin = async (): Promise<void> => {
     const flow = await window.contexture.schemaAgent.startLogin({ mode: 'chatgpt' });
     if (flow.url) window.open(flow.url, '_blank', 'noopener,noreferrer');
   };
 
-  const handleCodexApiKeyLogin = async (): Promise<void> => {
-    await window.contexture.schemaAgent.startLogin({ mode: 'api-key', apiKey: codexApiKey });
-    await refreshCodexStatus();
+  const handleCliLogin = async (): Promise<void> => {
+    await window.contexture.schemaAgent.startLogin({ mode: 'cli-session' });
+    await refreshProviderStatus();
   };
 
-  const handleCodexLogout = async (): Promise<void> => {
+  const handleApiKeyLogin = async (): Promise<void> => {
+    await window.contexture.schemaAgent.startLogin({ mode: 'api-key', apiKey: providerApiKey });
+    await refreshProviderStatus();
+  };
+
+  const handleLogout = async (): Promise<void> => {
     await window.contexture.schemaAgent.logout();
-    await refreshCodexStatus();
+    await refreshProviderStatus();
   };
 
   return (
@@ -121,29 +175,29 @@ export function Toolbar(): React.JSX.Element {
         open={providerPopoverOpen}
         onOpenChange={(open) => {
           setProviderPopoverOpen(open);
-          if (open) void refreshCodexStatus();
+          if (open) void refreshProviderStatus();
         }}
       >
         <PopoverTrigger asChild>
           <Button
             variant="ghost"
             className="h-8 px-2 gap-1.5 text-muted-foreground hover:bg-icon-btn-hover"
-            title={schemaAgentAvailable ? 'Codex settings' : 'Claude settings'}
+            title={schemaAgentAvailable ? `${providerLabel} settings` : 'Claude settings'}
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
           >
             <Bot className="size-4" />
             <span
               className={cn(
                 'size-1.5 rounded-full',
-                (schemaAgentAvailable ? codexReady : isReady)
+                (schemaAgentAvailable ? providerReady : isReady)
                   ? 'bg-success'
                   : 'bg-muted-foreground/40',
               )}
               title={
                 schemaAgentAvailable
-                  ? codexReady
-                    ? 'Codex ready'
-                    : 'Codex not configured'
+                  ? providerReady
+                    ? `${providerLabel} ready`
+                    : `${providerLabel} not configured`
                   : isReady
                     ? 'Claude ready'
                     : 'Claude not configured'
@@ -155,20 +209,49 @@ export function Toolbar(): React.JSX.Element {
         <PopoverContent className="w-64 p-3 space-y-2" align="end">
           {schemaAgentAvailable ? (
             <>
-              <p className="text-xs text-muted-foreground">{codexStatus}</p>
               <div className="flex gap-1">
                 <Button
                   size="sm"
-                  variant="default"
-                  onClick={() => void handleCodexChatGptLogin()}
+                  variant={provider === 'codex' ? 'default' : 'secondary'}
+                  onClick={() => void handleProviderChange('codex')}
                   className="text-xs h-7 flex-1"
                 >
-                  ChatGPT
+                  Codex
                 </Button>
                 <Button
                   size="sm"
+                  variant={provider === 'claude' ? 'default' : 'secondary'}
+                  onClick={() => void handleProviderChange('claude')}
+                  className="text-xs h-7 flex-1"
+                >
+                  Claude
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">{providerStatus}</p>
+              <div className="flex gap-1">
+                {provider === 'codex' ? (
+                  <Button
+                    size="sm"
+                    variant="default"
+                    onClick={() => void handleChatGptLogin()}
+                    className="text-xs h-7 flex-1"
+                  >
+                    ChatGPT
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="default"
+                    onClick={() => void handleCliLogin()}
+                    className="text-xs h-7 flex-1"
+                  >
+                    Claude CLI
+                  </Button>
+                )}
+                <Button
+                  size="sm"
                   variant="secondary"
-                  onClick={() => void handleCodexLogout()}
+                  onClick={() => void handleLogout()}
                   className="text-xs h-7 flex-1"
                 >
                   Logout
@@ -177,16 +260,16 @@ export function Toolbar(): React.JSX.Element {
               <div className="space-y-1.5">
                 <Input
                   type="password"
-                  value={codexApiKey}
-                  onChange={(e) => setCodexApiKey(e.target.value)}
-                  placeholder="OPENAI_API_KEY"
+                  value={providerApiKey}
+                  onChange={(e) => setProviderApiKey(e.target.value)}
+                  placeholder={provider === 'codex' ? 'OPENAI_API_KEY' : 'ANTHROPIC_API_KEY'}
                   className="h-8 text-xs font-mono"
                 />
                 <Button
                   size="sm"
                   variant="secondary"
-                  disabled={!codexApiKey.trim()}
-                  onClick={() => void handleCodexApiKeyLogin()}
+                  disabled={!providerApiKey.trim()}
+                  onClick={() => void handleApiKeyLogin()}
                   className="text-xs h-7 w-full"
                 >
                   Use API key
@@ -256,13 +339,15 @@ export function Toolbar(): React.JSX.Element {
   );
 }
 
-function codexStatusCopy(readiness: unknown): string {
-  if (readiness === 'authenticated_chatgpt') return 'Codex authenticated with ChatGPT.';
-  if (readiness === 'authenticated_api_key') return 'Codex authenticated with API key.';
-  if (readiness === 'cli_missing') return 'Codex CLI not detected.';
-  if (readiness === 'cli_outdated') return 'Codex CLI is outdated.';
-  if (readiness === 'not_signed_in') return 'Codex is not signed in.';
-  if (readiness === 'rate_limited') return 'Codex is rate-limited.';
-  if (readiness === 'app_server_unavailable') return 'Codex app-server is unavailable.';
-  return 'Codex is not ready.';
+function providerStatusCopy(provider: SchemaAgentProvider, readiness: unknown): string {
+  const label = provider === 'codex' ? 'Codex' : 'Claude';
+  if (readiness === 'authenticated_chatgpt') return `${label} authenticated with ChatGPT.`;
+  if (readiness === 'authenticated_api_key') return `${label} authenticated with API key.`;
+  if (readiness === 'authenticated_cli') return `${label} CLI session available.`;
+  if (readiness === 'cli_missing') return `${label} CLI not detected.`;
+  if (readiness === 'cli_outdated') return `${label} CLI is outdated.`;
+  if (readiness === 'not_signed_in') return `${label} is not signed in.`;
+  if (readiness === 'rate_limited') return `${label} is rate-limited.`;
+  if (readiness === 'app_server_unavailable') return `${label} app-server is unavailable.`;
+  return `${label} is not ready.`;
 }

--- a/apps/desktop/src/renderer/src/model/chat-history.ts
+++ b/apps/desktop/src/renderer/src/model/chat-history.ts
@@ -25,6 +25,7 @@ export interface ChatHistory {
   providerThreadRef?: unknown;
   model?: string;
   effort?: string;
+  modelOptions?: Record<string, string | boolean>;
   /**
    * Agent SDK session id for this chat. Present after the first turn;
    * restored on app reopen so follow-up turns pass `resume: sessionId`
@@ -85,6 +86,7 @@ export function loadChatHistory(raw: string): LoadChatHistoryResult {
       : undefined;
   const model = typeof obj.model === 'string' ? obj.model : undefined;
   const effort = typeof obj.effort === 'string' ? obj.effort : undefined;
+  const modelOptions = sanitiseModelOptions(obj.modelOptions);
   const sessionId = typeof obj.sessionId === 'string' ? obj.sessionId : undefined;
   return {
     history: {
@@ -94,6 +96,7 @@ export function loadChatHistory(raw: string): LoadChatHistoryResult {
       ...(providerThreadRef ? { providerThreadRef } : {}),
       ...(model ? { model } : {}),
       ...(effort ? { effort } : {}),
+      ...(modelOptions ? { modelOptions } : {}),
       ...(sessionId ? { sessionId } : {}),
     },
     warnings: [],
@@ -106,6 +109,15 @@ export function saveChatHistory(history: ChatHistory): string {
 
 function defaults(): ChatHistory {
   return { version: CHAT_HISTORY_VERSION, messages: [] };
+}
+
+function sanitiseModelOptions(input: unknown): Record<string, string | boolean> | undefined {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return undefined;
+  const entries = Object.entries(input as Record<string, unknown>).filter(
+    (entry): entry is [string, string | boolean] =>
+      typeof entry[1] === 'string' || typeof entry[1] === 'boolean',
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 function sanitiseMessages(input: unknown): ChatMessage[] {

--- a/apps/desktop/src/renderer/src/model/chat-history.ts
+++ b/apps/desktop/src/renderer/src/model/chat-history.ts
@@ -21,6 +21,10 @@ export interface ChatMessage {
 export interface ChatHistory {
   version: '1';
   messages: ChatMessage[];
+  provider?: 'codex' | 'claude';
+  providerThreadRef?: unknown;
+  model?: string;
+  effort?: string;
   /**
    * Agent SDK session id for this chat. Present after the first turn;
    * restored on app reopen so follow-up turns pass `resume: sessionId`
@@ -74,11 +78,22 @@ export function loadChatHistory(raw: string): LoadChatHistoryResult {
   }
 
   const messages = sanitiseMessages(obj.messages);
+  const provider = obj.provider === 'codex' || obj.provider === 'claude' ? obj.provider : undefined;
+  const providerThreadRef =
+    obj.providerThreadRef && typeof obj.providerThreadRef === 'object'
+      ? obj.providerThreadRef
+      : undefined;
+  const model = typeof obj.model === 'string' ? obj.model : undefined;
+  const effort = typeof obj.effort === 'string' ? obj.effort : undefined;
   const sessionId = typeof obj.sessionId === 'string' ? obj.sessionId : undefined;
   return {
     history: {
       version: CHAT_HISTORY_VERSION,
       messages,
+      ...(provider ? { provider } : {}),
+      ...(providerThreadRef ? { providerThreadRef } : {}),
+      ...(model ? { model } : {}),
+      ...(effort ? { effort } : {}),
       ...(sessionId ? { sessionId } : {}),
     },
     warnings: [],

--- a/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
+++ b/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
@@ -1,6 +1,6 @@
 import { useSchemaAgentChat } from '@renderer/chat/useSchemaAgentChat';
 import { useUndoStore } from '@renderer/store/undo';
-import { act, cleanup, renderHook } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ContextureSchemaAgentAPI } from '../../src/preload/index.d';
 
@@ -29,7 +29,24 @@ function makeApi(status: unknown = { provider: 'codex', readiness: 'authenticate
     setIR,
     abort: vi.fn(async () => ({ ok: true })),
     getStatus: vi.fn(async () => status),
-    listModels: vi.fn(async () => []),
+    listModels: vi.fn(async () => [
+      {
+        id: 'gpt-5.4',
+        label: 'GPT-5.4',
+        optionDescriptors: [
+          {
+            id: 'reasoningEffort',
+            type: 'select',
+            label: 'Reasoning',
+            options: [
+              { id: 'low', label: 'Low' },
+              { id: 'medium', label: 'Medium' },
+              { id: 'high', label: 'High', isDefault: true },
+            ],
+          },
+        ],
+      },
+    ]),
     setProvider: vi.fn(async () => ({ ok: true })),
     setModelOptions: vi.fn(async () => ({ ok: true })),
     startLogin: vi.fn(async () => ({ id: 'login-1', mode: 'chatgpt' })),
@@ -143,6 +160,7 @@ function makeApi(status: unknown = { provider: 'codex', readiness: 'authenticate
 
 describe('useSchemaAgentChat', () => {
   beforeEach(() => {
+    localStorage.clear();
     useUndoStore.getState().apply({ kind: 'replace_schema', schema: { version: '1', types: [] } });
   });
   afterEach(cleanup);
@@ -250,6 +268,310 @@ describe('useSchemaAgentChat', () => {
 
     expect(result.current.isReady).toBe(false);
     expect(result.current.unavailableMessage).toBe('Codex CLI not detected.');
+  });
+
+  it('normalizes stored effort values for the selected provider', async () => {
+    localStorage.setItem('contexture-schema-agent-codex-effort', 'med');
+    const { api } = makeApi();
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await act(async () => undefined);
+
+    expect(result.current.effort).toBe('medium');
+
+    act(() => {
+      result.current.setEffort('auto');
+    });
+
+    expect(result.current.effort).toBe('high');
+    expect(localStorage.getItem('contexture-schema-agent-codex-effort')).toBe('high');
+  });
+
+  it('switches schema-agent providers through the shared API', async () => {
+    const { api } = makeApi({ provider: 'claude', readiness: 'authenticated_cli' });
+    vi.mocked(api.listModels).mockResolvedValue([
+      { id: 'claude-sonnet-4-6', label: 'Sonnet', supportsReasoningEffort: true },
+    ]);
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await act(async () => undefined);
+    await act(async () => {
+      result.current.setProvider('claude');
+    });
+    await act(async () => undefined);
+
+    expect(result.current.provider).toBe('claude');
+    expect(result.current.providerLabel).toBe('Claude');
+    expect(result.current.isReady).toBe(true);
+    expect(api.setProvider).toHaveBeenCalledWith('claude');
+  });
+
+  it('selects the provider before loading that provider model list', async () => {
+    const { api } = makeApi();
+    const calls: string[] = [];
+    let providerReady = false;
+    vi.mocked(api.setProvider).mockImplementation(async (provider) => {
+      calls.push(`set:${provider}`);
+      await Promise.resolve();
+      providerReady = true;
+      return { ok: true };
+    });
+    vi.mocked(api.listModels).mockImplementation(async () => {
+      calls.push('list');
+      if (!providerReady) return [];
+      return [{ id: 'gpt-5.4', label: 'GPT-5.4', supportsReasoningEffort: true }];
+    });
+
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await waitFor(() => {
+      expect(result.current.models).toEqual([
+        { id: 'gpt-5.4', label: 'GPT-5.4', supportsReasoningEffort: true },
+      ]);
+    });
+    expect(api.listModels).toHaveBeenCalledWith('codex');
+    expect(calls).toContain('list');
+  });
+
+  it('loads models for the selected provider instead of the globally active runtime', async () => {
+    const { api } = makeApi({ provider: 'claude', readiness: 'authenticated_cli' });
+    vi.mocked(api.listModels).mockImplementation(async (provider) => {
+      if (provider !== 'claude') return [];
+      return [{ id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' }];
+    });
+
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await act(async () => {
+      result.current.setProvider('claude');
+    });
+
+    await waitFor(() => {
+      expect(result.current.models).toEqual([
+        { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+      ]);
+    });
+    expect(api.listModels).toHaveBeenCalledWith('claude');
+  });
+
+  it('does not expose stale Codex models while persisted Claude models load', async () => {
+    localStorage.setItem('contexture-schema-agent-provider', 'claude');
+    localStorage.setItem('contexture-schema-agent-claude-model', 'gpt-5.4');
+    const { api } = makeApi({ provider: 'claude', readiness: 'authenticated_cli' });
+    vi.mocked(api.listModels).mockImplementation(async (provider) =>
+      provider === 'claude'
+        ? [{ id: 'claude-opus-4-7', label: 'Opus 4.7' }]
+        : [{ id: 'gpt-5.4', label: 'GPT-5.4' }],
+    );
+
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    expect(result.current.provider).toBe('claude');
+    expect(result.current.models).toEqual([]);
+    await waitFor(() => {
+      expect(result.current.models).toEqual([{ id: 'claude-opus-4-7', label: 'Opus 4.7' }]);
+    });
+    expect(result.current.model).toBe('claude-opus-4-7');
+  });
+
+  it('defaults to the selected provider model when no model is stored on boot', async () => {
+    localStorage.setItem('contexture-schema-agent-provider', 'claude');
+    const { api } = makeApi({ provider: 'claude', readiness: 'authenticated_cli' });
+    vi.mocked(api.listModels).mockResolvedValue([
+      { id: 'claude-sonnet-4-6', label: 'Sonnet' },
+      { id: 'claude-opus-4-7', label: 'Opus 4.7' },
+    ]);
+
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    expect(result.current.model).toBe('');
+    expect(result.current.modelsLoading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.model).toBe('claude-sonnet-4-6');
+    });
+    expect(result.current.modelsUnavailable).toBe(false);
+    expect(localStorage.getItem('contexture-schema-agent-claude-model')).toBe('claude-sonnet-4-6');
+    expect(api.setModelOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'claude-sonnet-4-6' }),
+    );
+  });
+
+  it('restores provider, model, effort, and options atomically', async () => {
+    const { api } = makeApi();
+    vi.mocked(api.listModels).mockImplementation(async (provider) =>
+      provider === 'claude'
+        ? [{ id: 'opus', label: 'Opus' }]
+        : [{ id: 'gpt-5.4', label: 'GPT-5.4' }],
+    );
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await waitFor(() => {
+      expect(result.current.provider).toBe('codex');
+    });
+
+    act(() => {
+      result.current.restoreSettings({
+        provider: 'claude',
+        model: 'opus',
+        effort: 'xhigh',
+        modelOptions: { reasoningEffort: 'xhigh', fastMode: true },
+      });
+    });
+
+    expect(result.current.provider).toBe('claude');
+    expect(result.current.model).toBe('opus');
+    expect(result.current.effort).toBe('xhigh');
+    expect(result.current.modelOptions).toEqual({ reasoningEffort: 'xhigh', fastMode: true });
+    expect(localStorage.getItem('contexture-schema-agent-claude-model')).toBe('opus');
+    expect(localStorage.getItem('contexture-schema-agent-claude-effort')).toBe('xhigh');
+    expect(api.setProvider).toHaveBeenCalledWith('claude');
+  });
+
+  it('keeps loaded models when restoring the already-selected provider', async () => {
+    const { api } = makeApi();
+    vi.mocked(api.listModels).mockResolvedValue([
+      { id: 'gpt-5.4', label: 'GPT-5.4' },
+      { id: 'gpt-5.5', label: 'GPT-5.5' },
+    ]);
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await waitFor(() => {
+      expect(result.current.modelsLoading).toBe(false);
+    });
+    expect(result.current.models.map((model) => model.id)).toEqual(['gpt-5.4', 'gpt-5.5']);
+
+    act(() => {
+      result.current.setProvider('codex');
+    });
+
+    expect(result.current.modelsLoading).toBe(false);
+    expect(result.current.models.map((model) => model.id)).toEqual(['gpt-5.4', 'gpt-5.5']);
+  });
+
+  it('surfaces an empty model state instead of pretending a model is selected', async () => {
+    const { api } = makeApi();
+    vi.mocked(api.listModels).mockResolvedValue([]);
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await waitFor(() => {
+      expect(result.current.modelsUnavailable).toBe(true);
+    });
+    expect(result.current.model).toBe('');
+
+    await act(async () => {
+      await result.current.send('hello');
+    });
+
+    expect(api.send).not.toHaveBeenCalled();
+    expect(result.current.unavailableMessage).toBe(
+      'No model is available for the selected provider.',
+    );
+  });
+
+  it('persists and pushes generic model options', async () => {
+    const { api } = makeApi();
+    vi.mocked(api.listModels).mockResolvedValue([
+      {
+        id: 'gpt-5.5',
+        label: 'GPT-5.5',
+        optionDescriptors: [
+          {
+            id: 'reasoningEffort',
+            type: 'select',
+            label: 'Reasoning',
+            options: [
+              { id: 'low', label: 'Low' },
+              { id: 'medium', label: 'Medium', isDefault: true },
+              { id: 'high', label: 'High' },
+              { id: 'xhigh', label: 'Extra High' },
+            ],
+          },
+          { id: 'fastMode', type: 'boolean', label: 'Fast', defaultValue: false },
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await waitFor(() => {
+      expect(result.current.modelOptions).toEqual({
+        reasoningEffort: 'medium',
+        fastMode: false,
+      });
+    });
+
+    act(() => {
+      result.current.setModelOption('fastMode', true);
+    });
+
+    await waitFor(() => {
+      expect(api.setModelOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-5.5',
+          options: { reasoningEffort: 'medium', fastMode: true },
+        }),
+      );
+    });
+  });
+
+  it('pushes the displayed default model before the first send', async () => {
+    const { api, calls } = makeApi();
+    vi.mocked(api.listModels).mockResolvedValue([
+      {
+        id: 'gpt-5.5',
+        label: 'GPT-5.5',
+        optionDescriptors: [
+          {
+            id: 'reasoningEffort',
+            type: 'select',
+            label: 'Reasoning',
+            options: [
+              { id: 'low', label: 'Low' },
+              { id: 'medium', label: 'Medium', isDefault: true },
+              { id: 'high', label: 'High' },
+              { id: 'xhigh', label: 'Extra High' },
+            ],
+          },
+          { id: 'fastMode', type: 'boolean', label: 'Fast', defaultValue: false },
+        ],
+      },
+      {
+        id: 'gpt-5.4',
+        label: 'GPT-5.4',
+        optionDescriptors: [
+          {
+            id: 'reasoningEffort',
+            type: 'select',
+            label: 'Reasoning',
+            options: [
+              { id: 'low', label: 'Low' },
+              { id: 'medium', label: 'Medium' },
+              { id: 'high', label: 'High', isDefault: true },
+              { id: 'xhigh', label: 'Extra High' },
+            ],
+          },
+        ],
+      },
+    ]);
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await waitFor(() => {
+      expect(result.current.model).toBe('gpt-5.5');
+    });
+    vi.mocked(api.setModelOptions).mockClear();
+
+    await act(async () => {
+      await result.current.send('hello');
+    });
+
+    expect(api.setModelOptions).toHaveBeenCalledWith({
+      model: 'gpt-5.5',
+      effort: 'medium',
+      options: { reasoningEffort: 'medium', fastMode: false },
+    });
+    expect(vi.mocked(api.setModelOptions).mock.invocationCallOrder.at(-1)).toBeLessThan(
+      calls.send.mock.invocationCallOrder[0],
+    );
   });
 
   it('tracks provider thread refs and desync state from schema-agent events', () => {

--- a/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
+++ b/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
@@ -1,0 +1,274 @@
+import { useSchemaAgentChat } from '@renderer/chat/useSchemaAgentChat';
+import { useUndoStore } from '@renderer/store/undo';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ContextureSchemaAgentAPI } from '../../src/preload/index.d';
+
+type Listener<T> = (payload: T) => void;
+
+function makeApi(status: unknown = { provider: 'codex', readiness: 'authenticated_chatgpt' }) {
+  const listeners = {
+    assistantDelta: new Set<Listener<{ text: string }>>(),
+    assistantFinal: new Set<Listener<{ text: string }>>(),
+    toolCallStarted: new Set<Listener<{ id: string; name: string; input?: unknown }>>(),
+    error: new Set<Listener<{ message: string }>>(),
+    statusChanged: new Set<Listener<unknown>>(),
+    turnBegin: new Set<() => void>(),
+    turnCommit: new Set<() => void>(),
+    turnRollback: new Set<() => void>(),
+    toolRequest: new Set<Listener<{ id: string; op: unknown }>>(),
+    threadUpdated: new Set<Listener<{ thread: unknown }>>(),
+    threadDesynced: new Set<Listener<{ thread: unknown; reason: string }>>(),
+  };
+  const send = vi.fn(async () => ({ ok: true }));
+  const setIR = vi.fn();
+  const replyTool = vi.fn();
+
+  const api: ContextureSchemaAgentAPI = {
+    send,
+    setIR,
+    abort: vi.fn(async () => ({ ok: true })),
+    getStatus: vi.fn(async () => status),
+    listModels: vi.fn(async () => []),
+    setProvider: vi.fn(async () => ({ ok: true })),
+    setModelOptions: vi.fn(async () => ({ ok: true })),
+    startLogin: vi.fn(async () => ({ id: 'login-1', mode: 'chatgpt' })),
+    cancelLogin: vi.fn(async () => undefined),
+    logout: vi.fn(async () => undefined),
+    threadSet: vi.fn(async () => ({ ok: true })),
+    threadClear: vi.fn(async () => ({ ok: true })),
+    replyTool,
+    onAssistantDelta: (l) => {
+      listeners.assistantDelta.add(l);
+      return () => listeners.assistantDelta.delete(l);
+    },
+    onAssistantFinal: (l) => {
+      listeners.assistantFinal.add(l);
+      return () => listeners.assistantFinal.delete(l);
+    },
+    onToolCallStarted: (l) => {
+      listeners.toolCallStarted.add(l);
+      return () => listeners.toolCallStarted.delete(l);
+    },
+    onToolCallFinished: () => () => undefined,
+    onError: (l) => {
+      listeners.error.add(l);
+      return () => listeners.error.delete(l);
+    },
+    onStatusChanged: (l) => {
+      listeners.statusChanged.add(l);
+      return () => listeners.statusChanged.delete(l);
+    },
+    onThreadUpdated: (l) => {
+      listeners.threadUpdated.add(l);
+      return () => listeners.threadUpdated.delete(l);
+    },
+    onThreadDesynced: (l) => {
+      listeners.threadDesynced.add(l);
+      return () => listeners.threadDesynced.delete(l);
+    },
+    onToolRequest: (l) => {
+      listeners.toolRequest.add(l);
+      return () => listeners.toolRequest.delete(l);
+    },
+    onTurnBegin: (l) => {
+      listeners.turnBegin.add(l);
+      return () => listeners.turnBegin.delete(l);
+    },
+    onTurnCommit: (l) => {
+      listeners.turnCommit.add(l);
+      return () => listeners.turnCommit.delete(l);
+    },
+    onTurnRollback: (l) => {
+      listeners.turnRollback.add(l);
+      return () => listeners.turnRollback.delete(l);
+    },
+  };
+
+  const emit = {
+    assistantDelta: (p: { text: string }) => {
+      listeners.assistantDelta.forEach((l) => {
+        l(p);
+      });
+    },
+    assistantFinal: (p: { text: string }) => {
+      listeners.assistantFinal.forEach((l) => {
+        l(p);
+      });
+    },
+    toolCallStarted: (p: { id: string; name: string; input?: unknown }) => {
+      listeners.toolCallStarted.forEach((l) => {
+        l(p);
+      });
+    },
+    error: (p: { message: string }) => {
+      listeners.error.forEach((l) => {
+        l(p);
+      });
+    },
+    statusChanged: (p: unknown) => {
+      listeners.statusChanged.forEach((l) => {
+        l(p);
+      });
+    },
+    turnBegin: () => {
+      listeners.turnBegin.forEach((l) => {
+        l();
+      });
+    },
+    turnCommit: () => {
+      listeners.turnCommit.forEach((l) => {
+        l();
+      });
+    },
+    toolRequest: (p: { id: string; op: unknown }) => {
+      listeners.toolRequest.forEach((l) => {
+        l(p);
+      });
+    },
+    threadUpdated: (p: { thread: unknown }) => {
+      listeners.threadUpdated.forEach((l) => {
+        l(p);
+      });
+    },
+    threadDesynced: (p: { thread: unknown; reason: string }) => {
+      listeners.threadDesynced.forEach((l) => {
+        l(p);
+      });
+    },
+  };
+
+  return { api, emit, calls: { send, setIR, replyTool } };
+}
+
+describe('useSchemaAgentChat', () => {
+  beforeEach(() => {
+    useUndoStore.getState().apply({ kind: 'replace_schema', schema: { version: '1', types: [] } });
+  });
+  afterEach(cleanup);
+
+  it('reads provider readiness and sends the current IR', async () => {
+    const { api, calls } = makeApi();
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await act(async () => undefined);
+    expect(result.current.isReady).toBe(true);
+
+    await act(async () => {
+      await result.current.send('hello');
+    });
+
+    expect(result.current.messages.map((m) => [m.role, m.content])).toEqual([['user', 'hello']]);
+    expect(calls.setIR).toHaveBeenCalledTimes(1);
+    expect(calls.send).toHaveBeenCalledWith('hello');
+    expect(result.current.isStreaming).toBe(true);
+  });
+
+  it('aggregates deltas and flushes on assistant_final', async () => {
+    const { api, emit } = makeApi();
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await act(async () => undefined);
+    await act(async () => {
+      await result.current.send('hi');
+    });
+    act(() => {
+      emit.assistantDelta({ text: 'Hello ' });
+      emit.assistantDelta({ text: 'world' });
+      emit.assistantFinal({ text: 'Hello world' });
+    });
+
+    expect(result.current.messages.map((m) => [m.role, m.content])).toEqual([
+      ['user', 'hi'],
+      ['assistant', 'Hello world'],
+    ]);
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it('surfaces schema-agent send failures that happen before streaming starts', async () => {
+    const { api } = makeApi();
+    vi.mocked(api.send).mockResolvedValueOnce({ ok: false, error: 'Codex app-server unavailable' });
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await act(async () => undefined);
+    await act(async () => {
+      await result.current.send('hi');
+    });
+
+    expect(result.current.messages.map((m) => [m.role, m.content])).toEqual([
+      ['user', 'hi'],
+      ['assistant', 'Error: Codex app-server unavailable'],
+    ]);
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it('applies renderer op requests and replies through schema-agent', () => {
+    const { api, emit, calls } = makeApi();
+    renderHook(() => useSchemaAgentChat({ api }));
+
+    act(() => {
+      emit.toolRequest({
+        id: 'op-1',
+        op: { kind: 'add_type', type: { kind: 'object', name: 'Plot', fields: [] } },
+      });
+    });
+
+    expect(useUndoStore.getState().schema.types.map((t) => t.name)).toEqual(['Plot']);
+    expect(calls.replyTool).toHaveBeenCalledWith(
+      'op-1',
+      expect.objectContaining({ schema: expect.any(Object) }),
+    );
+  });
+
+  it('turn lifecycle still collapses many ops to one undo entry', () => {
+    const { api, emit } = makeApi();
+    renderHook(() => useSchemaAgentChat({ api }));
+
+    act(() => {
+      emit.turnBegin();
+      emit.toolRequest({
+        id: '1',
+        op: { kind: 'add_type', type: { kind: 'object', name: 'A', fields: [] } },
+      });
+      emit.toolRequest({
+        id: '2',
+        op: { kind: 'add_type', type: { kind: 'object', name: 'B', fields: [] } },
+      });
+      emit.turnCommit();
+    });
+
+    expect(useUndoStore.getState().schema.types.map((t) => t.name)).toEqual(['A', 'B']);
+    act(() => useUndoStore.getState().undo());
+    expect(useUndoStore.getState().schema.types).toEqual([]);
+  });
+
+  it('surfaces non-ready Codex status', async () => {
+    const { api } = makeApi({ provider: 'codex', readiness: 'cli_missing' });
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await act(async () => undefined);
+
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.unavailableMessage).toBe('Codex CLI not detected.');
+  });
+
+  it('tracks provider thread refs and desync state from schema-agent events', () => {
+    const { api, emit } = makeApi();
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+    const thread = { provider: 'codex', threadId: 'thread-1' };
+
+    act(() => {
+      emit.threadUpdated({ thread });
+    });
+
+    expect(result.current.providerThreadRef).toEqual(thread);
+    expect(result.current.desynced).toBe(false);
+
+    act(() => {
+      emit.threadDesynced({ thread, reason: 'rollback failed' });
+    });
+
+    expect(result.current.providerThreadRef).toEqual(thread);
+    expect(result.current.desynced).toBe(true);
+  });
+});

--- a/apps/desktop/tests/components/App.codex.test.tsx
+++ b/apps/desktop/tests/components/App.codex.test.tsx
@@ -1,0 +1,78 @@
+import App from '@renderer/App';
+import { useGraphSelectionStore } from '@renderer/store/selection';
+import { useUndoStore } from '@renderer/store/undo';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const unsub = () => undefined;
+
+beforeEach(() => {
+  localStorage.clear();
+  useUndoStore.getState().apply({ kind: 'replace_schema', schema: { version: '1', types: [] } });
+  while (useUndoStore.getState().canUndo) useUndoStore.getState().undo();
+  useGraphSelectionStore.getState().clear();
+  (window as unknown as { contexture: unknown }).contexture = {
+    chat: {
+      send: vi.fn(async () => ({ ok: false })),
+      setIR: vi.fn(),
+      detectClaudeCli: vi.fn(async () => ({ installed: false, path: null })),
+      setAuth: vi.fn(async () => ({ ok: true })),
+      setModelOptions: vi.fn(async () => ({ ok: true })),
+      abort: vi.fn(async () => ({ ok: true })),
+      replyOp: vi.fn(),
+      onAssistant: () => unsub,
+      onToolUse: () => unsub,
+      onResult: () => unsub,
+      onError: () => unsub,
+      onAuthRequired: () => unsub,
+      onTurnBegin: () => unsub,
+      onTurnCommit: () => unsub,
+      onTurnRollback: () => unsub,
+      onOpRequest: () => unsub,
+      onSession: () => unsub,
+      setSessionId: vi.fn(async () => ({ ok: true })),
+      clearSession: vi.fn(async () => ({ ok: true })),
+    },
+    schemaAgent: {
+      send: vi.fn(async () => ({ ok: true })),
+      setIR: vi.fn(),
+      abort: vi.fn(async () => ({ ok: true })),
+      getStatus: vi.fn(async () => ({ provider: 'codex', readiness: 'authenticated_chatgpt' })),
+      listModels: vi.fn(async () => [{ id: 'gpt-5.4', label: 'GPT-5.4' }]),
+      setProvider: vi.fn(async () => ({ ok: true })),
+      setModelOptions: vi.fn(async () => ({ ok: true })),
+      startLogin: vi.fn(async () => ({ id: 'login-1', mode: 'chatgpt' })),
+      cancelLogin: vi.fn(async () => undefined),
+      logout: vi.fn(async () => undefined),
+      threadSet: vi.fn(async () => ({ ok: true })),
+      threadClear: vi.fn(async () => ({ ok: true })),
+      replyTool: vi.fn(),
+      onAssistantDelta: () => unsub,
+      onAssistantFinal: () => unsub,
+      onToolCallStarted: () => unsub,
+      onToolCallFinished: () => unsub,
+      onError: () => unsub,
+      onStatusChanged: () => unsub,
+      onThreadUpdated: () => unsub,
+      onThreadDesynced: () => unsub,
+      onToolRequest: () => unsub,
+      onTurnBegin: () => unsub,
+      onTurnCommit: () => unsub,
+      onTurnRollback: () => unsub,
+    },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('App Codex-first copy', () => {
+  it('names Codex in the empty-state schema chat prompt when schema-agent is available', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/start chatting with Codex to create one/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/desktop/tests/components/chat/ChatPanel.test.tsx
+++ b/apps/desktop/tests/components/chat/ChatPanel.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import type { ClaudeSchemaChatState } from '@renderer/chat/useClaudeSchemaChat';
+import type { SchemaAgentChatState } from '@renderer/chat/useSchemaAgentChat';
 import { ChatPanel } from '@renderer/components/chat/ChatPanel';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -19,6 +20,57 @@ function makeChat(overrides: Partial<ClaudeSchemaChatState> = {}): ClaudeSchemaC
     authRequired: false,
     clearAuthRequired: vi.fn(),
     send: vi.fn().mockResolvedValue(undefined),
+    hydrate: vi.fn(),
+    clear: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeSchemaAgentChat(overrides: Partial<SchemaAgentChatState> = {}): SchemaAgentChatState {
+  return {
+    provider: 'codex',
+    providerLabel: 'Codex',
+    setProvider: vi.fn(),
+    restoreSettings: vi.fn(),
+    models: [
+      {
+        id: 'gpt-5.4',
+        label: 'GPT-5.4',
+        supportsReasoningEffort: true,
+        optionDescriptors: [
+          {
+            id: 'reasoningEffort',
+            type: 'select',
+            label: 'Reasoning',
+            options: [
+              { id: 'low', label: 'Low' },
+              { id: 'medium', label: 'Medium' },
+              { id: 'high', label: 'High', isDefault: true },
+              { id: 'xhigh', label: 'Extra High' },
+            ],
+          },
+        ],
+      },
+    ],
+    modelsLoading: false,
+    modelsUnavailable: false,
+    model: 'gpt-5.4',
+    setModel: vi.fn(),
+    modelOptions: { reasoningEffort: 'high' },
+    setModelOption: vi.fn(),
+    effort: 'high',
+    setEffort: vi.fn(),
+    messages: [],
+    isStreaming: false,
+    liveAssistant: '',
+    authRequired: false,
+    isReady: true,
+    unavailableMessage: null,
+    providerThreadRef: undefined,
+    desynced: false,
+    clearAuthRequired: vi.fn(),
+    send: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn().mockResolvedValue(undefined),
     hydrate: vi.fn(),
     clear: vi.fn(),
     ...overrides,
@@ -110,6 +162,60 @@ describe('ChatPanel', () => {
     render(<ChatPanel chat={makeChat({ isStreaming: true })} />);
     expect(screen.getByTitle('Stop')).toBeInTheDocument();
     expect(screen.queryByTitle('Send')).not.toBeInTheDocument();
+  });
+
+  it('keeps the effort control visible for schema-agent chats', () => {
+    render(<ChatPanel chat={makeSchemaAgentChat()} />);
+    expect(screen.getByTestId('chat-effort-select')).toHaveTextContent(/High/i);
+    expect(screen.getByTestId('chat-effort-select')).toHaveAttribute('title', 'Reasoning');
+  });
+
+  it('falls back to a provider default when schema-agent effort is empty', () => {
+    render(<ChatPanel chat={makeSchemaAgentChat({ effort: '' })} />);
+    expect(screen.getByTestId('chat-effort-select')).toHaveTextContent(/High/i);
+  });
+
+  it('renders model-provided effort options instead of hard-coded provider values', () => {
+    render(
+      <ChatPanel
+        chat={makeSchemaAgentChat({
+          effort: 'xhigh',
+          modelOptions: { reasoningEffort: 'xhigh' },
+        })}
+      />,
+    );
+    expect(screen.getByTestId('chat-effort-select')).toHaveTextContent(/Extra High/i);
+  });
+
+  it('restores provider model options when hydrating the active schema-agent thread', () => {
+    const restoreSettings = vi.fn();
+    localStorage.setItem('contexture-active-thread', 'thread-1');
+    localStorage.setItem(
+      'contexture-chat-threads',
+      JSON.stringify([
+        {
+          id: 'thread-1',
+          provider: 'claude',
+          title: 'Record shop',
+          messages: [{ id: 'u', role: 'user', content: 'hello', createdAt: 1 }],
+          model: 'opus',
+          effort: 'xhigh',
+          modelOptions: { reasoningEffort: 'xhigh', fastMode: true },
+          filePath: null,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]),
+    );
+
+    render(<ChatPanel chat={makeSchemaAgentChat({ restoreSettings })} />);
+
+    expect(restoreSettings).toHaveBeenCalledWith({
+      provider: 'claude',
+      model: 'opus',
+      effort: 'xhigh',
+      modelOptions: { reasoningEffort: 'xhigh', fastMode: true },
+    });
   });
 
   it('auto-grows the textarea via CSS field-sizing with an 8-line cap and scroll overflow', async () => {

--- a/apps/desktop/tests/components/toolbar/Toolbar.test.tsx
+++ b/apps/desktop/tests/components/toolbar/Toolbar.test.tsx
@@ -1,0 +1,89 @@
+import { Toolbar } from '@renderer/components/toolbar/Toolbar';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const unsub = () => undefined;
+
+function installContexture(overrides: Record<string, unknown> = {}): void {
+  (window as unknown as { contexture: unknown }).contexture = {
+    schemaAgent: {
+      getStatus: vi.fn(async () => ({ provider: 'codex', readiness: 'not_signed_in' })),
+      onStatusChanged: vi.fn(() => unsub),
+      startLogin: vi.fn(async () => ({
+        id: 'login-1',
+        mode: 'chatgpt',
+        url: 'https://auth.example.test',
+      })),
+      logout: vi.fn(async () => undefined),
+      ...overrides,
+    },
+    shell: { openInEditor: vi.fn(async () => undefined) },
+  };
+}
+
+describe('Toolbar Codex settings', () => {
+  beforeEach(() => {
+    installContexture();
+    vi.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('shows Codex readiness and starts ChatGPT login', async () => {
+    installContexture({
+      getStatus: vi.fn(async () => ({ provider: 'codex', readiness: 'authenticated_chatgpt' })),
+    });
+    render(<Toolbar />);
+
+    fireEvent.click(screen.getByTitle('Codex settings'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex authenticated with ChatGPT.')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ChatGPT' }));
+
+    await waitFor(() => {
+      expect(window.contexture.schemaAgent.startLogin).toHaveBeenCalledWith({ mode: 'chatgpt' });
+      expect(window.open).toHaveBeenCalledWith(
+        'https://auth.example.test',
+        '_blank',
+        'noopener,noreferrer',
+      );
+    });
+  });
+
+  it('submits Codex API-key login', async () => {
+    render(<Toolbar />);
+
+    fireEvent.click(screen.getByTitle('Codex settings'));
+    const input = await screen.findByPlaceholderText('OPENAI_API_KEY');
+    fireEvent.change(input, { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Use API key' }));
+
+    await waitFor(() => {
+      expect(window.contexture.schemaAgent.startLogin).toHaveBeenCalledWith({
+        mode: 'api-key',
+        apiKey: 'sk-test',
+      });
+    });
+  });
+
+  it('refreshes Codex status when the provider popover opens', async () => {
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce({ provider: 'codex', readiness: 'not_signed_in' })
+      .mockResolvedValueOnce({ provider: 'codex', readiness: 'authenticated_chatgpt' });
+    installContexture({ getStatus });
+    render(<Toolbar />);
+
+    fireEvent.click(screen.getByTitle('Codex settings'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex authenticated with ChatGPT.')).toBeInTheDocument();
+    });
+    expect(getStatus).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/tests/components/toolbar/Toolbar.test.tsx
+++ b/apps/desktop/tests/components/toolbar/Toolbar.test.tsx
@@ -7,6 +7,7 @@ const unsub = () => undefined;
 function installContexture(overrides: Record<string, unknown> = {}): void {
   (window as unknown as { contexture: unknown }).contexture = {
     schemaAgent: {
+      setProvider: vi.fn(async () => ({ ok: true })),
       getStatus: vi.fn(async () => ({ provider: 'codex', readiness: 'not_signed_in' })),
       onStatusChanged: vi.fn(() => unsub),
       startLogin: vi.fn(async () => ({
@@ -23,6 +24,7 @@ function installContexture(overrides: Record<string, unknown> = {}): void {
 
 describe('Toolbar Codex settings', () => {
   beforeEach(() => {
+    localStorage.clear();
     installContexture();
     vi.spyOn(window, 'open').mockImplementation(() => null);
   });
@@ -72,10 +74,10 @@ describe('Toolbar Codex settings', () => {
   });
 
   it('refreshes Codex status when the provider popover opens', async () => {
-    const getStatus = vi
-      .fn()
-      .mockResolvedValueOnce({ provider: 'codex', readiness: 'not_signed_in' })
-      .mockResolvedValueOnce({ provider: 'codex', readiness: 'authenticated_chatgpt' });
+    const getStatus = vi.fn(async () => ({
+      provider: 'codex',
+      readiness: 'authenticated_chatgpt',
+    }));
     installContexture({ getStatus });
     render(<Toolbar />);
 
@@ -84,6 +86,30 @@ describe('Toolbar Codex settings', () => {
     await waitFor(() => {
       expect(screen.getByText('Codex authenticated with ChatGPT.')).toBeInTheDocument();
     });
-    expect(getStatus).toHaveBeenCalledTimes(2);
+    expect(getStatus).toHaveBeenCalled();
+  });
+
+  it('switches to Claude and starts CLI login through schema-agent', async () => {
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce({ provider: 'codex', readiness: 'not_signed_in' })
+      .mockResolvedValue({ provider: 'claude', readiness: 'authenticated_cli' });
+    installContexture({ getStatus });
+    render(<Toolbar />);
+
+    fireEvent.click(screen.getByTitle('Codex settings'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Claude' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Claude CLI session available.')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Claude CLI' }));
+
+    await waitFor(() => {
+      expect(window.contexture.schemaAgent.setProvider).toHaveBeenCalledWith('claude');
+      expect(window.contexture.schemaAgent.startLogin).toHaveBeenCalledWith({
+        mode: 'cli-session',
+      });
+    });
   });
 });

--- a/apps/desktop/tests/main/claude-runtime.test.ts
+++ b/apps/desktop/tests/main/claude-runtime.test.ts
@@ -1,0 +1,202 @@
+import type { OpToolDescriptor } from '@main/ops';
+import type { ExecFileFn } from '@main/providers/claude/cli';
+import {
+  ClaudeProviderRuntime,
+  type ClaudeProviderRuntimeOptions,
+} from '@main/providers/claude/runtime';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+function supportedExec(): ExecFileFn {
+  return vi.fn<ExecFileFn>(async (file) => {
+    if (file === 'which') return { stdout: '/opt/bin/claude\n' };
+    return { stdout: '' };
+  });
+}
+
+function interruptibleQuery(messages: unknown[], supportedModels: unknown[] = []) {
+  return vi.fn(() => {
+    const iterator = (async function* () {
+      for (const message of messages) yield message;
+    })();
+    return Object.assign(iterator, {
+      close: vi.fn(() => undefined),
+      interrupt: vi.fn(async () => undefined),
+      supportedModels: vi.fn(async () => supportedModels),
+    });
+  }) as unknown as NonNullable<ClaudeProviderRuntimeOptions['queryFn']>;
+}
+
+function descriptor(): OpToolDescriptor {
+  return {
+    name: 'add_type',
+    description: 'Add type.',
+    inputSchema: { payload: z.object({ name: z.string() }) },
+    handler: vi.fn(async () => ({ schema: { version: '1', types: [] } })),
+  };
+}
+
+describe('ClaudeProviderRuntime', () => {
+  it('reports Claude CLI readiness and supports API-key login', async () => {
+    const runtime = new ClaudeProviderRuntime({
+      execFile: supportedExec(),
+      queryFn: interruptibleQuery([]),
+      skillsPluginPath: null,
+    });
+
+    await expect(runtime.getStatus()).resolves.toMatchObject({
+      provider: 'claude',
+      readiness: 'authenticated_cli',
+    });
+    await expect(runtime.startLogin({ mode: 'api-key', apiKey: 'sk-ant-test' })).resolves.toEqual({
+      id: 'api-key',
+      mode: 'api-key',
+    });
+    await expect(runtime.getStatus()).resolves.toMatchObject({
+      provider: 'claude',
+      readiness: 'authenticated_api_key',
+    });
+  });
+
+  it('exposes Claude model effort options through model descriptors', async () => {
+    const runtime = new ClaudeProviderRuntime({
+      execFile: supportedExec(),
+      queryFn: interruptibleQuery(
+        [],
+        [
+          {
+            value: 'sonnet',
+            displayName: 'Sonnet',
+            supportsEffort: true,
+            supportedEffortLevels: ['low', 'medium', 'high', 'max'],
+          },
+          {
+            value: 'haiku',
+            displayName: 'Haiku',
+            description: 'Haiku 4.5 · Fastest for quick answers',
+          },
+        ],
+      ),
+      skillsPluginPath: null,
+    });
+
+    await expect(runtime.listModels()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'sonnet',
+          optionDescriptors: [
+            expect.objectContaining({
+              id: 'reasoningEffort',
+              type: 'select',
+              options: expect.arrayContaining([
+                { id: 'medium', label: 'Medium', isDefault: true },
+                { id: 'xhigh', label: 'Ultrathink' },
+              ]),
+            }),
+            expect.objectContaining({ id: 'contextWindow', type: 'select' }),
+          ],
+        }),
+        expect.objectContaining({
+          id: 'haiku',
+          label: 'Haiku',
+          optionDescriptors: [
+            expect.objectContaining({ id: 'thinking', type: 'boolean', defaultValue: false }),
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it('maps Claude Agent SDK messages to provider events and persists session refs', async () => {
+    const queryFn = interruptibleQuery([
+      { type: 'system', subtype: 'init', session_id: 'session-1' },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'Sure.' }] } },
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'tool-1', name: 'add_type', input: { payload: {} } }],
+        },
+      },
+      { type: 'result', subtype: 'success', is_error: false },
+    ]);
+    const runtime = new ClaudeProviderRuntime({
+      execFile: supportedExec(),
+      queryFn,
+      opToolDescriptors: [descriptor()],
+      skillsPluginPath: null,
+    });
+    const thread = await runtime.startThread({ schema: { version: '1', types: [] } });
+
+    const events = [];
+    for await (const event of runtime.sendTurn({
+      thread,
+      schema: { version: '1', types: [] },
+      message: 'hello',
+      model: 'claude-sonnet-4-6',
+      effort: 'med',
+    })) {
+      events.push(event);
+    }
+
+    expect(thread).toMatchObject({
+      provider: 'claude',
+      threadId: 'session-1',
+      opaque: { sessionId: 'session-1' },
+    });
+    expect(events).toEqual([
+      { type: 'turn_started', thread },
+      { type: 'thread_resumed', thread },
+      { type: 'assistant_delta', text: 'Sure.' },
+      { type: 'tool_call_started', id: 'tool-1', name: 'add_type', input: { payload: {} } },
+      { type: 'turn_completed' },
+      { type: 'assistant_final', text: 'Sure.' },
+    ]);
+    expect(queryFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'hello',
+        options: expect.objectContaining({
+          allowedTools: ['mcp__contexture-ops__add_type'],
+          disallowedTools: expect.arrayContaining(['Read', 'Write', 'Bash']),
+          effort: 'medium',
+          model: 'claude-sonnet-4-6',
+        }),
+      }),
+    );
+  });
+
+  it('translates model option descriptors into Claude query options', async () => {
+    const queryFn = interruptibleQuery([{ type: 'result', subtype: 'success', is_error: false }]);
+    const runtime = new ClaudeProviderRuntime({
+      execFile: supportedExec(),
+      queryFn,
+      skillsPluginPath: null,
+    });
+    const thread = await runtime.startThread({ schema: { version: '1', types: [] } });
+
+    for await (const _event of runtime.sendTurn({
+      thread,
+      schema: { version: '1', types: [] },
+      message: 'hello',
+      model: 'sonnet',
+      options: {
+        contextWindow: '1m',
+        reasoningEffort: 'xhigh',
+        thinking: false,
+        fastMode: true,
+      },
+    })) {
+      // drain
+    }
+
+    expect(queryFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          model: 'sonnet[1m]',
+          effort: 'xhigh',
+          thinking: { type: 'disabled' },
+          settings: { fastMode: true, fastModePerSessionOptIn: true },
+        }),
+      }),
+    );
+  });
+});

--- a/apps/desktop/tests/main/codex-app-server.test.ts
+++ b/apps/desktop/tests/main/codex-app-server.test.ts
@@ -1,0 +1,53 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { type SpawnCodexAppServerFn, startCodexAppServer } from '@main/providers/codex/app-server';
+import { describe, expect, it, vi } from 'vitest';
+
+function fakeChild() {
+  const child = new EventEmitter() as ReturnType<SpawnCodexAppServerFn>;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  return child;
+}
+
+describe('startCodexAppServer', () => {
+  it('spawns codex app-server over stdio', () => {
+    const child = fakeChild();
+    const spawnFn = vi.fn<SpawnCodexAppServerFn>(() => child);
+
+    const connection = startCodexAppServer({
+      codexPath: '/opt/bin/codex',
+      spawnFn,
+      env: { PATH: '/opt/bin' },
+    });
+
+    expect(spawnFn).toHaveBeenCalledWith('/opt/bin/codex', ['app-server', '--listen', 'stdio://'], {
+      stdio: 'pipe',
+      env: { PATH: '/opt/bin' },
+    });
+
+    connection.dispose();
+    expect(child.kill).toHaveBeenCalledOnce();
+  });
+
+  it('disposes the JSON-RPC client when the process exits', async () => {
+    const child = fakeChild();
+    const onExit = vi.fn();
+    const connection = startCodexAppServer({
+      spawnFn: vi.fn<SpawnCodexAppServerFn>(() => child),
+      onExit,
+    });
+    const pending = connection.client.request('initialize', {});
+
+    child.emit('exit', 1, null);
+
+    await expect(pending).rejects.toThrow('Codex app-server connection closed');
+    expect(onExit).toHaveBeenCalledWith(1, null);
+  });
+});

--- a/apps/desktop/tests/main/codex-cli.test.ts
+++ b/apps/desktop/tests/main/codex-cli.test.ts
@@ -1,0 +1,81 @@
+import {
+  codexCliInfoToStatus,
+  compareSemver,
+  detectCodexCli,
+  type ExecFileFn,
+  parseCodexVersion,
+} from '@main/providers/codex/cli';
+import { CODEX_PROVIDER_MIN_CLI_VERSION } from '@main/providers/codex/version';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('Codex CLI detection', () => {
+  it('parses codex-cli version output', () => {
+    expect(parseCodexVersion('codex-cli 0.130.0')).toBe('0.130.0');
+    expect(parseCodexVersion('unexpected')).toBeNull();
+  });
+
+  it('compares semantic versions', () => {
+    expect(compareSemver('0.130.0', CODEX_PROVIDER_MIN_CLI_VERSION)).toBe(0);
+    expect(compareSemver('0.131.0', CODEX_PROVIDER_MIN_CLI_VERSION)).toBeGreaterThan(0);
+    expect(compareSemver('0.129.9', CODEX_PROVIDER_MIN_CLI_VERSION)).toBeLessThan(0);
+  });
+
+  it('reports missing CLI status', async () => {
+    const exec = vi.fn<ExecFileFn>(async () => {
+      throw new Error('not found');
+    });
+
+    const info = await detectCodexCli(exec);
+
+    expect(info).toEqual({ installed: false, path: null, version: null, supported: false });
+    expect(codexCliInfoToStatus(info)).toMatchObject({
+      provider: 'codex',
+      readiness: 'cli_missing',
+      minimumCliVersion: CODEX_PROVIDER_MIN_CLI_VERSION,
+    });
+  });
+
+  it('reports outdated CLI status', async () => {
+    const exec = vi.fn<ExecFileFn>(async (file) => {
+      if (file === 'which') return { stdout: '/usr/local/bin/codex\n' };
+      return { stdout: 'codex-cli 0.129.0\n' };
+    });
+
+    const info = await detectCodexCli(exec);
+
+    expect(info).toEqual({
+      installed: true,
+      path: '/usr/local/bin/codex',
+      version: '0.129.0',
+      supported: false,
+    });
+    expect(codexCliInfoToStatus(info)).toMatchObject({
+      provider: 'codex',
+      readiness: 'cli_outdated',
+      cliVersion: '0.129.0',
+      minimumCliVersion: CODEX_PROVIDER_MIN_CLI_VERSION,
+    });
+  });
+
+  it('reports supported CLI before app-server is initialized', async () => {
+    const exec = vi.fn<ExecFileFn>(async (file) => {
+      if (file === 'which') return { stdout: '/opt/bin/codex\n' };
+      return { stdout: 'codex-cli 0.130.0\n' };
+    });
+
+    const info = await detectCodexCli(exec);
+
+    expect(info).toEqual({
+      installed: true,
+      path: '/opt/bin/codex',
+      version: '0.130.0',
+      supported: true,
+    });
+    expect(codexCliInfoToStatus(info)).toMatchObject({
+      provider: 'codex',
+      readiness: 'app_server_unavailable',
+      cliVersion: '0.130.0',
+      minimumCliVersion: CODEX_PROVIDER_MIN_CLI_VERSION,
+    });
+  });
+});

--- a/apps/desktop/tests/main/codex-json-rpc.test.ts
+++ b/apps/desktop/tests/main/codex-json-rpc.test.ts
@@ -1,0 +1,102 @@
+import { PassThrough } from 'node:stream';
+import {
+  CodexJsonRpcClient,
+  type JsonRpcNotificationMessage,
+  type JsonRpcRequestMessage,
+} from '@main/providers/codex/json-rpc';
+import { describe, expect, it, vi } from 'vitest';
+
+function makeClient(
+  options: {
+    onNotification?: (message: JsonRpcNotificationMessage) => void;
+    onServerRequest?: (message: JsonRpcRequestMessage, client: CodexJsonRpcClient) => void;
+  } = {},
+) {
+  const serverToClient = new PassThrough();
+  const clientToServer = new PassThrough();
+  const writes: string[] = [];
+  clientToServer.on('data', (chunk) => writes.push(chunk.toString('utf8')));
+  const client = new CodexJsonRpcClient({
+    input: serverToClient,
+    output: clientToServer,
+    ...options,
+  });
+  return { client, serverToClient, writes };
+}
+
+describe('CodexJsonRpcClient', () => {
+  it('writes requests and resolves matching responses', async () => {
+    const { client, serverToClient, writes } = makeClient();
+
+    const promise = client.request<{ ok: boolean }>('initialize', { clientInfo: { name: 'test' } });
+    expect(JSON.parse(writes[0])).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { clientInfo: { name: 'test' } },
+    });
+
+    serverToClient.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, result: { ok: true } })}\n`);
+
+    await expect(promise).resolves.toEqual({ ok: true });
+  });
+
+  it('rejects failed responses', async () => {
+    const { client, serverToClient } = makeClient();
+
+    const promise = client.request('thread/start', {});
+    serverToClient.write(
+      `${JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: -32000, message: 'bad' } })}\n`,
+    );
+
+    await expect(promise).rejects.toThrow('bad');
+  });
+
+  it('routes notifications and server requests', async () => {
+    const onNotification = vi.fn();
+    const onServerRequest = vi.fn((message: JsonRpcRequestMessage, client: CodexJsonRpcClient) => {
+      client.respond(message.id, { success: true });
+    });
+    const { serverToClient, writes } = makeClient({ onNotification, onServerRequest });
+
+    serverToClient.write(
+      `${JSON.stringify({ jsonrpc: '2.0', method: 'thread/started', params: { threadId: 't1' } })}\n`,
+    );
+    serverToClient.write(
+      `${JSON.stringify({ jsonrpc: '2.0', id: 99, method: 'item/tool/call', params: {} })}\n`,
+    );
+
+    expect(onNotification).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      method: 'thread/started',
+      params: { threadId: 't1' },
+    });
+    expect(onServerRequest).toHaveBeenCalledOnce();
+    expect(JSON.parse(writes[0])).toEqual({
+      jsonrpc: '2.0',
+      id: 99,
+      result: { success: true },
+    });
+  });
+
+  it('stops routing server requests after the first runtime handler accepts them', () => {
+    const { client, serverToClient, writes } = makeClient();
+    const first = vi.fn((message: JsonRpcRequestMessage, rpc: CodexJsonRpcClient) => {
+      rpc.respond(message.id, { handledBy: 'first' });
+      return true;
+    });
+    const second = vi.fn(() => true);
+    client.onServerRequest(first);
+    client.onServerRequest(second);
+
+    serverToClient.write(
+      `${JSON.stringify({ jsonrpc: '2.0', id: 100, method: 'item/tool/call', params: {} })}\n`,
+    );
+
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).not.toHaveBeenCalled();
+    expect(writes.map((write) => JSON.parse(write))).toEqual([
+      { jsonrpc: '2.0', id: 100, result: { handledBy: 'first' } },
+    ]);
+  });
+});

--- a/apps/desktop/tests/main/codex-runtime.test.ts
+++ b/apps/desktop/tests/main/codex-runtime.test.ts
@@ -537,6 +537,14 @@ describe('CodexProviderRuntime', () => {
     const runtime = new CodexProviderRuntime({
       execFile: supportedExec(),
       appServerFactory: vi.fn(() => fakeConnection(request)),
+      opToolDescriptors: [
+        {
+          name: 'add_type',
+          description: 'Add type.',
+          inputSchema: { payload: z.object({ name: z.string() }) },
+          handler: vi.fn(async () => ({ schema: { version: '1', types: [] } })),
+        },
+      ],
     });
 
     const resumed = await runtime.resumeThread({
@@ -562,6 +570,12 @@ describe('CodexProviderRuntime', () => {
           }),
         }),
         sandbox: 'read-only',
+        dynamicTools: [
+          expect.objectContaining({
+            namespace: CODEX_CONTEXTURE_TOOL_NAMESPACE,
+            name: 'add_type',
+          }),
+        ],
         excludeTurns: true,
         persistExtendedHistory: false,
       }),
@@ -835,6 +849,101 @@ describe('CodexProviderRuntime', () => {
       sandboxPolicy: { type: 'readOnly', networkAccess: false },
       model: null,
       effort: null,
+    });
+  });
+
+  it('ignores completion notifications for a different nested Codex turn id', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'turn/start') {
+        return {
+          turn: {
+            id: 'turn-current',
+            items: [],
+            itemsView: 'complete',
+            status: 'inProgress',
+            error: null,
+            startedAt: 1,
+            completedAt: null,
+            durationMs: null,
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const connection = fakeConnection(request);
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => connection),
+    });
+    const thread = { provider: 'codex' as const, threadId: 'thread-1' };
+    const iterator = runtime
+      .sendTurn({ thread, schema: { version: '1', types: [] }, message: 'hello' })
+      [Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({
+      value: { type: 'turn_started', thread },
+      done: false,
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: {
+          id: 'turn-stale',
+          items: [],
+          itemsView: 'complete',
+          status: 'completed',
+          error: null,
+          startedAt: 1,
+          completedAt: 2,
+          durationMs: 1,
+        },
+      },
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-current',
+        itemId: 'item-1',
+        delta: 'Still running',
+      },
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: {
+          id: 'turn-current',
+          items: [],
+          itemsView: 'complete',
+          status: 'completed',
+          error: null,
+          startedAt: 3,
+          completedAt: 4,
+          durationMs: 1,
+        },
+      },
+    });
+
+    await expect(iterator.next()).resolves.toEqual({
+      value: { type: 'assistant_delta', text: 'Still running' },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      value: { type: 'turn_completed' },
+      done: false,
     });
   });
 

--- a/apps/desktop/tests/main/codex-runtime.test.ts
+++ b/apps/desktop/tests/main/codex-runtime.test.ts
@@ -1,0 +1,1336 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { OpToolDescriptor } from '@main/ops';
+import type { CodexAppServerConnection } from '@main/providers/codex/app-server';
+import type { ExecFileFn } from '@main/providers/codex/cli';
+import type {
+  JsonRpcNotificationMessage,
+  JsonRpcRequestMessage,
+} from '@main/providers/codex/json-rpc';
+import { CodexProviderRuntime } from '@main/providers/codex/runtime';
+import { CODEX_CONTEXTURE_TOOL_NAMESPACE } from '@main/providers/codex/tools';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+interface FakeConnection extends CodexAppServerConnection {
+  emitNotification(message: JsonRpcNotificationMessage): void;
+  emitServerRequest(message: JsonRpcRequestMessage): void;
+}
+
+function supportedExec(): ExecFileFn {
+  return vi.fn<ExecFileFn>(async (file) => {
+    if (file === 'which') return { stdout: '/opt/bin/codex\n' };
+    return { stdout: 'codex-cli 0.130.0\n' };
+  });
+}
+
+function rateLimitSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    limitId: 'codex',
+    limitName: 'Codex',
+    primary: null,
+    secondary: null,
+    credits: { hasCredits: true, unlimited: false, balance: '10' },
+    planType: 'plus',
+    rateLimitReachedType: null,
+    ...overrides,
+  };
+}
+
+function fakeConnection(request: CodexAppServerConnection['client']['request']): FakeConnection {
+  const process = new EventEmitter() as CodexAppServerConnection['process'];
+  process.stdin = new PassThrough();
+  process.stdout = new PassThrough();
+  process.stderr = new PassThrough();
+  process.killed = false;
+  process.kill = vi.fn(() => true);
+  const notifications = new Set<(message: JsonRpcNotificationMessage) => void>();
+  const serverRequests = new Set<
+    (
+      message: JsonRpcRequestMessage,
+      client: CodexAppServerConnection['client'],
+    ) => boolean | undefined
+  >();
+  const client = {
+    request,
+    notify: vi.fn(),
+    respond: vi.fn(),
+    respondError: vi.fn(),
+    dispose: vi.fn(),
+    onNotification: vi.fn((listener) => {
+      notifications.add(listener);
+      return () => notifications.delete(listener);
+    }),
+    onServerRequest: vi.fn((listener) => {
+      serverRequests.add(listener);
+      return () => serverRequests.delete(listener);
+    }),
+  } as unknown as CodexAppServerConnection['client'];
+  return {
+    process,
+    client,
+    dispose: vi.fn(),
+    emitNotification: (message: JsonRpcNotificationMessage) => {
+      for (const listener of notifications) listener(message);
+    },
+    emitServerRequest: (message: JsonRpcRequestMessage) => {
+      for (const listener of serverRequests) listener(message, client);
+    },
+  } as unknown as FakeConnection;
+}
+
+describe('CodexProviderRuntime', () => {
+  it('reports ChatGPT readiness from Codex account state', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'account/read') {
+        return {
+          account: { type: 'chatgpt', email: 'user@example.com', planType: 'plus' },
+          requiresOpenaiAuth: false,
+        };
+      }
+      if (method === 'account/rateLimits/read') {
+        return { rateLimits: rateLimitSnapshot(), rateLimitsByLimitId: null };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const appServerFactory = vi.fn(() => fakeConnection(request));
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory,
+    });
+
+    await expect(runtime.getStatus()).resolves.toMatchObject({
+      provider: 'codex',
+      readiness: 'authenticated_chatgpt',
+      cliVersion: '0.130.0',
+    });
+    expect(appServerFactory).toHaveBeenCalledWith('/opt/bin/codex');
+  });
+
+  it('reports authenticated ChatGPT accounts as rate-limited when Codex says the Codex bucket is exhausted', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'account/read') {
+        return {
+          account: { type: 'chatgpt', email: 'user@example.com', planType: 'plus' },
+          requiresOpenaiAuth: false,
+        };
+      }
+      if (method === 'account/rateLimits/read') {
+        return {
+          rateLimits: rateLimitSnapshot(),
+          rateLimitsByLimitId: {
+            codex: rateLimitSnapshot({ rateLimitReachedType: 'rate_limit_reached' }),
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => fakeConnection(request)),
+    });
+
+    await expect(runtime.getStatus()).resolves.toMatchObject({
+      provider: 'codex',
+      readiness: 'rate_limited',
+      detail: 'rate limit reached',
+      cliVersion: '0.130.0',
+    });
+  });
+
+  it('keeps ChatGPT accounts ready when credits are empty but Codex has not reached a limit', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'account/read') {
+        return {
+          account: { type: 'chatgpt', email: 'user@example.com', planType: 'plus' },
+          requiresOpenaiAuth: false,
+        };
+      }
+      if (method === 'account/rateLimits/read') {
+        return {
+          rateLimits: rateLimitSnapshot({
+            credits: { hasCredits: false, unlimited: false, balance: '0' },
+            primary: { usedPercent: 22, windowDurationMins: 300, resetsAt: 1778772745 },
+            secondary: { usedPercent: 3, windowDurationMins: 10080, resetsAt: 1779359545 },
+          }),
+          rateLimitsByLimitId: null,
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => fakeConnection(request)),
+    });
+
+    await expect(runtime.getStatus()).resolves.toMatchObject({
+      provider: 'codex',
+      readiness: 'authenticated_chatgpt',
+      cliVersion: '0.130.0',
+    });
+  });
+
+  it('reports not-signed-in when Codex has no account', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'account/read') return { account: null, requiresOpenaiAuth: true };
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => fakeConnection(request)),
+    });
+
+    await expect(runtime.getStatus()).resolves.toMatchObject({
+      provider: 'codex',
+      readiness: 'not_signed_in',
+      cliVersion: '0.130.0',
+    });
+  });
+
+  it('restarts app-server after the cached Codex connection exits', async () => {
+    const connections: FakeConnection[] = [];
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'account/read') return { account: null, requiresOpenaiAuth: true };
+      throw new Error(`unexpected method ${method}`);
+    });
+    const appServerFactory = vi.fn(() => {
+      const connection = fakeConnection(request);
+      connections.push(connection);
+      return connection;
+    });
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory,
+    });
+
+    await expect(runtime.getStatus()).resolves.toMatchObject({
+      provider: 'codex',
+      readiness: 'not_signed_in',
+    });
+    connections[0].process.emit('exit', 1, null);
+    await expect(runtime.getStatus()).resolves.toMatchObject({
+      provider: 'codex',
+      readiness: 'not_signed_in',
+    });
+
+    expect(appServerFactory).toHaveBeenCalledTimes(2);
+  });
+
+  it('starts and cancels ChatGPT login through app-server', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'account/login/start') {
+        return { type: 'chatgpt', loginId: 'login-1', authUrl: 'https://auth.example.test' };
+      }
+      if (method === 'account/login/cancel') return {};
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => fakeConnection(request)),
+    });
+
+    await expect(runtime.startLogin({ mode: 'chatgpt' })).resolves.toEqual({
+      id: 'login-1',
+      mode: 'chatgpt',
+      url: 'https://auth.example.test',
+    });
+    await runtime.cancelLogin({ flowId: 'login-1' });
+    expect(request).toHaveBeenNthCalledWith(2, 'account/login/start', {
+      type: 'chatgpt',
+      codexStreamlinedLogin: true,
+    });
+    expect(request).toHaveBeenNthCalledWith(3, 'account/login/cancel', {
+      loginId: 'login-1',
+    });
+  });
+
+  it('supports API-key login and logout through app-server', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'account/login/start') return { type: 'apiKey' };
+      if (method === 'account/logout') return {};
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => fakeConnection(request)),
+    });
+
+    await expect(runtime.startLogin({ mode: 'api-key', apiKey: 'sk-test' })).resolves.toEqual({
+      id: 'api-key',
+      mode: 'api-key',
+    });
+    await runtime.logout();
+    expect(request).toHaveBeenNthCalledWith(2, 'account/login/start', {
+      type: 'apiKey',
+      apiKey: 'sk-test',
+    });
+    expect(request).toHaveBeenNthCalledWith(3, 'account/logout', undefined);
+  });
+
+  it('normalizes model/list results after initializing app-server', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'model/list') {
+        return {
+          data: [
+            {
+              id: 'gpt-5.4-id',
+              model: 'gpt-5.4',
+              displayName: 'GPT-5.4',
+              supportedReasoningEfforts: [{ reasoningEffort: 'high', description: 'High' }],
+              upgrade: null,
+              upgradeInfo: null,
+              availabilityNux: null,
+              description: '',
+              hidden: false,
+              defaultReasoningEffort: 'high',
+              inputModalities: ['text'],
+              supportsPersonality: false,
+              additionalSpeedTiers: [],
+              serviceTiers: [],
+              isDefault: true,
+            },
+          ],
+          nextCursor: null,
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const appServerFactory = vi.fn(() => fakeConnection(request));
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory,
+    });
+
+    await expect(runtime.listModels()).resolves.toEqual([
+      { id: 'gpt-5.4', label: 'GPT-5.4', supportsReasoningEffort: true },
+    ]);
+    expect(appServerFactory).toHaveBeenCalledWith('/opt/bin/codex');
+    expect(request).toHaveBeenNthCalledWith(1, 'initialize', {
+      clientInfo: { name: 'contexture', title: 'Contexture', version: '0.14.0' },
+      capabilities: { experimentalApi: true },
+    });
+    expect(request).toHaveBeenNthCalledWith(2, 'model/list', {
+      cursor: null,
+      includeHidden: false,
+    });
+  });
+
+  it('does not start app-server when Codex CLI is unsupported', async () => {
+    const exec = vi.fn<ExecFileFn>(async (file) => {
+      if (file === 'which') return { stdout: '/opt/bin/codex\n' };
+      return { stdout: 'codex-cli 0.129.0\n' };
+    });
+    const appServerFactory = vi.fn(() =>
+      fakeConnection(vi.fn<CodexAppServerConnection['client']['request']>()),
+    );
+    const runtime = new CodexProviderRuntime({ execFile: exec, appServerFactory });
+
+    await expect(runtime.listModels()).rejects.toThrow('Codex CLI version is not supported');
+    expect(appServerFactory).not.toHaveBeenCalled();
+  });
+
+  it('starts and rolls back Codex threads through app-server', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') {
+        return {
+          thread: {
+            id: 'thread-123',
+            sessionId: 'session-123',
+            forkedFromId: null,
+            preview: '',
+            ephemeral: false,
+            modelProvider: 'openai',
+            createdAt: 1,
+            updatedAt: 1,
+            status: 'idle',
+            path: null,
+            cwd: '/tmp',
+            cliVersion: '0.130.0',
+            source: 'app-server',
+            threadSource: null,
+            agentNickname: null,
+            agentRole: null,
+            gitInfo: null,
+            name: null,
+            turns: [],
+          },
+          model: 'gpt-5.4',
+          modelProvider: 'openai',
+          serviceTier: null,
+          cwd: '/tmp',
+          instructionSources: [],
+          approvalPolicy: 'never',
+          approvalsReviewer: 'client',
+          sandbox: 'read-only',
+          permissionProfile: null,
+          activePermissionProfile: null,
+          reasoningEffort: null,
+        };
+      }
+      if (method === 'thread/rollback') return {};
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => fakeConnection(request)),
+    });
+
+    const thread = await runtime.startThread({
+      schema: { version: '1', types: [] },
+      model: 'gpt-5.4',
+    });
+    await runtime.rollbackThread({ thread, turns: 1 });
+
+    expect(thread).toMatchObject({ provider: 'codex', threadId: 'thread-123' });
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      'thread/start',
+      expect.objectContaining({
+        model: 'gpt-5.4',
+        cwd: expect.any(String),
+        approvalPolicy: expect.objectContaining({
+          granular: expect.objectContaining({
+            sandbox_approval: true,
+            rules: true,
+            skill_approval: true,
+            request_permissions: true,
+            mcp_elicitations: true,
+          }),
+        }),
+        sandbox: 'read-only',
+        environments: [],
+        config: {
+          web_search: 'disabled',
+          tools: { view_image: false },
+        },
+        dynamicTools: [],
+        experimentalRawEvents: false,
+        persistExtendedHistory: false,
+      }),
+    );
+    expect(request).toHaveBeenNthCalledWith(3, 'thread/rollback', {
+      threadId: 'thread-123',
+      numTurns: 1,
+    });
+  });
+
+  it('resumes persisted Codex threads before reuse', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/resume') {
+        return {
+          thread: {
+            id: 'thread-123',
+            sessionId: 'session-123',
+            forkedFromId: null,
+            preview: '',
+            ephemeral: false,
+            modelProvider: 'openai',
+            createdAt: 1,
+            updatedAt: 2,
+            status: 'idle',
+            path: null,
+            cwd: '/tmp',
+            cliVersion: '0.130.0',
+            source: 'app-server',
+            threadSource: null,
+            agentNickname: null,
+            agentRole: null,
+            gitInfo: null,
+            name: null,
+            turns: [],
+          },
+          model: 'gpt-5.4',
+          modelProvider: 'openai',
+          serviceTier: null,
+          cwd: '/tmp',
+          instructionSources: [],
+          approvalPolicy: 'never',
+          approvalsReviewer: 'client',
+          sandbox: 'read-only',
+          permissionProfile: null,
+          activePermissionProfile: null,
+          reasoningEffort: null,
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => fakeConnection(request)),
+    });
+
+    const resumed = await runtime.resumeThread({
+      thread: { provider: 'codex', threadId: 'thread-123' },
+      model: 'gpt-5.4',
+    });
+
+    expect(resumed).toMatchObject({ provider: 'codex', threadId: 'thread-123' });
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      'thread/resume',
+      expect.objectContaining({
+        threadId: 'thread-123',
+        model: 'gpt-5.4',
+        cwd: expect.any(String),
+        approvalPolicy: expect.objectContaining({
+          granular: expect.objectContaining({
+            sandbox_approval: true,
+            rules: true,
+            skill_approval: true,
+            request_permissions: true,
+            mcp_elicitations: true,
+          }),
+        }),
+        sandbox: 'read-only',
+        excludeTurns: true,
+        persistExtendedHistory: false,
+      }),
+    );
+  });
+
+  it('starts schema threads with only Contexture dynamic tools and constrained runtime settings', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') {
+        return {
+          thread: {
+            id: 'thread-123',
+            sessionId: 'session-123',
+            forkedFromId: null,
+            preview: '',
+            ephemeral: false,
+            modelProvider: 'openai',
+            createdAt: 1,
+            updatedAt: 1,
+            status: 'idle',
+            path: null,
+            cwd: '/tmp',
+            cliVersion: '0.130.0',
+            source: 'appServer',
+            threadSource: null,
+            agentNickname: null,
+            agentRole: null,
+            gitInfo: null,
+            name: null,
+            turns: [],
+          },
+          model: 'gpt-5.4',
+          modelProvider: 'openai',
+          serviceTier: null,
+          cwd: '/tmp',
+          instructionSources: [],
+          approvalPolicy: 'never',
+          approvalsReviewer: 'user',
+          sandbox: { type: 'readOnly', networkAccess: false },
+          permissionProfile: null,
+          activePermissionProfile: null,
+          reasoningEffort: null,
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const tool: OpToolDescriptor = {
+      name: 'add_type',
+      description: 'Add type.',
+      inputSchema: { payload: z.object({ name: z.string() }) },
+      handler: vi.fn(async () => ({ schema: { version: '1', types: [] } })),
+    };
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => fakeConnection(request)),
+      opToolDescriptors: [tool],
+    });
+
+    await runtime.startThread({ schema: { version: '1', types: [] }, model: 'gpt-5.4' });
+
+    const params = request.mock.calls.find(([method]) => method === 'thread/start')?.[1] as {
+      dynamicTools: Array<{ namespace?: string; name: string }>;
+      approvalPolicy: unknown;
+      cwd: string;
+      sandbox: string;
+      environments: unknown[];
+      config: { web_search?: unknown; tools?: { view_image?: unknown } };
+    };
+    expect(params.cwd.length).toBeGreaterThan(0);
+    expect(params.approvalPolicy).toEqual({
+      granular: {
+        sandbox_approval: true,
+        rules: true,
+        skill_approval: true,
+        request_permissions: true,
+        mcp_elicitations: true,
+      },
+    });
+    expect(params.sandbox).toBe('read-only');
+    expect(params.environments).toEqual([]);
+    expect(params.config).toEqual({
+      web_search: 'disabled',
+      tools: { view_image: false },
+    });
+    expect(params.dynamicTools).toEqual([
+      expect.objectContaining({ namespace: 'contexture', name: 'add_type' }),
+    ]);
+    expect(params.dynamicTools.map((tool) => tool.name)).not.toEqual(
+      expect.arrayContaining(['Read', 'Write', 'Edit', 'Bash', 'WebSearch', 'WebFetch']),
+    );
+  });
+
+  it('interrupts only when a Codex turn id is available', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'turn/interrupt') return {};
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => fakeConnection(request)),
+    });
+
+    await expect(
+      runtime.interruptTurn({ thread: { provider: 'codex', threadId: 'thread-1' } }),
+    ).rejects.toThrow('Cannot interrupt Codex turn before a turn id is known');
+
+    await runtime.interruptTurn({
+      thread: { provider: 'codex', threadId: 'thread-1', opaque: { currentTurnId: 'turn-1' } },
+    });
+    expect(request).toHaveBeenLastCalledWith('turn/interrupt', {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    });
+  });
+
+  it('streams Codex turn notifications as provider events', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'turn/start') {
+        return {
+          turn: {
+            id: 'turn-1',
+            items: [],
+            itemsView: 'complete',
+            status: 'inProgress',
+            error: null,
+            startedAt: 1,
+            completedAt: null,
+            durationMs: null,
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const connection = fakeConnection(request);
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => connection),
+    });
+    const thread = { provider: 'codex' as const, threadId: 'thread-1' };
+    const iterator = runtime
+      .sendTurn({ thread, schema: { version: '1', types: [] }, message: 'hello' })
+      [Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({
+      value: { type: 'turn_started', thread },
+      done: false,
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'item/agentMessage/delta',
+      params: { threadId: 'thread-1', turnId: 'turn-1', itemId: 'item-1', delta: 'Hello' },
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'item/started',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        startedAtMs: 1,
+        item: {
+          type: 'dynamicToolCall',
+          id: 'call-1',
+          namespace: CODEX_CONTEXTURE_TOOL_NAMESPACE,
+          tool: 'add_type',
+          arguments: { payload: { name: 'Plot' } },
+          status: 'inProgress',
+          contentItems: null,
+          success: null,
+          durationMs: null,
+        },
+      },
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        completedAtMs: 2,
+        item: {
+          type: 'dynamicToolCall',
+          id: 'call-1',
+          namespace: CODEX_CONTEXTURE_TOOL_NAMESPACE,
+          tool: 'add_type',
+          arguments: { payload: { name: 'Plot' } },
+          status: 'completed',
+          contentItems: [{ type: 'inputText', text: '{"schema":{"version":"1","types":[]}}' }],
+          success: true,
+          durationMs: 1,
+        },
+      },
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: {
+          id: 'turn-1',
+          items: [],
+          itemsView: 'complete',
+          status: 'completed',
+          error: null,
+          startedAt: 1,
+          completedAt: 2,
+          durationMs: 1,
+        },
+      },
+    });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: 'assistant_delta', text: 'Hello' },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: 'tool_call_started', id: 'call-1', name: 'add_type' },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: 'tool_call_finished', id: 'call-1', name: 'add_type', ok: true },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      value: { type: 'turn_completed' },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      value: { type: 'assistant_final', text: 'Hello' },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+    expect(thread.opaque).toEqual({ currentTurnId: 'turn-1' });
+    expect(request).toHaveBeenLastCalledWith('turn/start', {
+      threadId: 'thread-1',
+      input: [{ type: 'text', text: 'hello', text_elements: [] }],
+      environments: [],
+      cwd: expect.any(String),
+      approvalPolicy: {
+        granular: {
+          sandbox_approval: true,
+          rules: true,
+          skill_approval: true,
+          request_permissions: true,
+          mcp_elicitations: true,
+        },
+      },
+      sandboxPolicy: { type: 'readOnly', networkAccess: false },
+      model: null,
+      effort: null,
+    });
+  });
+
+  it('maps Codex account and rate-limit notifications to canonical status events', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'turn/start') {
+        return {
+          turn: {
+            id: 'turn-1',
+            items: [],
+            itemsView: 'complete',
+            status: 'inProgress',
+            error: null,
+            startedAt: 1,
+            completedAt: null,
+            durationMs: null,
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const connection = fakeConnection(request);
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => connection),
+    });
+    const thread = { provider: 'codex' as const, threadId: 'thread-1' };
+    const iterator = runtime
+      .sendTurn({ thread, schema: { version: '1', types: [] }, message: 'hello' })
+      [Symbol.asyncIterator]();
+
+    await iterator.next();
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'account/updated',
+      params: { authMode: 'chatgpt', planType: 'plus' },
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'account/rateLimits/updated',
+      params: { rateLimits: rateLimitSnapshot({ rateLimitReachedType: 'rate_limit_reached' }) },
+    });
+
+    await expect(iterator.next()).resolves.toEqual({
+      value: {
+        type: 'auth_changed',
+        status: { provider: 'codex', readiness: 'authenticated_chatgpt' },
+      },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      value: {
+        type: 'status_changed',
+        status: {
+          provider: 'codex',
+          readiness: 'rate_limited',
+          detail: 'rate limit reached',
+        },
+      },
+      done: false,
+    });
+  });
+
+  it('replies to Codex dynamic tool-call server requests', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'turn/start') {
+        return {
+          turn: {
+            id: 'turn-1',
+            items: [],
+            itemsView: 'complete',
+            status: 'inProgress',
+            error: null,
+            startedAt: 1,
+            completedAt: null,
+            durationMs: null,
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const tool: OpToolDescriptor = {
+      name: 'add_type',
+      description: 'Add type.',
+      inputSchema: { payload: z.object({ name: z.string() }) },
+      handler: vi.fn(async () => ({ schema: { version: '1', types: [] } })),
+    };
+    const connection = fakeConnection(request);
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => connection),
+      opToolDescriptors: [tool],
+    });
+    const iterator = runtime
+      .sendTurn({
+        thread: { provider: 'codex', threadId: 'thread-1' },
+        schema: { version: '1', types: [] },
+        message: 'hello',
+      })
+      [Symbol.asyncIterator]();
+
+    await iterator.next();
+    connection.emitServerRequest({
+      jsonrpc: '2.0',
+      id: 42,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        callId: 'call-1',
+        namespace: CODEX_CONTEXTURE_TOOL_NAMESPACE,
+        tool: 'add_type',
+        arguments: { payload: { name: 'Plot' } },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(connection.client.respond).toHaveBeenCalledWith(42, {
+        success: true,
+        contentItems: [{ type: 'inputText', text: '{"schema":{"version":"1","types":[]}}' }],
+      });
+    });
+    expect(tool.handler).toHaveBeenCalledWith({ payload: { name: 'Plot' } });
+  });
+
+  it('rejects forbidden shell/file approval requests and fails the turn', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'turn/start') {
+        return {
+          turn: {
+            id: 'turn-1',
+            items: [],
+            itemsView: 'complete',
+            status: 'inProgress',
+            error: null,
+            startedAt: 1,
+            completedAt: null,
+            durationMs: null,
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const connection = fakeConnection(request);
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => connection),
+    });
+    const iterator = runtime
+      .sendTurn({
+        thread: { provider: 'codex', threadId: 'thread-1' },
+        schema: { version: '1', types: [] },
+        message: 'read a file',
+      })
+      [Symbol.asyncIterator]();
+
+    await iterator.next();
+    connection.emitServerRequest({
+      jsonrpc: '2.0',
+      id: 77,
+      method: 'item/commandExecution/requestApproval',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'cmd-1',
+        command: 'cat package.json',
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(connection.client.respondError).toHaveBeenCalledWith(
+        77,
+        -32000,
+        'Codex requested forbidden schema-chat capability: item/commandExecution/requestApproval',
+      );
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      value: {
+        type: 'turn_failed',
+        message:
+          'Codex requested forbidden schema-chat capability: item/commandExecution/requestApproval',
+      },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it('fails the turn if Codex starts a built-in command execution item', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'turn/start') {
+        return {
+          turn: {
+            id: 'turn-1',
+            items: [],
+            itemsView: 'complete',
+            status: 'inProgress',
+            error: null,
+            startedAt: 1,
+            completedAt: null,
+            durationMs: null,
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const connection = fakeConnection(request);
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => connection),
+    });
+    const iterator = runtime
+      .sendTurn({
+        thread: { provider: 'codex', threadId: 'thread-1' },
+        schema: { version: '1', types: [] },
+        message: 'start the dev server',
+      })
+      [Symbol.asyncIterator]();
+
+    await iterator.next();
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'item/started',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-1',
+          command: 'bun run dev',
+          cwd: '/Users/rufus/Apps/contexture',
+          processId: null,
+          source: 'agent',
+          status: 'inProgress',
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      },
+    });
+
+    await expect(iterator.next()).resolves.toEqual({
+      value: {
+        type: 'turn_failed',
+        message: 'Codex attempted forbidden schema-chat item: commandExecution',
+      },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it('rejects unsupported interactive server requests and fails the turn', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'turn/start') {
+        return {
+          turn: {
+            id: 'turn-1',
+            items: [],
+            itemsView: 'complete',
+            status: 'inProgress',
+            error: null,
+            startedAt: 1,
+            completedAt: null,
+            durationMs: null,
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const connection = fakeConnection(request);
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => connection),
+    });
+    const iterator = runtime
+      .sendTurn({
+        thread: { provider: 'codex', threadId: 'thread-1' },
+        schema: { version: '1', types: [] },
+        message: 'ask the user',
+      })
+      [Symbol.asyncIterator]();
+
+    await iterator.next();
+    connection.emitServerRequest({
+      jsonrpc: '2.0',
+      id: 78,
+      method: 'mcpServer/elicitation/request',
+      params: { threadId: 'thread-1', turnId: 'turn-1' },
+    });
+
+    await vi.waitFor(() => {
+      expect(connection.client.respondError).toHaveBeenCalledWith(
+        78,
+        -32000,
+        'Codex requested forbidden schema-chat capability: mcpServer/elicitation/request',
+      );
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      value: {
+        type: 'turn_failed',
+        message: 'Codex requested forbidden schema-chat capability: mcpServer/elicitation/request',
+      },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it('ignores forbidden requests that explicitly belong to another Codex thread', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'turn/start') {
+        return {
+          turn: {
+            id: 'turn-1',
+            items: [],
+            itemsView: 'complete',
+            status: 'inProgress',
+            error: null,
+            startedAt: 1,
+            completedAt: null,
+            durationMs: null,
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const connection = fakeConnection(request);
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => connection),
+    });
+    const iterator = runtime
+      .sendTurn({
+        thread: { provider: 'codex', threadId: 'thread-1' },
+        schema: { version: '1', types: [] },
+        message: 'hello',
+      })
+      [Symbol.asyncIterator]();
+
+    await iterator.next();
+    connection.emitServerRequest({
+      jsonrpc: '2.0',
+      id: 79,
+      method: 'item/commandExecution/requestApproval',
+      params: {
+        threadId: 'thread-2',
+        turnId: 'turn-2',
+        itemId: 'cmd-1',
+        command: 'cat package.json',
+      },
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: {
+          id: 'turn-1',
+          items: [],
+          itemsView: 'complete',
+          status: 'completed',
+          error: null,
+          startedAt: 1,
+          completedAt: 2,
+          durationMs: 1,
+        },
+      },
+    });
+
+    expect(connection.client.respondError).not.toHaveBeenCalled();
+    await expect(iterator.next()).resolves.toEqual({
+      value: { type: 'turn_completed' },
+      done: false,
+    });
+  });
+
+  it('ignores forbidden requests that explicitly belong to another Codex turn', async () => {
+    const request = vi.fn<CodexAppServerConnection['client']['request']>(async (method) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'codex',
+          codexHome: '/tmp/codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'turn/start') {
+        return {
+          turn: {
+            id: 'turn-1',
+            items: [],
+            itemsView: 'complete',
+            status: 'inProgress',
+            error: null,
+            startedAt: 1,
+            completedAt: null,
+            durationMs: null,
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const connection = fakeConnection(request);
+    const runtime = new CodexProviderRuntime({
+      execFile: supportedExec(),
+      appServerFactory: vi.fn(() => connection),
+    });
+    const iterator = runtime
+      .sendTurn({
+        thread: { provider: 'codex', threadId: 'thread-1' },
+        schema: { version: '1', types: [] },
+        message: 'hello',
+      })
+      [Symbol.asyncIterator]();
+
+    await iterator.next();
+    connection.emitServerRequest({
+      jsonrpc: '2.0',
+      id: 80,
+      method: 'item/commandExecution/requestApproval',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-2',
+        itemId: 'cmd-1',
+        command: 'cat package.json',
+      },
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: {
+          id: 'turn-1',
+          items: [],
+          itemsView: 'complete',
+          status: 'completed',
+          error: null,
+          startedAt: 1,
+          completedAt: 2,
+          durationMs: 1,
+        },
+      },
+    });
+
+    expect(connection.client.respondError).not.toHaveBeenCalled();
+    await expect(iterator.next()).resolves.toEqual({
+      value: { type: 'turn_completed' },
+      done: false,
+    });
+  });
+});

--- a/apps/desktop/tests/main/codex-runtime.test.ts
+++ b/apps/desktop/tests/main/codex-runtime.test.ts
@@ -339,7 +339,7 @@ describe('CodexProviderRuntime', () => {
             {
               id: 'gpt-5.4-id',
               model: 'gpt-5.4',
-              displayName: 'GPT-5.4',
+              displayName: 'gpt-5.4',
               supportedReasoningEfforts: [{ reasoningEffort: 'high', description: 'High' }],
               upgrade: null,
               upgradeInfo: null,
@@ -366,7 +366,25 @@ describe('CodexProviderRuntime', () => {
     });
 
     await expect(runtime.listModels()).resolves.toEqual([
-      { id: 'gpt-5.4', label: 'GPT-5.4', supportsReasoningEffort: true },
+      {
+        id: 'gpt-5.4',
+        label: 'GPT-5.4',
+        supportsReasoningEffort: true,
+        optionDescriptors: [
+          {
+            id: 'reasoningEffort',
+            type: 'select',
+            label: 'Effort',
+            options: [{ id: 'high', label: 'High', isDefault: true }],
+          },
+          {
+            id: 'fastMode',
+            type: 'boolean',
+            label: 'Fast',
+            defaultValue: false,
+          },
+        ],
+      },
     ]);
     expect(appServerFactory).toHaveBeenCalledWith('/opt/bin/codex');
     expect(request).toHaveBeenNthCalledWith(1, 'initialize', {
@@ -848,6 +866,7 @@ describe('CodexProviderRuntime', () => {
       },
       sandboxPolicy: { type: 'readOnly', networkAccess: false },
       model: null,
+      serviceTier: null,
       effort: null,
     });
   });

--- a/apps/desktop/tests/main/codex-tools.test.ts
+++ b/apps/desktop/tests/main/codex-tools.test.ts
@@ -1,0 +1,82 @@
+import type { OpToolDescriptor } from '@main/ops';
+import {
+  CODEX_CONTEXTURE_TOOL_NAMESPACE,
+  handleCodexDynamicToolCall,
+  toCodexDynamicTools,
+} from '@main/providers/codex/tools';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+function descriptor(): OpToolDescriptor {
+  return {
+    name: 'add_type',
+    description: 'Add a type.',
+    inputSchema: {
+      payload: z.object({
+        kind: z.literal('object'),
+        name: z.string(),
+        fields: z.array(z.unknown()),
+      }),
+    },
+    handler: vi.fn(async () => ({ schema: { version: '1', types: [] } })),
+  };
+}
+
+describe('Codex dynamic tool adapter', () => {
+  it('generates namespaced Codex dynamic tools from op descriptors', () => {
+    const [tool] = toCodexDynamicTools([descriptor()]);
+
+    expect(tool).toMatchObject({
+      namespace: CODEX_CONTEXTURE_TOOL_NAMESPACE,
+      name: 'add_type',
+      description: 'Add a type.',
+    });
+    expect(tool.inputSchema).toMatchObject({
+      type: 'object',
+      properties: {
+        payload: expect.objectContaining({ type: 'object' }),
+      },
+    });
+  });
+
+  it('dispatches Codex tool calls to the shared descriptor handler', async () => {
+    const tool = descriptor();
+
+    const response = await handleCodexDynamicToolCall(
+      {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        callId: 'call-1',
+        namespace: CODEX_CONTEXTURE_TOOL_NAMESPACE,
+        tool: 'add_type',
+        arguments: { payload: { kind: 'object', name: 'Plot', fields: [] } },
+      },
+      [tool],
+    );
+
+    expect(tool.handler).toHaveBeenCalledWith({
+      payload: { kind: 'object', name: 'Plot', fields: [] },
+    });
+    expect(response).toEqual({
+      success: true,
+      contentItems: [{ type: 'inputText', text: '{"schema":{"version":"1","types":[]}}' }],
+    });
+  });
+
+  it('returns a failed tool response for unknown tools', async () => {
+    const response = await handleCodexDynamicToolCall(
+      {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        callId: 'call-1',
+        namespace: CODEX_CONTEXTURE_TOOL_NAMESPACE,
+        tool: 'missing',
+        arguments: {},
+      },
+      [descriptor()],
+    );
+
+    expect(response.success).toBe(false);
+    expect(response.contentItems[0].text).toContain('Unknown Contexture tool');
+  });
+});

--- a/apps/desktop/tests/main/op-tools.test.ts
+++ b/apps/desktop/tests/main/op-tools.test.ts
@@ -199,6 +199,23 @@ describe('createOpTools', () => {
     expect((forwardedOp as { schema: unknown }).schema).toEqual(schema);
   });
 
+  it('replace_schema accepts Claude-style payload and direct schema shapes', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const replace = toolNamed(tools, 'replace_schema');
+    const schema = { version: '1', types: [{ kind: 'object', name: 'X', fields: [] }] };
+
+    await replace.handler({ payload: schema });
+    await replace.handler(schema);
+    await replace.handler({ payload: JSON.stringify(schema) });
+
+    expect(forwardSpy.mock.calls.map((call) => call[0])).toEqual([
+      { kind: 'replace_schema', schema },
+      { kind: 'replace_schema', schema },
+      { kind: 'replace_schema', schema },
+    ]);
+  });
+
   it('replace_schema rejects an invalid IR before forwarding', async () => {
     const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
     const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
@@ -254,6 +271,22 @@ describe('createOpTools', () => {
       typeName: 'Role',
       value: 'admin',
     });
+  });
+
+  it('delete_type accepts top-level and payload-wrapped Claude shapes', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const tool = toolNamed(tools, 'delete_type');
+
+    await tool.handler({ name: 'SaleLineItem' });
+    await tool.handler({ payload: { name: 'SaleLineItem' } });
+    await tool.handler({ payload: JSON.stringify({ name: 'SaleLineItem' }) });
+
+    expect(forwardSpy.mock.calls.map((call) => call[0])).toEqual([
+      { kind: 'delete_type', name: 'SaleLineItem' },
+      { kind: 'delete_type', name: 'SaleLineItem' },
+      { kind: 'delete_type', name: 'SaleLineItem' },
+    ]);
   });
 
   it('propagates ApplyResult errors back to the SDK caller', async () => {

--- a/apps/desktop/tests/main/ops-tool-error.test.ts
+++ b/apps/desktop/tests/main/ops-tool-error.test.ts
@@ -9,9 +9,10 @@
  * This is the bridge layer Claude sees in-band per turn; false positives
  * here would make validation errors invisible to the model.
  */
-import { invokeOpHandler } from '@main/ipc/op-tool-bridge';
+import { invokeOpHandler, normalizeOpToolArgs } from '@main/ipc/op-tool-bridge';
 import type { OpToolDescriptor } from '@main/ops';
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 describe('invokeOpHandler', () => {
   it('forwards a successful ApplyResult as JSON text', async () => {
@@ -50,5 +51,37 @@ describe('invokeOpHandler', () => {
     const result = await invokeOpHandler(handler, {});
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toBe('boom');
+  });
+
+  it('normalizes flattened Claude args for payload-only op tools', () => {
+    const descriptor: OpToolDescriptor = {
+      name: 'delete_type',
+      description: 'Delete a type.',
+      inputSchema: { payload: z.unknown() },
+      handler: async () => ({ schema: { version: '1', types: [] } }),
+    };
+
+    expect(normalizeOpToolArgs(descriptor, { name: 'SaleLineItem' })).toEqual({
+      payload: { name: 'SaleLineItem' },
+    });
+    expect(
+      normalizeOpToolArgs(descriptor, { payload: { payload: { name: 'SaleLineItem' } } }),
+    ).toEqual({
+      payload: { name: 'SaleLineItem' },
+    });
+  });
+
+  it('normalizes flattened Claude args for replace_schema', () => {
+    const schema = { version: '1', types: [] };
+    const descriptor: OpToolDescriptor = {
+      name: 'replace_schema',
+      description: 'Replace schema.',
+      inputSchema: { schema: z.unknown() },
+      handler: async () => ({ schema }),
+    };
+
+    expect(normalizeOpToolArgs(descriptor, schema)).toEqual({ schema });
+    expect(normalizeOpToolArgs(descriptor, { payload: schema })).toEqual({ schema });
+    expect(normalizeOpToolArgs(descriptor, { payload: { schema } })).toEqual({ schema });
   });
 });

--- a/apps/desktop/tests/main/schema-agent-driver.test.ts
+++ b/apps/desktop/tests/main/schema-agent-driver.test.ts
@@ -1,0 +1,153 @@
+import { ChatTurnController } from '@main/ipc/chat-turn';
+import type {
+  ProviderCapabilities,
+  ProviderRuntime,
+  ProviderRuntimeEvent,
+  ProviderThreadRef,
+} from '@main/providers/runtime';
+import {
+  SCHEMA_AGENT_ASSISTANT_DELTA,
+  SCHEMA_AGENT_ERROR,
+  SCHEMA_AGENT_THREAD_DESYNCED,
+  SCHEMA_AGENT_THREAD_UPDATED,
+  SCHEMA_AGENT_TOOL_CALL_FINISHED,
+  SCHEMA_AGENT_TOOL_CALL_STARTED,
+  SchemaAgentDriver,
+  type SchemaAgentTransport,
+} from '@main/providers/schema-agent-driver';
+import type { Schema } from '@renderer/model/ir';
+import { describe, expect, it, vi } from 'vitest';
+
+const capabilities: ProviderCapabilities = {
+  authModes: ['chatgpt', 'api-key'],
+  modelSource: 'runtime',
+  supportsThreadResume: true,
+  supportsThreadRollback: true,
+  supportsDynamicTools: true,
+  supportsMcpTools: false,
+  supportsInterrupt: true,
+  supportsRateLimitStatus: true,
+  supportsReasoningEffort: true,
+  supportsSchemaOnlyMode: true,
+};
+
+const emptyIR: Schema = { version: '1', types: [] };
+const thread: ProviderThreadRef = { provider: 'codex', threadId: 'thread-1' };
+
+function fakeTransport(): {
+  transport: SchemaAgentTransport;
+  sent: Array<{ channel: string; payload: unknown }>;
+} {
+  const sent: Array<{ channel: string; payload: unknown }> = [];
+  return {
+    transport: { send: (channel, payload) => sent.push({ channel, payload }) },
+    sent,
+  };
+}
+
+function makeRuntime(events: ProviderRuntimeEvent[]): ProviderRuntime {
+  return {
+    provider: 'codex',
+    capabilities,
+    getStatus: vi.fn(),
+    listModels: vi.fn(),
+    startThread: vi.fn(async () => thread),
+    resumeThread: vi.fn(async ({ thread: nextThread }) => nextThread),
+    sendTurn: vi.fn(async function* () {
+      for (const event of events) yield event;
+    }),
+    interruptTurn: vi.fn(),
+    rollbackThread: vi.fn(),
+    startLogin: vi.fn(),
+    cancelLogin: vi.fn(),
+    logout: vi.fn(),
+  };
+}
+
+function makeDriver(runtime: ProviderRuntime, transport: SchemaAgentTransport) {
+  let currentThread: ProviderThreadRef | undefined;
+  const desynced: Array<{ thread: ProviderThreadRef; reason: string }> = [];
+  const turnSent: Array<{ channel: string; payload?: unknown }> = [];
+  const turnController = new ChatTurnController({
+    send: (channel, payload) => turnSent.push({ channel, payload }),
+  });
+
+  const driver = new SchemaAgentDriver({
+    runtime,
+    transport,
+    turnController,
+    getCurrentIR: () => emptyIR,
+    getThreadRef: () => currentThread,
+    setThreadRef: (next) => {
+      currentThread = next;
+    },
+    markThreadDesynced: (next, reason) => {
+      desynced.push({ thread: next, reason });
+    },
+  });
+
+  return { driver, turnSent, desynced, getThread: () => currentThread };
+}
+
+describe('SchemaAgentDriver', () => {
+  it('starts a provider thread, maps canonical events, and commits the renderer turn', async () => {
+    const runtime = makeRuntime([
+      { type: 'assistant_delta', text: 'Adding ' },
+      { type: 'tool_call_started', id: 'tool-1', name: 'add_type', input: { name: 'Plot' } },
+      { type: 'tool_call_finished', id: 'tool-1', name: 'add_type', ok: true },
+      { type: 'turn_completed' },
+    ]);
+    const { transport, sent } = fakeTransport();
+    const { driver, turnSent, getThread } = makeDriver(runtime, transport);
+
+    await driver.send('add a Plot type');
+
+    expect(runtime.startThread).toHaveBeenCalledWith({ schema: emptyIR });
+    expect(runtime.rollbackThread).not.toHaveBeenCalled();
+    expect(getThread()).toEqual(thread);
+    expect(turnSent.map((s) => s.channel)).toEqual(['turn:begin', 'turn:commit']);
+    expect(sent.map((s) => s.channel)).toEqual([
+      SCHEMA_AGENT_THREAD_UPDATED,
+      SCHEMA_AGENT_ASSISTANT_DELTA,
+      SCHEMA_AGENT_TOOL_CALL_STARTED,
+      SCHEMA_AGENT_TOOL_CALL_FINISHED,
+    ]);
+  });
+
+  it('rolls back renderer and provider state when the provider reports turn failure', async () => {
+    const runtime = makeRuntime([
+      { type: 'assistant_delta', text: 'Starting' },
+      { type: 'turn_failed', message: 'tool call failed' },
+    ]);
+    const { transport, sent } = fakeTransport();
+    const { driver, turnSent } = makeDriver(runtime, transport);
+
+    await expect(driver.send('add a Plot type')).rejects.toThrow('tool call failed');
+
+    expect(turnSent.map((s) => s.channel)).toEqual(['turn:begin', 'turn:rollback']);
+    expect(runtime.rollbackThread).toHaveBeenCalledWith({ thread, turns: 1 });
+    expect(sent.at(-1)).toEqual({
+      channel: SCHEMA_AGENT_ERROR,
+      payload: { message: 'tool call failed' },
+    });
+  });
+
+  it('marks the thread desynced if provider rollback fails', async () => {
+    const runtime = makeRuntime([{ type: 'turn_interrupted', message: 'stopped' }]);
+    vi.mocked(runtime.rollbackThread).mockRejectedValue(new Error('rollback unavailable'));
+    const { transport, sent } = fakeTransport();
+    const { driver, desynced } = makeDriver(runtime, transport);
+
+    await expect(driver.send('stop')).rejects.toThrow('stopped');
+
+    expect(desynced).toEqual([{ thread, reason: 'rollback unavailable' }]);
+    expect(sent).toContainEqual({
+      channel: SCHEMA_AGENT_THREAD_DESYNCED,
+      payload: { thread, reason: 'rollback unavailable' },
+    });
+    expect(sent.at(-1)).toEqual({
+      channel: SCHEMA_AGENT_ERROR,
+      payload: { message: 'stopped' },
+    });
+  });
+});

--- a/apps/desktop/tests/model/chat-history.test.ts
+++ b/apps/desktop/tests/model/chat-history.test.ts
@@ -52,6 +52,26 @@ describe('chat history sidecar', () => {
     expect(warnings).toEqual([]);
   });
 
+  it('round-trips provider metadata and opaque provider thread refs', () => {
+    const history = {
+      version: '1' as const,
+      provider: 'codex' as const,
+      model: 'gpt-5.4',
+      effort: 'high',
+      providerThreadRef: {
+        provider: 'codex',
+        threadId: 'thread-1',
+        opaque: { currentTurnId: 't1' },
+      },
+      messages: [{ id: 'm1', role: 'user' as const, content: 'hi', createdAt: 1 }],
+    };
+    const raw = saveChatHistory(history);
+    const { history: round, warnings } = loadChatHistory(raw);
+
+    expect(round).toEqual(history);
+    expect(warnings).toEqual([]);
+  });
+
   it('treats sessionId as absent when not a string', () => {
     const raw = JSON.stringify({
       version: '1',

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -16,7 +16,7 @@ The Contexture marketing website built with Next.js.
 
 ```bash
 # From the monorepo root
-bun run dev
+bun run dev:web
 
 # Or directly
 cd apps/web

--- a/docs/codex-provider-support-plan.md
+++ b/docs/codex-provider-support-plan.md
@@ -1,313 +1,484 @@
-# Codex Provider Support Plan
+# Codex-First Provider Runtime Plan
 
 - **Status:** Proposed
-- **Date:** 2026-05-02
+- **Date:** 2026-05-14
+
+## Context
+
+Contexture's existing schema chat implementation is Claude-shaped. It uses the Claude Agent SDK plus MCP op tools and assumes Claude Code CLI / Agent SDK behavior as the primary runtime.
+
+That priority has changed. Claude Code CLI / Agent SDK usage now draws from API tokens rather than the user's subscription, which makes it a poor default for Contexture's product goal. Codex has become the primary integration target because `codex app-server` supports ChatGPT-managed auth and gives Contexture a path to subscription-backed local agent use.
+
+There are no external users to preserve compatibility for. We can replace persisted chat/provider state, rename IPC and renderer hooks, and drop old Claude-only sessions without migration work. The old Claude implementation is useful as reference material, not as an incumbent architecture to protect.
 
 ## Goal
 
-Add Codex as a second chat provider in the desktop Electron app while preserving Contexture's current product contract:
+Rebuild Contexture's schema-agent chat around a provider-neutral runtime contract, with Codex as the primary and default implementation.
 
-- chat edits the in-memory schema through the closed-world op vocabulary
-- graph updates animate per op
-- one chat turn maps to one undoable transaction
-- stop / interrupt rolls back the whole in-flight turn
+The user-facing contract remains:
 
-The implementation should follow the same high-level separation used by `t3code`: one UI surface, separate provider runtimes, provider-specific auth/model state, and a provider-neutral renderer contract.
+- chat edits the in-memory schema only through Contexture's closed-world op vocabulary
+- graph updates animate incrementally per op
+- one assistant turn maps to one undoable transaction
+- stop / interrupt / failure rolls back the whole in-flight turn
+- provider credentials are owned by the provider runtime, not stored by Contexture
 
-## Agreed decisions
+Claude Agent SDK support remains desirable, but it is no longer on the critical path. It should be added later only if it fits the Codex-proven provider contract without distorting it.
 
-### Product and scope
+## Architectural Posture
 
-- Introduce multiple provider support now, starting with `Codex`.
-- Keep provider runtimes separate, not unified internally.
-- Start Codex in constrained schema-agent mode only.
-- Expose only Contexture schema op tools to Codex at first.
-- Defer broader coding-agent capabilities to a separate future surface.
-- Defer Codex support for reconcile/eval flows until the main schema chat path is proven.
+Use the `t3code` approach as the conceptual base: provider-neutral shell, provider-specific adapters, canonical runtime events, provider capabilities, and opaque provider resume state.
 
-### Runtime architecture
+But Contexture should keep a narrower product surface than `t3code`. We do not need T3Code's full coding-agent project/worktree/checkpoint machinery for schema chat. Contexture's v1 surface is a constrained schema agent, not a general repo mutation agent.
 
-- Refactor to a provider-neutral boundary before adding Codex behavior.
-- Keep the existing Claude implementation behind `ClaudeProviderRuntime`.
-- Implement Codex through `codex app-server`, not `codex exec`.
-- Run one long-lived Codex `app-server` child process per app window.
-- Wrap that process in a main-side runtime service that owns lifecycle, transport, thread mapping, auth polling, interrupt, and tool dispatch.
-- Keep the renderer isolated from provider processes.
+The right framing is:
 
-### Tooling and turn semantics
+- **provider-neutral contract now**
+- **Codex runtime first**
+- **Claude compatibility later**
+- **no backward-compat persistence migration**
 
-- Reuse `createOpTools()` as the single source of truth for both providers.
-- Claude continues using Agent SDK + MCP tools.
-- Codex uses dynamic tools generated from the same descriptors.
-- Reuse the existing `ChatTurnController` transaction envelope for both providers.
-- Preserve current stop semantics: partial tool effects are provisional until turn completion and are rolled back on interrupt or failure.
+## Non-Negotiable Product Invariants
 
-### Auth and readiness
+### Schema Ops Only
 
-- Use a unified auth popover with provider-specific content.
-- Keep auth state provider-specific.
-- Support Codex `ChatGPT subscription` login with `API key` fallback.
-- Use Codex as the source of truth for auth state.
-- Do not store Codex credentials in Contexture local storage.
-- Persist only lightweight UI preferences in Contexture.
-- Query provider auth/account state on startup and when the popover opens.
-- Show explicit readiness states instead of a single configured/unconfigured bit.
+The schema chat surface must expose only Contexture schema ops to the model.
 
-### Models and persistence
+No general filesystem, shell, repo mutation, browser, or network tools should be available from schema chat v1. If broader coding-agent features are added later, they should live in a separate surface with separate safety semantics.
 
-- Make models provider-specific and runtime-driven.
-- Replace the current thread persistence shape outright with a provider-aware format.
-- No backward-compat migration work is required.
-- Rename Claude-specific code paths and storage keys to provider-neutral names as part of the refactor.
+### Shared Op Registry
 
-### Versioning and protocol
+`createOpTools()` remains the single source of truth for agent-visible schema mutations.
 
-- Pin to a minimum supported Codex CLI version.
-- Hard-fail Codex into an unavailable state if the installed CLI is too old.
-- Updating the local Codex CLI to the pinned version is acceptable and expected.
-- Generate or vendor Codex app-server protocol types instead of hand-maintaining request shapes.
+Adapters may present those descriptors differently:
 
-## External references
+- Codex: dynamic tools or another app-server-compatible tool bridge
+- Claude: MCP tools if/when Claude support returns
+- CLI: existing `@contexture/cli` op commands
 
-- Codex auth docs: ChatGPT sign-in and API key sign-in are both supported for CLI/app/IDE.
-- Codex app-server docs: primary integration path for embedded clients.
-- Codex GitHub repo: local CLI releases move quickly, so version pinning matters.
-- `t3code`: useful reference for provider separation and unified UI shape.
+Do not create a second hand-maintained tool catalog.
 
-## Non-goals for v1
+### Turn Atomicity
 
-- No general filesystem, shell, or repository mutation from the Contexture chat surface.
-- No attempt to force Claude and Codex onto one lower-level runtime.
-- No backward-compat persistence migration for old Claude-only thread records.
-- No Codex parity for reconcile/eval before the main schema chat path works end to end.
+The existing `ChatTurnController` invariant survives the rewrite:
 
-## Target UX
+- `turn:begin` opens one renderer transaction
+- each accepted op applies and animates immediately
+- `turn:commit` creates one undo entry
+- `turn:rollback` discards all ops from that turn
 
-### Unified auth popover
+Codex must also roll back provider conversation state for failed/interrupted turns. If the renderer rolls back but Codex remembers successful tool calls, the next turn can become semantically desynced.
 
-One popover with:
+### Provider Conversation Rollback
 
-- provider switcher
-- provider-specific auth controls
-- provider-specific model selector
-- provider-specific effort selector
-- provider-specific readiness and error state
+Codex app-server supports provider-side thread rollback. The Codex runtime must call it when a Contexture turn rolls back.
+
+If provider rollback fails, the runtime should mark the provider thread as desynced and force a fresh Codex thread or inject the current IR as authoritative context on the next turn.
+
+## Runtime Contract
+
+Introduce a small provider runtime contract in Electron main. It should describe Contexture's needs, not mirror any one provider's protocol.
+
+Suggested shape:
+
+```ts
+type ProviderKind = "codex" | "claude";
+
+interface ProviderRuntime {
+  provider: ProviderKind;
+  capabilities: ProviderCapabilities;
+
+  getStatus(): Promise<ProviderStatus>;
+  listModels(): Promise<ModelInfo[]>;
+
+  startThread(input: StartThreadInput): Promise<ProviderThreadRef>;
+  sendTurn(input: SendTurnInput): AsyncIterable<ProviderRuntimeEvent>;
+  interruptTurn(input: InterruptTurnInput): Promise<void>;
+  rollbackThread(input: RollbackThreadInput): Promise<void>;
+
+  startLogin(input: StartLoginInput): Promise<LoginFlow>;
+  cancelLogin(input: CancelLoginInput): Promise<void>;
+  logout(): Promise<void>;
+}
+```
+
+Provider-native request payloads, notification names, thread ids, and auth details stay behind adapters.
+
+The renderer should see only:
+
+- provider status/readiness
+- available models and provider-specific option metadata
+- canonical chat events
+- canonical tool-call status
+- turn lifecycle events
+- provider-scoped thread references
+
+## Canonical Runtime Events
+
+Normalize provider-native events into a small Contexture event vocabulary:
+
+- `status_changed`
+- `auth_changed`
+- `thread_started`
+- `thread_resumed`
+- `turn_started`
+- `assistant_delta`
+- `assistant_final`
+- `tool_call_started`
+- `tool_call_finished`
+- `turn_completed`
+- `turn_failed`
+- `turn_interrupted`
+- `thread_desynced`
+
+Provider-specific event detail may be logged for debugging, but it should not leak into renderer state or shared chat logic.
+
+## Provider Capabilities
+
+Expose provider differences through capabilities rather than shared-code conditionals.
+
+Initial capabilities:
+
+- `authModes`: ChatGPT, API key, CLI/session, or none
+- `modelSource`: runtime-driven or static
+- `supportsThreadResume`
+- `supportsThreadRollback`
+- `supportsDynamicTools`
+- `supportsMcpTools`
+- `supportsInterrupt`
+- `supportsRateLimitStatus`
+- `supportsReasoningEffort`
+- `supportsSchemaOnlyMode`
+
+The Codex runtime should drive the contract. Claude can be fit into it later where possible.
+
+## Codex Runtime
+
+Implement `CodexProviderRuntime` in Electron main.
+
+Responsibilities:
+
+- detect `codex` CLI presence and version
+- enforce a minimum supported Codex CLI version
+- generate or vendor app-server protocol types for the pinned version
+- spawn and manage `codex app-server`
+- initialize JSON-RPC over stdio
+- route request/response ids
+- handle server-initiated requests, including tool calls and approvals if enabled
+- map app-server notifications into canonical runtime events
+- start, resume, interrupt, and roll back threads
+- read auth/account state from Codex
+- start/cancel ChatGPT and API-key login flows through Codex
+- list models from Codex where available
+- surface ChatGPT rate-limit state where available
+- restart or degrade cleanly when app-server exits
+
+Codex should be the default provider once it can complete schema chat turns end to end.
+
+## Codex Tool Strategy
+
+Start with a spike before committing to the full adapter.
+
+Spike goals:
+
+1. Generate protocol types from the pinned Codex CLI.
+2. Start `codex app-server`.
+3. Initialize with the required stable capabilities, and with experimental capability only if dynamic tools require it.
+4. Start a thread.
+5. Send a turn with one minimal Contexture dynamic tool.
+6. Confirm tool-call request/response behavior is reliable.
+7. Confirm interrupt and provider rollback behavior.
+
+Preferred v1 path:
+
+- generate Codex dynamic tool specs from `createOpTools()`
+- forward each tool call to the renderer op bridge
+- return the renderer `ApplyResult` to Codex
+
+Fallback path:
+
+- expose Contexture op tools through an MCP adapter if dynamic tools are not stable enough
+
+Either way, `createOpTools()` remains the source of truth.
+
+## Safety and Containment
+
+Schema chat must be constrained even though Codex is a coding agent.
+
+Implementation requirements:
+
+- run schema-chat turns with the strictest viable sandbox/profile
+- deny or omit shell, filesystem, browser, web, and repo mutation tools
+- do not enable full-access runtime modes in schema chat
+- add tests or live smoke checks proving attempts to read files, write files, or run commands are unavailable or rejected
+- treat hidden approval stalls or unsupported approval flows as runtime failures, not silent hangs
+
+If Contexture later adds a coding-agent surface, it should have a separate runtime mode, separate UI, and separate user expectations.
+
+## Auth and Readiness
+
+Codex is the source of truth for Codex auth state.
+
+Contexture should:
+
+- support ChatGPT managed auth as the preferred path
+- support API key fallback
+- not store Codex credentials in localStorage or sidecars
+- persist only lightweight UI preferences
+- call Codex account/status APIs on startup and when the provider popover opens
+- surface explicit readiness states
+- surface rate-limit state when available
 
 Codex readiness states:
 
 - CLI missing
 - CLI outdated
+- app-server unavailable
 - not signed in
 - authenticated with ChatGPT
 - authenticated with API key
+- authenticated but rate-limited
+- desynced thread
 
-Claude keeps equivalent provider-specific readiness states.
+Claude readiness can be added later as a secondary provider state.
 
-### Provider behavior
+## Models and Provider Options
 
-- The active provider is explicit in renderer state.
-- Threads are provider-scoped.
-- Session ids are provider-scoped.
-- Switching provider swaps available models and auth state presentation.
-- Claude remains the default selected provider until Codex reaches parity on the main schema chat flow.
+Models should be provider-specific and runtime-driven where possible.
 
-## Architecture plan
+Renderer state should store:
 
-### 1. Introduce provider-neutral contracts
-
-Create a minimal provider contract in main and preload. Normalize only the events Contexture actually needs:
-
-- `status`
-- `assistant_delta`
-- `assistant_final`
-- `tool_call_started`
-- `tool_call_finished`
-- `turn_started`
-- `turn_committed`
-- `turn_rolled_back`
-- `turn_failed`
-- `session_updated`
-- `auth_state_updated`
-
-Provider-native detail should stay behind the main-side runtime boundary unless the renderer actually needs it.
-
-### 2. Rename Claude-shaped plumbing
-
-Refactor existing Claude-specific names to provider-neutral ones first:
-
-- `claude:*` IPC channels
-- preload chat/auth methods
-- `useClaude*` hooks
-- Claude-specific store keys
-- provider-specific copy in shared chat components
-
-The goal is to keep behavior stable while changing the shape of the boundary.
-
-### 3. Adapt Claude to the new boundary
-
-Wrap the current Agent SDK + MCP integration in `ClaudeProviderRuntime`.
-
-Preserve:
-
-- current auth flow
-- current tool behavior
-- current turn transaction semantics
-- current interrupt rollback behavior
-
-This phase should not add new product behavior. It is a containment refactor.
-
-### 4. Add the Codex runtime service
-
-Implement `CodexProviderRuntime` in Electron main:
-
-- spawn `codex app-server`
-- perform initialize handshake
-- manage JSON-RPC request ids
-- map server notifications to normalized events
-- manage long-lived provider thread ids
-- support turn start and interrupt
-- support provider auth/account queries
-- support provider login/logout actions
-- enforce minimum CLI version
-
-This service should also handle process restart and degraded unavailable states cleanly.
-
-### 5. Reuse the shared op registry for dynamic tools
-
-Keep [`packages/core/src/op-tools.ts`](/Users/davehudson/Apps/Contexture/packages/core/src/op-tools.ts) as the single source of truth.
-
-Adapters:
-
-- Claude adapter: existing MCP `tool(...)` wrapping
-- Codex adapter: dynamic tool spec generation plus tool-call response handling
-
-Do not create a second hand-maintained tool catalog.
-
-### 6. Keep the existing turn transaction model
-
-Map both providers into the same `ChatTurnController` envelope so:
-
-- every completed turn commits as one undo entry
-- every interrupted or failed turn rolls back
-- per-op animation remains incremental
-
-This preserves the strongest user-facing invariant in the current product.
-
-### 7. Replace renderer/provider state
-
-Add explicit provider-aware renderer state:
-
-- `activeProvider`
-- provider-specific auth mode and readiness
+- active provider
 - provider-specific selected model
-- provider-specific effort setting
-- provider-specific session id
-- provider-aware thread records
+- provider-specific reasoning/effort option
+- provider-specific readiness
+- provider-specific thread reference
 
-The persistence format can be replaced outright because migration compatibility is not required.
+Do not hardcode a Claude-oriented model list into shared chat state.
 
-### 8. Land the unified auth popover
+## Persistence
 
-The popover should:
+Replace the old Claude-shaped persistence outright.
 
-- switch provider
-- show provider-specific readiness
-- initiate provider login/logout flows
-- allow Codex ChatGPT or API key auth selection
-- keep Contexture as the owner of UI state only, not credentials
+No migration is required for:
 
-Codex login/logout should be initiated through the Codex runtime where possible, with manual terminal instructions only as fallback copy.
+- Claude Agent SDK session ids
+- Claude auth mode localStorage keys
+- Claude model localStorage keys
+- Claude-only thread records
 
-## Suggested implementation order
+New thread records should be provider-aware:
 
-1. Pin and install the supported Codex CLI version locally.
-2. Add a new plan/protocol module for Codex app-server types and version checks.
-3. Introduce provider-neutral interfaces in main/preload.
-4. Rename Claude-specific renderer and preload surfaces to neutral names.
-5. Wrap the current Claude flow in `ClaudeProviderRuntime`.
-6. Add provider-aware renderer state and thread persistence.
-7. Add unified auth popover with provider switching.
-8. Implement the long-lived Codex runtime service.
-9. Generate Codex dynamic tools from `createOpTools()`.
-10. Connect Codex normalized events to the shared renderer contract.
-11. Add focused tests around the provider boundary.
-12. Verify Claude behavior still matches current semantics.
-13. Verify Codex can authenticate, stream text, call op tools, resume threads, and roll back on interrupt.
+```ts
+interface SchemaAgentThreadRecord {
+  id: string;
+  provider: ProviderKind;
+  providerThreadRef?: unknown;
+  title: string;
+  messages: ChatMessage[];
+  model?: string;
+  effort?: string;
+  filePath: string | null;
+  desynced?: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+```
 
-## File touchpoints
+The provider thread reference is opaque outside the provider runtime.
 
-Expected high-change areas:
+## Renderer and IPC Rewrite
 
-- [`apps/desktop/src/main/ipc/claude.ts`](/Users/davehudson/Apps/Contexture/apps/desktop/src/main/ipc/claude.ts)
-- [`apps/desktop/src/main/ipc/chat-driver.ts`](/Users/davehudson/Apps/Contexture/apps/desktop/src/main/ipc/chat-driver.ts)
-- [`apps/desktop/src/main/ipc/chat-turn.ts`](/Users/davehudson/Apps/Contexture/apps/desktop/src/main/ipc/chat-turn.ts)
-- [`apps/desktop/src/preload/index.ts`](/Users/davehudson/Apps/Contexture/apps/desktop/src/preload/index.ts)
-- [`apps/desktop/src/preload/index.d.ts`](/Users/davehudson/Apps/Contexture/apps/desktop/src/preload/index.d.ts)
-- [`apps/desktop/src/renderer/src/chat/useClaude.ts`](/Users/davehudson/Apps/Contexture/apps/desktop/src/renderer/src/chat/useClaude.ts)
-- [`apps/desktop/src/renderer/src/chat/useClaudeSchemaChat.ts`](/Users/davehudson/Apps/Contexture/apps/desktop/src/renderer/src/chat/useClaudeSchemaChat.ts)
-- [`apps/desktop/src/renderer/src/chat/useChatThreads.ts`](/Users/davehudson/Apps/Contexture/apps/desktop/src/renderer/src/chat/useChatThreads.ts)
-- [`apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx`](/Users/davehudson/Apps/Contexture/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx)
-- [`packages/core/src/op-tools.ts`](/Users/davehudson/Apps/Contexture/packages/core/src/op-tools.ts)
+Replace Claude-named renderer and IPC surfaces rather than gradually renaming them for compatibility.
+
+Target names:
+
+- `registerSchemaAgentIpc`
+- `useSchemaAgentChat`
+- `useProviderSettings`
+- `useSchemaAgentThreads`
+- `SchemaAgentPanel`
+
+IPC should be provider-neutral:
+
+- `schema-agent:send`
+- `schema-agent:abort`
+- `schema-agent:set-ir`
+- `schema-agent:set-provider`
+- `schema-agent:set-model-options`
+- `schema-agent:get-status`
+- `schema-agent:list-models`
+- `schema-agent:start-login`
+- `schema-agent:cancel-login`
+- `schema-agent:logout`
+- `schema-agent:tool-reply`
+- `schema-agent:thread-set`
+- `schema-agent:thread-clear`
+
+Renderer event channels should likewise be provider-neutral:
+
+- `schema-agent:assistant-delta`
+- `schema-agent:assistant-final`
+- `schema-agent:tool-call-started`
+- `schema-agent:tool-call-finished`
+- `schema-agent:error`
+- `schema-agent:auth-required`
+- `schema-agent:status-changed`
+- `schema-agent:thread-updated`
+- `schema-agent:tool-request`
+- `turn:begin`
+- `turn:commit`
+- `turn:rollback`
+
+The old `claude:*` channels can be removed as part of the rewrite.
+
+## Claude Runtime
+
+Claude support is optional after Codex is stable.
+
+If restored, it should be implemented as `ClaudeProviderRuntime` behind the same provider contract. It should not force the shared contract to preserve Agent SDK-specific concepts such as Claude session ids, Claude-specific error classes, or Claude-specific model settings.
+
+Claude-specific limitations should be exposed through capabilities.
+
+If Claude cannot support provider-side conversation rollback, its runtime must either:
+
+- restart the Claude session after rollback and treat the current IR as authoritative, or
+- mark the thread desynced and require a fresh thread
+
+## Reconcile and Eval
+
+Codex support for reconcile/eval is out of scope for the first milestone.
+
+Options:
+
+- temporarily disable these features when Codex is active
+- keep the old Claude implementation locally while clearly marking it secondary
+- rebuild them after schema chat works end to end
+
+Do not block Codex schema chat on reconcile/eval parity.
+
+## Suggested Implementation Order
+
+1. Pin a supported Codex CLI version.
+2. Generate or vendor Codex app-server protocol types for that version.
+3. Run the Codex app-server spike: initialize, auth read, model list, thread start, turn start, one tool call, interrupt, rollback.
+4. Add provider-neutral main-side runtime interfaces and canonical events.
+5. Implement `CodexProviderRuntime`.
+6. Replace Claude-shaped IPC with `schema-agent:*` IPC.
+7. Replace `useClaude*` renderer hooks with schema-agent/provider hooks.
+8. Replace chat thread persistence with provider-aware records.
+9. Wire Codex auth/readiness/model UI.
+10. Generate the full Codex tool surface from `createOpTools()`.
+11. Connect Codex tool calls to the existing renderer op bridge.
+12. Preserve `ChatTurnController` turn atomicity and add provider rollback on failure/interrupt.
+13. Add containment tests for forbidden shell/filesystem behavior.
+14. Make Codex the default provider.
+15. Remove obsolete Claude localStorage keys/channels/tests that no longer apply.
+16. Reintroduce Claude as a secondary runtime only after Codex is stable.
+
+## File Touchpoints
+
+Expected high-change or replacement areas:
+
+- [`apps/desktop/src/main/ipc/claude.ts`](/Users/rufus/Apps/contexture/apps/desktop/src/main/ipc/claude.ts)
+- [`apps/desktop/src/main/ipc/chat-driver.ts`](/Users/rufus/Apps/contexture/apps/desktop/src/main/ipc/chat-driver.ts)
+- [`apps/desktop/src/main/ipc/chat-turn.ts`](/Users/rufus/Apps/contexture/apps/desktop/src/main/ipc/chat-turn.ts)
+- [`apps/desktop/src/main/ipc/claude-bridge.ts`](/Users/rufus/Apps/contexture/apps/desktop/src/main/ipc/claude-bridge.ts)
+- [`apps/desktop/src/main/ipc/op-tool-bridge.ts`](/Users/rufus/Apps/contexture/apps/desktop/src/main/ipc/op-tool-bridge.ts)
+- [`apps/desktop/src/preload/index.ts`](/Users/rufus/Apps/contexture/apps/desktop/src/preload/index.ts)
+- [`apps/desktop/src/preload/index.d.ts`](/Users/rufus/Apps/contexture/apps/desktop/src/preload/index.d.ts)
+- [`apps/desktop/src/renderer/src/chat/useClaude.ts`](/Users/rufus/Apps/contexture/apps/desktop/src/renderer/src/chat/useClaude.ts)
+- [`apps/desktop/src/renderer/src/chat/useClaudeSchemaChat.ts`](/Users/rufus/Apps/contexture/apps/desktop/src/renderer/src/chat/useClaudeSchemaChat.ts)
+- [`apps/desktop/src/renderer/src/chat/useChatThreads.ts`](/Users/rufus/Apps/contexture/apps/desktop/src/renderer/src/chat/useChatThreads.ts)
+- [`apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx`](/Users/rufus/Apps/contexture/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx)
+- [`packages/core/src/op-tools.ts`](/Users/rufus/Apps/contexture/packages/core/src/op-tools.ts)
 
 Expected new modules:
 
-- provider-neutral runtime interfaces
-- `ClaudeProviderRuntime`
+- provider runtime interfaces
+- provider runtime event types
+- provider capabilities
 - `CodexProviderRuntime`
-- Codex app-server transport/service
-- Codex protocol/version support modules
+- Codex app-server transport
+- Codex app-server protocol generated types
+- Codex auth/status service
+- Codex dynamic-tool adapter
+- schema-agent IPC registration
+- schema-agent renderer hooks
 
-## Testing strategy
+## Testing Strategy
 
-Focus first on the shared provider boundary rather than reproducing the full Claude test matrix for Codex immediately.
+Focus tests around the new provider boundary and Contexture invariants.
 
 Must-cover behaviors:
 
-- normalized event mapping
+- Codex CLI missing/outdated status
+- app-server initialize failure
 - auth state update flow
-- thread/session update flow
+- ChatGPT login flow event handling
+- model list normalization
+- thread start/resume
+- assistant delta/final mapping
+- dynamic tool call mapping
+- op result mapping
 - turn commit
 - turn rollback
+- provider-side thread rollback
 - interrupt behavior
-- tool call dispatch and result mapping
-- degraded unavailable state on missing/outdated Codex CLI
+- desynced-thread handling
+- forbidden shell/filesystem behavior
+- renderer transaction binding
+- provider-aware thread persistence
 
-Provider-specific tests should stay thinner under the shared contract.
+Use fake provider runtimes for shared contract tests. Keep Codex protocol translation tests adapter-specific.
 
-## Definition of done for first Codex milestone
+## Definition of Done for First Codex Milestone
 
 Codex is considered integrated when the desktop app can:
 
 - detect supported Codex CLI presence and version
-- show Codex auth/readiness in the unified popover
-- authenticate via ChatGPT or API key
-- start a schema chat turn
+- show Codex auth/readiness in the provider popover
+- authenticate via ChatGPT managed auth or API key
+- list/select Codex models
+- start a schema-agent chat turn
 - stream assistant text into the transcript
-- call Contexture op tools through dynamic tools
-- update the graph incrementally
+- call Contexture op tools through the shared op registry
+- update the graph incrementally as ops arrive
+- commit a completed turn as one undo entry
+- roll back renderer ops on interrupt/failure
+- roll back Codex provider conversation state on interrupt/failure
 - resume provider-scoped threads
-- roll back the whole turn on interrupt or failure
+- mark or recover from desynced provider threads
+- prevent schema chat from using shell/filesystem/repo mutation tools
 
 Everything else is out of scope for the first milestone.
 
-## Risks and watchpoints
+## Risks and Watchpoints
 
-### Protocol drift
+### Dynamic Tool Stability
 
-Codex CLI releases move quickly. The app-server protocol should be treated as versioned and pinned.
+If Codex dynamic tools require experimental app-server APIs or have protocol drift, validate them before wiring the full op catalog.
 
-### Strict request encoding
+### Provider/UI Desync
 
-The local probe already showed strict union decoding in app-server request payloads. Hand-rolled request bodies are likely to fail in subtle ways.
+Renderer rollback without provider rollback can corrupt the assistant's understanding of the schema. Treat provider rollback as part of the turn transaction.
 
-### Auth complexity
+### Hidden Approval Stalls
 
-Codex readiness is not just "binary exists." It depends on CLI version plus provider auth/account state from the runtime.
+If app-server can request approvals that the client cannot see or resolve, schema chat may hang. The constrained schema-agent profile should avoid approval-requiring built-ins entirely.
 
-### Refactor size
+### Protocol Drift
 
-The current chat stack is deeply Claude-shaped. The rename/extraction pass is real work and should not be minimized in planning.
+Codex CLI releases move quickly. Pin a supported version, generate protocol types from that version, and hard-fail unsupported versions.
 
-## Immediate next step
+### Auth Complexity
 
-Start with the provider-neutral rename and boundary extraction, then adapt Claude behind it before introducing any Codex runtime behavior.
+Codex readiness depends on CLI version, app-server availability, active account mode, token freshness, and rate limits. Avoid reducing this to a single configured/unconfigured boolean.
+
+### Over-Borrowing from T3Code
+
+T3Code is a good provider architecture reference, but Contexture should not import its whole coding-agent orchestration model into schema chat.
+
+## Immediate Next Step
+
+Run the Codex app-server spike against a pinned CLI version, then build the provider-neutral schema-agent contract around the successful Codex path.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "turbo dev",
+    "dev": "turbo dev --filter=@contexture/desktop",
+    "dev:all": "turbo dev",
+    "dev:web": "turbo dev --filter=@contexture/web",
     "build": "turbo build",
     "test": "turbo test",
     "typecheck": "turbo typecheck",

--- a/packages/core/src/op-tools.ts
+++ b/packages/core/src/op-tools.ts
@@ -145,6 +145,42 @@ function lenientTool(
   };
 }
 
+function flexiblePayloadTool<Shape extends Record<string, ZodTypeAny>>(
+  name: string,
+  description: string,
+  shape: Shape,
+  toOp: (payload: unknown) => Op,
+  validate: (op: Op) => void,
+  forward: ForwardOp,
+): OpToolDescriptor {
+  return {
+    name,
+    description,
+    inputSchema: { ...shape, payload: z.unknown().optional() },
+    handler: async (args) => {
+      const payload = unwrapFlexiblePayload(args);
+      const op = toOp(payload);
+      validate(op);
+      return forward(op);
+    },
+  };
+}
+
+function unwrapFlexiblePayload(args: Record<string, unknown>): unknown {
+  const raw = 'payload' in args ? args.payload : args;
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return raw;
+    }
+  }
+  if (raw && typeof raw === 'object' && !Array.isArray(raw) && 'payload' in raw) {
+    return (raw as { payload: unknown }).payload;
+  }
+  return raw;
+}
+
 // ---- IR meta-schema checks for type-level payloads ---------------------
 
 const TypeDefItemSchema = IRSchemaObject.shape.types.element;
@@ -323,9 +359,10 @@ export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
       (op) => assertTypeDef((op as Extract<Op, { kind: 'add_type' }>).type, 'add_type'),
       forward,
     ),
-    lenientTool(
+    flexiblePayloadTool(
       'update_type',
       "Update a TypeDef's top-level properties (excluding kind/name).",
+      { name: z.string().min(1).optional(), patch: z.record(z.string(), z.unknown()).optional() },
       (payload) => {
         const p = (payload ?? {}) as { name?: unknown; patch?: unknown };
         if (typeof p.name !== 'string')
@@ -339,9 +376,10 @@ export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
       () => undefined,
       forward,
     ),
-    lenientTool(
+    flexiblePayloadTool(
       'rename_type',
       'Rename a TypeDef; refs and layout keys cascade.',
+      { from: z.string().min(1).optional(), to: z.string().min(1).optional() },
       (payload) => {
         const p = (payload ?? {}) as { from?: unknown; to?: unknown };
         if (typeof p.from !== 'string' || typeof p.to !== 'string') {
@@ -352,9 +390,10 @@ export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
       () => undefined,
       forward,
     ),
-    lenientTool(
+    flexiblePayloadTool(
       'delete_type',
       'Delete a TypeDef by name.',
+      { name: z.string().min(1).optional() },
       (payload) => {
         const p = (payload ?? {}) as { name?: unknown };
         if (typeof p.name !== 'string')
@@ -385,9 +424,26 @@ export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
     {
       name: 'replace_schema',
       description: 'Bulk rewrite: replace the entire IR. Use only when surgical ops are awkward.',
-      inputSchema: { schema: z.unknown() },
+      inputSchema: {
+        schema: z.unknown().optional(),
+        payload: z.unknown().optional(),
+        version: z.literal('1').optional(),
+        types: z.array(z.unknown()).optional(),
+        imports: z.array(z.unknown()).optional(),
+        layout: z.unknown().optional(),
+      },
       handler: async (args) => {
-        const { schema } = args as { schema: unknown };
+        const rawSchema = 'schema' in args ? args.schema : 'payload' in args ? args.payload : args;
+        const schema =
+          typeof rawSchema === 'string'
+            ? (() => {
+                try {
+                  return JSON.parse(rawSchema) as unknown;
+                } catch {
+                  return rawSchema;
+                }
+              })()
+            : rawSchema;
         const res = IRSchema.safeParse(schema);
         if (!res.success) {
           throw new Error(


### PR DESCRIPTION
## Summary
- add a Codex app-server backed schema-agent runtime with provider-neutral driver and IPC wiring
- wire Codex auth, status, model controls, and provider-aware schema chat state
- constrain schema chat to Contexture operation tools, with rollback/desync handling and Codex readiness fixes
- make root dev start desktop only, with explicit dev:all and dev:web scripts

## Tests
- turbo typecheck
- turbo test