### PR TITLE
Add opt-in output config

### DIFF
--- a/docs/agent-contexture-workflow.md
+++ b/docs/agent-contexture-workflow.md
@@ -86,6 +86,24 @@ contexture emit [--json]
 Writes the full bundle (Zod schema, JSON Schema, schema-index barrel,
 Convex schema) to the locations resolved by `bundlePathsFor(irPath)`.
 
+### Output Config
+
+The IR may include an optional top-level `outputs` block. When omitted,
+Contexture emits the existing bundle exactly as before: Zod, JSON Schema,
+schema index, and Convex schema. Existing targets can be disabled explicitly:
+
+```json
+{
+  "outputs": {
+    "jsonSchema": { "enabled": false },
+    "convex": { "enabled": false }
+  }
+}
+```
+
+Future AI-pipeline targets live under `outputs.aiPipeline` and are opt-in.
+Goal 7 will attach the first emitter to this shape.
+
 ## Standard agent loop
 
 ```

--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -137,8 +137,20 @@ Completion evidence:
 
 ## Goal 6 — Opt-In Output Config
 
+**Status:** Done.
+
 Add the IR shape for target-specific emit configuration. Existing outputs
 should preserve current behavior; new AI-pipeline outputs should be opt-in.
+
+Completion evidence:
+
+- The IR accepts an optional top-level `outputs` config with current emit target
+  switches and future AI-pipeline target slots.
+- Omitted output config preserves the existing emitted bundle.
+- Current generated targets can be disabled explicitly and are removed from the
+  emitted manifest/drift surface.
+- AI-pipeline target slots round-trip through load/save but do not emit files
+  until Goal 7 adds the first opt-in emitter.
 
 ## Goal 7 — First AI-Pipeline Emitter
 

--- a/packages/core/src/ir.ts
+++ b/packages/core/src/ir.ts
@@ -173,6 +173,31 @@ const MetadataSchema = z.object({
   description: z.string().optional(),
 });
 
+const OutputTargetConfigSchema = z.object({
+  enabled: z.boolean().optional(),
+});
+
+export type OutputTargetConfig = z.infer<typeof OutputTargetConfigSchema>;
+
+const AiPipelineOutputsSchema = z.object({
+  toolSchemas: OutputTargetConfigSchema.optional(),
+  structuredOutputs: OutputTargetConfigSchema.optional(),
+  mcpDefinitions: OutputTargetConfigSchema.optional(),
+  formValidators: OutputTargetConfigSchema.optional(),
+});
+
+export type AiPipelineOutputs = z.infer<typeof AiPipelineOutputsSchema>;
+
+const OutputsConfigSchema = z.object({
+  zod: OutputTargetConfigSchema.optional(),
+  jsonSchema: OutputTargetConfigSchema.optional(),
+  schemaIndex: OutputTargetConfigSchema.optional(),
+  convex: OutputTargetConfigSchema.optional(),
+  aiPipeline: AiPipelineOutputsSchema.optional(),
+});
+
+export type OutputsConfig = z.infer<typeof OutputsConfigSchema>;
+
 // Raw object schema — exposes `.shape` for callers that need to pick
 // a specific field's schema (`src/main/ops/index.ts` narrows to
 // `types.element` and `imports.element`). The public `IRSchema` is cast
@@ -182,6 +207,7 @@ export const IRSchemaObject = z.object({
   types: z.array(TypeDefSchema),
   imports: z.array(ImportDeclSchema).optional(),
   metadata: MetadataSchema.optional(),
+  outputs: OutputsConfigSchema.optional(),
 });
 
 export type Schema = {
@@ -189,6 +215,7 @@ export type Schema = {
   types: TypeDef[];
   imports?: ImportDecl[];
   metadata?: { name?: string; description?: string };
+  outputs?: OutputsConfig;
 };
 
 export const IRSchema = IRSchemaObject as unknown as z.ZodType<Schema>;

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -46,6 +46,10 @@ function sha256(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
 }
 
+function outputEnabled(schema: Schema, target: 'zod' | 'jsonSchema' | 'schemaIndex' | 'convex') {
+  return schema.outputs?.[target]?.enabled !== false;
+}
+
 export function buildManifest(entries: ReadonlyArray<FileEntry>): EmittedManifest {
   const files: Record<string, string> = {};
   for (const { path, content } of entries) files[path] = sha256(content);
@@ -65,17 +69,27 @@ export function runEmitPipeline(
     emitSchemaIndex: emitSchemaIndexImpl = emitSchemaIndex,
     emitConvex: emitConvexImpl = emitConvexSchema,
   } = deps;
-  const schemaTs = emitZodImpl(schema, irPath);
-  const schemaJson = `${JSON.stringify(emitJsonSchemaImpl(schema, irPath), null, 2)}\n`;
-  const schemaIndex = emitSchemaIndexImpl(baseNameFor(irPath), irPath);
-  const convexSource = emitConvexImpl(schema, irPath);
 
-  const emitted: FileEntry[] = [
-    { path: paths.schemaTs, content: schemaTs },
-    { path: paths.schemaJson, content: schemaJson },
-    { path: paths.schemaIndex, content: schemaIndex },
-    { path: paths.convex, content: convexSource },
-  ];
+  const emitted: FileEntry[] = [];
+
+  if (outputEnabled(schema, 'zod')) {
+    emitted.push({ path: paths.schemaTs, content: emitZodImpl(schema, irPath) });
+  }
+  if (outputEnabled(schema, 'jsonSchema')) {
+    emitted.push({
+      path: paths.schemaJson,
+      content: `${JSON.stringify(emitJsonSchemaImpl(schema, irPath), null, 2)}\n`,
+    });
+  }
+  if (outputEnabled(schema, 'schemaIndex')) {
+    emitted.push({
+      path: paths.schemaIndex,
+      content: emitSchemaIndexImpl(baseNameFor(irPath), irPath),
+    });
+  }
+  if (outputEnabled(schema, 'convex')) {
+    emitted.push({ path: paths.convex, content: emitConvexImpl(schema, irPath) });
+  }
 
   return { emitted, manifest: buildManifest(emitted) };
 }

--- a/packages/core/tests/pipeline.test.ts
+++ b/packages/core/tests/pipeline.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { load, runEmitPipeline, type Schema, save } from '../src';
+
+const baseSchema: Schema = {
+  version: '1',
+  types: [{ kind: 'object', name: 'Post', fields: [] }],
+};
+
+describe('runEmitPipeline output config', () => {
+  it('keeps existing generated outputs enabled when outputs config is omitted', () => {
+    const { emitted } = runEmitPipeline(
+      baseSchema,
+      '/repo/packages/contexture/app.contexture.json',
+    );
+
+    expect(emitted.map((file) => file.path)).toEqual([
+      '/repo/packages/contexture/app.schema.ts',
+      '/repo/packages/contexture/app.schema.json',
+      '/repo/packages/contexture/index.ts',
+      '/repo/packages/contexture/convex/schema.ts',
+    ]);
+  });
+
+  it('can disable existing generated targets explicitly', () => {
+    const schema: Schema = {
+      ...baseSchema,
+      outputs: {
+        jsonSchema: { enabled: false },
+        convex: { enabled: false },
+      },
+    };
+
+    const { emitted, manifest } = runEmitPipeline(
+      schema,
+      '/repo/packages/contexture/app.contexture.json',
+    );
+
+    expect(emitted.map((file) => file.path)).toEqual([
+      '/repo/packages/contexture/app.schema.ts',
+      '/repo/packages/contexture/index.ts',
+    ]);
+    expect(Object.keys(manifest.files)).toEqual([
+      '/repo/packages/contexture/app.schema.ts',
+      '/repo/packages/contexture/index.ts',
+    ]);
+  });
+
+  it('round-trips opt-in future AI-pipeline output slots without emitting them yet', () => {
+    const schema: Schema = {
+      ...baseSchema,
+      outputs: {
+        aiPipeline: {
+          toolSchemas: { enabled: true },
+          structuredOutputs: { enabled: false },
+        },
+      },
+    };
+
+    const { schema: parsed } = load(save(schema));
+    expect(parsed.outputs).toEqual(schema.outputs);
+
+    const { emitted } = runEmitPipeline(parsed, '/repo/packages/contexture/app.contexture.json');
+    expect(emitted.map((file) => file.path)).toEqual([
+      '/repo/packages/contexture/app.schema.ts',
+      '/repo/packages/contexture/app.schema.json',
+      '/repo/packages/contexture/index.ts',
+      '/repo/packages/contexture/convex/schema.ts',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add optional top-level `outputs` config to the Contexture IR
- preserve existing Zod/JSON Schema/schema-index/Convex emissions when config is omitted
- allow current generated targets to be disabled and add inert opt-in slots for future AI-pipeline outputs
- document the contract and mark Goal 6 complete

## Verification
- `bun run --filter=@contexture/core test`
- `bun run --filter=@contexture/core typecheck`
- `bun run typecheck && bun run test`