### PR TITLE
Expose generated file drift status in CLI

### DIFF
--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -58,9 +58,19 @@ Notes:
 
 ## Goal 3 — CLI/Agent Drift Contract
 
+**Status:** Done.
+
 Expose machine-readable drift status for CI and coding agents. The CLI
 should report path, status, and a non-zero exit when generated files drift
 or become unreadable.
+
+Completion evidence:
+
+- `contexture check-generated --json` reports every generated target as
+  `{ path, status }`, where status is `clean`, `drifted`, or `unreadable`.
+- Drifted or unreadable generated targets set a non-zero exit code.
+- The older `stale` JSON field remains for compatibility while agents can
+  consume the new `files` and `drift` arrays directly.
 
 ## Goal 4 — MCP Inspect/Validate Server
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,13 @@ interface JsonError {
   error: { message: string; code: string };
 }
 
+type GeneratedFileStatus = 'clean' | 'drifted' | 'unreadable';
+
+interface GeneratedFileCheck {
+  path: string;
+  status: GeneratedFileStatus;
+}
+
 const HELP = `contexture <command> [args]
 
 Read helpers:
@@ -537,7 +544,7 @@ async function run(argv: string[]): Promise<void> {
   if (command === 'check-generated') {
     const schema = await readSchema(irPath);
     const { emitted } = runEmitPipeline(schema, irPath);
-    const stale: Array<{ path: string; reason: 'missing' | 'mismatch' }> = [];
+    const files: GeneratedFileCheck[] = [];
     for (const entry of emitted) {
       let onDisk: string | undefined;
       try {
@@ -545,24 +552,31 @@ async function run(argv: string[]): Promise<void> {
       } catch {
         onDisk = undefined;
       }
-      if (onDisk === undefined) stale.push({ path: entry.path, reason: 'missing' });
-      else if (onDisk !== entry.content) stale.push({ path: entry.path, reason: 'mismatch' });
+      if (onDisk === undefined) files.push({ path: entry.path, status: 'unreadable' });
+      else if (onDisk !== entry.content) files.push({ path: entry.path, status: 'drifted' });
+      else files.push({ path: entry.path, status: 'clean' });
     }
-    if (stale.length > 0) {
+    const drift = files.filter((file) => file.status !== 'clean');
+    if (drift.length > 0) {
       process.exitCode = 1;
+      const stale = drift.map((file) => ({
+        path: file.path,
+        reason: file.status === 'drifted' ? 'mismatch' : 'missing',
+        status: file.status,
+      }));
       if (options.json) {
-        writeJson({ ok: false, stale });
+        writeJson({ ok: false, checked: files.length, files, drift, stale });
       } else {
-        process.stderr.write('Generated files are stale:\n');
-        for (const { path, reason } of stale) {
-          process.stderr.write(`  ${path} (${reason})\n`);
+        process.stderr.write('Generated files are not up to date:\n');
+        for (const { path, status } of drift) {
+          process.stderr.write(`  ${path} (${status})\n`);
         }
         process.stderr.write('\nRun: contexture emit\n');
       }
       return;
     }
     writeResult(
-      { message: 'Generated files are up to date.', checked: emitted.length },
+      { message: 'Generated files are up to date.', checked: files.length, files },
       options.json,
     );
     return;

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -151,10 +151,17 @@ describe('@contexture/cli', () => {
     expect(result.exitCode).toBe(1);
     const parsed = JSON.parse(result.stdout);
     expect(parsed.ok).toBe(false);
+    expect(parsed.checked).toBeGreaterThan(0);
+    expect(parsed.files.every((entry: { status: string }) => entry.status === 'unreadable')).toBe(
+      true,
+    );
+    expect(parsed.drift.every((entry: { status: string }) => entry.status === 'unreadable')).toBe(
+      true,
+    );
     expect(Array.isArray(parsed.stale)).toBe(true);
     expect(parsed.stale.length).toBeGreaterThan(0);
     for (const entry of parsed.stale) {
-      expect(entry).toMatchObject({ reason: 'missing' });
+      expect(entry).toMatchObject({ reason: 'missing', status: 'unreadable' });
     }
   });
 
@@ -168,6 +175,12 @@ describe('@contexture/cli', () => {
     expect(JSON.parse(checkResult.stdout)).toMatchObject({
       ok: true,
       message: expect.stringContaining('up to date'),
+      files: expect.arrayContaining([
+        expect.objectContaining({
+          path: expect.stringContaining('packages/contexture/convex/schema.ts'),
+          status: 'clean',
+        }),
+      ]),
     });
   });
 
@@ -181,10 +194,26 @@ describe('@contexture/cli', () => {
     const result = await runCli(dir, ['check-generated', '--json']);
     expect(result.exitCode).toBe(1);
     const parsed = JSON.parse(result.stdout);
+    expect(parsed.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: expect.stringContaining('packages/contexture/convex/schema.ts'),
+          status: 'drifted',
+        }),
+      ]),
+    );
+    expect(parsed.drift).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: expect.stringContaining('packages/contexture/convex/schema.ts'),
+          status: 'drifted',
+        }),
+      ]),
+    );
     expect(
       parsed.stale.some(
-        (s: { path: string; reason: string }) =>
-          s.path.endsWith('convex/schema.ts') && s.reason === 'mismatch',
+        (s: { path: string; reason: string; status: string }) =>
+          s.path.endsWith('convex/schema.ts') && s.reason === 'mismatch' && s.status === 'drifted',
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
## Summary
- add machine-readable generated-file status entries to `contexture check-generated --json`
- report all generated targets as `clean`, `drifted`, or `unreadable`
- keep the existing `stale` compatibility field while adding agent-friendly `files` and `drift` arrays
- mark ADR 0022 Goal 3 complete in the roadmap

## Verification
- bunx vitest run tests/cli.test.ts
- bun run check
- bun run typecheck
- commit hook: turbo typecheck && turbo test