### PR TITLE
Reorder schema editor actions

### DIFF
--- a/.codex/agents/dan.toml
+++ b/.codex/agents/dan.toml
@@ -1,4 +1,4 @@
-name = "dan"
+name = "qa"
 description = "Contexture QA agent for regression risk, acceptance gaps, and behaviour-focused verification."
 model = "gpt-5.4"
 model_reasoning_effort = "high"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Instructions
+
+## Orientation
+
+Contexture is a Turborepo monorepo using Bun workspaces. See [README.md](README.md) for the app/package table and tech stack.
+
+Coding standards live in [.sandcastle/CODING_STANDARDS.md](.sandcastle/CODING_STANDARDS.md) and apply to all contributors.
+
+## Commands
+
+```bash
+bun run dev         # all apps in dev mode (turbo)
+bun run ci          # typecheck + test + biome check
+bun run typecheck   # turbo typecheck
+bun run test        # turbo test (Vitest)
+bun run lint        # biome lint
+bun run format      # biome format --write
+```
+
+Run a single test file from the package directory:
+
+```bash
+bun run test -- path/to/file.test.ts
+```
+
+Do not use `bun test`; this repo uses Vitest through package scripts.
+
+## Quality
+
+- Do not add lint suppressions such as `biome-ignore` or `eslint-disable`.
+- If a rule fails, fix the underlying code.
+- Run focused tests for local changes, and prefer `bun run ci` before pushing.
+
+## Env Vars
+
+Real secret values never sit on disk in this repo. Each surface declares env metadata in a committed `.env.schema` file. Do not invent or guess secret values; if env is missing, fail loudly so a human can populate Infisical.
+
+## Commits
+
+Use conventional commits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ bun run lint        # biome lint
 bun run format      # biome format --write
 ```
 
-Run a single test file: `cd packages/<pkg> && bun test path/to/file.test.ts`.
+Run a single test file: `cd packages/<pkg> && bun run test -- path/to/file.test.ts`.
 
 ## CI
 

--- a/apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx
@@ -377,20 +377,6 @@ export function SchemaPanel({
             <span className="truncate font-mono">{selectedOutput.fileName}</span>
           </div>
           <div className="-my-1 -mr-1 flex shrink-0 items-center gap-1">
-            {selectedOutputPath && onOpenGeneratedFile ? (
-              <Button
-                size="icon"
-                type="button"
-                variant="ghost"
-                className="size-7"
-                onClick={() => onOpenGeneratedFile(selectedOutputPath)}
-                aria-label={`Open ${selectedOutput.fileName} in VS Code`}
-                title={`Open ${selectedOutput.fileName} in VS Code`}
-                data-testid="schema-open-generated"
-              >
-                <ExternalLink className="size-3.5" />
-              </Button>
-            ) : null}
             <Button
               size="icon"
               type="button"
@@ -429,6 +415,20 @@ export function SchemaPanel({
             >
               {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
             </Button>
+            {selectedOutputPath && onOpenGeneratedFile ? (
+              <Button
+                size="icon"
+                type="button"
+                variant="ghost"
+                className="size-7"
+                onClick={() => onOpenGeneratedFile(selectedOutputPath)}
+                aria-label={`Open ${selectedOutput.fileName} in VS Code`}
+                title={`Open ${selectedOutput.fileName} in VS Code`}
+                data-testid="schema-open-generated"
+              >
+                <ExternalLink className="size-3.5" />
+              </Button>
+            ) : null}
           </div>
         </div>
         <div

--- a/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
+++ b/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
@@ -10,6 +10,7 @@
 
 import { SchemaPanel } from '@renderer/components/schema/SchemaPanel';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Keep shiki init pending forever so the panel renders the plain
@@ -242,7 +243,8 @@ describe('SchemaPanel', () => {
       expect(onCopy).toHaveBeenCalledWith(jsonSrc);
     });
 
-    it('opens the active generated file in the external editor', () => {
+    it('opens the active generated file in the external editor', async () => {
+      const user = userEvent.setup();
       const onOpenGeneratedFile = vi.fn();
       render(
         <SchemaPanel
@@ -257,6 +259,9 @@ describe('SchemaPanel', () => {
 
       fireEvent.click(screen.getByTestId('schema-open-generated'));
       expect(onOpenGeneratedFile).toHaveBeenLastCalledWith('/repo/garden.schema.ts');
+      screen.getByTestId('schema-copy').focus();
+      await user.tab();
+      expect(screen.getByTestId('schema-open-generated')).toHaveFocus();
 
       fireEvent.click(screen.getByTestId('schema-output-json-schema'));
       fireEvent.click(screen.getByTestId('schema-open-generated'));


### PR DESCRIPTION
## Summary
- Move the schema panel Open in VS Code action to the right of the Copy action
- Cover the accessible focus order for Copy -> Open in VS Code
- Add root AGENTS.md guidance and fix the stale CLAUDE.md single-test command
- Rename the Dan agent type from dan to qa for UI display

## Verification
- bun run test -- tests/components/schema/SchemaPanel.test.tsx
- commit hook ran turbo typecheck and turbo test