### PR TITLE
Deepen the generated bundle writer

### DIFF
--- a/apps/desktop/src/main/documents/document-store.ts
+++ b/apps/desktop/src/main/documents/document-store.ts
@@ -19,9 +19,11 @@
 import {
   bundlePathsFor,
   contextureDirFor,
+  type FileEntry,
   IR_SUFFIX,
   projectRootFor,
-  runEmitPipeline,
+  writeFilesAtomic,
+  writeGeneratedBundle,
 } from '@contexture/core';
 import { NAMESPACES as STDLIB_NAMESPACES } from '@contexture/stdlib/registry';
 import { type ChatHistory, loadChatHistory, saveChatHistory } from '@renderer/model/chat-history';
@@ -226,47 +228,6 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
     return { irPath, mode, schema, layout, chat, warnings };
   }
 
-  async function writeBundleAtomic(
-    files: ReadonlyArray<{ path: string; content: string }>,
-  ): Promise<void> {
-    interface Snapshot {
-      path: string;
-      existed: boolean;
-      prior?: string;
-      renamed: boolean;
-    }
-    const snapshots: Snapshot[] = [];
-    try {
-      for (const file of files) {
-        const snap: Snapshot = { path: file.path, existed: false, renamed: false };
-        try {
-          snap.prior = await fs.readFile(file.path);
-          snap.existed = true;
-        } catch (err) {
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-        }
-        snapshots.push(snap);
-
-        const tmp = `${file.path}.tmp`;
-        await fs.writeFile(tmp, file.content);
-        await fs.rename(tmp, file.path);
-        snap.renamed = true;
-      }
-    } catch (err) {
-      for (const snap of snapshots.slice().reverse()) {
-        if (snap.renamed) {
-          if (snap.existed && snap.prior !== undefined) {
-            await fs.writeFile(snap.path, snap.prior).catch(() => undefined);
-          } else {
-            await fs.remove(snap.path).catch(() => undefined);
-          }
-        }
-        await fs.remove(`${snap.path}.tmp`).catch(() => undefined);
-      }
-      throw err;
-    }
-  }
-
   async function saveImpl(irPath: string, input: SaveInput): Promise<void> {
     const paths = bundlePathsFor(irPath);
     const mode: DocumentMode = (await fs.dirExists(contextureDirFor(irPath)))
@@ -278,29 +239,30 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
     // artefacts graduate to project mode by running `mkdir .contexture/`
     // (or, eventually, the New Project flow).
     if (mode === 'scratch') {
-      await writeBundleAtomic([{ path: paths.ir, content: `${saveIR(input.schema)}\n` }]);
+      await writeFilesAtomic(fs, [{ path: paths.ir, content: `${saveIR(input.schema)}\n` }]);
       await bumpRecent(irPath);
       return;
     }
 
     // Project mode: full bundle. Emit first — a throwing emitter must
     // abort before any write touches disk.
-    const { emitted, manifest } = runEmitPipeline(input.schema, irPath, {
-      emitZod,
-      emitJsonSchema,
-      emitSchemaIndex,
-      emitConvex,
-    });
-
-    const files = [
-      { path: paths.ir, content: `${saveIR(input.schema)}\n` },
+    const sidecars: FileEntry[] = [
       { path: paths.layout, content: saveLayout(input.layout) },
       { path: paths.chat, content: saveChatHistory(input.chat) },
-      ...emitted,
-      { path: paths.emitted, content: `${JSON.stringify(manifest, null, 2)}\n` },
     ];
 
-    await writeBundleAtomic(files);
+    await writeGeneratedBundle({
+      irPath,
+      schema: input.schema,
+      fs,
+      sidecars,
+      emitDeps: {
+        emitZod,
+        emitJsonSchema,
+        emitSchemaIndex,
+        emitConvex,
+      },
+    });
     await bumpRecent(irPath);
   }
 

--- a/apps/desktop/tests/main/document-store.test.ts
+++ b/apps/desktop/tests/main/document-store.test.ts
@@ -402,6 +402,29 @@ describe('DocumentStore', () => {
     }
   });
 
+  it('project-mode save refuses to clobber drifted generated files', async () => {
+    await harness.store.save({
+      irPath,
+      schema: sampleIR,
+      layout: sampleLayout,
+      chat: sampleChat,
+    });
+    await harness.fs.writeFile(schemaTsPath, '// hand edit\n');
+
+    await expect(
+      harness.store.save({
+        irPath,
+        schema: { version: '1', types: [{ kind: 'object', name: 'Updated', fields: [] }] },
+        layout: sampleLayout,
+        chat: sampleChat,
+      }),
+    ).rejects.toThrow(/Generated files have drifted/);
+
+    expect(await harness.fs.readFile(schemaTsPath)).toBe('// hand edit\n');
+    const reopened = await harness.store.open(irPath);
+    expect(reopened.schema).toEqual(sampleIR);
+  });
+
   it('emitted.json does not track seeded per-table CRUD files', async () => {
     // Seeded files are not @contexture-generated, so they must not appear
     // in the drift manifest. A drift check flags regen-on-mismatch;

--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -246,7 +246,26 @@ Progress:
 - Tests cover non-IR path rejection, scratch-file read-only inspection, and
   write-capable CLI/MCP rejection for scratch IR paths.
 
-Next goal candidate:
+## Goal 11 — Shared Generated-Bundle Writer
 
-- Deepen the shared generated-bundle writer so desktop, CLI, and MCP all share
-  one atomic write and drift preflight implementation.
+**Status:** Done.
+
+Deepen the generated-bundle writer so desktop, CLI, and MCP share one core
+implementation for building generated files, writing them atomically, checking
+generated-file drift, and refusing implicit overwrites when the last emitted
+manifest shows user or agent edits.
+
+Completion evidence:
+
+- `@contexture/core` owns `generated-bundle-writer`, which builds generated
+  bundle entries, writes them with rollback, checks current generated output,
+  and runs manifest-based drift preflight before implicit writes.
+- CLI `emit` performs an explicit re-emit through the shared writer, while
+  `check-generated` reports status through the shared checker.
+- MCP `emit_contexture` and `check_contexture_drift` use the same writer/checker
+  as the CLI.
+- Desktop project-mode saves use the shared writer for generated artefacts and
+  sidecars, while scratch saves use the same atomic file writer.
+- Tests cover atomic rollback, generated drift preflight, explicit re-emit over
+  drift, shared generated checks, file-backed op rejection over drift, and
+  desktop save refusal to clobber edited generated files.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { join, resolve } from 'node:path';
 import {
   assertContextureIrPath,
   assertWritableContextureProjectIrPath,
-  bundlePathsFor,
+  checkGeneratedBundle,
   createFileBackedForward,
   createOpTools,
   type FieldDef,
@@ -12,9 +12,10 @@ import {
   type ImportDecl,
   IRSchema,
   load,
-  runEmitPipeline,
+  nodeFileBackedFs,
   type Schema,
   type TypeDef,
+  writeGeneratedBundle,
 } from '@contexture/core';
 
 interface CliOptions {
@@ -34,13 +35,6 @@ interface ParsedArgs {
 interface JsonError {
   ok: false;
   error: { message: string; code: string };
-}
-
-type GeneratedFileStatus = 'clean' | 'drifted' | 'unreadable';
-
-interface GeneratedFileCheck {
-  path: string;
-  status: GeneratedFileStatus;
 }
 
 const HELP = `contexture <command> [args]
@@ -539,8 +533,12 @@ async function run(argv: string[]): Promise<void> {
   if (command === 'emit') {
     const writableIrPath = assertWritableContextureProjectIrPath(irPath);
     const schema = await readSchema(writableIrPath);
-    const { emitted, manifest } = runEmitPipeline(schema, writableIrPath);
-    await createFileBackedForward(writableIrPath)({ kind: 'replace_schema', schema });
+    const { emitted, manifest } = await writeGeneratedBundle({
+      irPath: writableIrPath,
+      schema,
+      fs: nodeFileBackedFs,
+      driftPreflight: false,
+    });
     writeResult({ message: `Emitted ${emitted.length} files.`, manifest }, options.json);
     return;
   }
@@ -548,24 +546,7 @@ async function run(argv: string[]): Promise<void> {
   if (command === 'check-generated') {
     const writableIrPath = assertWritableContextureProjectIrPath(irPath);
     const schema = await readSchema(writableIrPath);
-    const { emitted, manifest } = runEmitPipeline(schema, writableIrPath);
-    const paths = bundlePathsFor(writableIrPath);
-    const expectedFiles = [
-      ...emitted,
-      { path: paths.emitted, content: `${JSON.stringify(manifest, null, 2)}\n` },
-    ];
-    const files: GeneratedFileCheck[] = [];
-    for (const entry of expectedFiles) {
-      let onDisk: string | undefined;
-      try {
-        onDisk = await Bun.file(entry.path).text();
-      } catch {
-        onDisk = undefined;
-      }
-      if (onDisk === undefined) files.push({ path: entry.path, status: 'unreadable' });
-      else if (onDisk !== entry.content) files.push({ path: entry.path, status: 'drifted' });
-      else files.push({ path: entry.path, status: 'clean' });
-    }
+    const files = await checkGeneratedBundle(schema, writableIrPath, nodeFileBackedFs);
     const drift = files.filter((file) => file.status !== 'clean');
     if (drift.length > 0) {
       process.exitCode = 1;

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -336,6 +336,61 @@ describe('Contexture MCP server', () => {
     });
   });
 
+  it('returns generated drift preflight failures as structured apply results', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Plot',
+          fields: [{ name: 'name', type: { kind: 'string' } }],
+        },
+      ],
+    });
+
+    await withClient(async (client) => {
+      await client.callTool({
+        name: 'apply_contexture_op',
+        arguments: {
+          irPath,
+          op: {
+            kind: 'add_field',
+            typeName: 'Plot',
+            field: { name: 'size', type: { kind: 'number', int: true } },
+          },
+        },
+      });
+
+      const schemaTsPath = irPath.replace(/\.contexture\.json$/, '.schema.ts');
+      await writeFile(schemaTsPath, '// hand edit\n', 'utf8');
+
+      const result = await client.callTool({
+        name: 'apply_contexture_op',
+        arguments: {
+          irPath,
+          op: {
+            kind: 'add_field',
+            typeName: 'Plot',
+            field: { name: 'soil', type: { kind: 'string' } },
+          },
+        },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        applied: false,
+        opKind: 'add_field',
+        error: expect.stringContaining('Generated files have drifted'),
+      });
+      expect(result.isError).not.toBe(true);
+
+      const updatedIr = JSON.parse(await readFile(irPath, 'utf8')) as {
+        types: Array<{ fields?: Array<{ name: string }> }>;
+      };
+      expect(updatedIr.types[0]?.fields?.map((field) => field.name)).toEqual(['name', 'size']);
+    });
+  });
+
   it('rejects write-capable tools for scratch IR paths', async () => {
     const irPath = await fixtureScratchIr({
       version: '1',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
     "./emit-table-crud": "./src/emit-table-crud.ts",
     "./emit-zod": "./src/emit-zod.ts",
     "./file-forward": "./src/file-forward.ts",
+    "./generated-bundle-writer": "./src/generated-bundle-writer.ts",
     "./ir": "./src/ir.ts",
     "./load": "./src/load.ts",
     "./mcp-server": "./src/mcp-server.ts",

--- a/packages/core/src/file-forward.ts
+++ b/packages/core/src/file-forward.ts
@@ -1,11 +1,11 @@
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { load, save } from './load';
+import { type GeneratedBundleFs, writeGeneratedBundle } from './generated-bundle-writer';
+import { load } from './load';
 import { type ApplyResult, apply, type Op } from './ops';
 import { assertWritableContextureProjectIrPath } from './paths';
-import { bundlePathsFor, type FileEntry, runEmitPipeline } from './pipeline';
 
-export interface FileBackedFs {
+export interface FileBackedFs extends GeneratedBundleFs {
   readFile(path: string): Promise<string>;
   writeFile(path: string, content: string): Promise<void>;
   rename(from: string, to: string): Promise<void>;
@@ -28,67 +28,16 @@ export const nodeFileBackedFs: FileBackedFs = {
   mkdirp: (path) => mkdir(path, { recursive: true }).then(() => undefined),
 };
 
-async function writeBundleAtomic(fs: FileBackedFs, files: ReadonlyArray<FileEntry>): Promise<void> {
-  interface Snapshot {
-    path: string;
-    existed: boolean;
-    prior?: string;
-    renamed: boolean;
-  }
-
-  const snapshots: Snapshot[] = [];
-  try {
-    for (const file of files) {
-      const snap: Snapshot = { path: file.path, existed: false, renamed: false };
-      try {
-        snap.prior = await fs.readFile(file.path);
-        snap.existed = true;
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-      }
-      snapshots.push(snap);
-
-      const tmp = `${file.path}.tmp`;
-      await fs.writeFile(tmp, file.content);
-      await fs.rename(tmp, file.path);
-      snap.renamed = true;
-    }
-  } catch (err) {
-    for (const snap of snapshots.slice().reverse()) {
-      if (snap.renamed) {
-        if (snap.existed && snap.prior !== undefined) {
-          await fs.writeFile(snap.path, snap.prior).catch(() => undefined);
-        } else {
-          await fs.remove(snap.path).catch(() => undefined);
-        }
-      }
-      await fs.remove(`${snap.path}.tmp`).catch(() => undefined);
-    }
-    throw err;
-  }
-}
-
 export function createFileBackedForward(irPath: string, fs: FileBackedFs = nodeFileBackedFs) {
   const resolvedIrPath = assertWritableContextureProjectIrPath(irPath);
 
   return async function forward(op: Op): Promise<ApplyResult> {
-    // TODO(#160): run drift pre-flight before writing generated artefacts.
     const raw = await fs.readFile(resolvedIrPath);
     const { schema } = load(raw);
     const result = apply(schema, op);
     if ('error' in result) return result;
 
-    const paths = bundlePathsFor(resolvedIrPath);
-    await fs.mkdirp(dirname(paths.emitted));
-    await fs.mkdirp(dirname(paths.convex));
-
-    const { emitted, manifest } = runEmitPipeline(result.schema, resolvedIrPath);
-    const files: FileEntry[] = [
-      { path: paths.ir, content: `${save(result.schema)}\n` },
-      ...emitted,
-      { path: paths.emitted, content: `${JSON.stringify(manifest, null, 2)}\n` },
-    ];
-    await writeBundleAtomic(fs, files);
+    await writeGeneratedBundle({ irPath: resolvedIrPath, schema: result.schema, fs });
     return result;
   };
 }

--- a/packages/core/src/generated-bundle-writer.ts
+++ b/packages/core/src/generated-bundle-writer.ts
@@ -1,0 +1,212 @@
+import type { Schema } from './ir';
+import { save } from './load';
+import { type BundlePaths, bundlePathsFor, contextureDirFor } from './paths';
+import {
+  type EmitPipelineDeps,
+  type EmittedManifest,
+  type FileEntry,
+  hashContent,
+  runEmitPipeline,
+} from './pipeline';
+
+export type GeneratedFileStatus = 'clean' | 'drifted' | 'unreadable';
+
+export interface GeneratedFileCheck {
+  path: string;
+  status: GeneratedFileStatus;
+}
+
+export interface GeneratedBundleFs {
+  readFile(path: string): Promise<string>;
+  writeFile(path: string, content: string): Promise<void>;
+  rename(from: string, to: string): Promise<void>;
+  remove(path: string): Promise<void>;
+  mkdirp?(path: string): Promise<void>;
+}
+
+export interface GeneratedBundleBuild {
+  paths: BundlePaths;
+  emitted: FileEntry[];
+  manifest: EmittedManifest;
+  manifestFile: FileEntry;
+}
+
+export interface GeneratedBundleWriteInput {
+  irPath: string;
+  schema: Schema;
+  fs: GeneratedBundleFs;
+  emitDeps?: EmitPipelineDeps;
+  sidecars?: ReadonlyArray<FileEntry>;
+  includeIr?: boolean;
+  driftPreflight?: boolean;
+}
+
+export interface GeneratedBundleWriteResult extends GeneratedBundleBuild {
+  files: FileEntry[];
+}
+
+export class GeneratedBundleDriftError extends Error {
+  readonly problems: GeneratedFileCheck[];
+
+  constructor(problems: ReadonlyArray<GeneratedFileCheck>) {
+    const rendered = problems.map((problem) => `${problem.path} (${problem.status})`).join(', ');
+    super(`Generated files have drifted; refusing to overwrite: ${rendered}`);
+    this.name = 'GeneratedBundleDriftError';
+    this.problems = [...problems];
+  }
+}
+
+export function buildGeneratedBundle(
+  schema: Schema,
+  irPath: string,
+  emitDeps?: EmitPipelineDeps,
+): GeneratedBundleBuild {
+  const paths = bundlePathsFor(irPath);
+  const { emitted, manifest } = runEmitPipeline(schema, irPath, emitDeps);
+  return {
+    paths,
+    emitted,
+    manifest,
+    manifestFile: { path: paths.emitted, content: `${JSON.stringify(manifest, null, 2)}\n` },
+  };
+}
+
+export async function checkGeneratedBundle(
+  schema: Schema,
+  irPath: string,
+  fs: Pick<GeneratedBundleFs, 'readFile'>,
+  emitDeps?: EmitPipelineDeps,
+): Promise<GeneratedFileCheck[]> {
+  const { emitted, manifestFile } = buildGeneratedBundle(schema, irPath, emitDeps);
+  const files = [...emitted, manifestFile];
+  const checks: GeneratedFileCheck[] = [];
+
+  for (const entry of files) {
+    let onDisk: string | undefined;
+    try {
+      onDisk = await fs.readFile(entry.path);
+    } catch {
+      onDisk = undefined;
+    }
+
+    if (onDisk === undefined) checks.push({ path: entry.path, status: 'unreadable' });
+    else if (onDisk !== entry.content) checks.push({ path: entry.path, status: 'drifted' });
+    else checks.push({ path: entry.path, status: 'clean' });
+  }
+
+  return checks;
+}
+
+export async function checkGeneratedManifestDrift(
+  irPath: string,
+  fs: Pick<GeneratedBundleFs, 'readFile'>,
+): Promise<GeneratedFileCheck[]> {
+  const paths = bundlePathsFor(irPath);
+  let manifest: EmittedManifest;
+  try {
+    manifest = JSON.parse(await fs.readFile(paths.emitted)) as EmittedManifest;
+  } catch {
+    return [];
+  }
+
+  const checks: GeneratedFileCheck[] = [];
+  for (const [path, expectedHash] of Object.entries(manifest.files ?? {})) {
+    let content: string | undefined;
+    try {
+      content = await fs.readFile(path);
+    } catch {
+      content = undefined;
+    }
+
+    if (content === undefined) checks.push({ path, status: 'unreadable' });
+    else if (hashContent(content) !== expectedHash) checks.push({ path, status: 'drifted' });
+    else checks.push({ path, status: 'clean' });
+  }
+
+  return checks;
+}
+
+export async function writeGeneratedBundle(
+  input: GeneratedBundleWriteInput,
+): Promise<GeneratedBundleWriteResult> {
+  const {
+    irPath,
+    schema,
+    fs,
+    emitDeps,
+    sidecars = [],
+    includeIr = true,
+    driftPreflight = true,
+  } = input;
+
+  if (driftPreflight) {
+    const drift = (await checkGeneratedManifestDrift(irPath, fs)).filter(
+      (check) => check.status !== 'clean',
+    );
+    if (drift.length > 0) throw new GeneratedBundleDriftError(drift);
+  }
+
+  const bundle = buildGeneratedBundle(schema, irPath, emitDeps);
+  await fs.mkdirp?.(contextureDirFor(irPath));
+  await fs.mkdirp?.(dirname(bundle.paths.convex));
+
+  const files = [
+    ...(includeIr ? [{ path: bundle.paths.ir, content: `${save(schema)}\n` }] : []),
+    ...sidecars,
+    ...bundle.emitted,
+    bundle.manifestFile,
+  ];
+
+  await writeFilesAtomic(fs, files);
+  return { ...bundle, files };
+}
+
+export async function writeFilesAtomic(
+  fs: GeneratedBundleFs,
+  files: ReadonlyArray<FileEntry>,
+): Promise<void> {
+  interface Snapshot {
+    path: string;
+    existed: boolean;
+    prior?: string;
+    renamed: boolean;
+  }
+
+  const snapshots: Snapshot[] = [];
+  try {
+    for (const file of files) {
+      const snap: Snapshot = { path: file.path, existed: false, renamed: false };
+      try {
+        snap.prior = await fs.readFile(file.path);
+        snap.existed = true;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+      snapshots.push(snap);
+
+      const tmp = `${file.path}.tmp`;
+      await fs.writeFile(tmp, file.content);
+      await fs.rename(tmp, file.path);
+      snap.renamed = true;
+    }
+  } catch (err) {
+    for (const snap of snapshots.slice().reverse()) {
+      if (snap.renamed) {
+        if (snap.existed && snap.prior !== undefined) {
+          await fs.writeFile(snap.path, snap.prior).catch(() => undefined);
+        } else {
+          await fs.remove(snap.path).catch(() => undefined);
+        }
+      }
+      await fs.remove(`${snap.path}.tmp`).catch(() => undefined);
+    }
+    throw err;
+  }
+}
+
+function dirname(path: string): string {
+  const normalized = path.replaceAll('\\', '/');
+  const slash = normalized.lastIndexOf('/');
+  if (slash <= 0) return slash === 0 ? '/' : '.';
+  return normalized.slice(0, slash);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export { emit as emitSchemaIndex } from './emit-schema-index';
 export { emitTableCrud } from './emit-table-crud';
 export { emit as emitZod } from './emit-zod';
 export * from './file-forward';
+export * from './generated-bundle-writer';
 export * from './ir';
 export * from './load';
 export * from './migrations';

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -356,7 +356,17 @@ async function applyContextureOp(
     };
   }
 
-  const result = await createFileBackedForward(path)(parsed.data);
+  let result: Awaited<ReturnType<ReturnType<typeof createFileBackedForward>>>;
+  try {
+    result = await createFileBackedForward(path)(parsed.data);
+  } catch (err) {
+    return {
+      path,
+      applied: false,
+      opKind,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
   if ('error' in result) {
     return { path, applied: false, opKind, error: result.error };
   }

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -1,7 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ZodError, z } from 'zod';
-import { createFileBackedForward } from './file-forward';
+import { createFileBackedForward, nodeFileBackedFs } from './file-forward';
+import { checkGeneratedBundle, writeGeneratedBundle } from './generated-bundle-writer';
 import {
   FieldDefSchema,
   type FieldType,
@@ -14,12 +15,7 @@ import {
 } from './ir';
 import { load } from './load';
 import type { Op } from './ops';
-import {
-  assertContextureIrPath,
-  assertWritableContextureProjectIrPath,
-  bundlePathsFor,
-} from './paths';
-import { runEmitPipeline } from './pipeline';
+import { assertContextureIrPath, assertWritableContextureProjectIrPath } from './paths';
 import { checkSemantic } from './semantic-validation';
 
 const VERSION = '0.0.0';
@@ -386,12 +382,12 @@ async function emitContextureBundle(
 ): Promise<z.infer<z.ZodObject<typeof EmitContextureOutput>>> {
   const path = assertWritableContextureProjectIrPath(irPath);
   const { schema } = await readContextureFile(path);
-  const { emitted, manifest } = runEmitPipeline(schema, path);
-  const result = await createFileBackedForward(path)({
-    kind: 'replace_schema',
+  const { emitted, manifest } = await writeGeneratedBundle({
+    irPath: path,
     schema,
+    fs: nodeFileBackedFs,
+    driftPreflight: false,
   });
-  if ('error' in result) throw new Error(result.error);
   return {
     path,
     emitted: emitted.map((file) => file.path),
@@ -399,33 +395,12 @@ async function emitContextureBundle(
   };
 }
 
-type GeneratedFileStatus = z.infer<typeof GeneratedFileStatusSchema>;
-
 async function checkContextureDrift(
   irPath: string,
 ): Promise<z.infer<z.ZodObject<typeof CheckContextureDriftOutput>>> {
   const path = assertWritableContextureProjectIrPath(irPath);
   const { schema } = await readContextureFile(path);
-  const { emitted, manifest } = runEmitPipeline(schema, path);
-  const paths = bundlePathsFor(path);
-  const expectedFiles = [
-    ...emitted,
-    { path: paths.emitted, content: `${JSON.stringify(manifest, null, 2)}\n` },
-  ];
-  const files: Array<{ path: string; status: GeneratedFileStatus }> = [];
-
-  for (const entry of expectedFiles) {
-    let onDisk: string | undefined;
-    try {
-      onDisk = await readFile(entry.path, 'utf8');
-    } catch {
-      onDisk = undefined;
-    }
-
-    if (onDisk === undefined) files.push({ path: entry.path, status: 'unreadable' });
-    else if (onDisk !== entry.content) files.push({ path: entry.path, status: 'drifted' });
-    else files.push({ path: entry.path, status: 'clean' });
-  }
+  const files = await checkGeneratedBundle(schema, path, nodeFileBackedFs);
 
   const drift = files.filter((file) => file.status !== 'clean');
   return {

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -46,7 +46,7 @@ export interface EmitPipelineDeps {
   emitAiToolSchemas?: (schema: Schema, sourcePath?: string) => unknown;
 }
 
-function sha256(content: string): string {
+export function hashContent(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
 }
 
@@ -60,7 +60,7 @@ function aiOutputEnabled(schema: Schema, target: 'toolSchemas') {
 
 export function buildManifest(entries: ReadonlyArray<FileEntry>): EmittedManifest {
   const files: Record<string, string> = {};
-  for (const { path, content } of entries) files[path] = sha256(content);
+  for (const { path, content } of entries) files[path] = hashContent(content);
   return { version: '1', files };
 }
 

--- a/packages/core/tests/file-forward.test.ts
+++ b/packages/core/tests/file-forward.test.ts
@@ -82,4 +82,34 @@ describe('createFileBackedForward', () => {
 
     expect(files.get(irPath)).toBe(`${JSON.stringify(initialSchema, null, 2)}\n`);
   });
+
+  it('refuses to apply ops over hand-edited generated files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'contexture-core-'));
+    const irPath = join(dir, 'packages/contexture/app.contexture.json');
+    await mkdir(join(dir, 'packages/contexture'), { recursive: true });
+    await writeFile(irPath, `${JSON.stringify(initialSchema, null, 2)}\n`, 'utf8');
+
+    const forward = createFileBackedForward(irPath);
+    await forward({
+      kind: 'add_field',
+      typeName: 'Post',
+      field: { name: 'title', type: { kind: 'string' } },
+    });
+    await writeFile(join(dir, 'packages/contexture/app.schema.ts'), '// hand edit\n', 'utf8');
+
+    await expect(
+      forward({
+        kind: 'add_field',
+        typeName: 'Post',
+        field: { name: 'body', type: { kind: 'string' } },
+      }),
+    ).rejects.toThrow(/Generated files have drifted/);
+
+    const written = JSON.parse(await readFile(irPath, 'utf8')) as Schema;
+    const type = written.types[0];
+    expect(type?.kind).toBe('object');
+    expect(type?.kind === 'object' ? type.fields.map((field) => field.name) : []).toEqual([
+      'title',
+    ]);
+  });
 });

--- a/packages/core/tests/generated-bundle-writer.test.ts
+++ b/packages/core/tests/generated-bundle-writer.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkGeneratedBundle,
+  GeneratedBundleDriftError,
+  type GeneratedBundleFs,
+  type Schema,
+  writeGeneratedBundle,
+} from '../src';
+
+const irPath = '/proj/packages/contexture/app.contexture.json';
+
+const schema: Schema = {
+  version: '1',
+  types: [{ kind: 'object', name: 'Post', table: true, fields: [] }],
+};
+
+function enoent(path: string): NodeJS.ErrnoException {
+  const err = new Error(`ENOENT: ${path}`) as NodeJS.ErrnoException;
+  err.code = 'ENOENT';
+  return err;
+}
+
+function createFs(seed: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(seed));
+  let failPattern: RegExp | null = null;
+
+  const fs: GeneratedBundleFs & {
+    files: Map<string, string>;
+    failWritesMatching(pattern: RegExp): void;
+    tmpFiles(): string[];
+  } = {
+    files,
+    async readFile(path) {
+      const value = files.get(path);
+      if (value === undefined) throw enoent(path);
+      return value;
+    },
+    async writeFile(path, content) {
+      if (failPattern?.test(path)) throw new Error(`write failed: ${path}`);
+      files.set(path, content);
+    },
+    async rename(from, to) {
+      const value = files.get(from);
+      if (value === undefined) throw enoent(from);
+      files.set(to, value);
+      files.delete(from);
+    },
+    async remove(path) {
+      files.delete(path);
+    },
+    async mkdirp() {
+      // The in-memory fake has implicit directories.
+    },
+    failWritesMatching(pattern) {
+      failPattern = pattern;
+    },
+    tmpFiles() {
+      return [...files.keys()].filter((path) => path.endsWith('.tmp'));
+    },
+  };
+
+  return fs;
+}
+
+describe('generated bundle writer', () => {
+  it('writes the IR, generated artefacts, and manifest atomically', async () => {
+    const fs = createFs();
+
+    const result = await writeGeneratedBundle({ irPath, schema, fs });
+
+    expect(fs.files.get(irPath)).toContain('"Post"');
+    expect(fs.files.get('/proj/packages/contexture/app.schema.ts')).toContain(
+      '@contexture-generated',
+    );
+    expect(fs.files.get('/proj/packages/contexture/.contexture/emitted.json')).toContain(
+      'app.schema.ts',
+    );
+    expect(result.emitted.map((file) => file.path).sort()).toEqual(
+      [
+        '/proj/packages/contexture/app.schema.json',
+        '/proj/packages/contexture/app.schema.ts',
+        '/proj/packages/contexture/convex/schema.ts',
+        '/proj/packages/contexture/index.ts',
+      ].sort(),
+    );
+  });
+
+  it('rolls back prior writes when a later generated artefact fails', async () => {
+    const original = `${JSON.stringify(schema, null, 2)}\n`;
+    const fs = createFs({ [irPath]: original });
+    fs.failWritesMatching(/app\.schema\.ts\.tmp$/);
+
+    await expect(
+      writeGeneratedBundle({
+        irPath,
+        schema: {
+          version: '1',
+          types: [{ kind: 'object', name: 'Changed', table: true, fields: [] }],
+        },
+        fs,
+      }),
+    ).rejects.toThrow(/write failed/);
+
+    expect(fs.files.get(irPath)).toBe(original);
+    expect(fs.tmpFiles()).toEqual([]);
+  });
+
+  it('preflights against the last manifest before overwriting generated files', async () => {
+    const fs = createFs();
+    await writeGeneratedBundle({ irPath, schema, fs });
+    await fs.writeFile('/proj/packages/contexture/app.schema.ts', '// hand edit\n');
+
+    await expect(
+      writeGeneratedBundle({
+        irPath,
+        schema: {
+          version: '1',
+          types: [
+            {
+              kind: 'object',
+              name: 'Post',
+              table: true,
+              fields: [{ name: 'title', type: { kind: 'string' } }],
+            },
+          ],
+        },
+        fs,
+      }),
+    ).rejects.toBeInstanceOf(GeneratedBundleDriftError);
+
+    expect(fs.files.get('/proj/packages/contexture/app.schema.ts')).toBe('// hand edit\n');
+  });
+
+  it('allows explicit re-emits to overwrite generated drift', async () => {
+    const fs = createFs();
+    await writeGeneratedBundle({ irPath, schema, fs });
+    await fs.writeFile('/proj/packages/contexture/app.schema.ts', '// hand edit\n');
+
+    await writeGeneratedBundle({ irPath, schema, fs, driftPreflight: false });
+
+    expect(fs.files.get('/proj/packages/contexture/app.schema.ts')).toContain(
+      '@contexture-generated',
+    );
+  });
+
+  it('checks generated files through the same expected bundle shape', async () => {
+    const fs = createFs();
+    await writeGeneratedBundle({ irPath, schema, fs });
+    await fs.writeFile('/proj/packages/contexture/app.schema.json', '{}\n');
+
+    const checks = await checkGeneratedBundle(schema, irPath, fs);
+
+    expect(checks.find((check) => check.path.endsWith('app.schema.json'))).toEqual({
+      path: '/proj/packages/contexture/app.schema.json',
+      status: 'drifted',
+    });
+    expect(checks.find((check) => check.path.endsWith('app.schema.ts'))?.status).toBe('clean');
+  });
+});


### PR DESCRIPTION
## Summary
- Added a shared `@contexture/core/generated-bundle-writer` module for building generated files, atomic writes, manifest drift checks, and preflight drift refusal
- Wired desktop project saves, CLI `emit`/`check-generated`, and MCP emit/drift flows through the shared implementation
- Added coverage for atomic rollback, drift preflight, explicit re-emit over drift, and desktop save refusal when generated files have been edited
- Marked Goal 11 complete in the roadmap

## Testing
- `bun run ci`
- `bun run build --filter=@contexture/desktop`
- `bun run typecheck --filter=@contexture/core`
- `bun run typecheck --filter=@contexture/cli`
- `bun --filter @contexture/desktop typecheck`
- New and updated unit tests passed across core, CLI, and desktop