### PR TITLE
Bump desktop app version to 0.15.4

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",


### PR DESCRIPTION
## Summary
- Bump @contexture/desktop from 0.15.3 to 0.15.4
- Keep bun.lock workspace metadata in sync

## Verification
- Pre-commit hook ran biome check --write --no-errors-on-unmatched
- Pre-commit hook ran turbo typecheck
- Pre-commit hook ran turbo test