### PR TITLE
Rewrite marketing around domain-model control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Contexture
 
-Visual Zod schema editor with LLM support. Chat to Claude about a domain;
-Claude edits a closed-world schema via a small op vocabulary; the graph
-animates per op. Generate `.schema.ts` (Zod) and `.schema.json` alongside
-the source-of-truth `.contexture.json` for downstream products to import.
+Contexture is the domain-model control plane for AI-native TypeScript apps.
+Design your domain once in source-of-truth `.contexture.json`, then emit the
+typed surfaces your products and agents need: Zod, JSON Schema, Convex schemas,
+schema indexes, MCP tools, and opt-in AI tool definitions.
 
-Built for engineers shipping LLM structured-output pipelines.
+Built for engineers who want humans and agents to change the model, regenerate
+artifacts, and prove drift is gone before the code ships.
 
 ## Repository Structure
 

--- a/apps/web/.env.schema
+++ b/apps/web/.env.schema
@@ -4,7 +4,7 @@
 # @plugin(@varlock/infisical-plugin)
 # @initInfisical(projectId=1b05b542-9803-44ab-89fe-eee9e57cf4eb, environment=$INFISICAL_ENV, siteUrl=https://eu.infisical.com, clientId=$INFISICAL_CLIENT_ID, clientSecret=$INFISICAL_CLIENT_SECRET)
 # ---
-# @type=enum(dev, staging, prod)
+# @type=enum(dev, staging, prod) @sensitive=false
 INFISICAL_ENV=dev
 # @type=infisicalClientId
 INFISICAL_CLIENT_ID=

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -23,9 +23,10 @@ cd apps/web
 bun run dev
 ```
 
-`dev` runs Next.js through [Portless](https://portless.sh) so each git
-worktree gets its own stable URL with no port conflicts. Portless is a
-`devDependency`, so a normal `bun install` covers it.
+`dev` runs Next.js through [Portless](https://portless.sh) on unprivileged
+port `1355`, so each git worktree gets its own stable URL with no port
+conflicts and no `sudo` prompt. Portless is a `devDependency`, so a normal
+`bun install` covers it.
 
 Main worktree resolves to `http://web.localhost:1355` (name inferred from
 `package.json`). Linked git worktrees auto-prepend the branch as a subdomain,
@@ -47,10 +48,18 @@ PORTLESS=0 bun run dev
 The Playwright e2e config bypasses the package script and runs `bunx next dev`
 directly so test runners can manage the process on `http://localhost:3000`.
 
-Optional: enable HTTP/2 + TLS once for faster page loads and no browser warnings:
+Optional: enable HTTP/2 + TLS on port `443` once for faster page loads and no
+browser warnings. This requires elevated privileges because `443` is a
+privileged port:
 
 ```bash
 bunx portless proxy start --https
+```
+
+For TLS without `sudo`, keep the unprivileged proxy port:
+
+```bash
+bunx portless proxy start --port 1355 --https
 ```
 
 ## Deployment

--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 test.describe('Home page', () => {
   test('loads and displays hero section', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('h1')).toContainText('Design the schemas that power');
+    await expect(page.locator('h1')).toContainText('Design your domain once. Ship it everywhere.');
     await expect(page.locator('nav')).toBeVisible();
   });
 
@@ -17,7 +17,9 @@ test.describe('Home page', () => {
     await page.goto('/');
     const features = page.locator('#features');
     await expect(features).toBeVisible();
-    await expect(features.locator('h2')).toContainText('schema editor built for LLM pipelines');
+    await expect(features.locator('h2')).toContainText(
+      'control plane for AI-native TypeScript apps',
+    );
   });
 
   test('download section has CTA link', async ({ page }) => {
@@ -33,14 +35,14 @@ test.describe('Home page', () => {
     await expect(cards).toHaveCount(6);
   });
 
-  test('AI section promotes model independence', async ({ page }) => {
+  test('AI section promotes agent-safe model changes', async ({ page }) => {
     await page.goto('/');
     const aiSection = page.locator('section', {
-      has: page.locator('h2:has-text("Describe your domain")'),
+      has: page.locator('h2:has-text("Let agents change the model")'),
     });
     await expect(aiSection).toBeVisible();
     await expect(aiSection.locator('text=Powered by Claude')).toHaveCount(0);
-    await expect(aiSection.locator('text=Multi-model AI')).toBeVisible();
+    await expect(aiSection.locator('text=Agent-safe by design')).toBeVisible();
   });
 
   test('footer contains expected links', async ({ page }) => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "portless run next dev",
+    "dev": "PORTLESS_PORT=1355 PORTLESS_HTTPS=0 portless run next dev",
     "build": "NODE_ENV=production next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",

--- a/apps/web/src/app/brand/page.tsx
+++ b/apps/web/src/app/brand/page.tsx
@@ -316,7 +316,7 @@ export default function BrandPage() {
               font="font-sans"
               name="Geist Sans"
               weights="100 — 900 (variable)"
-              example="Design the schemas that power your LLM pipelines."
+              example="Design your domain once. Ship it everywhere."
             />
             <TypeSpecimen
               font="font-mono"
@@ -408,28 +408,30 @@ export default function BrandPage() {
               Key phrases
             </h3>
             <div className="grid sm:grid-cols-3 gap-x-8 gap-y-2 text-sm">
-              <p className="text-foreground">&ldquo;Where schemas take shape.&rdquo;</p>
               <p className="text-foreground">
-                &ldquo;Design the schemas that power your LLM pipelines.&rdquo;
+                &ldquo;Design your domain once. Ship it everywhere.&rdquo;
               </p>
               <p className="text-foreground">
-                &ldquo;From natural language to typed Zod in minutes.&rdquo;
-              </p>
-              <p className="text-foreground">&ldquo;See your schema as a living graph.&rdquo;</p>
-              <p className="text-foreground">
-                &ldquo;The schema editor built for LLM pipelines.&rdquo;
+                &ldquo;The domain-model control plane for AI-native TypeScript apps.&rdquo;
               </p>
               <p className="text-foreground">
-                &ldquo;Zod + JSON Schema emitted side-by-side — no runtime lock-in.&rdquo;
+                &ldquo;One source-of-truth IR for apps, databases, and agents.&rdquo;
+              </p>
+              <p className="text-foreground">&ldquo;Change the model, not the contract.&rdquo;</p>
+              <p className="text-foreground">
+                &ldquo;Emit Zod, JSON Schema, Convex, MCP, and AI tool schemas.&rdquo;
               </p>
               <p className="text-foreground">
-                &ldquo;Closed-world schemas for structured output you can trust.&rdquo;
+                &ldquo;Manifest-backed drift checks for every generated surface.&rdquo;
               </p>
               <p className="text-foreground">
-                &ldquo;Eval your schema with realistic data before you ship the prompt.&rdquo;
+                &ldquo;Closed-world ops agents can use safely.&rdquo;
               </p>
               <p className="text-foreground">
-                &ldquo;One schema, many products — import the generated Zod directly.&rdquo;
+                &ldquo;Inspect, mutate, emit, and validate through CLI or MCP.&rdquo;
+              </p>
+              <p className="text-foreground">
+                &ldquo;One model, many products — import the generated contracts directly.&rdquo;
               </p>
             </div>
           </div>
@@ -515,7 +517,7 @@ export default function BrandPage() {
           </h3>
           <div className="flex flex-wrap gap-3 mb-10">
             <span className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1 rounded-full border border-accent/20 bg-accent/5 text-accent">
-              Multi-model AI
+              Agent-safe by design
             </span>
             <span className="inline-flex items-center text-xs font-medium px-3 py-1 rounded-full border border-border/60 text-muted-foreground">
               v0.1.0

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -93,19 +93,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Gradient orb animations */
-@keyframes float-slow {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  33% { transform: translate(30px, -20px) scale(1.05); }
-  66% { transform: translate(-20px, 15px) scale(0.95); }
-}
-
-@keyframes float-slower {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  33% { transform: translate(-25px, 25px) scale(1.08); }
-  66% { transform: translate(20px, -30px) scale(0.92); }
-}
-
 @keyframes fade-in-up {
   from {
     opacity: 0;
@@ -115,14 +102,6 @@ body {
     opacity: 1;
     transform: translateY(0);
   }
-}
-
-.animate-float-slow {
-  animation: float-slow 20s ease-in-out infinite;
-}
-
-.animate-float-slower {
-  animation: float-slower 25s ease-in-out infinite;
 }
 
 .animate-fade-in-up {
@@ -165,8 +144,6 @@ body {
 
 /* Respect reduced motion preferences */
 @media (prefers-reduced-motion: reduce) {
-  .animate-float-slow,
-  .animate-float-slower,
   .animate-fade-in-up,
   .animate-fade-in-up-delay-1,
   .animate-fade-in-up-delay-2,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,18 +6,19 @@ import { PostHogProvider } from '@/components/providers/posthog-provider';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: 'Contexture — Visual Zod schema editor',
+  title: 'Contexture — Design your domain once. Ship it everywhere.',
   description:
-    'Visual Zod schema editor with multi-model AI support. Chat with any LLM to build closed-world schemas; emit Zod + JSON Schema for your structured-output pipelines.',
+    'Contexture is the domain-model control plane for AI-native TypeScript apps. Design one source-of-truth IR, then emit Zod, JSON Schema, Convex, MCP, and AI tool schemas.',
   keywords: [
-    'Zod schema editor',
-    'visual schema builder',
+    'domain model control plane',
+    'TypeScript domain model',
+    'Contexture',
+    'Zod schema generator',
+    'Convex schema generator',
+    'MCP server',
     'LLM structured output',
     'JSON Schema editor',
-    'TypeScript schema tool',
-    'multi-model AI',
-    'schema design',
-    'AI agents',
+    'AI tool schemas',
   ],
   icons: {
     icon: [
@@ -27,9 +28,9 @@ export const metadata: Metadata = {
     apple: '/apple-touch-icon.png',
   },
   openGraph: {
-    title: 'Contexture — Visual Zod schema editor',
+    title: 'Contexture — Design your domain once. Ship it everywhere.',
     description:
-      'Chat with any LLM to build closed-world Zod schemas. Emit Zod + JSON Schema for your structured-output pipelines.',
+      'Design one source-of-truth domain model and emit the typed surfaces your apps, agents, and databases need.',
     type: 'website',
     siteName: 'Contexture',
     images: [
@@ -43,9 +44,8 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Contexture — Visual Zod schema editor',
-    description:
-      'Chat to build closed-world Zod schemas; emit Zod + JSON Schema for LLM structured-output pipelines.',
+    title: 'Contexture — Design your domain once. Ship it everywhere.',
+    description: 'The domain-model control plane for AI-native TypeScript apps.',
     images: ['/images/hero-graph.png'],
   },
 };

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,14 @@
-import { ArrowRight, Brain, Download, GitGraph, Layers, Network, Shield, Zap } from 'lucide-react';
+import {
+  ArrowRight,
+  Bot,
+  Brain,
+  Database,
+  Download,
+  GitGraph,
+  Network,
+  Shield,
+  Zap,
+} from 'lucide-react';
 import { DownloadButton } from '@/components/download-button';
 import { TrackedLink } from '@/components/tracked-link';
 import { AnimatedGraph } from '@/components/ui/animated-graph';
@@ -54,39 +64,39 @@ function GithubIcon({ className }: { className?: string }) {
 const features = [
   {
     icon: GitGraph,
-    title: 'Visual schema editor',
+    title: 'Source-of-truth IR',
     description:
-      'See every type as a node, every field as a sub-row, every ref as an edge. Drag, select, and refine your schema on an interactive canvas.',
+      'Keep `*.contexture.json` as the canonical domain model. The graph is an editor for the truth, not another drawing to keep in sync.',
   },
   {
     icon: Brain,
-    title: 'Chat-driven authoring',
+    title: 'Closed-world agent ops',
     description:
-      'Describe a domain and your LLM edits the schema via a small op vocabulary. Every turn animates on the graph so you can follow what changed.',
+      'Codex and Claude change schemas through explicit Contexture operations, so every AI edit is reviewable, undoable, and constrained.',
   },
   {
     icon: Network,
-    title: 'Zod + JSON Schema outputs',
+    title: 'App-ready emit targets',
     description:
-      '`.contexture.json` is the source of truth; `.schema.ts` and `.schema.json` are emitted alongside and git-checked for downstream products to import.',
+      'Emit Zod, JSON Schema, schema indexes, and Convex schemas from the same model, then commit the generated surface your app imports.',
   },
   {
-    icon: Zap,
-    title: 'Eval panel',
+    icon: Bot,
+    title: 'Agent-ready surfaces',
     description:
-      'Generate sample data — realistic, minimal, edge-case, or adversarial — against any root type. Zod-validate the output and save fixtures.',
+      'Opt into provider-neutral AI tool schemas and expose the same model over MCP so coding agents can inspect, mutate, emit, and check drift.',
   },
   {
     icon: Shield,
-    title: 'Curated stdlib',
+    title: 'Drift you can trust',
     description:
-      'Email, URL, UUID, Address, Money, PhoneE164 — 19 types across 5 namespaces, published as `@contexture/runtime` for your generated code to import.',
+      'Generated files carry a manifest. Contexture tells you when Zod, JSON Schema, Convex, or agent outputs no longer match the IR.',
   },
   {
-    icon: Layers,
-    title: 'Open source & free',
+    icon: Database,
+    title: 'Dogfooded on real apps',
     description:
-      'MIT licensed and free forever. Built in the open by engineers who believe schema tooling should be accessible to everyone.',
+      'The workflow is already being used on Applification products: start from the IR, regenerate artifacts, and let drift checks prove it.',
   },
 ];
 
@@ -137,27 +147,20 @@ export default function Home() {
           <AnimatedGraph />
         </div>
 
-        {/* Gradient orbs */}
-        <div className="hidden sm:block absolute top-20 left-1/4 w-[500px] h-[500px] rounded-full bg-primary/[0.07] blur-[100px] animate-float-slow pointer-events-none" />
-        <div className="hidden sm:block absolute top-40 right-1/4 w-[400px] h-[400px] rounded-full bg-accent/[0.05] blur-[100px] animate-float-slower pointer-events-none" />
-
         <div className="relative max-w-3xl mx-auto text-center pt-28 sm:pt-44 pb-12 sm:pb-16">
           <p className="animate-fade-in-up text-sm text-accent font-medium mb-6 tracking-widest uppercase">
-            Visual Zod schema editor with LLM support
+            Domain-model control plane
           </p>
           <h1 className="animate-fade-in-up-delay-1 text-3xl sm:text-5xl font-bold tracking-tight leading-[1.15] mb-6">
-            Design the schemas that power{' '}
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary to-accent">
-              your LLM pipelines.
-            </span>
+            Design your domain once. Ship it everywhere.
           </h1>
           <p className="animate-fade-in-up-delay-2 text-lg text-accent font-medium mb-3">
-            Where schemas take shape.
+            One model for your app, database, and agents.
           </p>
           <p className="animate-fade-in-up-delay-2 text-base text-muted-foreground max-w-xl mx-auto mb-12 leading-relaxed">
-            Contexture pairs a visual graph editor with your choice of LLM — chat to describe a
-            domain, watch the graph assemble, and emit Zod + JSON Schema your products can import
-            directly.
+            Contexture turns a source-of-truth IR into Zod, JSON Schema, Convex schemas, MCP tools,
+            and AI tool definitions. Humans and agents edit the same domain model; drift checks keep
+            the emitted code honest.
           </p>
           <div className="animate-fade-in-up-delay-3 flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4">
             <TrackedLink
@@ -208,16 +211,15 @@ export default function Home() {
         id="features"
         className="relative py-16 sm:py-32 px-4 sm:px-8 border-t border-border/30"
       >
-        <div className="hidden sm:block absolute top-1/2 left-0 w-[300px] h-[300px] rounded-full bg-primary/[0.04] blur-[80px] animate-float-slower pointer-events-none" />
-
         <div className="relative max-w-5xl mx-auto">
           <div className="text-center mb-12 sm:mb-20">
             <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-4">
-              The schema editor built for LLM pipelines
+              The control plane for AI-native TypeScript apps
             </h2>
             <p className="text-muted-foreground text-base max-w-2xl mx-auto">
-              Design the closed-world schemas your structured-output prompts depend on. Built for
-              engineers shipping products with any LLM — Claude, GPT, Gemini, and more.
+              Model the domain once, then emit the contracts every runtime needs. Contexture keeps
+              visual editing, agent mutation, generated code, and drift detection tied to one
+              explicit source of truth.
             </p>
           </div>
 
@@ -254,25 +256,19 @@ export default function Home() {
 
       {/* AI Section — two-column layout with panel screenshot */}
       <section className="relative py-16 sm:py-32 px-4 sm:px-8 border-t border-border/30">
-        <div className="hidden sm:block absolute top-1/3 right-0 w-[400px] h-[400px] rounded-full bg-accent/[0.04] blur-[100px] animate-float-slow pointer-events-none" />
-        <div className="hidden sm:block absolute bottom-1/4 left-1/4 w-[350px] h-[350px] rounded-full bg-primary/[0.05] blur-[80px] animate-float-slower pointer-events-none" />
-
         <div className="relative max-w-5xl mx-auto">
           <div className="text-center mb-10 sm:mb-16">
             <div className="inline-flex items-center gap-2 text-sm text-accent font-medium mb-6 px-4 py-1.5 rounded-full border border-accent/20 bg-accent/5">
               <Brain className="size-4" />
-              Multi-model AI
+              Agent-safe by design
             </div>
             <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-5">
-              Describe your domain.{' '}
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary to-accent">
-                Watch your schema emerge.
-              </span>
+              Let agents change the model, not the contract.
             </h2>
             <p className="text-muted-foreground max-w-2xl mx-auto leading-relaxed">
-              Build schemas through conversation, not configuration. Your LLM edits via a small op
-              vocabulary — add_type, add_field, set_discriminator, rename — so every turn is an
-              atomic change you can undo or refine.
+              Contexture exposes a narrow mutation vocabulary through chat, CLI, and MCP. Codex or
+              Claude can inspect a schema, apply one closed-world op, regenerate artifacts, and
+              prove the repo is still clean.
             </p>
           </div>
 
@@ -289,11 +285,13 @@ export default function Home() {
               />
             </div>
             <div className="sm:col-span-3 space-y-6">
-              <h3 className="text-2xl font-bold tracking-tight">Eval your schema with real data</h3>
+              <h3 className="text-2xl font-bold tracking-tight">
+                Emit contracts your pipeline can actually use
+              </h3>
               <p className="text-muted-foreground leading-relaxed">
-                Pick a root type, pick a generation mode, and get a JSON sample that — by
-                construction — parses against your schema. Test realism, edge cases, or adversarial
-                input before you ship the prompt.
+                The same IR can serve product code, database definitions, structured output, and
+                agent tools. Opt-in AI pipeline targets generate provider-neutral tool schemas
+                without forcing a runtime choice.
               </p>
               <div className="space-y-3">
                 <div className="flex items-center gap-3 text-sm">
@@ -301,7 +299,7 @@ export default function Home() {
                     <Zap className="size-4 text-accent" />
                   </div>
                   <span className="text-muted-foreground">
-                    Four modes: realistic, minimal, edge-case, adversarial
+                    Zod, JSON Schema, schema indexes, and Convex schema from one IR
                   </span>
                 </div>
                 <div className="flex items-center gap-3 text-sm">
@@ -309,7 +307,7 @@ export default function Home() {
                     <Shield className="size-4 text-accent" />
                   </div>
                   <span className="text-muted-foreground">
-                    Post-generation Zod validation with field-level errors
+                    Manifest-backed drift checks for every emitted target
                   </span>
                 </div>
                 <div className="flex items-center gap-3 text-sm">
@@ -317,7 +315,7 @@ export default function Home() {
                     <Brain className="size-4 text-accent" />
                   </div>
                   <span className="text-muted-foreground">
-                    Save fixtures alongside the schema for test reuse
+                    MCP access for agents that need to inspect, mutate, emit, and validate
                   </span>
                 </div>
               </div>
@@ -330,13 +328,12 @@ export default function Home() {
               You:
             </div>
             <div className="text-foreground mb-6">
-              Add a Harvest type for my allotment schema with a date, quantity (kg), and a ref to
-              the Crop it came from.
+              Add a Discogs release ID to my Release model and make it queryable.
             </div>
             <div className="text-accent/80 text-xs uppercase tracking-wide mb-2">AI:</div>
             <div className="text-muted-foreground">
-              add_type Harvest (object) · add_field Harvest.date (date) · add_field
-              Harvest.quantityKg (number, min=0) · add_field Harvest.crop (ref → Crop)
+              add_field Release.discogsReleaseId (string, optional) · add_index Release
+              by_discogs_release_id · emit · check_generated clean
             </div>
           </div>
         </div>
@@ -344,16 +341,14 @@ export default function Home() {
 
       {/* Use Cases */}
       <section className="relative py-16 sm:py-32 px-4 sm:px-8 border-t border-border/30">
-        <div className="hidden sm:block absolute top-1/2 right-1/4 w-[350px] h-[350px] rounded-full bg-accent/[0.04] blur-[80px] animate-float-slow pointer-events-none" />
-
         <div className="relative max-w-5xl mx-auto">
           <div className="text-center mb-10 sm:mb-16">
             <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-4">
-              Structured output is only as good as the schema behind it
+              Ship every surface from the same domain model
             </h2>
             <p className="text-muted-foreground max-w-2xl mx-auto">
-              Contexture lets you design, visualise, and evaluate the closed-world schemas your LLM
-              pipelines parse against.
+              Contexture is deliberately narrow: it owns the model boundary, then gets out of the
+              way. Your app, agent, and database code consume generated artifacts.
             </p>
           </div>
 
@@ -363,27 +358,26 @@ export default function Home() {
                 Structured output
               </div>
               <p className="text-sm text-muted-foreground leading-relaxed">
-                Emit Zod at build time; your prompt runner hands the same schema to any LLM —
-                Claude, GPT, Gemini — for typed, validated responses. Parse failures become
-                compile-time errors.
+                Generate JSON Schema and AI tool definitions from the same type graph your app
+                imports. The prompt surface and TypeScript surface stop drifting apart.
               </p>
             </div>
             <div className="rounded-xl border border-border/60 bg-card/50 p-6 sm:p-8 hover:border-accent/30 transition-colors">
               <div className="text-accent text-sm font-medium uppercase tracking-wider mb-4">
-                Data ingestion
+                App schemas
               </div>
               <p className="text-sm text-muted-foreground leading-relaxed">
-                Shape what your LLM extracts from PDFs, emails, or transcripts. The IR ships in the
-                prompt so every tool call targets a known, named type.
+                Emit Zod and Convex schema files for the product repo. Generated markers and the
+                manifest make review and drift detection part of normal git flow.
               </p>
             </div>
             <div className="rounded-xl border border-border/60 bg-card/50 p-6 sm:p-8 hover:border-accent/30 transition-colors">
               <div className="text-accent text-sm font-medium uppercase tracking-wider mb-4">
-                Shared models
+                Agent workflows
               </div>
               <p className="text-sm text-muted-foreground leading-relaxed">
-                Reference types across projects with relative imports or pull from the curated
-                `@contexture/runtime` stdlib. One schema, many products.
+                Let Codex or Claude work through CLI and MCP instead of hand-editing generated
+                files. Agents update the IR, regenerate artifacts, and report whether drift remains.
               </p>
             </div>
           </div>
@@ -395,17 +389,16 @@ export default function Home() {
         id="download"
         className="relative py-16 sm:py-32 px-4 sm:px-8 border-t border-border/30"
       >
-        <div className="hidden sm:block absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] rounded-full bg-primary/[0.06] blur-[120px] pointer-events-none" />
-
         <div className="relative max-w-3xl mx-auto text-center">
           <p className="text-sm text-accent font-medium mb-4 tracking-widest uppercase">
             Open source & free
           </p>
           <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-4">
-            Start designing your schemas
+            Start with your source-of-truth model
           </h2>
           <p className="text-muted-foreground mb-10">
-            Free and open source. Available for macOS, Windows, and Linux.
+            Free and open source. Build visually, collaborate with agents, and ship generated
+            contracts from the desktop app for macOS, Windows, and Linux.
           </p>
           <DownloadButton
             location="footer_cta"

--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -194,6 +194,20 @@ Completion evidence:
 
 ## Goal 9 — Marketing Rewrite
 
+**Status:** Done.
+
 Rewrite public positioning only after the trust layer, agent loop, and at
 least one AI-pipeline output are credible. The site should sell: "Design
 your domain once. Ship it everywhere."
+
+Completion evidence:
+
+- Rewrote the homepage hero around "Design your domain once. Ship it
+  everywhere."
+- Shifted public positioning from "visual Zod schema editor" to
+  "domain-model control plane for AI-native TypeScript apps."
+- Updated homepage sections to cover source-of-truth IR, closed-world agent
+  ops, app-ready emit targets, MCP, AI tool schemas, manifest-backed drift
+  checks, and Recordshop dogfooding.
+- Updated site metadata, brand phrase guidance, README copy, and homepage smoke
+  tests to match the new positioning.


### PR DESCRIPTION
## Summary
- Reposition the public site and README around “Design your domain once. Ship it everywhere.”
- Update homepage, metadata, brand phrases, and smoke tests for the domain-model control-plane story
- Mark Goal 9 complete in the roadmap and make INFISICAL_ENV non-sensitive so production build output is not falsely treated as leaked config

## Tests
- bun run --filter=@contexture/web typecheck
- bun run --filter=@contexture/web test
- bun run --filter=@contexture/web build
- bun run --filter=@contexture/web test:e2e
- bun run typecheck && bun run test
- git diff --check