### PR TITLE
fix: resolve desktop release packaging sdk dependency

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/scripts/electron-builder-before-pack.cjs
+++ b/apps/desktop/scripts/electron-builder-before-pack.cjs
@@ -1,25 +1,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-function parseVersion(version) {
-  return version.split('.').map((part) => Number.parseInt(part, 10));
-}
-
-function satisfiesCaretZero(version, range) {
-  if (!range.startsWith('^0.')) {
-    return version === range || range === '*' || range === version;
-  }
-
-  const [major, minor, patch] = parseVersion(range.slice(1));
-  const [candidateMajor, candidateMinor, candidatePatch] = parseVersion(version);
-
-  if (candidateMajor !== major || candidateMinor !== minor) {
-    return false;
-  }
-
-  return candidatePatch >= patch;
-}
-
 function findWorkspaceRoot(startDir) {
   let current = startDir;
 
@@ -44,6 +25,38 @@ function findWorkspaceRoot(startDir) {
   }
 }
 
+function findResolvedPackage(startDir, packageName) {
+  let packageEntry;
+
+  try {
+    packageEntry = require.resolve(packageName, { paths: [startDir] });
+  } catch {
+    return undefined;
+  }
+
+  let current = path.dirname(packageEntry);
+
+  while (true) {
+    const packageJsonPath = path.join(current, 'package.json');
+
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+      if (packageJson.name === packageName) {
+        return current;
+      }
+    }
+
+    const parent = path.dirname(current);
+
+    if (parent === current) {
+      throw new Error(`Could not find package root for ${packageName} from ${packageEntry}`);
+    }
+
+    current = parent;
+  }
+}
+
 function findInstalledPackage(workspaceRoot, packageName, range) {
   const bunStoreDir = path.join(workspaceRoot, 'node_modules', '.bun');
   const packageDirName = packageName.replace('/', '+');
@@ -62,12 +75,16 @@ function findInstalledPackage(workspaceRoot, packageName, range) {
 
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
-    if (satisfiesCaretZero(packageJson.version, range)) {
+    if (packageJson.version === range || range === '*' || range === packageJson.version) {
       return packageDir;
     }
   }
 
   throw new Error(`Could not find ${packageName}@${range} in ${bunStoreDir}`);
+}
+
+function readPackageJson(packageDir) {
+  return JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
 }
 
 exports.default = async function beforePack(context) {
@@ -76,18 +93,23 @@ exports.default = async function beforePack(context) {
   const claudeAgentSdkDir = fs.realpathSync(
     path.join(appDir, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
   );
-  const claudeAgentSdkPackageJson = JSON.parse(
-    fs.readFileSync(path.join(claudeAgentSdkDir, 'package.json'), 'utf8'),
-  );
+  const claudeAgentSdkPackageJsonPath = path.join(claudeAgentSdkDir, 'package.json');
+  const claudeAgentSdkPackageJson = JSON.parse(fs.readFileSync(claudeAgentSdkPackageJsonPath, 'utf8'));
   const sdkRange = claudeAgentSdkPackageJson.dependencies?.['@anthropic-ai/sdk'];
 
   if (!sdkRange) {
     return;
   }
 
-  const sdkDir = findInstalledPackage(workspaceRoot, '@anthropic-ai/sdk', sdkRange);
+  const sdkDir = fs.realpathSync(
+    findResolvedPackage(appDir, '@anthropic-ai/sdk') ?? findInstalledPackage(workspaceRoot, '@anthropic-ai/sdk', sdkRange),
+  );
+  const sdkPackageJson = readPackageJson(sdkDir);
   const linkDir = path.join(claudeAgentSdkDir, 'node_modules', '@anthropic-ai');
   const linkPath = path.join(linkDir, 'sdk');
+
+  claudeAgentSdkPackageJson.dependencies['@anthropic-ai/sdk'] = sdkPackageJson.version;
+  fs.writeFileSync(claudeAgentSdkPackageJsonPath, `${JSON.stringify(claudeAgentSdkPackageJson, null, 2)}\n`);
 
   fs.mkdirSync(linkDir, { recursive: true });
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.5",
+      "version": "0.15.6",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",


### PR DESCRIPTION
## Summary
- Fix the desktop electron-builder beforePack hook so it resolves the installed @anthropic-ai/sdk package from the app/workspace dependency graph
- Patch claude-agent-sdk's packaged dependency metadata to match the SDK version Bun actually installed so electron-builder's Bun collector can package it
- Bump the desktop app version to 0.15.6 because v0.15.5 is already tagged at the failed release commit

## CI failure addressed
The v0.15.5 release job failed during macOS packaging with:

`Could not find @anthropic-ai/sdk@^0.81.0 in .../node_modules/.bun`

After resolving that, a local packaging dry-run also exposed electron-builder's collector rejecting the same dependency range. This patch handles both parts of the failure.

## Verification
- Reproduced the beforePack failure by hiding older local @anthropic-ai/sdk Bun store entries
- Verified the beforePack hook passes with only @anthropic-ai/sdk@0.95.1 available
- `bun run typecheck:node`
- `bun run build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false bunx electron-builder --mac --dir --publish never`
- Commit hook ran `turbo typecheck` successfully
- Commit hook ran `turbo test` successfully