### PR TITLE
Harden Contexture trust envelope

### DIFF
--- a/apps/desktop/src/main/app-main.ts
+++ b/apps/desktop/src/main/app-main.ts
@@ -13,11 +13,13 @@ import { registerClaudeIpc } from './ipc/claude';
 import { registerDriftIpc } from './ipc/drift';
 import { registerFileIpc } from './ipc/file';
 import { registerProjectIpc } from './ipc/project';
+import { registerReconcileIpc } from './ipc/reconcile';
 import { registerScaffoldIpc } from './ipc/scaffold';
 import { registerSchemaAgentIpc } from './ipc/schema-agent';
 import { registerShellIpc } from './ipc/shell';
 import { registerUpdateIpc } from './ipc/update';
 import { createMenu } from './menu';
+import { isSafeExternalUrl } from './security';
 
 function createWindow(): BrowserWindow {
   const mainWindow = new BrowserWindow({
@@ -39,7 +41,9 @@ function createWindow(): BrowserWindow {
   });
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
-    shell.openExternal(details.url);
+    if (isSafeExternalUrl(details.url)) {
+      void shell.openExternal(details.url);
+    }
     return { action: 'deny' };
   });
 
@@ -79,6 +83,7 @@ app.whenReady().then(() => {
   registerScaffoldIpc(mainWindow);
   registerShellIpc();
   registerProjectIpc();
+  registerReconcileIpc();
   registerSchemaAgentIpc(mainWindow);
   registerClaudeIpc(mainWindow);
   registerDriftIpc(mainWindow);

--- a/apps/desktop/src/main/ipc/project.ts
+++ b/apps/desktop/src/main/ipc/project.ts
@@ -7,12 +7,23 @@
  * calling — main is deliberately dumb here. Delete is `force: true` so a
  * partial scaffold (unwritable child files, etc.) still cleans up.
  */
-import { rm } from 'node:fs/promises';
+import { lstat, rm } from 'node:fs/promises';
 import { ipcMain } from 'electron';
+import { assertSafeRecursiveDeleteTarget } from '../security';
+
+export async function deleteProjectDirectory(path: string): Promise<void> {
+  const target = assertSafeRecursiveDeleteTarget(path);
+  try {
+    const stat = await lstat(target);
+    if (!stat.isDirectory()) throw new Error('Delete target must be a directory.');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+  await rm(target, { recursive: true, force: true });
+}
 
 export function registerProjectIpc(): void {
   ipcMain.handle('project:delete-directory', async (_evt, path: string) => {
-    if (typeof path !== 'string' || path === '' || path === '/') return;
-    await rm(path, { recursive: true, force: true });
+    await deleteProjectDirectory(path);
   });
 }

--- a/apps/desktop/src/main/ipc/reconcile.ts
+++ b/apps/desktop/src/main/ipc/reconcile.ts
@@ -1,0 +1,38 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { ipcMain } from 'electron';
+import { assertGeneratedTargetForIr } from '../security';
+
+export interface GeneratedTargetInput {
+  irPath: string;
+  targetPath: string;
+}
+
+export interface WriteGeneratedTargetInput extends GeneratedTargetInput {
+  contents: string;
+}
+
+export async function readGeneratedTarget(input: GeneratedTargetInput): Promise<string | null> {
+  const target = assertGeneratedTargetForIr(input.irPath, input.targetPath);
+  try {
+    return await readFile(target, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+export async function writeGeneratedTarget(input: WriteGeneratedTargetInput): Promise<void> {
+  const target = assertGeneratedTargetForIr(input.irPath, input.targetPath);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, input.contents, 'utf8');
+}
+
+export function registerReconcileIpc(): void {
+  ipcMain.handle('reconcile:read-generated-target', async (_evt, input: GeneratedTargetInput) =>
+    readGeneratedTarget(input),
+  );
+  ipcMain.handle(
+    'reconcile:write-generated-target',
+    async (_evt, input: WriteGeneratedTargetInput) => writeGeneratedTarget(input),
+  );
+}

--- a/apps/desktop/src/main/security.ts
+++ b/apps/desktop/src/main/security.ts
@@ -1,0 +1,59 @@
+import { homedir } from 'node:os';
+import { basename, dirname, isAbsolute, parse, resolve } from 'node:path';
+import { bundlePathsFor } from '@contexture/core/paths';
+
+const SAFE_EXTERNAL_PROTOCOLS = new Set(['https:', 'http:', 'mailto:']);
+
+export function isSafeExternalUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    return SAFE_EXTERNAL_PROTOCOLS.has(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
+export function assertGeneratedTargetForIr(irPath: string, targetPath: string): string {
+  if (!isAbsolute(irPath) || !isAbsolute(targetPath)) {
+    throw new Error('Contexture generated target paths must be absolute.');
+  }
+
+  const paths = bundlePathsFor(resolve(irPath));
+  const target = resolve(targetPath);
+  const allowed = new Set(
+    [paths.schemaTs, paths.schemaJson, paths.schemaIndex, paths.convex, paths.aiToolSchemas].map(
+      (path) => resolve(path),
+    ),
+  );
+
+  if (!allowed.has(target)) {
+    throw new Error('Target is not a generated Contexture artifact for this IR.');
+  }
+  return target;
+}
+
+export function assertSafeRecursiveDeleteTarget(inputPath: string): string {
+  if (typeof inputPath !== 'string' || inputPath.trim() === '') {
+    throw new Error('Delete target must be a non-empty path.');
+  }
+  if (!isAbsolute(inputPath)) {
+    throw new Error('Delete target must be an absolute path.');
+  }
+
+  const target = resolve(inputPath);
+  const root = parse(target).root;
+  if (target === root) {
+    throw new Error('Refusing to delete a filesystem root.');
+  }
+  if (target === resolve(homedir())) {
+    throw new Error('Refusing to delete the home directory.');
+  }
+  if (dirname(target) === root) {
+    throw new Error(`Refusing to delete top-level directory "${basename(target)}".`);
+  }
+  if (target === resolve(process.cwd())) {
+    throw new Error('Refusing to delete the current working directory.');
+  }
+
+  return target;
+}

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -230,6 +230,12 @@ export interface DriftDetectedPayload {
 }
 
 export interface ContextureReconcileAPI {
+  readGeneratedTarget: (payload: { irPath: string; targetPath: string }) => Promise<string | null>;
+  writeGeneratedTarget: (payload: {
+    irPath: string;
+    targetPath: string;
+    contents: string;
+  }) => Promise<void>;
   /**
    * Fire a one-shot schema-agent query that proposes IR ops to align
    * the current schema with the user's hand-edited on-disk source. The

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -13,7 +13,6 @@
  *
  * Renderer code should never touch `ipcRenderer` directly.
  */
-import { promises as fs } from 'node:fs';
 import { electronAPI } from '@electron-toolkit/preload';
 import { contextBridge, ipcRenderer } from 'electron';
 
@@ -231,6 +230,14 @@ const drift = {
 };
 
 const reconcile = {
+  readGeneratedTarget: (payload: { irPath: string; targetPath: string }): Promise<string | null> =>
+    ipcRenderer.invoke('reconcile:read-generated-target', payload) as Promise<string | null>,
+  writeGeneratedTarget: (payload: {
+    irPath: string;
+    targetPath: string;
+    contents: string;
+  }): Promise<void> =>
+    ipcRenderer.invoke('reconcile:write-generated-target', payload) as Promise<void>,
   /**
    * Fire a one-shot schema-agent query that returns reconcile ops for
    * the current IR + on-disk source of any emitted file.
@@ -250,21 +257,16 @@ const reconcile = {
 const contexture = { chat, schemaAgent, file, scaffold, shell, project, drift, reconcile };
 
 /**
- * Legacy surface. Sidecar reads/writes use the preload process's
- * Node `fs` directly — the files live next to the open document and
- * don't need a main-side dialog. Update + menu handlers route through
- * the existing `update:*` / `file:*` IPC channels.
+ * Legacy surface. Direct file access is intentionally disabled; retained
+ * methods either route through curated IPC or fail closed so old imports
+ * cannot regain preload-level filesystem access.
  */
 const legacyApi = {
-  readFileSilent: async (path: string): Promise<string | null> => {
-    try {
-      return await fs.readFile(path, 'utf-8');
-    } catch {
-      return null;
-    }
+  readFileSilent: async (_path: string): Promise<string | null> => {
+    return null;
   },
-  saveFile: async (path: string, contents: string): Promise<void> => {
-    await fs.writeFile(path, contents, 'utf-8');
+  saveFile: async (_path: string, _contents: string): Promise<void> => {
+    throw new Error('Legacy direct file writes are disabled; use window.contexture.* IPC.');
   },
   openFile: () => ipcRenderer.invoke('file:open-dialog'),
   saveFileAs: () => ipcRenderer.invoke('file:save-as-dialog'),

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -217,9 +217,17 @@ export function ReconcileModal(): React.JSX.Element {
   }, [proposedOps, selectedIndices, setApplying, setError, close]);
 
   const handleRegenerate = useCallback(() => {
-    if (!targetPath || targetKind === 'unknown' || !currentEmit.source || currentEmit.error) return;
-    void window.api
-      ?.saveFile(targetPath, currentEmit.source)
+    if (
+      !filePath ||
+      !targetPath ||
+      targetKind === 'unknown' ||
+      !currentEmit.source ||
+      currentEmit.error
+    ) {
+      return;
+    }
+    void window.contexture?.reconcile
+      .writeGeneratedTarget({ irPath: filePath, targetPath, contents: currentEmit.source })
       .then(async () => {
         await window.contexture?.drift.check();
         close();
@@ -228,7 +236,7 @@ export function ReconcileModal(): React.JSX.Element {
         const message = err instanceof Error ? err.message : String(err);
         setError(`Failed to overwrite file: ${message}`);
       });
-  }, [targetPath, targetKind, currentEmit, close, setError]);
+  }, [filePath, targetPath, targetKind, currentEmit, close, setError]);
 
   const handleOpenInChat = useCallback(() => {
     const irJson = JSON.stringify(schema, null, 2);

--- a/apps/desktop/src/renderer/src/hooks/useSchemaAgentReconcile.ts
+++ b/apps/desktop/src/renderer/src/hooks/useSchemaAgentReconcile.ts
@@ -4,7 +4,7 @@
  *
  * Sequence:
  *   1. Read the on-disk source for the target path via the legacy preload
- *      helper `window.api.readFileSilent` (already wired to Node fs).
+ *      helper `window.contexture.reconcile.readGeneratedTarget`.
  *   2. Snapshot the current IR from the undo store.
  *   3. Derive the target kind from the file path.
  *   4. Round-trip via the provider-neutral reconcile bridge.
@@ -61,7 +61,16 @@ export function useSchemaAgentReconcile(): void {
     }
 
     void (async () => {
-      const onDiskSource = await window.api?.readFileSilent(targetPath);
+      const irPath = docStore.filePath;
+      if (!irPath) {
+        reconcileStore.setError('No open Contexture document.');
+        return;
+      }
+
+      const onDiskSource = await window.contexture?.reconcile.readGeneratedTarget({
+        irPath,
+        targetPath,
+      });
       if (cancelledRef.current) return;
       if (onDiskSource === null || onDiskSource === undefined) {
         reconcileStore.setError(`Cannot read ${targetPath}.`);

--- a/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
+++ b/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
@@ -43,12 +43,14 @@ beforeEach(() => {
   useDocumentStore.setState({ filePath: IR_PATH, mode: 'project' });
   useDriftStore.getState().setResolved();
   useReconcileStore.getState().reset();
-  window.api.saveFile = vi.fn().mockResolvedValue(undefined);
   Object.defineProperty(window, 'contexture', {
     value: {
       drift: {
         check: vi.fn().mockResolvedValue({ ok: true }),
         dismiss: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      reconcile: {
+        writeGeneratedTarget: vi.fn().mockResolvedValue(undefined),
       },
     },
     writable: true,
@@ -72,9 +74,13 @@ describe('ReconcileModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /regenerate from ir/i }));
 
-    await waitFor(() => expect(window.api.saveFile).toHaveBeenCalledOnce());
-    const [path, contents] = vi.mocked(window.api.saveFile).mock.calls[0] ?? [];
-    expect(path).toBe(ZOD_PATH);
+    await waitFor(() =>
+      expect(window.contexture?.reconcile.writeGeneratedTarget).toHaveBeenCalledOnce(),
+    );
+    const [payload] =
+      vi.mocked(window.contexture?.reconcile.writeGeneratedTarget).mock.calls[0] ?? [];
+    expect(payload).toMatchObject({ irPath: IR_PATH, targetPath: ZOD_PATH });
+    const contents = payload?.contents ?? '';
     expect(contents).toContain('@contexture-generated');
     expect(contents).toContain('Plot');
     expect(window.contexture?.drift.check).toHaveBeenCalledOnce();
@@ -107,7 +113,7 @@ describe('ReconcileModal', () => {
     render(<ReconcileModal />);
     fireEvent.click(screen.getByRole('button', { name: /leave dirty/i }));
 
-    expect(window.api.saveFile).not.toHaveBeenCalled();
+    expect(window.contexture?.reconcile.writeGeneratedTarget).not.toHaveBeenCalled();
     expect(useDriftStore.getState().driftedPaths).toEqual([ZOD_PATH]);
     expect(useReconcileStore.getState().isOpen).toBe(false);
   });

--- a/apps/desktop/tests/main/project-ipc.test.ts
+++ b/apps/desktop/tests/main/project-ipc.test.ts
@@ -1,0 +1,35 @@
+import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { deleteProjectDirectory } from '@main/ipc/project';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+describe('deleteProjectDirectory', () => {
+  it('deletes a nested project directory', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'contexture-delete-'));
+    const target = join(parent, 'project');
+    await mkdir(target);
+    await writeFile(join(target, 'package.json'), '{}\n', 'utf8');
+
+    await deleteProjectDirectory(target);
+    await expect(stat(target)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('rejects protected or ambiguous targets', async () => {
+    await expect(deleteProjectDirectory(homedir())).rejects.toThrow(/home directory/);
+    await expect(deleteProjectDirectory('relative/project')).rejects.toThrow(/absolute/);
+  });
+
+  it('rejects file targets', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'contexture-delete-file-'));
+    const target = join(parent, 'not-a-directory');
+    await writeFile(target, 'keep me\n', 'utf8');
+
+    await expect(deleteProjectDirectory(target)).rejects.toThrow(/directory/);
+    await expect(readFile(target, 'utf8')).resolves.toBe('keep me\n');
+  });
+});

--- a/apps/desktop/tests/main/reconcile-ipc.test.ts
+++ b/apps/desktop/tests/main/reconcile-ipc.test.ts
@@ -1,0 +1,36 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readGeneratedTarget, writeGeneratedTarget } from '@main/ipc/reconcile';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+describe('reconcile generated-target IPC helpers', () => {
+  it('reads and writes known generated targets for the open IR', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'contexture-reconcile-'));
+    const ctxDir = join(dir, 'packages/contexture');
+    await mkdir(ctxDir, { recursive: true });
+    const irPath = join(ctxDir, 'garden.contexture.json');
+    const targetPath = join(ctxDir, 'garden.schema.ts');
+    await writeFile(irPath, '{"version":"1","types":[]}\n', 'utf8');
+    await writeFile(targetPath, 'before\n', 'utf8');
+
+    await expect(readGeneratedTarget({ irPath, targetPath })).resolves.toBe('before\n');
+    await writeGeneratedTarget({ irPath, targetPath, contents: 'after\n' });
+    await expect(readFile(targetPath, 'utf8')).resolves.toBe('after\n');
+  });
+
+  it('rejects writes outside the generated bundle', async () => {
+    const irPath = '/repo/packages/contexture/garden.contexture.json';
+    await expect(
+      writeGeneratedTarget({
+        irPath,
+        targetPath: '/repo/packages/contexture/src/index.ts',
+        contents: 'nope',
+      }),
+    ).rejects.toThrow(/not a generated Contexture artifact/);
+  });
+});

--- a/apps/desktop/tests/main/security.test.ts
+++ b/apps/desktop/tests/main/security.test.ts
@@ -1,0 +1,48 @@
+import { homedir } from 'node:os';
+import { join, parse } from 'node:path';
+import {
+  assertGeneratedTargetForIr,
+  assertSafeRecursiveDeleteTarget,
+  isSafeExternalUrl,
+} from '@main/security';
+import { describe, expect, it } from 'vitest';
+
+describe('main security guards', () => {
+  it('allows only expected external window-open protocols', () => {
+    expect(isSafeExternalUrl('https://contexture.dev')).toBe(true);
+    expect(isSafeExternalUrl('http://localhost:3000')).toBe(true);
+    expect(isSafeExternalUrl('mailto:hello@example.com')).toBe(true);
+    expect(isSafeExternalUrl('file:///etc/passwd')).toBe(false);
+    expect(isSafeExternalUrl('vscode://file/tmp/project')).toBe(false);
+    expect(isSafeExternalUrl('not a url')).toBe(false);
+  });
+
+  it('accepts generated targets derived from the open IR', () => {
+    const irPath = '/repo/packages/contexture/garden.contexture.json';
+    expect(assertGeneratedTargetForIr(irPath, '/repo/packages/contexture/garden.schema.ts')).toBe(
+      '/repo/packages/contexture/garden.schema.ts',
+    );
+    expect(assertGeneratedTargetForIr(irPath, '/repo/packages/contexture/convex/schema.ts')).toBe(
+      '/repo/packages/contexture/convex/schema.ts',
+    );
+  });
+
+  it('rejects user-owned paths that are not generated targets for the IR', () => {
+    const irPath = '/repo/packages/contexture/garden.contexture.json';
+    expect(() =>
+      assertGeneratedTargetForIr(irPath, '/repo/packages/contexture/src/index.ts'),
+    ).toThrow(/not a generated Contexture artifact/);
+  });
+
+  it('rejects dangerous recursive delete targets', () => {
+    const root = parse(homedir()).root;
+    expect(() => assertSafeRecursiveDeleteTarget(root)).toThrow(/root/);
+    expect(() => assertSafeRecursiveDeleteTarget(homedir())).toThrow(/home/);
+    expect(() => assertSafeRecursiveDeleteTarget('relative/project')).toThrow(/absolute/);
+  });
+
+  it('allows a nested absolute recursive delete target', () => {
+    const target = join(parse(homedir()).root, 'tmp', 'contexture-delete-me');
+    expect(assertSafeRecursiveDeleteTarget(target)).toBe(target);
+  });
+});

--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -211,3 +211,42 @@ Completion evidence:
   checks, and Recordshop dogfooding.
 - Updated site metadata, brand phrase guidance, README copy, and homepage smoke
   tests to match the new positioning.
+
+## Goal 10 — Agent/Electron Trust Envelope
+
+**Status:** Done.
+
+Harden the writable trust envelope opened by the agent loop and desktop
+project flows. Contexture now exposes real mutation surfaces through MCP, CLI,
+schema chat, reconcile, and Electron IPC; those surfaces need explicit path,
+protocol, and destructive-action guards before the next architecture
+simplification pass.
+
+Completion evidence:
+
+- Reconcile generated-file reads/writes route through main-side IPC that only
+  accepts known generated targets for the open `.contexture.json` bundle.
+- Recursive project deletion rejects root, home, non-absolute, and non-directory
+  targets even if the renderer misbehaves.
+- Window-open external links are limited to expected external protocols.
+- Tests cover allowed and rejected paths/protocols.
+- MCP/CLI mutation and emit paths have explicit path-policy tests for accepted
+  `.contexture.json` inputs and rejected output locations.
+
+Progress:
+
+- Reconcile now uses main-side generated-target IPC instead of legacy preload
+  filesystem reads/writes.
+- Project recursive delete now fails closed for root, home, relative, top-level,
+  current-working-directory, and file targets.
+- External window-open handling now denies non-http/mailto protocols.
+- CLI and MCP now share core path policy: read-only operations accept resolved
+  `.contexture.json` inputs, while write-capable agent operations require
+  `packages/contexture/*.contexture.json`.
+- Tests cover non-IR path rejection, scratch-file read-only inspection, and
+  write-capable CLI/MCP rejection for scratch IR paths.
+
+Next goal candidate:
+
+- Deepen the shared generated-bundle writer so desktop, CLI, and MCP all share
+  one atomic write and drift preflight implementation.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,8 @@
 import { readdir, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import {
+  assertContextureIrPath,
+  assertWritableContextureProjectIrPath,
   bundlePathsFor,
   createFileBackedForward,
   createOpTools,
@@ -483,7 +485,7 @@ async function run(argv: string[]): Promise<void> {
     return;
   }
 
-  const irPath = options.irPath ?? (await findIrPath(options.cwd));
+  const irPath = assertContextureIrPath(options.irPath ?? (await findIrPath(options.cwd)));
 
   if (command === 'inspect') {
     const schema = await readSchema(irPath);
@@ -535,17 +537,19 @@ async function run(argv: string[]): Promise<void> {
   }
 
   if (command === 'emit') {
-    const schema = await readSchema(irPath);
-    const { emitted, manifest } = runEmitPipeline(schema, irPath);
-    await createFileBackedForward(irPath)({ kind: 'replace_schema', schema });
+    const writableIrPath = assertWritableContextureProjectIrPath(irPath);
+    const schema = await readSchema(writableIrPath);
+    const { emitted, manifest } = runEmitPipeline(schema, writableIrPath);
+    await createFileBackedForward(writableIrPath)({ kind: 'replace_schema', schema });
     writeResult({ message: `Emitted ${emitted.length} files.`, manifest }, options.json);
     return;
   }
 
   if (command === 'check-generated') {
-    const schema = await readSchema(irPath);
-    const { emitted, manifest } = runEmitPipeline(schema, irPath);
-    const paths = bundlePathsFor(irPath);
+    const writableIrPath = assertWritableContextureProjectIrPath(irPath);
+    const schema = await readSchema(writableIrPath);
+    const { emitted, manifest } = runEmitPipeline(schema, writableIrPath);
+    const paths = bundlePathsFor(writableIrPath);
     const expectedFiles = [
       ...emitted,
       { path: paths.emitted, content: `${JSON.stringify(manifest, null, 2)}\n` },
@@ -589,6 +593,7 @@ async function run(argv: string[]): Promise<void> {
   }
 
   if (command === 'apply') {
+    const writableIrPath = assertWritableContextureProjectIrPath(irPath);
     let opJson = options.opJson;
     if (!opJson && options.opFile) {
       opJson = await Bun.file(options.opFile).text();
@@ -600,7 +605,7 @@ async function run(argv: string[]): Promise<void> {
     if (!op || typeof op !== 'object' || typeof op.kind !== 'string') {
       throw new Error('op must be an object with a string "kind" field');
     }
-    const forward = createFileBackedForward(irPath);
+    const forward = createFileBackedForward(writableIrPath);
     type ForwardResult = Awaited<ReturnType<typeof forward>>;
     let result: ForwardResult;
     try {
@@ -623,7 +628,8 @@ async function run(argv: string[]): Promise<void> {
     return;
   }
 
-  const forward = createFileBackedForward(irPath);
+  const writableIrPath = assertWritableContextureProjectIrPath(irPath);
+  const forward = createFileBackedForward(writableIrPath);
   const tools = new Map(createOpTools(forward).map((tool) => [tool.name, tool]));
   const { tool: toolName, input } = commandToToolInput(command, args);
   const tool = tools.get(toolName);

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -18,6 +18,17 @@ async function fixtureProject() {
   return { dir, irPath };
 }
 
+async function fixtureScratch() {
+  const dir = await mkdtemp(join(tmpdir(), 'contexture-cli-scratch-'));
+  const irPath = join(dir, 'scratch.contexture.json');
+  const schema = {
+    version: '1',
+    types: [{ kind: 'object', name: 'Note', fields: [] }],
+  };
+  await writeFile(irPath, `${JSON.stringify(schema, null, 2)}\n`, 'utf8');
+  return { dir, irPath };
+}
+
 async function runCli(cwd: string, args: string[]) {
   return new Promise<{ stdout: string; stderr: string; exitCode: number | null }>((resolve) => {
     const proc = spawn('bun', [cliPath, ...args], { cwd });
@@ -101,6 +112,30 @@ describe('@contexture/cli', () => {
     expect(result.stdout).toContain('Post [table]');
   });
 
+  it('allows read-only inspection of scratch .contexture.json files', async () => {
+    const { dir, irPath } = await fixtureScratch();
+    const result = await runCli(dir, ['inspect', '--ir', irPath, '--json']);
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      path: irPath,
+      types: [expect.objectContaining({ name: 'Note' })],
+    });
+  });
+
+  it('rejects non-.contexture.json IR paths before reading or writing', async () => {
+    const { dir } = await fixtureProject();
+    const badPath = join(dir, 'packages/contexture/app.schema.json');
+    await writeFile(badPath, '{}\n', 'utf8');
+
+    const result = await runCli(dir, ['inspect', '--ir', badPath, '--json']);
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining('Expected a .contexture.json path') },
+    });
+  });
+
   it('lists types as structured JSON', async () => {
     const { dir } = await fixtureProject();
     const result = await runCli(dir, ['list-types', '--json']);
@@ -181,6 +216,16 @@ describe('@contexture/cli', () => {
           status: 'clean',
         }),
       ]),
+    });
+  });
+
+  it('rejects generated-output commands for scratch IR paths', async () => {
+    const { dir, irPath } = await fixtureScratch();
+    const result = await runCli(dir, ['emit', '--ir', irPath, '--json']);
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining('packages/contexture/*.contexture.json') },
     });
   });
 

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -14,6 +14,13 @@ async function fixtureIr(schema: unknown): Promise<string> {
   return irPath;
 }
 
+async function fixtureScratchIr(schema: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'contexture-mcp-scratch-'));
+  const irPath = join(dir, 'scratch.contexture.json');
+  await writeFile(irPath, `${JSON.stringify(schema, null, 2)}\n`, 'utf8');
+  return irPath;
+}
+
 async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
   const server = createContextureMcpServer();
   const client = new Client({ name: 'contexture-mcp-test', version: '0.0.0' });
@@ -106,6 +113,44 @@ describe('Contexture MCP server', () => {
             fields: [{ name: 'name', type: 'string' }],
           },
         ],
+      });
+    });
+  });
+
+  it('allows read-only inspection of scratch .contexture.json files', async () => {
+    const irPath = await fixtureScratchIr({
+      version: '1',
+      types: [{ kind: 'object', name: 'Note', fields: [] }],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'inspect_contexture',
+        arguments: { irPath },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        types: [expect.objectContaining({ name: 'Note' })],
+      });
+    });
+  });
+
+  it('reports non-.contexture.json validation paths as validation failures', async () => {
+    const irPath = await fixtureIr({ version: '1', types: [] });
+    const badPath = irPath.replace(/\.contexture\.json$/, '.schema.json');
+    await writeFile(badPath, '{}\n', 'utf8');
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'validate_contexture',
+        arguments: { irPath: badPath },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: badPath,
+        valid: false,
+        errors: [expect.objectContaining({ message: expect.stringContaining('.contexture.json') })],
       });
     });
   });
@@ -287,6 +332,48 @@ describe('Contexture MCP server', () => {
       expect(cleanAgainResult.structuredContent).toMatchObject({
         clean: true,
         drift: [],
+      });
+    });
+  });
+
+  it('rejects write-capable tools for scratch IR paths', async () => {
+    const irPath = await fixtureScratchIr({
+      version: '1',
+      types: [{ kind: 'object', name: 'Note', fields: [] }],
+    });
+
+    await withClient(async (client) => {
+      const emitResult = await client.callTool({
+        name: 'emit_contexture',
+        arguments: { irPath },
+      });
+      expect(emitResult).toMatchObject({
+        isError: true,
+        content: [
+          expect.objectContaining({
+            text: expect.stringContaining('packages/contexture/*.contexture.json'),
+          }),
+        ],
+      });
+
+      const applyResult = await client.callTool({
+        name: 'apply_contexture_op',
+        arguments: {
+          irPath,
+          op: {
+            kind: 'add_field',
+            typeName: 'Note',
+            field: { name: 'body', type: { kind: 'string' } },
+          },
+        },
+      });
+      expect(applyResult).toMatchObject({
+        isError: true,
+        content: [
+          expect.objectContaining({
+            text: expect.stringContaining('packages/contexture/*.contexture.json'),
+          }),
+        ],
       });
     });
   });

--- a/packages/core/src/file-forward.ts
+++ b/packages/core/src/file-forward.ts
@@ -1,7 +1,8 @@
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { dirname } from 'node:path';
 import { load, save } from './load';
 import { type ApplyResult, apply, type Op } from './ops';
+import { assertWritableContextureProjectIrPath } from './paths';
 import { bundlePathsFor, type FileEntry, runEmitPipeline } from './pipeline';
 
 export interface FileBackedFs {
@@ -68,7 +69,7 @@ async function writeBundleAtomic(fs: FileBackedFs, files: ReadonlyArray<FileEntr
 }
 
 export function createFileBackedForward(irPath: string, fs: FileBackedFs = nodeFileBackedFs) {
-  const resolvedIrPath = resolve(irPath);
+  const resolvedIrPath = assertWritableContextureProjectIrPath(irPath);
 
   return async function forward(op: Op): Promise<ApplyResult> {
     // TODO(#160): run drift pre-flight before writing generated artefacts.

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -14,7 +14,11 @@ import {
 } from './ir';
 import { load } from './load';
 import type { Op } from './ops';
-import { bundlePathsFor } from './paths';
+import {
+  assertContextureIrPath,
+  assertWritableContextureProjectIrPath,
+  bundlePathsFor,
+} from './paths';
 import { runEmitPipeline } from './pipeline';
 import { checkSemantic } from './semantic-validation';
 
@@ -313,7 +317,8 @@ export function createContextureMcpServer(): McpServer {
 }
 
 async function readContextureFile(irPath: string): Promise<{ schema: Schema; warnings: string[] }> {
-  const raw = await readFile(irPath, 'utf8');
+  const path = assertContextureIrPath(irPath);
+  const raw = await readFile(path, 'utf8');
   return load(raw);
 }
 
@@ -344,22 +349,23 @@ async function applyContextureOp(
   op: Record<string, unknown>,
 ): Promise<z.infer<z.ZodObject<typeof ApplyContextureOpOutput>>> {
   const opKind = typeof op.kind === 'string' ? op.kind : 'unknown';
+  const path = assertWritableContextureProjectIrPath(irPath);
   const parsed = OpSchema.safeParse(op);
   if (!parsed.success) {
     return {
-      path: irPath,
+      path,
       applied: false,
       opKind,
       error: `invalid op: ${formatZodIssues(parsed.error)}`,
     };
   }
 
-  const result = await createFileBackedForward(irPath)(parsed.data);
+  const result = await createFileBackedForward(path)(parsed.data);
   if ('error' in result) {
-    return { path: irPath, applied: false, opKind, error: result.error };
+    return { path, applied: false, opKind, error: result.error };
   }
   return {
-    path: irPath,
+    path,
     applied: true,
     opKind,
     typeCount: result.schema.types.length,
@@ -378,15 +384,16 @@ function formatZodIssues(error: ZodError): string {
 async function emitContextureBundle(
   irPath: string,
 ): Promise<z.infer<z.ZodObject<typeof EmitContextureOutput>>> {
-  const { schema } = await readContextureFile(irPath);
-  const { emitted, manifest } = runEmitPipeline(schema, irPath);
-  const result = await createFileBackedForward(irPath)({
+  const path = assertWritableContextureProjectIrPath(irPath);
+  const { schema } = await readContextureFile(path);
+  const { emitted, manifest } = runEmitPipeline(schema, path);
+  const result = await createFileBackedForward(path)({
     kind: 'replace_schema',
     schema,
   });
   if ('error' in result) throw new Error(result.error);
   return {
-    path: irPath,
+    path,
     emitted: emitted.map((file) => file.path),
     manifest,
   };
@@ -397,9 +404,10 @@ type GeneratedFileStatus = z.infer<typeof GeneratedFileStatusSchema>;
 async function checkContextureDrift(
   irPath: string,
 ): Promise<z.infer<z.ZodObject<typeof CheckContextureDriftOutput>>> {
-  const { schema } = await readContextureFile(irPath);
-  const { emitted, manifest } = runEmitPipeline(schema, irPath);
-  const paths = bundlePathsFor(irPath);
+  const path = assertWritableContextureProjectIrPath(irPath);
+  const { schema } = await readContextureFile(path);
+  const { emitted, manifest } = runEmitPipeline(schema, path);
+  const paths = bundlePathsFor(path);
   const expectedFiles = [
     ...emitted,
     { path: paths.emitted, content: `${JSON.stringify(manifest, null, 2)}\n` },
@@ -421,7 +429,7 @@ async function checkContextureDrift(
 
   const drift = files.filter((file) => file.status !== 'clean');
   return {
-    path: irPath,
+    path,
     clean: drift.length === 0,
     checked: files.length,
     files,

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,5 +1,3 @@
-import { resolve } from 'node:path';
-
 export const IR_SUFFIX = '.contexture.json';
 export const SCHEMA_TS_SUFFIX = '.schema.ts';
 export const SCHEMA_JSON_SUFFIX = '.schema.json';
@@ -42,23 +40,23 @@ export function projectRootFor(irPath: string): string | null {
 }
 
 export function assertContextureIrPath(path: string): string {
-  const resolved = resolve(path);
-  if (!resolved.endsWith(IR_SUFFIX)) {
+  const normalized = normalizeContexturePath(path);
+  if (!normalized.endsWith(IR_SUFFIX)) {
     throw new Error(`Expected a ${IR_SUFFIX} path, got: ${path}`);
   }
-  return resolved;
+  return normalized;
 }
 
 export function assertWritableContextureProjectIrPath(path: string): string {
-  const resolved = assertContextureIrPath(path);
-  const slash = resolved.lastIndexOf('/');
-  const dir = slash === -1 ? '' : resolved.slice(0, slash);
+  const normalized = assertContextureIrPath(path);
+  const slash = normalized.lastIndexOf('/');
+  const dir = slash === -1 ? '' : normalized.slice(0, slash);
   if (!dir.endsWith('/packages/contexture')) {
     throw new Error(
       'Writable Contexture agent operations require an IR under packages/contexture/*.contexture.json.',
     );
   }
-  return resolved;
+  return normalized;
 }
 
 export function bundlePathsFor(irPath: string): BundlePaths {
@@ -77,4 +75,29 @@ export function bundlePathsFor(irPath: string): BundlePaths {
     convex: `${dir}/convex/schema.ts`,
     aiToolSchemas: `${ctxDir}/${AI_TOOL_SCHEMAS_FILE}`,
   };
+}
+
+function normalizeContexturePath(path: string): string {
+  const normalizedSlashes = path.replaceAll('\\', '/');
+  const drive = normalizedSlashes.match(/^([A-Za-z]:)(\/?)/);
+  const prefix = normalizedSlashes.startsWith('/')
+    ? '/'
+    : drive
+      ? `${drive[1]}${drive[2] ? '/' : ''}`
+      : '';
+  const rest = prefix ? normalizedSlashes.slice(prefix.length) : normalizedSlashes;
+  const parts: string[] = [];
+
+  for (const part of rest.split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      if (parts.length > 0 && parts[parts.length - 1] !== '..') parts.pop();
+      else if (!prefix) parts.push(part);
+      continue;
+    }
+    parts.push(part);
+  }
+
+  if (prefix) return `${prefix}${parts.join('/')}`;
+  return parts.length > 0 ? parts.join('/') : '.';
 }

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 export const IR_SUFFIX = '.contexture.json';
 export const SCHEMA_TS_SUFFIX = '.schema.ts';
 export const SCHEMA_JSON_SUFFIX = '.schema.json';
@@ -39,15 +41,33 @@ export function projectRootFor(irPath: string): string | null {
   return dir.slice(0, -suffix.length + 1);
 }
 
-export function bundlePathsFor(irPath: string): BundlePaths {
-  if (!irPath.endsWith(IR_SUFFIX)) {
-    throw new Error(`Expected a ${IR_SUFFIX} path, got: ${irPath}`);
+export function assertContextureIrPath(path: string): string {
+  const resolved = resolve(path);
+  if (!resolved.endsWith(IR_SUFFIX)) {
+    throw new Error(`Expected a ${IR_SUFFIX} path, got: ${path}`);
   }
-  const base = irPath.slice(0, -IR_SUFFIX.length);
-  const ctxDir = contextureDirFor(irPath);
+  return resolved;
+}
+
+export function assertWritableContextureProjectIrPath(path: string): string {
+  const resolved = assertContextureIrPath(path);
+  const slash = resolved.lastIndexOf('/');
+  const dir = slash === -1 ? '' : resolved.slice(0, slash);
+  if (!dir.endsWith('/packages/contexture')) {
+    throw new Error(
+      'Writable Contexture agent operations require an IR under packages/contexture/*.contexture.json.',
+    );
+  }
+  return resolved;
+}
+
+export function bundlePathsFor(irPath: string): BundlePaths {
+  const resolvedIrPath = assertContextureIrPath(irPath);
+  const base = resolvedIrPath.slice(0, -IR_SUFFIX.length);
+  const ctxDir = contextureDirFor(resolvedIrPath);
   const dir = ctxDir.slice(0, -'/.contexture'.length);
   return {
-    ir: irPath,
+    ir: resolvedIrPath,
     layout: `${ctxDir}/${LAYOUT_FILE}`,
     chat: `${ctxDir}/${CHAT_FILE}`,
     emitted: `${ctxDir}/${EMITTED_FILE}`,

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -9,6 +9,8 @@ import { type BundlePaths, baseNameFor, bundlePathsFor } from './paths';
 
 export type { BundlePaths } from './paths';
 export {
+  assertContextureIrPath,
+  assertWritableContextureProjectIrPath,
   baseNameFor,
   bundlePathsFor,
   CHAT_FILE,

--- a/packages/core/tests/paths.test.ts
+++ b/packages/core/tests/paths.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertContextureIrPath,
+  assertWritableContextureProjectIrPath,
+  bundlePathsFor,
+} from '../src';
+
+describe('Contexture path policy', () => {
+  it('normalizes .contexture.json paths before deriving generated bundle paths', () => {
+    const paths = bundlePathsFor('/repo/packages/contexture/../contexture/app.contexture.json');
+    expect(paths.ir).toBe('/repo/packages/contexture/app.contexture.json');
+    expect(paths.schemaIndex).toBe('/repo/packages/contexture/index.ts');
+    expect(paths.convex).toBe('/repo/packages/contexture/convex/schema.ts');
+  });
+
+  it('rejects non-IR paths', () => {
+    expect(() => assertContextureIrPath('/repo/packages/contexture/app.schema.json')).toThrow(
+      /Expected a \.contexture\.json path/,
+    );
+  });
+
+  it('allows write-capable operations only for project IR paths', () => {
+    expect(
+      assertWritableContextureProjectIrPath('/repo/packages/contexture/app.contexture.json'),
+    ).toBe('/repo/packages/contexture/app.contexture.json');
+    expect(() => assertWritableContextureProjectIrPath('/repo/app.contexture.json')).toThrow(
+      /packages\/contexture/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add Goal 10 to the roadmap and mark the agent/Electron trust envelope hardening complete.
- Restrict reconcile reads/writes to generated targets through main-side IPC and disable legacy preload direct filesystem writes.
- Add shared core path policy for CLI/MCP write-capable operations and harden destructive Electron seams.

## Verification
- Full pre-commit hook passed: `turbo typecheck` and `turbo test`.
- Focused checks also passed before commit: core/CLI tests, desktop targeted tests, desktop typecheck, and Biome on touched code.