### PR TITLE
Add packaged MCP entrypoint goal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 permissions:
   contents: write
@@ -16,6 +16,27 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - name: Verify desktop version matches release tag
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const tag = (process.env.TAG_NAME || "").replace(/^v/, "");
+          const version = JSON.parse(
+            fs.readFileSync("apps/desktop/package.json", "utf8"),
+          ).version;
+
+          if (version !== tag) {
+            console.error(
+              `Release tag ${process.env.TAG_NAME} does not match apps/desktop/package.json version ${version}.`,
+            );
+            process.exit(1);
+          }
+
+          console.log(`Release version ${version} matches ${process.env.TAG_NAME}.`);
+          NODE
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.14.0",
+  "version": "0.15.1",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.14.0",
+      "version": "0.15.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.83",
         "@contexture/core": "workspace:*",

--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -87,6 +87,32 @@ Completion evidence:
 - Tests exercise the MCP server with an in-memory MCP client, independent
   of the desktop app.
 
+## Goal 4.5 — Packaged MCP Entry Point
+
+**Status:** Next.
+
+Make the MCP server accessible from an installed Contexture app, not just
+from a source checkout. Agents need one stable, centrally installed command
+to register after the user has created a `.contexture.json` file.
+
+Target registration shape:
+
+```bash
+codex mcp add contexture -- /Applications/Contexture.app/Contents/MacOS/Contexture --mcp
+```
+
+Completion evidence:
+
+- The packaged macOS app can launch the MCP stdio server via `--mcp`
+  without opening the desktop window.
+- The MCP runtime does not require `bun`, a source checkout, or dev-only
+  TypeScript execution.
+- The registered installed-app command exposes the same
+  `inspect_contexture` and `validate_contexture` tools as Goal 4.
+- Tests or packaging verification cover the installed-app launch path.
+- Developer docs explain how agents register and smoke-test the installed
+  MCP server.
+
 ## Goal 5 — MCP Mutation/Emit Loop
 
 Let agents mutate the IR through the closed-world op vocabulary, emit the


### PR DESCRIPTION
## Summary
- add ADR 0022 Goal 4.5 for a packaged installed-app MCP entry point
- define the target Codex registration shape using `/Applications/Contexture.app/Contents/MacOS/Contexture --mcp`
- capture completion evidence for no Bun/source-checkout dependency, installed-app launch verification, and registration docs

## Verification
- commit hook: turbo typecheck && turbo test
- Biome ignores Markdown, so no formatter target was processed for the docs file