### PR TITLE
Add opt-in AI tool schema emitter

### DIFF
--- a/docs/agent-contexture-workflow.md
+++ b/docs/agent-contexture-workflow.md
@@ -101,8 +101,19 @@ schema index, and Convex schema. Existing targets can be disabled explicitly:
 }
 ```
 
-Future AI-pipeline targets live under `outputs.aiPipeline` and are opt-in.
-Goal 7 will attach the first emitter to this shape.
+AI-pipeline targets live under `outputs.aiPipeline` and are opt-in. Enabling
+tool schemas emits `.contexture/ai-tool-schemas.json`, a provider-neutral list
+of per-type JSON Schema tool definitions:
+
+```json
+{
+  "outputs": {
+    "aiPipeline": {
+      "toolSchemas": { "enabled": true }
+    }
+  }
+}
+```
 
 ## Standard agent loop
 

--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -154,9 +154,20 @@ Completion evidence:
 
 ## Goal 7 — First AI-Pipeline Emitter
 
+**Status:** Done.
+
 Add one high-value opt-in generated target for AI engineers, such as
 tool-call schema helpers or structured-output helper definitions. The new
 target must participate in the emit manifest and drift detection.
+
+Completion evidence:
+
+- `outputs.aiPipeline.toolSchemas.enabled` emits
+  `.contexture/ai-tool-schemas.json`.
+- The generated document contains provider-neutral per-type tool definitions
+  backed by JSON Schema parameters.
+- The new file participates in the emitted manifest and existing drift checks.
+- The target remains omitted unless explicitly enabled.
 
 ## Goal 8 — Dogfood One Real Product
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./emit-ai-tool-schemas": "./src/emit-ai-tool-schemas.ts",
     "./emit-claude-md": "./src/emit-claude-md.ts",
     "./emit-convex": "./src/emit-convex.ts",
     "./emit-json-schema": "./src/emit-json-schema.ts",

--- a/packages/core/src/emit-ai-tool-schemas.ts
+++ b/packages/core/src/emit-ai-tool-schemas.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure IR -> AI tool schema helper definitions.
+ *
+ * This opt-in target emits one JSON Schema function/tool definition per
+ * Contexture type. It is intentionally provider-neutral: downstream apps can
+ * adapt the `parameters` object into OpenAI, Anthropic, MCP, or local agent
+ * tool registries without Contexture choosing a runtime.
+ */
+import { emit as emitJsonSchema } from './emit-json-schema';
+import type { Schema } from './ir';
+
+const GENERATED_BY = '@contexture-generated';
+
+export interface AiToolSchemaDefinition {
+  name: string;
+  description: string;
+  parameters: object;
+}
+
+export interface AiToolSchemasDocument {
+  $contexture_generated: string;
+  version: '1';
+  tools: AiToolSchemaDefinition[];
+}
+
+function generatedMarker(sourcePath?: string): string {
+  const base = `${GENERATED_BY} - do not edit by hand. Regenerated on every IR save.`;
+  return sourcePath ? `${base} Source: ${sourcePath}` : base;
+}
+
+function slugToolName(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[^a-zA-Z0-9_]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+}
+
+export function emitAiToolSchemas(schema: Schema, sourcePath?: string): AiToolSchemasDocument {
+  return {
+    $contexture_generated: generatedMarker(sourcePath),
+    version: '1',
+    tools: schema.types.map((type) => ({
+      name: `submit_${slugToolName(type.name)}`,
+      description: type.description
+        ? `Submit a ${type.name}: ${type.description}`
+        : `Submit a ${type.name} object.`,
+      parameters: emitJsonSchema(schema, type.name, sourcePath),
+    })),
+  };
+}

--- a/packages/core/src/emit-ai-tool-schemas.ts
+++ b/packages/core/src/emit-ai-tool-schemas.ts
@@ -37,15 +37,29 @@ function slugToolName(name: string): string {
 }
 
 export function emitAiToolSchemas(schema: Schema, sourcePath?: string): AiToolSchemasDocument {
-  return {
-    $contexture_generated: generatedMarker(sourcePath),
-    version: '1',
-    tools: schema.types.map((type) => ({
-      name: `submit_${slugToolName(type.name)}`,
+  const toolNames = new Map<string, string>();
+  const tools = schema.types.map((type) => {
+    const name = `submit_${slugToolName(type.name)}`;
+    const existing = toolNames.get(name);
+    if (existing) {
+      throw new Error(
+        `AI tool schema name collision: "${existing}" and "${type.name}" both emit "${name}".`,
+      );
+    }
+    toolNames.set(name, type.name);
+
+    return {
+      name,
       description: type.description
         ? `Submit a ${type.name}: ${type.description}`
         : `Submit a ${type.name} object.`,
       parameters: emitJsonSchema(schema, type.name, sourcePath),
-    })),
+    };
+  });
+
+  return {
+    $contexture_generated: generatedMarker(sourcePath),
+    version: '1',
+    tools,
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export { emitAiToolSchemas } from './emit-ai-tool-schemas';
 export { emit as emitClaudeMd } from './emit-claude-md';
 export { emitConvexSchema } from './emit-convex';
 export { emit as emitJsonSchema } from './emit-json-schema';

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -4,6 +4,7 @@ export const SCHEMA_JSON_SUFFIX = '.schema.json';
 export const LAYOUT_FILE = 'layout.json';
 export const CHAT_FILE = 'chat.json';
 export const EMITTED_FILE = 'emitted.json';
+export const AI_TOOL_SCHEMAS_FILE = 'ai-tool-schemas.json';
 
 export interface BundlePaths {
   ir: string;
@@ -14,6 +15,7 @@ export interface BundlePaths {
   schemaJson: string;
   schemaIndex: string;
   convex: string;
+  aiToolSchemas: string;
 }
 
 export function contextureDirFor(irPath: string): string {
@@ -53,5 +55,6 @@ export function bundlePathsFor(irPath: string): BundlePaths {
     schemaJson: `${base}${SCHEMA_JSON_SUFFIX}`,
     schemaIndex: `${dir}/index.ts`,
     convex: `${dir}/convex/schema.ts`,
+    aiToolSchemas: `${ctxDir}/${AI_TOOL_SCHEMAS_FILE}`,
   };
 }

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { emitAiToolSchemas } from './emit-ai-tool-schemas';
 import { emitConvexSchema } from './emit-convex';
 import { emit as emitJsonSchema } from './emit-json-schema';
 import { emit as emitSchemaIndex } from './emit-schema-index';
@@ -40,6 +41,7 @@ export interface EmitPipelineDeps {
   emitJsonSchema?: (schema: Schema, sourcePath?: string) => unknown;
   emitSchemaIndex?: (baseName: string, sourcePath?: string) => string;
   emitConvex?: (schema: Schema, sourcePath?: string) => string;
+  emitAiToolSchemas?: (schema: Schema, sourcePath?: string) => unknown;
 }
 
 function sha256(content: string): string {
@@ -48,6 +50,10 @@ function sha256(content: string): string {
 
 function outputEnabled(schema: Schema, target: 'zod' | 'jsonSchema' | 'schemaIndex' | 'convex') {
   return schema.outputs?.[target]?.enabled !== false;
+}
+
+function aiOutputEnabled(schema: Schema, target: 'toolSchemas') {
+  return schema.outputs?.aiPipeline?.[target]?.enabled === true;
 }
 
 export function buildManifest(entries: ReadonlyArray<FileEntry>): EmittedManifest {
@@ -68,6 +74,7 @@ export function runEmitPipeline(
       emitJsonSchema(s, undefined, sp),
     emitSchemaIndex: emitSchemaIndexImpl = emitSchemaIndex,
     emitConvex: emitConvexImpl = emitConvexSchema,
+    emitAiToolSchemas: emitAiToolSchemasImpl = emitAiToolSchemas,
   } = deps;
 
   const emitted: FileEntry[] = [];
@@ -89,6 +96,12 @@ export function runEmitPipeline(
   }
   if (outputEnabled(schema, 'convex')) {
     emitted.push({ path: paths.convex, content: emitConvexImpl(schema, irPath) });
+  }
+  if (aiOutputEnabled(schema, 'toolSchemas')) {
+    emitted.push({
+      path: paths.aiToolSchemas,
+      content: `${JSON.stringify(emitAiToolSchemasImpl(schema, irPath), null, 2)}\n`,
+    });
   }
 
   return { emitted, manifest: buildManifest(emitted) };

--- a/packages/core/tests/emit-ai-tool-schemas.test.ts
+++ b/packages/core/tests/emit-ai-tool-schemas.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { emitAiToolSchemas, type Schema } from '../src';
+
+const schema: Schema = {
+  version: '1',
+  metadata: { name: 'CRM' },
+  types: [
+    {
+      kind: 'object',
+      name: 'CustomerProfile',
+      description: 'A customer record for intake.',
+      fields: [
+        { name: 'email', type: { kind: 'string', format: 'email' } },
+        { name: 'company', optional: true, type: { kind: 'string' } },
+      ],
+    },
+    {
+      kind: 'enum',
+      name: 'LeadStatus',
+      values: [{ value: 'new' }, { value: 'qualified' }],
+    },
+  ],
+};
+
+describe('emitAiToolSchemas', () => {
+  it('emits provider-neutral tool definitions backed by per-type JSON Schema', () => {
+    const doc = emitAiToolSchemas(schema, '/repo/packages/contexture/crm.contexture.json');
+
+    expect(doc).toMatchObject({
+      version: '1',
+      $contexture_generated: expect.stringContaining('@contexture-generated'),
+      tools: [
+        {
+          name: 'submit_customer_profile',
+          description: 'Submit a CustomerProfile: A customer record for intake.',
+          parameters: {
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'object',
+            properties: {
+              email: { type: 'string', format: 'email' },
+              company: { type: 'string' },
+            },
+            required: ['email'],
+            additionalProperties: false,
+          },
+        },
+        {
+          name: 'submit_lead_status',
+          description: 'Submit a LeadStatus object.',
+          parameters: {
+            type: 'string',
+            enum: ['new', 'qualified'],
+          },
+        },
+      ],
+    });
+  });
+});

--- a/packages/core/tests/emit-ai-tool-schemas.test.ts
+++ b/packages/core/tests/emit-ai-tool-schemas.test.ts
@@ -55,4 +55,18 @@ describe('emitAiToolSchemas', () => {
       ],
     });
   });
+
+  it('rejects generated tool name collisions', () => {
+    const collidingSchema: Schema = {
+      ...schema,
+      types: [
+        { kind: 'object', name: 'CustomerProfile', fields: [] },
+        { kind: 'object', name: 'Customer_Profile', fields: [] },
+      ],
+    };
+
+    expect(() => emitAiToolSchemas(collidingSchema)).toThrow(
+      'AI tool schema name collision: "CustomerProfile" and "Customer_Profile" both emit "submit_customer_profile".',
+    );
+  });
 });

--- a/packages/core/tests/pipeline.test.ts
+++ b/packages/core/tests/pipeline.test.ts
@@ -45,12 +45,11 @@ describe('runEmitPipeline output config', () => {
     ]);
   });
 
-  it('round-trips opt-in future AI-pipeline output slots without emitting them yet', () => {
+  it('omits AI-pipeline outputs until they are explicitly enabled', () => {
     const schema: Schema = {
       ...baseSchema,
       outputs: {
         aiPipeline: {
-          toolSchemas: { enabled: true },
           structuredOutputs: { enabled: false },
         },
       },
@@ -66,5 +65,30 @@ describe('runEmitPipeline output config', () => {
       '/repo/packages/contexture/index.ts',
       '/repo/packages/contexture/convex/schema.ts',
     ]);
+  });
+
+  it('emits opt-in AI tool schemas and tracks them in the manifest', () => {
+    const schema: Schema = {
+      ...baseSchema,
+      outputs: {
+        aiPipeline: {
+          toolSchemas: { enabled: true },
+        },
+      },
+    };
+
+    const { emitted, manifest } = runEmitPipeline(
+      schema,
+      '/repo/packages/contexture/app.contexture.json',
+    );
+
+    expect(emitted.map((file) => file.path)).toContain(
+      '/repo/packages/contexture/.contexture/ai-tool-schemas.json',
+    );
+    const toolSchemas = emitted.find((file) => file.path.endsWith('ai-tool-schemas.json'));
+    expect(toolSchemas?.content).toContain('submit_post');
+    expect(manifest.files).toHaveProperty(
+      '/repo/packages/contexture/.contexture/ai-tool-schemas.json',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add an opt-in aiPipeline.toolSchemas emit target for provider-neutral per-type tool schemas
- include the generated ai-tool-schemas.json file in the pipeline manifest for drift detection
- document the opt-in config and mark Goal 7 complete in the roadmap

## Tests
- bun run --filter=@contexture/core test -- tests/emit-ai-tool-schemas.test.ts tests/pipeline.test.ts
- bun run typecheck && bun run test
- commit hook: turbo typecheck && turbo test