### PR TITLE
Fix desktop release packaging with Bun dependencies

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -71,6 +71,7 @@ deb:
 appImage:
   artifactName: ${productName}-${version}.${ext}
 npmRebuild: false
+beforePack: scripts/electron-builder-before-pack.cjs
 publish:
   provider: github
   owner: applification

--- a/apps/desktop/scripts/electron-builder-before-pack.cjs
+++ b/apps/desktop/scripts/electron-builder-before-pack.cjs
@@ -1,0 +1,102 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function parseVersion(version) {
+  return version.split('.').map((part) => Number.parseInt(part, 10));
+}
+
+function satisfiesCaretZero(version, range) {
+  if (!range.startsWith('^0.')) {
+    return version === range || range === '*' || range === version;
+  }
+
+  const [major, minor, patch] = parseVersion(range.slice(1));
+  const [candidateMajor, candidateMinor, candidatePatch] = parseVersion(version);
+
+  if (candidateMajor !== major || candidateMinor !== minor) {
+    return false;
+  }
+
+  return candidatePatch >= patch;
+}
+
+function findWorkspaceRoot(startDir) {
+  let current = startDir;
+
+  while (true) {
+    const packageJsonPath = path.join(current, 'package.json');
+
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+      if (packageJson.workspaces) {
+        return current;
+      }
+    }
+
+    const parent = path.dirname(current);
+
+    if (parent === current) {
+      throw new Error(`Could not find workspace root from ${startDir}`);
+    }
+
+    current = parent;
+  }
+}
+
+function findInstalledPackage(workspaceRoot, packageName, range) {
+  const bunStoreDir = path.join(workspaceRoot, 'node_modules', '.bun');
+  const packageDirName = packageName.replace('/', '+');
+
+  for (const entry of fs.readdirSync(bunStoreDir)) {
+    if (!entry.startsWith(`${packageDirName}@`)) {
+      continue;
+    }
+
+    const packageDir = path.join(bunStoreDir, entry, 'node_modules', packageName);
+    const packageJsonPath = path.join(packageDir, 'package.json');
+
+    if (!fs.existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+    if (satisfiesCaretZero(packageJson.version, range)) {
+      return packageDir;
+    }
+  }
+
+  throw new Error(`Could not find ${packageName}@${range} in ${bunStoreDir}`);
+}
+
+exports.default = async function beforePack(context) {
+  const appDir = context.packager.projectDir;
+  const workspaceRoot = findWorkspaceRoot(appDir);
+  const claudeAgentSdkDir = fs.realpathSync(
+    path.join(appDir, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
+  );
+  const claudeAgentSdkPackageJson = JSON.parse(
+    fs.readFileSync(path.join(claudeAgentSdkDir, 'package.json'), 'utf8'),
+  );
+  const sdkRange = claudeAgentSdkPackageJson.dependencies?.['@anthropic-ai/sdk'];
+
+  if (!sdkRange) {
+    return;
+  }
+
+  const sdkDir = findInstalledPackage(workspaceRoot, '@anthropic-ai/sdk', sdkRange);
+  const linkDir = path.join(claudeAgentSdkDir, 'node_modules', '@anthropic-ai');
+  const linkPath = path.join(linkDir, 'sdk');
+
+  fs.mkdirSync(linkDir, { recursive: true });
+
+  if (fs.existsSync(linkPath)) {
+    return;
+  }
+
+  const linkType = process.platform === 'win32' ? 'junction' : 'dir';
+  const linkTarget = linkType === 'junction' ? sdkDir : path.relative(linkDir, sdkDir);
+
+  fs.symlinkSync(linkTarget, linkPath, linkType);
+};

--- a/bun.lock
+++ b/bun.lock
@@ -196,7 +196,6 @@
     "@biomejs/biome",
   ],
   "overrides": {
-    "@anthropic-ai/sdk": "0.95.1",
     "@next/env": "npm:@varlock/nextjs-integration@^1.1.0",
     "mermaid": "11.15.0",
     "postcss": "^8.5.14",
@@ -2955,6 +2954,8 @@
     "zustand": ["zustand@5.0.13", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/package.json
+++ b/package.json
@@ -48,12 +48,8 @@
   ],
   "overrides": {
     "@next/env": "npm:@varlock/nextjs-integration@^1.1.0",
-    "@anthropic-ai/sdk": "0.95.1",
     "mermaid": "11.15.0",
     "postcss": "^8.5.14"
-  },
-  "resolutions": {
-    "@anthropic-ai/sdk": "0.95.1"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,jsonc}": [


### PR DESCRIPTION
## Summary
- remove the forced @anthropic-ai/sdk override so @anthropic-ai/claude-agent-sdk can use its compatible transitive SDK
- add an electron-builder beforePack hook that links Bun's transitive SDK package into the package-store location traversed during packaging
- update bun.lock to include @anthropic-ai/sdk 0.81.0 under the Claude Agent SDK dependency

## Verification
- bun run build --filter=@contexture/desktop
- CSC_IDENTITY_AUTO_DISCOVERY=false bunx electron-builder --mac --dir --publish never
- bun run typecheck --filter=@contexture/desktop
- bun run test --filter=@contexture/desktop
- bun run check -- apps/desktop/electron-builder.yml package.json apps/desktop/scripts/electron-builder-before-pack.cjs
- pre-commit hook: turbo typecheck && turbo test