### PR TITLE
Dogfood Recordshop schema change and harden drift checks

### DIFF
--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -171,9 +171,26 @@ Completion evidence:
 
 ## Goal 8 — Dogfood One Real Product
 
+**Status:** Done.
+
 Use Contexture CLI/MCP to make one real schema change in an Applification
 product. The change should start from the IR, regenerate artifacts, pass
 drift checks, and feed sharp edges back into Contexture.
+
+Completion evidence:
+
+- Dogfooded against Recordshop's `packages/contexture/recordshop.contexture.json`.
+- Used the Contexture CLI to add `Release.discogsReleaseId` and a
+  `by_discogs_release_id` Convex index from the IR.
+- Regenerated Recordshop's Zod, JSON Schema, index, Convex schema, and emitted
+  manifest artifacts.
+- Recordshop passes `validate` and the strengthened `check-generated` drift
+  check.
+- Fed back one Contexture sharp edge: CLI/MCP drift checks now include
+  `.contexture/emitted.json`, so stale manifests cannot silently narrow the
+  desktop watcher surface.
+- Product typecheck was attempted, but Recordshop's top-level
+  `packageManager: "bun"` currently blocks Turbo before TypeScript runs.
 
 ## Goal 9 — Marketing Rewrite
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { readdir, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import {
+  bundlePathsFor,
   createFileBackedForward,
   createOpTools,
   type FieldDef,
@@ -543,9 +544,14 @@ async function run(argv: string[]): Promise<void> {
 
   if (command === 'check-generated') {
     const schema = await readSchema(irPath);
-    const { emitted } = runEmitPipeline(schema, irPath);
+    const { emitted, manifest } = runEmitPipeline(schema, irPath);
+    const paths = bundlePathsFor(irPath);
+    const expectedFiles = [
+      ...emitted,
+      { path: paths.emitted, content: `${JSON.stringify(manifest, null, 2)}\n` },
+    ];
     const files: GeneratedFileCheck[] = [];
-    for (const entry of emitted) {
+    for (const entry of expectedFiles) {
       let onDisk: string | undefined;
       try {
         onDisk = await Bun.file(entry.path).text();

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -218,6 +218,33 @@ describe('@contexture/cli', () => {
     ).toBe(true);
   });
 
+  it('check-generated detects stale emitted manifest files', async () => {
+    const { dir } = await fixtureProject();
+    await runCli(dir, ['emit', '--json']);
+    const emittedPath = join(dir, 'packages/contexture/.contexture/emitted.json');
+    await writeFile(emittedPath, `${JSON.stringify({ version: '1', files: {} }, null, 2)}\n`);
+
+    const result = await runCli(dir, ['check-generated', '--json']);
+    expect(result.exitCode).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: expect.stringContaining('packages/contexture/.contexture/emitted.json'),
+          status: 'drifted',
+        }),
+      ]),
+    );
+    expect(parsed.stale).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: expect.stringContaining('packages/contexture/.contexture/emitted.json'),
+          reason: 'mismatch',
+        }),
+      ]),
+    );
+  });
+
   it('apply --op-json applies a serialized op', async () => {
     const { dir, irPath } = await fixtureProject();
     const op = JSON.stringify({

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -246,7 +246,7 @@ describe('Contexture MCP server', () => {
       expect(cleanResult.structuredContent).toMatchObject({
         path: irPath,
         clean: true,
-        checked: 4,
+        checked: 5,
         drift: [],
       });
 

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -14,6 +14,7 @@ import {
 } from './ir';
 import { load } from './load';
 import type { Op } from './ops';
+import { bundlePathsFor } from './paths';
 import { runEmitPipeline } from './pipeline';
 import { checkSemantic } from './semantic-validation';
 
@@ -397,10 +398,15 @@ async function checkContextureDrift(
   irPath: string,
 ): Promise<z.infer<z.ZodObject<typeof CheckContextureDriftOutput>>> {
   const { schema } = await readContextureFile(irPath);
-  const { emitted } = runEmitPipeline(schema, irPath);
+  const { emitted, manifest } = runEmitPipeline(schema, irPath);
+  const paths = bundlePathsFor(irPath);
+  const expectedFiles = [
+    ...emitted,
+    { path: paths.emitted, content: `${JSON.stringify(manifest, null, 2)}\n` },
+  ];
   const files: Array<{ path: string; status: GeneratedFileStatus }> = [];
 
-  for (const entry of emitted) {
+  for (const entry of expectedFiles) {
     let onDisk: string | undefined;
     try {
       onDisk = await readFile(entry.path, 'utf8');


### PR DESCRIPTION
## Summary
- mark Goal 8 complete with Recordshop dogfood evidence
- make CLI and MCP drift checks include .contexture/emitted.json
- add regression coverage for stale emitted manifests so the desktop watcher surface cannot silently narrow

## Dogfood
- Recordshop branch: codex/goal-8-contexture-dogfood
- Recordshop commit: ce51eea Add Discogs release lookup to Contexture model
- Changed Release with optional discogsReleaseId and by_discogs_release_id index via Contexture CLI

## Tests
- bun run --filter=@contexture/cli test -- tests/cli.test.ts tests/mcp.test.ts
- bun run --filter=@contexture/core typecheck && bun run --filter=@contexture/cli typecheck
- bun run typecheck && bun run test
- Recordshop: contexture validate --json
- Recordshop: contexture check-generated --json (checked 5 files)
- Recordshop: bunx tsc --noEmit -p apps/web/tsconfig.json

## Notes
- Recordshop top-level bun run typecheck is currently blocked by packageManager: "bun" before Turbo starts TypeScript.
- Recordshop has no Git remote configured in this checkout, so the product commit is local only.