### PR TITLE
Harden drift watcher around IR-owned generated targets

### DIFF
--- a/apps/desktop/src/main/documents/drift-watcher.ts
+++ b/apps/desktop/src/main/documents/drift-watcher.ts
@@ -2,13 +2,14 @@
  * Drift detection for `@contexture-generated` files.
  *
  * `detectDrift` is a pure function that reads `.contexture/emitted.json`,
- * hashes every file listed in the manifest, and returns a per-file
- * status (`match | drifted | unreadable`). It has no side effects and
- * can be reused by the CLI's file-backed forward (#207).
+ * hashes manifest entries that are inside the caller's allowed target set,
+ * and returns a per-file status (`match | drifted | unreadable`). It has no
+ * side effects and can be reused by the CLI's file-backed forward (#207).
  *
- * `createDriftWatcher` wraps `detectDrift` with `fs.watch` subscriptions
- * so the Electron main process gets live callbacks when any manifest
- * file is hand-edited (or returns to its expected hash).
+ * `createDriftWatcher` derives the manifest path and generated target set
+ * from the open IR, then wraps `detectDrift` with `fs.watch` subscriptions
+ * so the Electron main process gets live callbacks when a generated file is
+ * hand-edited (or returns to its expected hash).
  *
  * Self-write suppression: the DocumentStore writes `emitted.json`
  * before it writes the watched files in the atomic bundle; by the time
@@ -17,6 +18,7 @@
  */
 import { createHash } from 'node:crypto';
 import { type FSWatcher, promises as fsPromises, watch } from 'node:fs';
+import { bundlePathsFor, generatedTargetsFor } from '@contexture/core';
 
 // ─── Pure detector ───────────────────────────────────────────────────
 
@@ -33,6 +35,7 @@ export interface DriftProblem {
 export async function detectDrift(
   emittedJsonPath: string,
   readFile: (path: string) => Promise<string> = (p) => fsPromises.readFile(p, 'utf-8'),
+  options: { allowedPaths?: readonly string[] } = {},
 ): Promise<DriftResult[]> {
   let manifest: { files?: Record<string, string> };
   try {
@@ -44,9 +47,11 @@ export async function detectDrift(
 
   const files = manifest.files;
   if (!files || Object.keys(files).length === 0) return [];
+  const allowed = options.allowedPaths ? new Set(options.allowedPaths) : null;
 
   const results: DriftResult[] = [];
   for (const [filePath, expectedHash] of Object.entries(files)) {
+    if (allowed && !allowed.has(filePath)) continue;
     let actual: string | null;
     try {
       const content = await readFile(filePath);
@@ -75,7 +80,7 @@ export interface DriftWatcher {
 }
 
 export interface DriftWatcherOptions {
-  emittedJsonPath: string;
+  irPath: string;
   onDrift: (paths: string[]) => void;
   onStatus?: (problems: DriftProblem[]) => void;
   onResolved: () => void;
@@ -85,13 +90,15 @@ export interface DriftWatcherOptions {
 
 export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
   const {
-    emittedJsonPath,
+    irPath,
     onDrift,
     onStatus,
     onResolved,
     debounceMs = 300,
     readFile = (p) => fsPromises.readFile(p, 'utf-8'),
   } = opts;
+  const emittedJsonPath = bundlePathsFor(irPath).emitted;
+  const allowedPaths = generatedTargetsFor(irPath).map((entry) => entry.path);
 
   let watchers: FSWatcher[] = [];
   let watchedPaths: string[] = [];
@@ -100,7 +107,7 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
   let stopped = false;
 
   async function doCheck(): Promise<void> {
-    const results = await detectDrift(emittedJsonPath, readFile);
+    const results = await detectDrift(emittedJsonPath, readFile, { allowedPaths });
     if (stopped || results.length === 0) return;
 
     const problems = results.filter((r): r is DriftProblem => r.status !== 'match');

--- a/apps/desktop/src/main/ipc/drift.ts
+++ b/apps/desktop/src/main/ipc/drift.ts
@@ -9,26 +9,29 @@
  *
  * `drift:check` is a one-shot manual re-check (window focus trigger).
  */
+
 import type { BrowserWindow } from 'electron';
 import { ipcMain } from 'electron';
 import { z } from 'zod';
 import { createDriftWatcher, type DriftWatcher } from '../documents/drift-watcher';
+import { assertSafeContextureIrPath } from '../security';
 import { IpcString, parseIpcPayload } from './validation';
 
 let activeWatcher: DriftWatcher | null = null;
 
 const WatchPayloadSchema = z
   .object({
-    emittedJsonPath: IpcString,
+    irPath: IpcString,
   })
   .strict();
 
 export function registerDriftIpc(mainWindow: BrowserWindow): void {
   ipcMain.handle('drift:watch', (_evt, payload: unknown) => {
     const parsed = parseIpcPayload('drift:watch', WatchPayloadSchema, payload);
+    const irPath = assertSafeContextureIrPath(parsed.irPath);
     activeWatcher?.stop();
     activeWatcher = createDriftWatcher({
-      emittedJsonPath: parsed.emittedJsonPath,
+      irPath,
       onDrift: (paths) => mainWindow.webContents.send('drift:detected', { paths }),
       onStatus: (problems) =>
         mainWindow.webContents.send('drift:detected', {

--- a/apps/desktop/src/main/ipc/file.ts
+++ b/apps/desktop/src/main/ipc/file.ts
@@ -25,6 +25,7 @@ import {
   type DocumentStore,
 } from '../documents/document-store';
 import { nodeFsAdapter } from '../documents/node-fs-adapter';
+import { assertSafeContextureIrPath } from '../security';
 import { IpcString, parseIpcPayload } from './validation';
 
 // Electron's FileFilter.extensions is a list of bare extensions (no dot,
@@ -102,16 +103,17 @@ export async function handleSave(input: HandleSaveInput): Promise<void> {
  * recent-files path to silently prune stale entries).
  */
 export async function handleOpen(irPath: string): Promise<OpenResult | null> {
+  const safeIrPath = assertSafeContextureIrPath(irPath);
   const s = getStore();
-  if (!(await s.fileExists(irPath))) return null;
-  const content = await s.readFile(irPath);
-  const bundle = await s.open(irPath);
+  if (!(await s.fileExists(safeIrPath))) return null;
+  const content = await s.readFile(safeIrPath);
+  const bundle = await s.open(safeIrPath);
   const warnings: OpenWarning[] = bundle.warnings.map((w) => ({
     message: w.message,
     severity: w.severity,
   }));
   return {
-    irPath,
+    irPath: safeIrPath,
     mode: bundle.mode,
     content,
     layout: bundle.layout,

--- a/apps/desktop/src/main/security.ts
+++ b/apps/desktop/src/main/security.ts
@@ -1,6 +1,6 @@
 import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, parse, resolve } from 'node:path';
-import { generatedTargetsFor } from '@contexture/core/paths';
+import { assertContextureIrPath, generatedTargetsFor } from '@contexture/core/paths';
 
 const SAFE_EXTERNAL_PROTOCOLS = new Set(['https:', 'http:', 'mailto:']);
 
@@ -25,6 +25,16 @@ export function assertGeneratedTargetForIr(irPath: string, targetPath: string): 
     throw new Error('Target is not a generated Contexture artifact for this IR.');
   }
   return target;
+}
+
+export function assertSafeContextureIrPath(inputPath: string): string {
+  if (typeof inputPath !== 'string' || inputPath.trim() === '') {
+    throw new Error('Contexture IR path must be a non-empty path.');
+  }
+  if (!isAbsolute(inputPath)) {
+    throw new Error('Contexture IR path must be absolute.');
+  }
+  return assertContextureIrPath(inputPath);
 }
 
 export function assertSafeRecursiveDeleteTarget(inputPath: string): string {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -152,7 +152,7 @@ export interface ContextureProjectAPI {
 
 export interface ContextureDriftAPI {
   /** Start watching all manifest files for drift against emitted.json. */
-  watch: (payload: { emittedJsonPath: string }) => Promise<{ ok: boolean }>;
+  watch: (payload: { irPath: string }) => Promise<{ ok: boolean }>;
   /** Stop the active watcher. */
   unwatch: () => Promise<{ ok: boolean }>;
   /** Trigger a manual hash check (window focus). */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -149,7 +149,7 @@ const project = {
 
 const drift = {
   /** Start watching all manifest files for drift; stops any previous watcher. */
-  watch: (payload: { emittedJsonPath: string }): Promise<{ ok: boolean }> =>
+  watch: (payload: { irPath: string }): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('drift:watch', payload) as Promise<{ ok: boolean }>,
   /** Stop the active watcher. */
   unwatch: (): Promise<{ ok: boolean }> =>

--- a/apps/desktop/src/renderer/src/hooks/useDrift.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDrift.ts
@@ -16,20 +16,6 @@ import { useDriftStore } from '../store/drift';
 const IR_SUFFIX = '.contexture.json';
 
 /**
- * Derives the emitted-manifest path from the IR file path.
- *
- * IR lives at: <root>/packages/contexture/<name>.contexture.json
- * Emitted manifest: <root>/packages/contexture/.contexture/emitted.json
- */
-export function emittedPathFor(irPath: string): string | null {
-  if (!irPath.endsWith(IR_SUFFIX)) return null;
-  const slash = irPath.lastIndexOf('/');
-  if (slash === -1) return null;
-  const dir = irPath.slice(0, slash);
-  return `${dir}/.contexture/emitted.json`;
-}
-
-/**
  * Derives the Convex schema path from the IR file path.
  * Used by the reconcile hook to read the on-disk Convex source.
  */
@@ -55,13 +41,12 @@ export function useDrift(): void {
       return;
     }
 
-    const emittedJsonPath = emittedPathFor(filePath);
-    if (!emittedJsonPath) {
+    if (!filePath.endsWith(IR_SUFFIX)) {
       void driftApi.unwatch();
       return;
     }
 
-    void driftApi.watch({ emittedJsonPath });
+    void driftApi.watch({ irPath: filePath });
 
     const unDetected = driftApi.onDetected((payload) => {
       if (payload.files) useDriftStore.getState().setDetected(payload.files);

--- a/apps/desktop/tests/hooks/useDrift.test.ts
+++ b/apps/desktop/tests/hooks/useDrift.test.ts
@@ -1,24 +1,14 @@
-import { convexPathFor, emittedPathFor } from '@renderer/hooks/useDrift';
-import { describe, expect, it } from 'vitest';
+import { convexPathFor, useDrift } from '@renderer/hooks/useDrift';
+import { useDocumentStore } from '@renderer/store/document';
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-describe('emittedPathFor', () => {
-  it('derives emitted.json path from a valid IR path', () => {
-    const ir = '/proj/packages/contexture/garden.contexture.json';
-    expect(emittedPathFor(ir)).toBe('/proj/packages/contexture/.contexture/emitted.json');
-  });
-
-  it('returns null for a non-IR path', () => {
-    expect(emittedPathFor('/proj/packages/contexture/schema.ts')).toBeNull();
-  });
-
-  it('returns null for a path with no slash', () => {
-    expect(emittedPathFor('garden.contexture.json')).toBeNull();
-  });
-
-  it('handles deeply nested IR paths', () => {
-    const ir = '/a/b/c/d/garden.contexture.json';
-    expect(emittedPathFor(ir)).toBe('/a/b/c/d/.contexture/emitted.json');
-  });
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  const document = useDocumentStore.getState();
+  document.setFilePath(null);
+  document.setMode('scratch');
 });
 
 describe('convexPathFor', () => {
@@ -33,5 +23,30 @@ describe('convexPathFor', () => {
 
   it('returns null for a path with no slash', () => {
     expect(convexPathFor('garden.contexture.json')).toBeNull();
+  });
+});
+
+describe('useDrift', () => {
+  it('starts the drift watcher with the open IR path, not a renderer-derived manifest path', () => {
+    const watch = vi.fn(async () => ({ ok: true }));
+    const unwatch = vi.fn(async () => ({ ok: true }));
+    (window as unknown as { contexture: unknown }).contexture = {
+      drift: {
+        watch,
+        unwatch,
+        check: vi.fn(async () => ({ ok: true })),
+        dismiss: vi.fn(async () => ({ ok: true })),
+        onDetected: vi.fn(() => () => undefined),
+        onResolved: vi.fn(() => () => undefined),
+      },
+    };
+    useDocumentStore.getState().setFilePath('/proj/packages/contexture/garden.contexture.json');
+    useDocumentStore.getState().setMode('project');
+
+    renderHook(() => useDrift());
+
+    expect(watch).toHaveBeenCalledWith({
+      irPath: '/proj/packages/contexture/garden.contexture.json',
+    });
   });
 });

--- a/apps/desktop/tests/main/drift-watcher.test.ts
+++ b/apps/desktop/tests/main/drift-watcher.test.ts
@@ -8,7 +8,8 @@ import { createHash } from 'node:crypto';
 import { createDriftWatcher, detectDrift } from '@main/documents/drift-watcher';
 import { describe, expect, it, vi } from 'vitest';
 
-const WATCHED = '/proj/apps/web/convex/schema.ts';
+const IR_PATH = '/proj/packages/contexture/garden.contexture.json';
+const WATCHED = '/proj/packages/contexture/convex/schema.ts';
 const SCHEMA_TS = '/proj/packages/contexture/garden.schema.ts';
 const SCHEMA_JSON = '/proj/packages/contexture/garden.schema.json';
 const SCHEMA_INDEX = '/proj/packages/contexture/index.ts';
@@ -51,7 +52,7 @@ function makeWatcher(
   } = {},
 ) {
   const watcher = createDriftWatcher({
-    emittedJsonPath: EMITTED,
+    irPath: IR_PATH,
     onDrift,
     onStatus,
     onResolved,
@@ -137,6 +138,23 @@ describe('detectDrift', () => {
     const results = await detectDrift(EMITTED, makeReadFile(files));
     expect(results).toEqual([]);
   });
+
+  it('ignores manifest entries outside the allowed generated target set', async () => {
+    const files: Record<string, string> = {
+      [WATCHED]: 'defineSchema({})',
+      '/etc/passwd': 'root',
+      [EMITTED]: makeManifest({
+        [WATCHED]: 'defineSchema({})',
+        '/etc/passwd': 'edited root',
+      }),
+    };
+
+    const results = await detectDrift(EMITTED, makeReadFile(files), {
+      allowedPaths: [WATCHED],
+    });
+
+    expect(results).toEqual([{ path: WATCHED, status: 'match' }]);
+  });
 });
 
 // ─── createDriftWatcher (multi-file) ─────────────────────────────────
@@ -170,7 +188,7 @@ describe('createDriftWatcher', () => {
     const onDrift = vi.fn();
     const onResolved = vi.fn();
     const watcher = createDriftWatcher({
-      emittedJsonPath: EMITTED,
+      irPath: IR_PATH,
       onDrift,
       onResolved,
       readFile,
@@ -294,7 +312,7 @@ describe('createDriftWatcher', () => {
     const onDrift = vi.fn();
     const onResolved = vi.fn();
     const watcher = createDriftWatcher({
-      emittedJsonPath: EMITTED,
+      irPath: IR_PATH,
       onDrift,
       onResolved,
       readFile,
@@ -327,7 +345,7 @@ describe('createDriftWatcher', () => {
     const onDrift = vi.fn();
     const onResolved = vi.fn();
     const watcher = createDriftWatcher({
-      emittedJsonPath: EMITTED,
+      irPath: IR_PATH,
       onDrift,
       onResolved,
       readFile,
@@ -386,7 +404,7 @@ describe('createDriftWatcher', () => {
     const onDrift = vi.fn();
     const onResolved = vi.fn();
     const watcher = createDriftWatcher({
-      emittedJsonPath: EMITTED,
+      irPath: IR_PATH,
       onDrift,
       onResolved,
       readFile,

--- a/apps/desktop/tests/main/file-ipc.test.ts
+++ b/apps/desktop/tests/main/file-ipc.test.ts
@@ -44,6 +44,15 @@ describe('handleOpen (routes through DocumentStore)', () => {
     );
     expect(await handleOpen('/missing.contexture.json')).toBeNull();
   });
+
+  it('rejects non-Contexture paths before reading file contents', async () => {
+    const fs = createMemFsAdapter({ '/work/secret.txt': 'do not read' });
+    setDocumentStoreForTesting(
+      createDocumentStore({ fs, recentFilesPath: '/userData/recent-files.json' }),
+    );
+
+    await expect(handleOpen('/work/secret.txt')).rejects.toThrow(/Expected a .contexture.json/);
+  });
 });
 
 describe('file IPC open/save filters', () => {

--- a/apps/desktop/tests/main/security.test.ts
+++ b/apps/desktop/tests/main/security.test.ts
@@ -2,6 +2,7 @@ import { homedir } from 'node:os';
 import { join, parse } from 'node:path';
 import {
   assertGeneratedTargetForIr,
+  assertSafeContextureIrPath,
   assertSafeRecursiveDeleteTarget,
   isSafeExternalUrl,
 } from '@main/security';
@@ -38,6 +39,16 @@ describe('main security guards', () => {
     expect(() =>
       assertGeneratedTargetForIr(irPath, '/repo/packages/contexture/src/index.ts'),
     ).toThrow(/not a generated Contexture artifact/);
+  });
+
+  it('accepts only absolute Contexture IR paths for desktop IPC file authority', () => {
+    expect(assertSafeContextureIrPath('/repo/packages/contexture/garden.contexture.json')).toBe(
+      '/repo/packages/contexture/garden.contexture.json',
+    );
+    expect(() => assertSafeContextureIrPath('garden.contexture.json')).toThrow(/absolute/);
+    expect(() => assertSafeContextureIrPath('/repo/packages/contexture/schema.ts')).toThrow(
+      /Expected a .contexture.json/,
+    );
   });
 
   it('rejects dangerous recursive delete targets', () => {


### PR DESCRIPTION
## Summary
- Route drift watching from the open IR path instead of a renderer-derived `emitted.json` path.
- Restrict drift detection to the generated targets associated with that IR, so unrelated manifest entries are ignored.
- Add desktop security validation for IR paths before file authority is used in IPC.
- Update preload, hooks, and tests to use the new `irPath` contract.

## Testing
- Added coverage for drift detection filtering, watcher wiring, IPC path validation, and `useDrift` behavior.
- Existing main and hook test suites were updated to assert the new authority flow.
- Not run (not requested).