### PR TITLE
feat: add regenerate reconcile flow

### DIFF
--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -12,12 +12,13 @@
  *
  * Apply selected → run checked ops through the undo store as one
  * transaction, mark drift resolved, close.
- * Discard on-disk → overwrite the target file with the current emit.
+ * Regenerate from IR → overwrite the generated target with the
+ * current Contexture emit, without applying any proposed ops.
  * Open in chat → seed a new chat thread with IR + source + proposed ops.
- * Cancel → leave drift state alone.
+ * Leave dirty → close the modal and leave drift state alone.
  */
 
-import { baseNameFor } from '@contexture/core/paths';
+import { baseNameFor, bundlePathsFor } from '@contexture/core/paths';
 import { MultiFileDiff } from '@pierre/diffs/react';
 import { useChatThreads } from '@renderer/chat/useChatThreads';
 import { useClaudeReconcile } from '@renderer/hooks/useClaudeReconcile';
@@ -30,7 +31,12 @@ import { STDLIB_REGISTRY } from '@renderer/services/stdlib-registry';
 import { useDocumentStore } from '@renderer/store/document';
 import { useDriftStore } from '@renderer/store/drift';
 import { apply } from '@renderer/store/ops';
-import { type ReconcileOp, targetKindFor, useReconcileStore } from '@renderer/store/reconcile';
+import {
+  type ReconcileOp,
+  type TargetKind,
+  targetKindFor,
+  useReconcileStore,
+} from '@renderer/store/reconcile';
 import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import { useUndoStore } from '@renderer/store/undo';
 import { diffLines } from 'diff';
@@ -54,8 +60,12 @@ interface EmitResult {
   error: string | null;
 }
 
-function safeEmitForTarget(schema: Schema, targetPath: string, irPath: string | null): EmitResult {
-  const kind = targetKindFor(targetPath);
+function safeEmitForTarget(
+  schema: Schema,
+  targetPath: string,
+  irPath: string | null,
+  kind: TargetKind = targetKindFor(targetPath),
+): EmitResult {
   try {
     let source: string;
     switch (kind) {
@@ -125,6 +135,20 @@ function shortPath(fullPath: string): string {
   return slash === -1 ? fullPath : fullPath.slice(slash + 1);
 }
 
+function generatedTargetKindFor(targetPath: string | null, irPath: string | null): TargetKind {
+  if (!targetPath || !irPath) return 'unknown';
+  try {
+    const paths = bundlePathsFor(irPath);
+    if (targetPath === paths.convex) return 'convex';
+    if (targetPath === paths.schemaTs) return 'zod';
+    if (targetPath === paths.schemaJson) return 'json-schema';
+    if (targetPath === paths.schemaIndex) return 'schema-index';
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
 export function ReconcileModal(): React.JSX.Element {
   const isOpen = useReconcileStore((s) => s.isOpen);
   const status = useReconcileStore((s) => s.status);
@@ -150,6 +174,7 @@ export function ReconcileModal(): React.JSX.Element {
   const filePath = useDocumentStore((s) => s.filePath);
 
   const displayName = targetPath ? shortPath(targetPath) : 'generated file';
+  const targetKind = generatedTargetKindFor(targetPath, filePath);
 
   // Recompute the would-be emit each time the user toggles an op.
   // Cheap (pure function, < 10ms even on large schemas), so a
@@ -157,9 +182,14 @@ export function ReconcileModal(): React.JSX.Element {
   const projection = useMemo(() => {
     if (!targetPath) return { schema, error: null, emit: { source: '', error: 'No target.' } };
     const projected = applySelectedOps(schema, proposedOps, selectedIndices);
-    const emit = safeEmitForTarget(projected.schema, targetPath, filePath);
+    const emit = safeEmitForTarget(projected.schema, targetPath, filePath, targetKind);
     return { ...projected, emit };
-  }, [schema, proposedOps, selectedIndices, targetPath, filePath]);
+  }, [schema, proposedOps, selectedIndices, targetPath, filePath, targetKind]);
+
+  const currentEmit = useMemo(() => {
+    if (!targetPath) return { source: '', error: 'No target.' };
+    return safeEmitForTarget(schema, targetPath, filePath, targetKind);
+  }, [schema, targetPath, filePath, targetKind]);
 
   const residualLines = useMemo(() => {
     if (onDiskSource === null) return 0;
@@ -186,20 +216,19 @@ export function ReconcileModal(): React.JSX.Element {
     close();
   }, [proposedOps, selectedIndices, setApplying, setError, close]);
 
-  const handleDiscard = useCallback(() => {
-    if (!targetPath || !projection.emit.source || projection.emit.error) return;
+  const handleRegenerate = useCallback(() => {
+    if (!targetPath || targetKind === 'unknown' || !currentEmit.source || currentEmit.error) return;
     void window.api
-      ?.saveFile(targetPath, projection.emit.source)
-      .then(() => {
-        useDriftStore.getState().setResolved();
-        void window.contexture?.drift.dismiss();
+      ?.saveFile(targetPath, currentEmit.source)
+      .then(async () => {
+        await window.contexture?.drift.check();
         close();
       })
       .catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
         setError(`Failed to overwrite file: ${message}`);
       });
-  }, [targetPath, projection, close, setError]);
+  }, [targetPath, targetKind, currentEmit, close, setError]);
 
   const handleOpenInChat = useCallback(() => {
     const irJson = JSON.stringify(schema, null, 2);
@@ -255,8 +284,8 @@ export function ReconcileModal(): React.JSX.Element {
   const applyDisabled =
     status !== 'ready' || selectedIndices.size === 0 || proposedOps.length === 0;
 
-  const discardDisabled =
-    status !== 'ready' || !targetPath || !!projection.emit.error || !projection.emit.source;
+  const regenerateDisabled =
+    !targetPath || targetKind === 'unknown' || !!currentEmit.error || !currentEmit.source;
 
   return (
     <Dialog
@@ -269,9 +298,9 @@ export function ReconcileModal(): React.JSX.Element {
         <DialogHeader>
           <DialogTitle>Reconcile changes</DialogTitle>
           <DialogDescription>
-            <code className="font-mono">{displayName}</code> was edited outside Contexture. Select
-            the ops to bring the IR in line with the file, or open the proposal in chat for
-            iteration.
+            <code className="font-mono">{displayName}</code> differs from Contexture's generated
+            output. Regenerate it from the current IR, leave it dirty, or use the proposal tools to
+            fold changes back into the model.
           </DialogDescription>
         </DialogHeader>
 
@@ -396,15 +425,15 @@ export function ReconcileModal(): React.JSX.Element {
 
         <DialogFooter>
           <Button variant="ghost" onClick={close}>
-            Cancel
+            Leave dirty
           </Button>
           <Button
             variant="outline"
-            onClick={handleDiscard}
-            disabled={discardDisabled}
-            title="Overwrite the on-disk file with what Contexture would emit"
+            onClick={handleRegenerate}
+            disabled={regenerateDisabled}
+            title="Overwrite this generated file with what Contexture emits from the current IR"
           >
-            Discard on-disk changes
+            Regenerate from IR
           </Button>
           <Button
             variant="outline"

--- a/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
+++ b/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
@@ -1,0 +1,114 @@
+import { ReconcileModal } from '@renderer/components/dialogs/ReconcileModal';
+import { useDocumentStore } from '@renderer/store/document';
+import { useDriftStore } from '@renderer/store/drift';
+import { useReconcileStore } from '@renderer/store/reconcile';
+import { useUndoStore } from '@renderer/store/undo';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@pierre/diffs/react', () => ({
+  MultiFileDiff: () => <div data-testid="reconcile-diff" />,
+}));
+
+vi.mock('@renderer/hooks/useClaudeReconcile', () => ({
+  useClaudeReconcile: () => undefined,
+}));
+
+const IR_PATH = '/repo/packages/contexture/garden.contexture.json';
+const ZOD_PATH = '/repo/packages/contexture/garden.schema.ts';
+const UNKNOWN_PATH = '/repo/packages/contexture/custom.ts';
+const USER_INDEX_PATH = '/repo/packages/contexture/src/index.ts';
+
+const SCHEMA = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Plot',
+      fields: [{ name: 'name', type: { kind: 'string' } }],
+    },
+  ],
+} as const;
+
+beforeEach(() => {
+  useUndoStore.setState({
+    schema: SCHEMA,
+    past: [],
+    future: [],
+    txDepth: 0,
+    txStart: null,
+    canUndo: false,
+    canRedo: false,
+  });
+  useDocumentStore.setState({ filePath: IR_PATH, mode: 'project' });
+  useDriftStore.getState().setResolved();
+  useReconcileStore.getState().reset();
+  window.api.saveFile = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(window, 'contexture', {
+    value: {
+      drift: {
+        check: vi.fn().mockResolvedValue({ ok: true }),
+        dismiss: vi.fn().mockResolvedValue({ ok: true }),
+      },
+    },
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  useDriftStore.getState().setResolved();
+  useReconcileStore.getState().reset();
+});
+
+describe('ReconcileModal', () => {
+  it('regenerates a generated file from the current IR even when reconcile analysis failed', async () => {
+    useDriftStore.getState().setDetected([{ path: ZOD_PATH, status: 'unreadable' }]);
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setError(`Cannot read ${ZOD_PATH}.`);
+
+    render(<ReconcileModal />);
+
+    fireEvent.click(screen.getByRole('button', { name: /regenerate from ir/i }));
+
+    await waitFor(() => expect(window.api.saveFile).toHaveBeenCalledOnce());
+    const [path, contents] = vi.mocked(window.api.saveFile).mock.calls[0] ?? [];
+    expect(path).toBe(ZOD_PATH);
+    expect(contents).toContain('@contexture-generated');
+    expect(contents).toContain('Plot');
+    expect(window.contexture?.drift.check).toHaveBeenCalledOnce();
+    expect(useReconcileStore.getState().isOpen).toBe(false);
+  });
+
+  it('does not offer regeneration for unknown or user-owned targets', () => {
+    useReconcileStore.getState().open(UNKNOWN_PATH);
+    useReconcileStore.getState().setReady([], 'user-owned source');
+
+    render(<ReconcileModal />);
+
+    expect(screen.getByRole('button', { name: /regenerate from ir/i })).toBeDisabled();
+  });
+
+  it('does not regenerate a user-owned nested index.ts even though it looks like a schema index', () => {
+    useReconcileStore.getState().open(USER_INDEX_PATH);
+    useReconcileStore.getState().setReady([], 'user-owned index');
+
+    render(<ReconcileModal />);
+
+    expect(screen.getByRole('button', { name: /regenerate from ir/i })).toBeDisabled();
+  });
+
+  it('leaves drift dirty when the user closes without regenerating', () => {
+    useDriftStore.getState().setDetected([{ path: ZOD_PATH, status: 'drifted' }]);
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setReady([], 'hand edited source');
+
+    render(<ReconcileModal />);
+    fireEvent.click(screen.getByRole('button', { name: /leave dirty/i }));
+
+    expect(window.api.saveFile).not.toHaveBeenCalled();
+    expect(useDriftStore.getState().driftedPaths).toEqual([ZOD_PATH]);
+    expect(useReconcileStore.getState().isOpen).toBe(false);
+  });
+});

--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -1,0 +1,88 @@
+# Domain-Model Control Plane Goals
+
+This roadmap turns [ADR 0022](../adr/0022-contexture-domain-model-control-plane.md) into
+Codex-sized goals. Each goal should be pursued as a small vertical slice:
+set one active goal, implement it end to end, verify it, then update this
+file with what changed and what the next goal should learn from it.
+
+## Goal 1 — Drift Status Trust Layer
+
+**Status:** Done in PR 259.
+
+Make generated-file drift detection reliable, visible, and tested. Missing
+or unreadable generated files must be surfaced as attention-worthy drift,
+not silently treated as clean.
+
+## Goal 2 — Reconcile Minimum Viable Flow
+
+**Status:** Done.
+
+Let users either regenerate a drifted generated file from the current IR or
+leave it dirty. This goal is intentionally narrower than semantic
+fold-back: it must be safe, obvious, and limited to generated targets.
+
+Completion evidence:
+
+- Reconcile UI offers `Regenerate from IR`.
+- `Leave dirty` closes the modal without clearing drift or writing files.
+- Unknown or user-owned targets cannot be overwritten by this flow.
+- Tests cover regenerate, leave-dirty, and generated-target safety.
+
+## Goal 2.5 — Provider-Neutral Reconcile Proposals
+
+**Status:** Next.
+
+Move reconcile proposals off the Claude-only IPC path and onto the active
+schema-agent provider. The reconcile modal should use the same selected
+provider, model, effort, and options as schema chat, without adding a
+second model picker in the modal.
+
+Completion evidence:
+
+- Reconcile proposal requests are routed through a provider-neutral
+  schema-agent path, not `ipc/claude.ts`.
+- Active Codex and Claude provider/model settings are respected.
+- If the active provider is unavailable, proposal generation fails
+  explicitly while `Regenerate from IR` and `Leave dirty` remain usable.
+- Tests cover Codex routing, Claude routing, and unavailable-provider
+  fallback behavior.
+
+## Goal 3 — CLI/Agent Drift Contract
+
+Expose machine-readable drift status for CI and coding agents. The CLI
+should report path, status, and a non-zero exit when generated files drift
+or become unreadable.
+
+## Goal 4 — MCP Inspect/Validate Server
+
+Ship a minimal MCP surface over `@contexture/core` that can inspect and
+validate a `.contexture.json` file without the desktop app running.
+
+## Goal 5 — MCP Mutation/Emit Loop
+
+Let agents mutate the IR through the closed-world op vocabulary, emit the
+bundle, and check drift. The agent loop should be: inspect, apply op,
+validate, emit, check drift.
+
+## Goal 6 — Opt-In Output Config
+
+Add the IR shape for target-specific emit configuration. Existing outputs
+should preserve current behavior; new AI-pipeline outputs should be opt-in.
+
+## Goal 7 — First AI-Pipeline Emitter
+
+Add one high-value opt-in generated target for AI engineers, such as
+tool-call schema helpers or structured-output helper definitions. The new
+target must participate in the emit manifest and drift detection.
+
+## Goal 8 — Dogfood One Real Product
+
+Use Contexture CLI/MCP to make one real schema change in an Applification
+product. The change should start from the IR, regenerate artifacts, pass
+drift checks, and feed sharp edges back into Contexture.
+
+## Goal 9 — Marketing Rewrite
+
+Rewrite public positioning only after the trust layer, agent loop, and at
+least one AI-pipeline output are credible. The site should sell: "Design
+your domain once. Ship it everywhere."


### PR DESCRIPTION
## Summary
- add a minimum viable reconcile action to regenerate exact generated bundle targets from the current IR
- rename the passive close action to Leave dirty so drift remains visible when the user does not regenerate
- add a durable ADR 0022 goal roadmap and mark Goal 2 done
- add ReconcileModal tests for regenerate, leave-dirty, and user-owned target safety

## Verification
- bunx vitest run tests/components/dialogs/ReconcileModal.test.tsx tests/store/reconcile.test.ts tests/components/DriftBanner.test.tsx tests/main/drift-watcher.test.ts
- bunx biome check apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx docs/roadmap/domain-model-control-plane-goals.md
- pre-commit hook: turbo typecheck; turbo test
