### PR TITLE
Add MCP mutation and emit loop

### DIFF
--- a/docs/agent-mcp.md
+++ b/docs/agent-mcp.md
@@ -1,9 +1,10 @@
 # Agent MCP Server
 
-Contexture exposes a read-only MCP server for agents that need to inspect or
-validate `.contexture.json` files. The source-checkout command is still
-available as `contexture-mcp`, but installed app users should register the
-packaged app entrypoint so every agent uses the same central install.
+Contexture exposes an MCP server for agents that need to inspect, validate,
+mutate, emit, and check drift for `.contexture.json` files. The source-checkout
+command is still available as `contexture-mcp`, but installed app users should
+register the packaged app entrypoint so every agent uses the same central
+install.
 
 ## Register the Installed App
 
@@ -24,6 +25,32 @@ known `.contexture.json` file. The server should expose:
 
 - `inspect_contexture`
 - `validate_contexture`
+- `apply_contexture_op`
+- `emit_contexture`
+- `check_contexture_drift`
+
+The intended agent loop is:
+
+1. `inspect_contexture`
+2. `apply_contexture_op`
+3. `validate_contexture`
+4. `emit_contexture`
+5. `check_contexture_drift`
+
+`apply_contexture_op` accepts one closed-world Contexture `Op` object, such as:
+
+```json
+{
+  "kind": "add_field",
+  "typeName": "Customer",
+  "field": { "name": "email", "type": { "kind": "string", "format": "email" } }
+}
+```
+
+The apply tool writes the IR and generated bundle through the same file-backed
+op path as the CLI. `emit_contexture` is available when the agent only needs to
+regenerate artifacts from the current IR, and `check_contexture_drift` verifies
+that generated files still match the IR.
 
 For local release verification before packaging, build the desktop app and start
 the built main entrypoint with the same flag:

--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -118,9 +118,22 @@ Completion evidence:
 
 ## Goal 5 — MCP Mutation/Emit Loop
 
+**Status:** Done.
+
 Let agents mutate the IR through the closed-world op vocabulary, emit the
 bundle, and check drift. The agent loop should be: inspect, apply op,
 validate, emit, check drift.
+
+Completion evidence:
+
+- The shared MCP server exposes `apply_contexture_op`, `emit_contexture`, and
+  `check_contexture_drift` alongside inspect/validate.
+- `apply_contexture_op` writes through `createFileBackedForward`, so MCP
+  mutations use the same closed-world op reducer and generated bundle path as
+  the CLI.
+- MCP tests exercise the full inspect/apply/emit/check loop against a temporary
+  `.contexture.json` project.
+- Agent docs describe the registered tool loop and example op payload.
 
 ## Goal 6 — Opt-In Output Config
 

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -170,6 +170,38 @@ describe('Contexture MCP server', () => {
     });
   });
 
+  it('returns structured failures for malformed mutation ops', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      metadata: { name: 'Garden' },
+      types: [
+        {
+          kind: 'object',
+          name: 'Plot',
+          fields: [{ name: 'name', type: { kind: 'string' } }],
+        },
+      ],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'apply_contexture_op',
+        arguments: {
+          irPath,
+          op: { kind: 'add_field', typeName: 'Plot' },
+        },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        applied: false,
+        opKind: 'add_field',
+        error: expect.stringContaining('invalid op'),
+      });
+      expect((result.structuredContent as { error?: string }).error).toContain('field');
+    });
+  });
+
   it('applies an op, emits generated files, and reports generated drift', async () => {
     const irPath = await fixtureIr({
       version: '1',

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -28,18 +28,45 @@ async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
 }
 
 describe('Contexture MCP server', () => {
-  it('lists read-only inspect and validate tools', async () => {
+  it('lists inspect, validate, mutation, emit, and drift tools', async () => {
     await withClient(async (client) => {
       const { tools } = await client.listTools();
       expect(tools).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: 'inspect_contexture',
-            annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+            annotations: expect.objectContaining({
+              readOnlyHint: true,
+              destructiveHint: false,
+            }),
           }),
           expect.objectContaining({
             name: 'validate_contexture',
-            annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+            annotations: expect.objectContaining({
+              readOnlyHint: true,
+              destructiveHint: false,
+            }),
+          }),
+          expect.objectContaining({
+            name: 'apply_contexture_op',
+            annotations: expect.objectContaining({
+              readOnlyHint: false,
+              destructiveHint: true,
+            }),
+          }),
+          expect.objectContaining({
+            name: 'emit_contexture',
+            annotations: expect.objectContaining({
+              readOnlyHint: false,
+              destructiveHint: false,
+            }),
+          }),
+          expect.objectContaining({
+            name: 'check_contexture_drift',
+            annotations: expect.objectContaining({
+              readOnlyHint: true,
+              destructiveHint: false,
+            }),
           }),
         ]),
       );
@@ -115,7 +142,10 @@ describe('Contexture MCP server', () => {
   });
 
   it('reports structural validation errors as data instead of requiring desktop IPC', async () => {
-    const irPath = await fixtureIr({ version: '1', types: [{ kind: 'object', name: '' }] });
+    const irPath = await fixtureIr({
+      version: '1',
+      types: [{ kind: 'object', name: '' }],
+    });
 
     await withClient(async (client) => {
       const result = await client.callTool({
@@ -136,6 +166,95 @@ describe('Contexture MCP server', () => {
             message: expect.any(String),
           }),
         ],
+      });
+    });
+  });
+
+  it('applies an op, emits generated files, and reports generated drift', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      metadata: { name: 'Garden' },
+      types: [
+        {
+          kind: 'object',
+          name: 'Plot',
+          fields: [{ name: 'name', type: { kind: 'string' } }],
+        },
+      ],
+    });
+
+    await withClient(async (client) => {
+      const applyResult = await client.callTool({
+        name: 'apply_contexture_op',
+        arguments: {
+          irPath,
+          op: {
+            kind: 'add_field',
+            typeName: 'Plot',
+            field: { name: 'size', type: { kind: 'number', int: true } },
+          },
+        },
+      });
+
+      expect(applyResult.structuredContent).toMatchObject({
+        path: irPath,
+        applied: true,
+        opKind: 'add_field',
+      });
+
+      const updatedIr = JSON.parse(await readFile(irPath, 'utf8')) as {
+        types: Array<{ name: string; fields?: Array<{ name: string }> }>;
+      };
+      expect(updatedIr.types[0]?.fields?.map((field) => field.name)).toEqual(['name', 'size']);
+
+      const cleanResult = await client.callTool({
+        name: 'check_contexture_drift',
+        arguments: { irPath },
+      });
+      expect(cleanResult.structuredContent).toMatchObject({
+        path: irPath,
+        clean: true,
+        checked: 4,
+        drift: [],
+      });
+
+      await writeFile(
+        irPath.replace(/\.contexture\.json$/, '.schema.json'),
+        '{"stale":true}\n',
+        'utf8',
+      );
+
+      const driftResult = await client.callTool({
+        name: 'check_contexture_drift',
+        arguments: { irPath },
+      });
+      expect(driftResult.structuredContent).toMatchObject({
+        path: irPath,
+        clean: false,
+        drift: [
+          expect.objectContaining({
+            path: irPath.replace(/\.contexture\.json$/, '.schema.json'),
+            status: 'drifted',
+          }),
+        ],
+      });
+
+      const emitResult = await client.callTool({
+        name: 'emit_contexture',
+        arguments: { irPath },
+      });
+      expect(emitResult.structuredContent).toMatchObject({
+        path: irPath,
+        emitted: expect.arrayContaining([irPath.replace(/\.contexture\.json$/, '.schema.json')]),
+      });
+
+      const cleanAgainResult = await client.callTool({
+        name: 'check_contexture_drift',
+        arguments: { irPath },
+      });
+      expect(cleanAgainResult.structuredContent).toMatchObject({
+        clean: true,
+        drift: [],
       });
     });
   });

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -1,8 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ZodError, z } from 'zod';
+import { createFileBackedForward } from './file-forward';
 import type { FieldType, Schema, TypeDef } from './ir';
 import { load } from './load';
+import type { Op } from './ops';
+import { runEmitPipeline } from './pipeline';
 import { checkSemantic } from './semantic-validation';
 
 const VERSION = '0.0.0';
@@ -60,6 +63,48 @@ const ValidateOutput = {
   errors: z.array(ValidationIssueSchema),
 };
 
+const ApplyContextureOpInput = {
+  irPath: IrPathInput.irPath,
+  op: z.record(z.string(), z.unknown()).describe('A Contexture closed-world Op object.'),
+};
+
+const ApplyContextureOpOutput = {
+  path: z.string(),
+  applied: z.boolean(),
+  opKind: z.string(),
+  error: z.string().optional(),
+  typeCount: z.number().optional(),
+};
+
+const EmitContextureOutput = {
+  path: z.string(),
+  emitted: z.array(z.string()),
+  manifest: z.object({
+    version: z.literal('1'),
+    files: z.record(z.string(), z.string()),
+  }),
+};
+
+const GeneratedFileStatusSchema = z.enum(['clean', 'drifted', 'unreadable']);
+
+const CheckContextureDriftOutput = {
+  path: z.string(),
+  clean: z.boolean(),
+  checked: z.number(),
+  files: z.array(
+    z.object({
+      path: z.string(),
+      status: GeneratedFileStatusSchema,
+    }),
+  ),
+  drift: z.array(
+    z.object({
+      path: z.string(),
+      status: GeneratedFileStatusSchema,
+    }),
+  ),
+};
+
 export function createContextureMcpServer(): McpServer {
   const server = new McpServer({ name: 'contexture-core', version: VERSION });
 
@@ -103,6 +148,66 @@ export function createContextureMcpServer(): McpServer {
     },
   );
 
+  server.registerTool(
+    'apply_contexture_op',
+    {
+      title: 'Apply Contexture Op',
+      description:
+        'Mutate a .contexture.json file by applying one Contexture closed-world Op, then rewrite generated artifacts.',
+      inputSchema: ApplyContextureOpInput,
+      outputSchema: ApplyContextureOpOutput,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+      },
+    },
+    async ({ irPath, op }) => {
+      const structuredContent = await applyContextureOp(irPath, op);
+      return jsonToolResult(structuredContent);
+    },
+  );
+
+  server.registerTool(
+    'emit_contexture',
+    {
+      title: 'Emit Contexture Bundle',
+      description:
+        'Regenerate Contexture artifacts from a .contexture.json file without changing the schema.',
+      inputSchema: IrPathInput,
+      outputSchema: EmitContextureOutput,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async ({ irPath }) => {
+      const structuredContent = await emitContextureBundle(irPath);
+      return jsonToolResult(structuredContent);
+    },
+  );
+
+  server.registerTool(
+    'check_contexture_drift',
+    {
+      title: 'Check Contexture Generated Drift',
+      description:
+        'Compare generated Contexture artifacts on disk with the current .contexture.json file.',
+      inputSchema: IrPathInput,
+      outputSchema: CheckContextureDriftOutput,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async ({ irPath }) => {
+      const structuredContent = await checkContextureDrift(irPath);
+      return jsonToolResult(structuredContent);
+    },
+  );
+
   return server;
 }
 
@@ -131,6 +236,81 @@ async function validateContextureFile(
       errors: normalizeValidationError(err),
     };
   }
+}
+
+async function applyContextureOp(
+  irPath: string,
+  op: Record<string, unknown>,
+): Promise<z.infer<z.ZodObject<typeof ApplyContextureOpOutput>>> {
+  const opKind = typeof op.kind === 'string' ? op.kind : 'unknown';
+  if (typeof op.kind !== 'string') {
+    return {
+      path: irPath,
+      applied: false,
+      opKind,
+      error: 'op.kind must be a string',
+    };
+  }
+
+  const result = await createFileBackedForward(irPath)(op as Op);
+  if ('error' in result) {
+    return { path: irPath, applied: false, opKind, error: result.error };
+  }
+  return {
+    path: irPath,
+    applied: true,
+    opKind,
+    typeCount: result.schema.types.length,
+  };
+}
+
+async function emitContextureBundle(
+  irPath: string,
+): Promise<z.infer<z.ZodObject<typeof EmitContextureOutput>>> {
+  const { schema } = await readContextureFile(irPath);
+  const { emitted, manifest } = runEmitPipeline(schema, irPath);
+  const result = await createFileBackedForward(irPath)({
+    kind: 'replace_schema',
+    schema,
+  });
+  if ('error' in result) throw new Error(result.error);
+  return {
+    path: irPath,
+    emitted: emitted.map((file) => file.path),
+    manifest,
+  };
+}
+
+type GeneratedFileStatus = z.infer<typeof GeneratedFileStatusSchema>;
+
+async function checkContextureDrift(
+  irPath: string,
+): Promise<z.infer<z.ZodObject<typeof CheckContextureDriftOutput>>> {
+  const { schema } = await readContextureFile(irPath);
+  const { emitted } = runEmitPipeline(schema, irPath);
+  const files: Array<{ path: string; status: GeneratedFileStatus }> = [];
+
+  for (const entry of emitted) {
+    let onDisk: string | undefined;
+    try {
+      onDisk = await readFile(entry.path, 'utf8');
+    } catch {
+      onDisk = undefined;
+    }
+
+    if (onDisk === undefined) files.push({ path: entry.path, status: 'unreadable' });
+    else if (onDisk !== entry.content) files.push({ path: entry.path, status: 'drifted' });
+    else files.push({ path: entry.path, status: 'clean' });
+  }
+
+  const drift = files.filter((file) => file.status !== 'clean');
+  return {
+    path: irPath,
+    clean: drift.length === 0,
+    checked: files.length,
+    files,
+    drift,
+  };
 }
 
 function normalizeValidationError(err: unknown): Array<z.infer<typeof ValidationIssueSchema>> {

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -2,7 +2,16 @@ import { readFile } from 'node:fs/promises';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ZodError, z } from 'zod';
 import { createFileBackedForward } from './file-forward';
-import type { FieldType, Schema, TypeDef } from './ir';
+import {
+  FieldDefSchema,
+  type FieldType,
+  IndexDefSchema,
+  IRSchema,
+  IRSchemaObject,
+  type Schema,
+  type TypeDef,
+  TypeDefSchema,
+} from './ir';
 import { load } from './load';
 import type { Op } from './ops';
 import { runEmitPipeline } from './pipeline';
@@ -104,6 +113,97 @@ const CheckContextureDriftOutput = {
     }),
   ),
 };
+
+const ImportDeclSchema = (
+  IRSchemaObject.shape.imports as z.ZodOptional<z.ZodArray<z.ZodType>>
+).unwrap().element;
+
+const OpSchema: z.ZodType<Op> = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('add_type'), type: TypeDefSchema }),
+  z.object({
+    kind: z.literal('update_type'),
+    name: z.string().min(1),
+    patch: z.record(z.string(), z.unknown()),
+  }),
+  z.object({ kind: z.literal('rename_type'), from: z.string().min(1), to: z.string().min(1) }),
+  z.object({ kind: z.literal('delete_type'), name: z.string().min(1) }),
+  z.object({
+    kind: z.literal('add_field'),
+    typeName: z.string().min(1),
+    field: FieldDefSchema,
+    index: z.number().int().optional(),
+  }),
+  z.object({
+    kind: z.literal('update_field'),
+    typeName: z.string().min(1),
+    fieldName: z.string().min(1),
+    patch: FieldDefSchema.partial(),
+  }),
+  z.object({
+    kind: z.literal('remove_field'),
+    typeName: z.string().min(1),
+    fieldName: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal('add_value'),
+    typeName: z.string().min(1),
+    value: z.string().min(1),
+    description: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal('update_value'),
+    typeName: z.string().min(1),
+    value: z.string().min(1),
+    patch: z.object({
+      value: z.string().min(1).optional(),
+      description: z.string().optional(),
+    }),
+  }),
+  z.object({
+    kind: z.literal('remove_value'),
+    typeName: z.string().min(1),
+    value: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal('reorder_fields'),
+    typeName: z.string().min(1),
+    order: z.array(z.string().min(1)),
+  }),
+  z.object({
+    kind: z.literal('add_variant'),
+    typeName: z.string().min(1),
+    variant: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal('set_discriminator'),
+    typeName: z.string().min(1),
+    discriminator: z.string().min(1),
+  }),
+  z.object({ kind: z.literal('add_import'), import: ImportDeclSchema }),
+  z.object({ kind: z.literal('remove_import'), alias: z.string().min(1) }),
+  z.object({
+    kind: z.literal('set_table_flag'),
+    typeName: z.string().min(1),
+    table: z.boolean(),
+  }),
+  z.object({
+    kind: z.literal('add_index'),
+    typeName: z.string().min(1),
+    index: IndexDefSchema,
+  }),
+  z.object({
+    kind: z.literal('remove_index'),
+    typeName: z.string().min(1),
+    name: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal('update_index'),
+    typeName: z.string().min(1),
+    name: z.string().min(1),
+    patch: IndexDefSchema.partial(),
+  }),
+  z.object({ kind: z.literal('replace_schema'), schema: IRSchema }),
+]) as z.ZodType<Op>;
 
 export function createContextureMcpServer(): McpServer {
   const server = new McpServer({ name: 'contexture-core', version: VERSION });
@@ -243,16 +343,17 @@ async function applyContextureOp(
   op: Record<string, unknown>,
 ): Promise<z.infer<z.ZodObject<typeof ApplyContextureOpOutput>>> {
   const opKind = typeof op.kind === 'string' ? op.kind : 'unknown';
-  if (typeof op.kind !== 'string') {
+  const parsed = OpSchema.safeParse(op);
+  if (!parsed.success) {
     return {
       path: irPath,
       applied: false,
       opKind,
-      error: 'op.kind must be a string',
+      error: `invalid op: ${formatZodIssues(parsed.error)}`,
     };
   }
 
-  const result = await createFileBackedForward(irPath)(op as Op);
+  const result = await createFileBackedForward(irPath)(parsed.data);
   if ('error' in result) {
     return { path: irPath, applied: false, opKind, error: result.error };
   }
@@ -262,6 +363,15 @@ async function applyContextureOp(
     opKind,
     typeCount: result.schema.types.length,
   };
+}
+
+function formatZodIssues(error: ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.join('.') || '(root)';
+      return `${path}: ${issue.message}`;
+    })
+    .join('; ');
 }
 
 async function emitContextureBundle(


### PR DESCRIPTION
## Summary
- add MCP tools for `apply_contexture_op`, `emit_contexture`, and `check_contexture_drift`
- route MCP mutations through `createFileBackedForward` so agents use the same closed-world op reducer and generated bundle path as the CLI
- document the agent loop and mark Goal 5 complete in the roadmap

## Verification
- `bun run --filter=@contexture/core typecheck`
- `bun run --filter=@contexture/cli test -- tests/mcp.test.ts`
- `bun run typecheck && bun run test`