### PR TITLE
Ignore Codex Desktop local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ playwright-report/
 # Paperclip agent worktrees and local state
 .paperclip/
 
+# Codex Desktop local state
+.codex/
+
 # Claude Code scheduled-task runtime artefacts
 .claude/scheduled_tasks.lock
 


### PR DESCRIPTION
## Summary
- Add `.codex/` to `.gitignore` as Codex Desktop-generated local state
- Remove the local untracked `.codex/` folder from the working tree

## Tests
- git diff --check
- pre-commit hook: turbo typecheck
- pre-commit hook: turbo test