### PR TITLE
Make drift status trustworthy and visible for generated files

### DIFF
--- a/apps/desktop/src/main/documents/drift-watcher.ts
+++ b/apps/desktop/src/main/documents/drift-watcher.ts
@@ -25,6 +25,11 @@ export interface DriftResult {
   status: 'match' | 'drifted' | 'unreadable';
 }
 
+export interface DriftProblem {
+  path: string;
+  status: 'drifted' | 'unreadable';
+}
+
 export async function detectDrift(
   emittedJsonPath: string,
   readFile: (path: string) => Promise<string> = (p) => fsPromises.readFile(p, 'utf-8'),
@@ -72,6 +77,7 @@ export interface DriftWatcher {
 export interface DriftWatcherOptions {
   emittedJsonPath: string;
   onDrift: (paths: string[]) => void;
+  onStatus?: (problems: DriftProblem[]) => void;
   onResolved: () => void;
   debounceMs?: number;
   readFile?: (path: string) => Promise<string>;
@@ -81,6 +87,7 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
   const {
     emittedJsonPath,
     onDrift,
+    onStatus,
     onResolved,
     debounceMs = 300,
     readFile = (p) => fsPromises.readFile(p, 'utf-8'),
@@ -89,26 +96,28 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
   let watchers: FSWatcher[] = [];
   let watchedPaths: string[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;
-  let driftedSet: Set<string> = new Set();
+  let problemSet: Set<string> = new Set();
   let stopped = false;
 
   async function doCheck(): Promise<void> {
     const results = await detectDrift(emittedJsonPath, readFile);
     if (stopped || results.length === 0) return;
 
-    const nowDrifted = results.filter((r) => r.status === 'drifted').map((r) => r.path);
-    const wasDrifted = driftedSet.size > 0;
-    const isDrifted = nowDrifted.length > 0;
+    const problems = results.filter((r): r is DriftProblem => r.status !== 'match');
+    const nowProblems = problems.map(problemKey);
+    const wasProblematic = problemSet.size > 0;
+    const isProblematic = problems.length > 0;
 
-    if (isDrifted) {
+    if (isProblematic) {
       const changed =
-        nowDrifted.length !== driftedSet.size || nowDrifted.some((p) => !driftedSet.has(p));
-      driftedSet = new Set(nowDrifted);
-      if (!wasDrifted || changed) {
-        onDrift(nowDrifted);
+        nowProblems.length !== problemSet.size || nowProblems.some((p) => !problemSet.has(p));
+      problemSet = new Set(nowProblems);
+      if (!wasProblematic || changed) {
+        if (onStatus) onStatus(problems);
+        else onDrift(problems.map((p) => p.path));
       }
-    } else if (wasDrifted) {
-      driftedSet = new Set();
+    } else if (wasProblematic) {
+      problemSet = new Set();
       onResolved();
     }
 
@@ -150,11 +159,15 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
         clearTimeout(timer);
         timer = null;
       }
-      driftedSet = new Set();
+      problemSet = new Set();
     },
     check: doCheck,
     resetDrifted() {
-      driftedSet = new Set();
+      problemSet = new Set();
     },
   };
+}
+
+function problemKey(problem: DriftProblem): string {
+  return `${problem.status}:${problem.path}`;
 }

--- a/apps/desktop/src/main/ipc/drift.ts
+++ b/apps/desktop/src/main/ipc/drift.ts
@@ -21,6 +21,11 @@ export function registerDriftIpc(mainWindow: BrowserWindow): void {
     activeWatcher = createDriftWatcher({
       emittedJsonPath: payload.emittedJsonPath,
       onDrift: (paths) => mainWindow.webContents.send('drift:detected', { paths }),
+      onStatus: (problems) =>
+        mainWindow.webContents.send('drift:detected', {
+          paths: problems.map((p) => p.path),
+          files: problems,
+        }),
       onResolved: () => mainWindow.webContents.send('drift:resolved'),
     });
     activeWatcher.start();

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -220,8 +220,13 @@ export interface ContextureDriftAPI {
   check: () => Promise<{ ok: boolean }>;
   /** Reset the main-side drifted flag after user dismisses the banner. */
   dismiss: () => Promise<{ ok: boolean }>;
-  onDetected: (listener: (payload: { paths: string[] }) => void) => Unsubscribe;
+  onDetected: (listener: (payload: DriftDetectedPayload) => void) => Unsubscribe;
   onResolved: (listener: () => void) => Unsubscribe;
+}
+
+export interface DriftDetectedPayload {
+  paths: string[];
+  files?: Array<{ path: string; status: 'drifted' | 'unreadable' }>;
 }
 
 export interface ContextureReconcileAPI {

--- a/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
@@ -1,7 +1,7 @@
 /**
  * `DriftBanner` — non-blocking banner shown at the top of the graph
- * view when any `@contexture-generated` file has been hand-edited
- * outside Contexture (drift detected by the main-process watcher).
+ * view when any `@contexture-generated` file has drifted from the
+ * emitted manifest or can no longer be read.
  *
  * Single-file drift shows the file path; multi-file drift shows a count.
  * "Review changes" opens the reconcile modal for the first drifted file;
@@ -22,29 +22,50 @@ function shortPath(fullPath: string): string {
 }
 
 export function DriftBanner(): React.JSX.Element | null {
+  const files = useDriftStore((s) => s.files);
   const driftedPaths = useDriftStore((s) => s.driftedPaths);
   const dismiss = useDriftStore((s) => s.dismiss);
   const openReconcile = useReconcileStore((s) => s.open);
 
   const message = useMemo(() => {
-    if (driftedPaths.length === 0) return null;
-    if (driftedPaths.length === 1) {
+    const statuses =
+      files.length > 0 ? files : driftedPaths.map((path) => ({ path, status: 'drifted' as const }));
+    if (statuses.length === 0) return null;
+    const unreadableCount = statuses.filter((file) => file.status === 'unreadable').length;
+    if (statuses.length === 1) {
+      const file = statuses[0];
+      if (!file) return null;
+      if (file.status === 'unreadable') {
+        return (
+          <>
+            <code className="font-mono">{shortPath(file.path)}</code> is missing or unreadable.
+          </>
+        );
+      }
       return (
         <>
-          <code className="font-mono">{shortPath(driftedPaths[0])}</code> was modified outside
-          Contexture.
+          <code className="font-mono">{shortPath(file.path)}</code> was modified outside Contexture.
         </>
       );
     }
-    return <>{driftedPaths.length} generated files were modified outside Contexture.</>;
-  }, [driftedPaths]);
+    if (unreadableCount > 0) {
+      return (
+        <>
+          {statuses.length} generated files need attention, including {unreadableCount} missing or
+          unreadable.
+        </>
+      );
+    }
+    return <>{statuses.length} generated files were modified outside Contexture.</>;
+  }, [files, driftedPaths]);
 
   if (!message) return null;
 
   // For multi-file drift, review the first drifted file. The user can
   // dismiss and let the banner re-appear for subsequent files, or use
   // the per-file list that drift detection surfaces.
-  const reviewTarget = driftedPaths[0];
+  const reviewTarget =
+    (files.find((file) => file.status === 'drifted') ?? files[0])?.path ?? driftedPaths[0];
 
   return (
     <div

--- a/apps/desktop/src/renderer/src/hooks/useDrift.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDrift.ts
@@ -63,9 +63,10 @@ export function useDrift(): void {
 
     void driftApi.watch({ emittedJsonPath });
 
-    const unDetected = driftApi.onDetected((payload) =>
-      useDriftStore.getState().setDrifted(payload.paths),
-    );
+    const unDetected = driftApi.onDetected((payload) => {
+      if (payload.files) useDriftStore.getState().setDetected(payload.files);
+      else useDriftStore.getState().setDrifted(payload.paths);
+    });
     const unResolved = driftApi.onResolved(() => useDriftStore.getState().setResolved());
 
     function onFocus(): void {

--- a/apps/desktop/src/renderer/src/store/drift.ts
+++ b/apps/desktop/src/renderer/src/store/drift.ts
@@ -1,24 +1,38 @@
 /**
- * `useDriftStore` — tracks which generated files have been hand-edited
- * outside Contexture. Set by drift IPC events from the main process;
- * cleared by user dismissal or when Contexture re-writes the files
- * (bringing hashes back into agreement).
+ * `useDriftStore` — tracks generated files whose on-disk state no
+ * longer matches the emitted manifest. Set by drift IPC events from the
+ * main process; cleared by user dismissal or when Contexture re-writes
+ * the files (bringing hashes back into agreement).
  */
 import { create } from 'zustand';
 
+export interface DriftFileStatus {
+  path: string;
+  status: 'drifted' | 'unreadable';
+}
+
 interface DriftState {
+  files: DriftFileStatus[];
   driftedPaths: string[];
+  setDetected: (files: DriftFileStatus[]) => void;
   setDrifted: (paths: string[]) => void;
   setResolved: () => void;
   dismiss: () => void;
 }
 
 export const useDriftStore = create<DriftState>((set) => ({
+  files: [],
   driftedPaths: [],
-  setDrifted: (paths: string[]) => set({ driftedPaths: paths }),
-  setResolved: () => set({ driftedPaths: [] }),
+  setDetected: (files: DriftFileStatus[]) =>
+    set({ files, driftedPaths: files.map((file) => file.path) }),
+  setDrifted: (paths: string[]) =>
+    set({
+      files: paths.map((path) => ({ path, status: 'drifted' })),
+      driftedPaths: paths,
+    }),
+  setResolved: () => set({ files: [], driftedPaths: [] }),
   dismiss: () => {
-    set({ driftedPaths: [] });
+    set({ files: [], driftedPaths: [] });
     void window.contexture?.drift.dismiss();
   },
 }));

--- a/apps/desktop/tests/components/DriftBanner.test.tsx
+++ b/apps/desktop/tests/components/DriftBanner.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DriftBanner } from '../../src/renderer/src/components/hud/DriftBanner';
+import { useDriftStore } from '../../src/renderer/src/store/drift';
+import { useReconcileStore } from '../../src/renderer/src/store/reconcile';
+
+afterEach(() => {
+  cleanup();
+  useDriftStore.getState().setResolved();
+  useReconcileStore.getState().reset();
+});
+
+describe('DriftBanner', () => {
+  it('is hidden when there are no generated-file problems', () => {
+    render(<DriftBanner />);
+
+    expect(screen.queryByTestId('drift-banner')).not.toBeInTheDocument();
+  });
+
+  it('shows drifted generated files as modified outside Contexture', () => {
+    useDriftStore
+      .getState()
+      .setDetected([{ path: '/repo/packages/contexture/garden.schema.ts', status: 'drifted' }]);
+
+    render(<DriftBanner />);
+
+    expect(screen.getByTestId('drift-banner')).toHaveTextContent(
+      'garden.schema.ts was modified outside Contexture.',
+    );
+  });
+
+  it('shows unreadable generated files as missing or unreadable', () => {
+    useDriftStore
+      .getState()
+      .setDetected([
+        { path: '/repo/packages/contexture/garden.schema.json', status: 'unreadable' },
+      ]);
+
+    render(<DriftBanner />);
+
+    expect(screen.getByTestId('drift-banner')).toHaveTextContent(
+      'garden.schema.json is missing or unreadable.',
+    );
+  });
+
+  it('reviews a drifted file before an unreadable file', () => {
+    useDriftStore.getState().setDetected([
+      { path: '/repo/packages/contexture/garden.schema.json', status: 'unreadable' },
+      { path: '/repo/packages/contexture/garden.schema.ts', status: 'drifted' },
+    ]);
+
+    render(<DriftBanner />);
+    fireEvent.click(screen.getByRole('button', { name: 'Review changes' }));
+
+    expect(useReconcileStore.getState().targetPath).toBe(
+      '/repo/packages/contexture/garden.schema.ts',
+    );
+  });
+});

--- a/apps/desktop/tests/main/drift-watcher.test.ts
+++ b/apps/desktop/tests/main/drift-watcher.test.ts
@@ -42,16 +42,22 @@ function makeWatcher(
   files: Record<string, string>,
   {
     onDrift = vi.fn(),
+    onStatus,
     onResolved = vi.fn(),
-  }: { onDrift?: ReturnType<typeof vi.fn>; onResolved?: ReturnType<typeof vi.fn> } = {},
+  }: {
+    onDrift?: ReturnType<typeof vi.fn>;
+    onStatus?: ReturnType<typeof vi.fn>;
+    onResolved?: ReturnType<typeof vi.fn>;
+  } = {},
 ) {
   const watcher = createDriftWatcher({
     emittedJsonPath: EMITTED,
     onDrift,
+    onStatus,
     onResolved,
     readFile: makeReadFile(files),
   });
-  return { watcher, onDrift, onResolved };
+  return { watcher, onDrift, onStatus, onResolved };
 }
 
 // ─── detectDrift (pure function) ─────────────────────────────────────
@@ -192,14 +198,40 @@ describe('createDriftWatcher', () => {
     expect(onResolved).not.toHaveBeenCalled();
   });
 
-  it('does not call onDrift when the watched file cannot be read', async () => {
+  it('calls onDrift when a manifest file cannot be read', async () => {
     const { watcher, onDrift } = makeWatcher({
       [EMITTED]: makeManifestSingleHash('somehash'),
-      // WATCHED is absent → ENOENT → unreadable → not drifted
+      // WATCHED is absent → ENOENT → unreadable → needs attention
     });
 
     await watcher.check();
+    expect(onDrift).toHaveBeenCalledWith([WATCHED]);
+  });
+
+  it('calls onStatus with drifted and unreadable file statuses', async () => {
+    const convex = 'defineSchema({})';
+    const editedConvex = 'defineSchema({ posts: defineTable({}) })';
+    const onDrift = vi.fn();
+    const onStatus = vi.fn();
+    const { watcher } = makeWatcher(
+      {
+        [WATCHED]: editedConvex,
+        [EMITTED]: makeManifest({
+          [WATCHED]: convex,
+          [SCHEMA_TS]: 'missing zod',
+        }),
+      },
+      { onDrift, onStatus },
+    );
+
+    await watcher.check();
+
     expect(onDrift).not.toHaveBeenCalled();
+    expect(onStatus).toHaveBeenCalledOnce();
+    expect(onStatus).toHaveBeenCalledWith([
+      { path: WATCHED, status: 'drifted' },
+      { path: SCHEMA_TS, status: 'unreadable' },
+    ]);
   });
 
   it('does not call onDrift when the emitted manifest cannot be read', async () => {

--- a/docs/adr/0022-contexture-domain-model-control-plane.md
+++ b/docs/adr/0022-contexture-domain-model-control-plane.md
@@ -1,0 +1,61 @@
+# ADR 0022: Contexture is the domain-model control plane, not an app builder
+
+- **Status:** Accepted
+- **Date:** 2026-05-16
+
+## Context
+
+Contexture's codebase has converged on a stronger product shape than "visual Zod schema editor":
+
+- `@contexture/core` owns a canonical IR, closed-world op vocabulary, validation, emitters, path conventions, and file-backed mutation helpers.
+- The desktop app provides local-first visual and chat-assisted authoring over that IR.
+- The CLI exposes the same IR/op/emit pipeline to downstream apps and coding agents.
+- The document bundle records generated artefact hashes so drift can be detected instead of silently overwritten.
+- The provider runtime work makes Codex/Claude adapters secondary to the same schema-only op contract.
+
+At the same time, adjacent systems such as Sandcastle, Codex, Claude Code, project scaffolding, and future app-generation workflows create pressure for Contexture to become a broader task runner or app builder. That would blur the product's trust boundary and make the IR less obviously authoritative.
+
+The product direction should preserve the narrow leverage point: Contexture owns the domain model and emits typed surfaces for apps and agents.
+
+## Decision
+
+Contexture is the **domain-model control plane for AI-native TypeScript apps**.
+
+The product owns:
+
+- Authoring and validating a canonical `.contexture.json` IR.
+- Applying all human, CLI, and agent edits through the closed-world op vocabulary.
+- Emitting typed surfaces from that IR, including Zod, JSON Schema, Convex schema, schema indexes, and future AI-pipeline artefacts such as tool schemas, extractor scaffolds, MCP definitions, and form validators.
+- Detecting and reconciling drift in generated artefacts using the emitted hash manifest.
+- Exposing the same model mutation surface to agents through CLI/MCP-style adapters.
+
+The product does **not** own:
+
+- Running coding agents as a general task orchestration surface.
+- Managing issue backlogs, Kanban boards, missions, or PR pipelines.
+- Shipping or deploying generated applications.
+- Two-way sync with downstream framework files as the default model.
+- Runtime schema editing for end users of downstream apps.
+
+The desktop app remains the human visual authoring surface. The CLI and future MCP server are the agent/programmatic surfaces. All three must share `@contexture/core` as the source of truth.
+
+## Consequences
+
+- The immediate roadmap should prioritise trust and interoperability over app-builder breadth:
+  1. Complete the project bundle and drift/reconcile experience.
+  2. Ship an MCP or equivalent agent tool surface over `@contexture/core`.
+  3. Add opt-in AI-pipeline emit targets.
+  4. Dog-food Contexture on real Applification products before broad public positioning.
+  5. Rebuild marketing around "Design your domain once. Ship it everywhere."
+- Sandcastle and future mission orchestration stay outside Contexture. They may consume Contexture through CLI/MCP, but Contexture should not absorb their workflow responsibilities.
+- Provider runtimes stay adapters. Codex-first and Claude-later work must preserve the schema-only op contract rather than turning schema chat into a general coding-agent surface.
+- Generated files remain one-way emissions by default. If a generated file is edited by a human or agent, drift/reconcile is the safety mechanism; the emitter does not silently merge or overwrite.
+- Future emit targets should be opt-in per project so the generated bundle stays focused on the app's actual needs.
+- The older JSON-LD/OWL/Kosmos direction is not on the active path. It should not be reopened without new evidence from real users.
+
+## Alternatives considered
+
+- **Keep positioning as a visual Zod editor.** Too small: it undersells the existing Convex, JSON Schema, drift, CLI, and agent-safe op architecture.
+- **Become a full app builder.** Too broad: it would compete with scaffolding, Sandcastle, and coding agents, while weakening Contexture's source-of-truth story.
+- **Become a general agent orchestration product.** Rejected because Sandcastle/missions already cover that adjacent space; Contexture's leverage is a safe domain-model interface those agents can call.
+- **Reopen the JSON-LD/frame pivot.** Rejected for now because the current implementation and product plan have converged on TypeScript/Zod/Convex/AI-pipeline schema design.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ Format: Context → Decision → Consequences → Alternatives. Status is `Propo
 | [0019](0019-separate-marketing-site-on-vercel.md) | Marketing site is a separate Next.js app on Vercel | Accepted |
 | [0020](0020-shadcn-tailwind-v4-oklch.md) | shadcn/ui + Tailwind v4 + OKLCH design tokens | Accepted |
 | [0021](0021-varlock-infisical-env-secrets.md) | varlock + Infisical for env and secrets management | Accepted |
+| [0022](0022-contexture-domain-model-control-plane.md) | Contexture is the domain-model control plane, not an app builder | Accepted |
 
 ## Adding a new ADR
 


### PR DESCRIPTION
## Summary
- Upgraded drift detection to treat unreadable or missing generated artifacts as first-class drift problems, not silent clean states.
- Threaded structured drift status through main IPC, preload, renderer store, and the drift banner so the UI can distinguish modified vs missing/unreadable files.
- Added coverage for the watcher and banner behavior, and recorded the product direction in ADR 0022.

## Testing
- `bunx vitest run tests/main/drift-watcher.test.ts tests/components/DriftBanner.test.tsx tests/hooks/useDrift.test.ts`
- `bun run typecheck`
- `bunx biome check` on all touched files