### PR TITLE
Add MCP agent setup guidance and Contexture integration skill draft

### DIFF
--- a/.agents/skills/contexture-integration/SKILL.md
+++ b/.agents/skills/contexture-integration/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: contexture-integration
+description: Use Contexture as the source of truth for a TypeScript app's domain model. Use when wiring Contexture IR, generated Zod or JSON Schema, Convex schema, MCP definitions, structured outputs, form validators, or drift checks into an existing repo.
+---
+
+# Contexture Integration
+
+Use Contexture as the source of truth for an app's domain model. Your job is to
+inspect the target repo, use Contexture CLI or MCP to operate on the IR, wire
+generated outputs into the app's existing integration points, and preserve the
+contract between the IR and generated files.
+
+## Core Rules
+
+- Treat the `*.contexture.json` IR as the primary domain model.
+- Do not edit files with a `@contexture-generated` header.
+- Prefer Contexture CLI or MCP operations over hand-editing generated output.
+- Configure or use the Contexture MCP server where the agent host supports MCP.
+- Wire outputs into the repo that exists; do not assume Next.js, Convex, React,
+  Express, or any other framework unless the repo already uses it.
+- Report framework-specific uncertainty instead of guessing.
+
+## First Pass
+
+1. Locate the Contexture IR. Search for `*.contexture.json`; if there is more
+   than one or none, ask the user which IR to use.
+2. Inspect the repo before choosing integration points. Check package scripts,
+   existing validation, API boundaries, form handling, schema exports, CI, and
+   any existing MCP or agent configuration.
+3. Inspect the current Contexture model:
+
+   ```bash
+   contexture inspect --json --ir path/to/model.contexture.json
+   ```
+
+4. Inspect the IR `outputs` block, if present, so you only wire enabled targets.
+5. Identify generated files by their configured output paths and
+   `@contexture-generated` headers.
+
+## Safe Contexture Loop
+
+For model changes, use this loop:
+
+```txt
+inspect -> apply or edit IR -> validate -> emit -> check-generated -> app checks
+```
+
+Commands:
+
+```bash
+contexture inspect --json --ir path/to/model.contexture.json
+contexture apply --ir path/to/model.contexture.json --op-file ./op.json
+contexture validate --ir path/to/model.contexture.json
+contexture emit --ir path/to/model.contexture.json
+contexture check-generated --ir path/to/model.contexture.json
+```
+
+Use typed subcommands such as `add-field`, `update-field`, `delete-field`,
+`add-type`, `set-table-flag`, and `add-index` when they are clearer than a
+generic `apply` operation. If you edit the IR JSON directly for a bulk rewrite,
+run `validate`, `emit`, and `check-generated` before touching app code.
+
+## Wiring Outputs
+
+Wire only the outputs the IR enables and the app can actually consume:
+
+- Zod schemas: connect to existing validation, request parsing, tests, or form
+  adapters where the repo already uses Zod or can accept it cleanly.
+- JSON Schema: connect to API docs, OpenAPI tooling, validation middleware, or
+  downstream tooling where those integration points already exist.
+- Convex schema: wire only when the repo already uses Convex.
+- Schema index barrels: use existing import/export conventions.
+- MCP definitions: configure the Contexture MCP server where supported, or wire
+  emitted definitions into an existing MCP server adapter.
+- Tool schemas and structured outputs: wire into existing AI provider adapters
+  or tool registries without hard-coding provider assumptions.
+- Form validators: wire into existing form boundaries without replacing the
+  app's form framework unless the user asks for that change.
+
+Keep repo-owned adapter code separate from generated files. If generated output
+does not match what the app needs, change the IR or output configuration and
+regenerate instead of patching emitted files.
+
+## Package Scripts and CI
+
+Configure package scripts only when appropriate for the target repo. Prefer
+adding `contexture validate` and `contexture check-generated` to existing
+typecheck, test, or CI flows over creating a new workflow shape from scratch.
+
+Before finishing, run the narrowest useful app checks. For a Bun repo that uses
+package scripts, prefer focused commands such as:
+
+```bash
+bun run typecheck
+bun run test
+```
+
+Use the repo's own package manager and scripts when they differ.
+
+## MCP Setup
+
+When the agent host supports MCP, configure the Contexture MCP server as the
+safe tool surface over IR inspection, mutation, validation, emit, and drift
+checks. Keep MCP setup separate from app wiring:
+
+- MCP provides safe operations over the Contexture model.
+- This skill decides where generated outputs belong in the target repo.
+
+If MCP cannot be configured in the current environment, continue with the CLI
+and report that limitation.
+
+## Finish Criteria
+
+- The IR remains the source of truth.
+- Generated files were regenerated, not manually edited.
+- `contexture validate` passed.
+- `contexture emit` ran after any direct IR edit.
+- `contexture check-generated` passed with no drift.
+- App typecheck/tests relevant to the wired outputs passed, or any skipped check
+  is reported with the reason.
+- The final report lists changed paths, checks run, and any remaining
+  framework-specific uncertainty.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,7 +31,7 @@ All colors use OKLCH for perceptual uniformity. The palette is built around deep
 | `--secondary-foreground` | `oklch(0.13 0.03 270)`    | `oklch(0.93 0.01 270)`    | Text on secondary                  |
 | `--muted`                | `oklch(0.95 0.01 270)`    | `oklch(0.2 0.02 270)`     | Muted backgrounds                  |
 | `--muted-foreground`     | `oklch(0.5 0.03 270)`     | `oklch(0.6 0.02 270)`     | Subdued text, labels, descriptions |
-| `--accent`               | `oklch(0.75 0.15 195)`    | `oklch(0.75 0.15 195)`    | Electric cyan — data, interactivity|
+| `--accent`               | `oklch(0.93 0.025 270)`   | `oklch(0.24 0.025 270)`   | Subtle hover/focus fill for shadcn chrome |
 | `--accent-foreground`    | `oklch(0.13 0.03 270)`    | `oklch(0.93 0.01 270)`    | Text on accent surfaces            |
 | `--border`               | `oklch(0.9 0.01 270)`     | `oklch(0.25 0.02 270)`    | Borders and dividers               |
 | `--input`                | `oklch(0.9 0.01 270)`     | `oklch(0.25 0.02 270)`    | Input field borders                |
@@ -156,9 +156,11 @@ Built on **shadcn/ui** with **Tailwind CSS v4**. Prefer existing shadcn componen
 ```
 Primary:    bg-primary text-primary-foreground rounded-lg hover:opacity-90 transition-opacity
 Secondary:  bg-secondary text-secondary-foreground border border-border/60 rounded-lg hover:bg-secondary/80 transition-colors
-Ghost:      text-muted-foreground rounded-lg hover:text-foreground hover:bg-muted/50 transition-colors
+Ghost:      text-muted-foreground rounded-lg hover:text-accent-foreground hover:bg-accent transition-colors
 Destructive: bg-destructive text-destructive-foreground rounded-lg hover:opacity-90 transition-opacity
 ```
+
+In shadcn primitives, `--accent` is the routine hover/focus surface, so keep it subtle. Electric cyan remains available through graph-specific tokens such as `--graph-node-selected` and through brand/web contexts where it is used deliberately.
 
 ### Card Patterns
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -393,6 +393,7 @@ export default function App(): React.JSX.Element {
                   onEnableOutput={enableSchemaOutput}
                   documentFilePath={filePath}
                   onOpenGeneratedFile={openGeneratedFile}
+                  onRequestSave={() => void fileMenu.handleSave()}
                   schemaFileName={schemaFileName}
                 />
               </div>

--- a/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
+++ b/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
@@ -21,6 +21,7 @@ export function ActivityBar({ activeTab, onTabChange }: ActivityBarProps): React
           type="button"
           key={id}
           title={label}
+          aria-label={label}
           onClick={() => onTabChange(id)}
           className={cn(
             'relative w-8 h-8 rounded-md flex items-center justify-center transition-colors',

--- a/apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx
@@ -41,6 +41,7 @@ import {
   ExternalLink,
   FileBracesCorner,
   FileCode,
+  PlugZap,
 } from 'lucide-react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '../ui/button';
@@ -95,6 +96,8 @@ export interface SchemaPanelProps {
   documentFilePath?: string | null;
   /** Open the selected generated file in an external editor. */
   onOpenGeneratedFile?: (path: string) => void;
+  /** Prompt the app save flow when agent setup needs a stable IR path. */
+  onRequestSave?: () => void;
 }
 
 /**
@@ -112,6 +115,19 @@ const OUTPUT_GROUPS: { group: GeneratedTargetGroup; label: string }[] = [
   { group: 'ai', label: 'AI' },
   { group: 'forms', label: 'Forms' },
 ];
+
+const CODEX_MCP_INSTALL_COMMAND =
+  'codex mcp add contexture -- /Applications/Contexture.app/Contents/MacOS/Contexture --mcp';
+
+const CONTEXTURE_MCP_TOOLS = [
+  'inspect_contexture',
+  'validate_contexture',
+  'apply_contexture_op',
+  'emit_contexture',
+  'check_contexture_drift',
+] as const;
+
+type AgentSetupCopyKey = 'install' | 'prompt' | 'smoke';
 
 interface OutputOption {
   type: SchemaOutputType;
@@ -143,12 +159,15 @@ export function SchemaPanel({
   onEnableOutput,
   documentFilePath = null,
   onOpenGeneratedFile,
+  onRequestSave,
 }: SchemaPanelProps): React.JSX.Element {
   const [activeOutput, setActiveOutput] = useState<SchemaOutputType>('zod');
   const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null);
   const [fontSizeIndex, setFontSizeIndex] = useState<number>(DEFAULT_FONT_SIZE_INDEX);
   const [copied, setCopied] = useState(false);
+  const [agentCopied, setAgentCopied] = useState<AgentSetupCopyKey | null>(null);
   const copyTimeoutRef = useRef<number | null>(null);
+  const agentCopyTimeoutRef = useRef<number | null>(null);
   const codeRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
@@ -248,6 +267,9 @@ export function SchemaPanel({
       if (copyTimeoutRef.current !== null) {
         window.clearTimeout(copyTimeoutRef.current);
       }
+      if (agentCopyTimeoutRef.current !== null) {
+        window.clearTimeout(agentCopyTimeoutRef.current);
+      }
     },
     [],
   );
@@ -261,6 +283,18 @@ export function SchemaPanel({
     copyTimeoutRef.current = window.setTimeout(() => {
       setCopied(false);
       copyTimeoutRef.current = null;
+    }, COPY_FEEDBACK_MS);
+  };
+
+  const handleAgentCopy = (key: AgentSetupCopyKey, text: string): void => {
+    onCopy?.(text);
+    setAgentCopied(key);
+    if (agentCopyTimeoutRef.current !== null) {
+      window.clearTimeout(agentCopyTimeoutRef.current);
+    }
+    agentCopyTimeoutRef.current = window.setTimeout(() => {
+      setAgentCopied(null);
+      agentCopyTimeoutRef.current = null;
     }, COPY_FEEDBACK_MS);
   };
 
@@ -282,6 +316,14 @@ export function SchemaPanel({
             </EmptyDescription>
           </EmptyHeader>
         </Empty>
+        <div className="px-3 pb-3">
+          <AgentSetupSection
+            documentFilePath={documentFilePath}
+            copied={agentCopied}
+            onCopy={handleAgentCopy}
+            onRequestSave={onRequestSave}
+          />
+        </div>
       </div>
     );
   }
@@ -370,6 +412,13 @@ export function SchemaPanel({
         })}
       </div>
 
+      <AgentSetupSection
+        documentFilePath={documentFilePath}
+        copied={agentCopied}
+        onCopy={handleAgentCopy}
+        onRequestSave={onRequestSave}
+      />
+
       <div className="group relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border bg-background text-foreground shadow-sm">
         <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/80 px-3 py-2 text-xs text-muted-foreground">
           <div className="flex min-w-0 items-center gap-2" data-testid="schema-filename">
@@ -443,6 +492,164 @@ export function SchemaPanel({
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function AgentSetupSection({
+  documentFilePath,
+  copied,
+  onCopy,
+  onRequestSave,
+}: {
+  documentFilePath: string | null;
+  copied: AgentSetupCopyKey | null;
+  onCopy: (key: AgentSetupCopyKey, text: string) => void;
+  onRequestSave?: () => void;
+}): React.JSX.Element {
+  const savedPrompt =
+    documentFilePath === null
+      ? null
+      : `Use the Contexture MCP server to inspect ${documentFilePath}, then validate, emit, and check drift before finishing.`;
+  const smokeTest =
+    documentFilePath === null
+      ? 'Ask Codex: "List the contexture MCP tools."'
+      : `Ask Codex: "List the contexture MCP tools, then inspect ${documentFilePath}."`;
+  const copiedLabel =
+    copied === 'install'
+      ? 'Copied install command'
+      : copied === 'prompt'
+        ? 'Copied saved-document prompt'
+        : copied === 'smoke'
+          ? 'Copied smoke test'
+          : '';
+
+  return (
+    <section
+      className="mb-2 shrink-0 rounded-md border border-border bg-muted/20 p-2"
+      aria-labelledby="agent-setup-title"
+      data-testid="agent-setup"
+    >
+      <div className="mb-2 flex items-start gap-2">
+        <PlugZap className="mt-0.5 size-3.5 shrink-0 text-accent" aria-hidden="true" />
+        <div className="min-w-0">
+          <h3 id="agent-setup-title" className="text-xs font-semibold text-foreground">
+            Agent setup
+          </h3>
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            Use this Contexture document from Codex or another MCP-capable agent.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <AgentCopyRow
+          label="Codex install command"
+          value={CODEX_MCP_INSTALL_COMMAND}
+          copied={copied === 'install'}
+          onCopy={() => onCopy('install', CODEX_MCP_INSTALL_COMMAND)}
+          copyLabel="Copy Codex MCP install command"
+          testId="agent-setup-install"
+        />
+
+        {savedPrompt === null ? (
+          <div
+            className="rounded border border-dashed border-border/80 bg-background/60 p-2 text-[11px] leading-snug text-muted-foreground"
+            data-testid="agent-setup-unsaved"
+          >
+            <p>
+              Save this document to create a stable .contexture.json path before handing it to an
+              agent.
+            </p>
+            {onRequestSave ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                className="mt-2 h-7 text-xs"
+                onClick={onRequestSave}
+              >
+                Save first
+              </Button>
+            ) : null}
+          </div>
+        ) : (
+          <AgentCopyRow
+            label="Saved-document prompt"
+            value={savedPrompt}
+            copied={copied === 'prompt'}
+            onCopy={() => onCopy('prompt', savedPrompt)}
+            copyLabel="Copy saved-document prompt"
+            testId="agent-setup-prompt"
+          />
+        )}
+
+        <AgentCopyRow
+          label="Smoke test"
+          value={smokeTest}
+          copied={copied === 'smoke'}
+          onCopy={() => onCopy('smoke', smokeTest)}
+          copyLabel="Copy MCP smoke test"
+          testId="agent-setup-smoke"
+        />
+      </div>
+
+      <ul className="mt-2 flex flex-wrap gap-1 text-[10px]" aria-label="Contexture MCP tools">
+        {CONTEXTURE_MCP_TOOLS.map((tool) => (
+          <li key={tool}>
+            <code className="rounded border border-border/70 bg-background/70 px-1.5 py-0.5 font-mono text-muted-foreground">
+              {tool}
+            </code>
+          </li>
+        ))}
+      </ul>
+      <p className="sr-only" aria-live="polite">
+        {copiedLabel}
+      </p>
+    </section>
+  );
+}
+
+function AgentCopyRow({
+  label,
+  value,
+  copied,
+  onCopy,
+  copyLabel,
+  testId,
+}: {
+  label: string;
+  value: string;
+  copied: boolean;
+  onCopy: () => void;
+  copyLabel: string;
+  testId: string;
+}): React.JSX.Element {
+  return (
+    <div className="rounded border border-border/70 bg-background/70 p-1.5" data-testid={testId}>
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <span className="text-[10px] font-semibold uppercase leading-none tracking-wider text-muted-foreground/70">
+          {label}
+        </span>
+        <Button
+          size="icon"
+          type="button"
+          variant="ghost"
+          className="size-6"
+          onClick={onCopy}
+          aria-label={copyLabel}
+          title={copied ? 'Copied' : copyLabel}
+          data-testid={`${testId}-copy`}
+        >
+          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+        </Button>
+      </div>
+      <textarea
+        readOnly
+        value={value}
+        aria-label={label}
+        className="min-h-10 w-full resize-none rounded border border-border/50 bg-muted/20 p-1.5 font-mono text-[11px] leading-snug text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx
@@ -42,10 +42,22 @@ import {
   FileBracesCorner,
   FileCode,
   PlugZap,
+  Settings2,
 } from 'lucide-react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '../ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../ui/empty';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import { getHighlighter, SHIKI_THEMES } from './shiki-highlighter';
 
@@ -90,7 +102,7 @@ export interface SchemaPanelProps {
    * available choices; enabled outputs with empty sources stay hidden.
    */
   additionalSources?: SchemaPanelAdditionalSource[];
-  /** Enable an optional output target from the grouped selector. */
+  /** Enable an optional output target from the output configuration popover. */
   onEnableOutput?: (type: SchemaOutputType) => void;
   /** Absolute path of the active `.contexture.json`; absent for unsaved documents. */
   documentFilePath?: string | null;
@@ -220,15 +232,23 @@ export function SchemaPanel({
       });
   }, [additionalSources, convexSource, jsonSource, schemaFileName, sources, zodSource]);
 
+  const enabledOutputOptions = useMemo(
+    () => outputOptions.filter((output) => output.enabled),
+    [outputOptions],
+  );
+  const disabledOutputOptions = useMemo(
+    () => outputOptions.filter((output) => !output.enabled),
+    [outputOptions],
+  );
+
   useEffect(() => {
-    if (!outputOptions.some((output) => output.type === activeOutput && output.enabled)) {
-      setActiveOutput('zod');
+    if (!enabledOutputOptions.some((output) => output.type === activeOutput)) {
+      setActiveOutput(enabledOutputOptions[0]?.type ?? 'zod');
     }
-  }, [activeOutput, outputOptions]);
+  }, [activeOutput, enabledOutputOptions]);
 
   const selectedOutput =
-    outputOptions.find((output) => output.type === activeOutput && output.enabled) ??
-    outputOptions[0];
+    enabledOutputOptions.find((output) => output.type === activeOutput) ?? enabledOutputOptions[0];
   const activeSource = selectedOutput?.source ?? '';
   const selectedOutputPath =
     selectedOutput && documentFilePath
@@ -317,7 +337,7 @@ export function SchemaPanel({
           </EmptyHeader>
         </Empty>
         <div className="px-3 pb-3">
-          <AgentSetupSection
+          <AgentSetupPopover
             documentFilePath={documentFilePath}
             copied={agentCopied}
             onCopy={handleAgentCopy}
@@ -339,91 +359,56 @@ export function SchemaPanel({
             Couldn't emit schema: {error}
           </p>
         </div>
+        <div className="pt-2">
+          <AgentSetupPopover
+            documentFilePath={documentFilePath}
+            copied={agentCopied}
+            onCopy={handleAgentCopy}
+            onRequestSave={onRequestSave}
+          />
+        </div>
       </div>
     );
   }
 
   return (
     <div className="flex h-full flex-col p-3" data-testid="schema-panel">
-      <div
-        className="mb-2 space-y-1 rounded-md border border-border bg-muted/35 p-1.5"
-        role="listbox"
-        aria-label="Generated outputs"
-        data-testid="schema-output-selector"
-      >
-        {OUTPUT_GROUPS.map(({ group, label }) => {
-          const groupOutputs = outputOptions.filter((output) => output.group === group);
-          if (groupOutputs.length === 0) return null;
-          return (
-            <div
-              key={group}
-              className="flex items-start gap-2"
-              data-testid={`schema-group-${group}`}
-            >
-              <div className="w-11 shrink-0 px-0.5 py-1.5 text-[9px] font-semibold uppercase leading-none tracking-wider text-muted-foreground/50">
-                {label}
-              </div>
-              <TooltipProvider delayDuration={250}>
-                <div className="flex min-w-0 flex-1 flex-wrap gap-1">
-                  {groupOutputs.map((output) => {
-                    const tooltip = output.enabled
-                      ? output.help
-                      : `Enable ${output.label}: ${output.help}`;
-                    return (
-                      <Tooltip key={output.type}>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            role="option"
-                            aria-selected={output.enabled && activeOutput === output.type}
-                            data-testid={`schema-output-${output.type}`}
-                            onClick={() => {
-                              if (!output.enabled) {
-                                setActiveOutput(output.type);
-                                setHighlightedHtml(null);
-                                onEnableOutput?.(output.type);
-                                return;
-                              }
-                              setActiveOutput(output.type);
-                              setHighlightedHtml(null);
-                            }}
-                            className={[
-                              'min-w-0 rounded px-2 py-1 text-left text-xs font-medium leading-none transition-colors',
-                              output.enabled && activeOutput === output.type
-                                ? 'bg-primary text-primary-foreground'
-                                : !output.enabled
-                                  ? 'border border-dashed border-border/80 text-muted-foreground/60 hover:border-border hover:bg-muted hover:text-foreground'
-                                  : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                            ].join(' ')}
-                          >
-                            <span className="truncate">{output.label}</span>
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" className="max-w-64 text-xs leading-snug">
-                          {tooltip}
-                        </TooltipContent>
-                      </Tooltip>
-                    );
-                  })}
-                </div>
-              </TooltipProvider>
-            </div>
-          );
-        })}
-      </div>
-
-      <AgentSetupSection
-        documentFilePath={documentFilePath}
-        copied={agentCopied}
-        onCopy={handleAgentCopy}
-        onRequestSave={onRequestSave}
-      />
-
       <div className="group relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border bg-background text-foreground shadow-sm">
-        <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/80 px-3 py-2 text-xs text-muted-foreground">
-          <div className="flex min-w-0 items-center gap-2" data-testid="schema-filename">
+        <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/80 px-2 py-2 text-xs text-muted-foreground">
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
             <FileCode className="size-3.5 shrink-0" />
-            <span className="truncate font-mono">{selectedOutput.fileName}</span>
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-1.5">
+                <OutputSelect
+                  activeOutput={activeOutput}
+                  enabledOptions={enabledOutputOptions}
+                  onValueChange={(type) => {
+                    setActiveOutput(type);
+                    setHighlightedHtml(null);
+                  }}
+                />
+                {disabledOutputOptions.length > 0 ? (
+                  <OutputConfigPopover
+                    disabledOptions={disabledOutputOptions}
+                    onEnableOutput={(type) => {
+                      setActiveOutput(type);
+                      setHighlightedHtml(null);
+                      onEnableOutput?.(type);
+                    }}
+                  />
+                ) : null}
+                <AgentSetupPopover
+                  documentFilePath={documentFilePath}
+                  copied={agentCopied}
+                  onCopy={handleAgentCopy}
+                  onRequestSave={onRequestSave}
+                  compact
+                />
+              </div>
+              <div className="truncate font-mono text-[10px]" data-testid="schema-filename">
+                {selectedOutput?.fileName ?? 'schema.ts'}
+              </div>
+            </div>
           </div>
           <div className="-my-1 -mr-1 flex shrink-0 items-center gap-1">
             <Button
@@ -496,16 +481,142 @@ export function SchemaPanel({
   );
 }
 
-function AgentSetupSection({
+function OutputSelect({
+  activeOutput,
+  enabledOptions,
+  onValueChange,
+}: {
+  activeOutput: SchemaOutputType;
+  enabledOptions: OutputOption[];
+  onValueChange: (type: SchemaOutputType) => void;
+}): React.JSX.Element {
+  return (
+    <Select
+      value={activeOutput}
+      onValueChange={(value) => onValueChange(value as SchemaOutputType)}
+    >
+      <SelectTrigger
+        className="h-7 min-w-0 flex-1 border-border/70 bg-background/80 px-2 py-1 text-xs"
+        aria-label="Generated output"
+        data-testid="schema-output-selector"
+      >
+        <SelectValue placeholder="Select output" />
+      </SelectTrigger>
+      <SelectContent align="start" className="max-h-80">
+        {OUTPUT_GROUPS.map(({ group, label }) => {
+          const groupOutputs = enabledOptions.filter((output) => output.group === group);
+          if (groupOutputs.length === 0) return null;
+          return (
+            <SelectGroup key={group} data-testid={`schema-group-${group}`}>
+              <SelectLabel className="py-1 pl-2 pr-2 text-[10px] uppercase tracking-wider text-muted-foreground/70">
+                {label}
+              </SelectLabel>
+              {groupOutputs.map((output) => (
+                <SelectItem
+                  key={output.type}
+                  value={output.type}
+                  className="text-xs"
+                  data-testid={`schema-output-${output.type}`}
+                >
+                  {output.label}
+                </SelectItem>
+              ))}
+              <SelectSeparator />
+            </SelectGroup>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function OutputConfigPopover({
+  disabledOptions,
+  onEnableOutput,
+}: {
+  disabledOptions: OutputOption[];
+  onEnableOutput?: (type: SchemaOutputType) => void;
+}): React.JSX.Element {
+  return (
+    <Popover>
+      <TooltipProvider delayDuration={250}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className="size-7 shrink-0"
+                aria-label="Configure generated outputs"
+                title="Configure generated outputs"
+                data-testid="schema-output-config"
+              >
+                <Settings2 className="size-3.5" />
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="text-xs">
+            Configure generated outputs
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <PopoverContent className="w-72 p-2" align="end">
+        <div className="mb-2 px-1">
+          <div className="text-xs font-semibold text-foreground">Generated outputs</div>
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            Enable optional targets for this Contexture bundle.
+          </p>
+        </div>
+        <div className="space-y-1">
+          {OUTPUT_GROUPS.map(({ group, label }) => {
+            const groupOutputs = disabledOptions.filter((output) => output.group === group);
+            if (groupOutputs.length === 0) return null;
+            return (
+              <div key={group} data-testid={`schema-group-${group}`}>
+                <div className="px-1 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                  {label}
+                </div>
+                {groupOutputs.map((output) => (
+                  <button
+                    key={output.type}
+                    type="button"
+                    className="flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onClick={() => onEnableOutput?.(output.type)}
+                    data-testid={`schema-output-${output.type}`}
+                  >
+                    <span className="mt-0.5 text-muted-foreground">+</span>
+                    <span className="min-w-0">
+                      <span className="block font-medium text-foreground">
+                        Enable {output.label}
+                      </span>
+                      <span className="block text-[11px] leading-snug text-muted-foreground">
+                        {output.help}
+                      </span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function AgentSetupPopover({
   documentFilePath,
   copied,
   onCopy,
   onRequestSave,
+  compact = false,
 }: {
   documentFilePath: string | null;
   copied: AgentSetupCopyKey | null;
   onCopy: (key: AgentSetupCopyKey, text: string) => void;
   onRequestSave?: () => void;
+  compact?: boolean;
 }): React.JSX.Element {
   const savedPrompt =
     documentFilePath === null
@@ -525,14 +636,31 @@ function AgentSetupSection({
           : '';
 
   return (
-    <section
-      className="mb-2 shrink-0 rounded-md border border-border bg-muted/20 p-2"
-      aria-labelledby="agent-setup-title"
-      data-testid="agent-setup"
-    >
-      <div className="mb-2 flex items-start gap-2">
-        <PlugZap className="mt-0.5 size-3.5 shrink-0 text-accent" aria-hidden="true" />
-        <div className="min-w-0">
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant={compact ? 'ghost' : 'secondary'}
+          className={
+            compact
+              ? 'h-7 shrink-0 gap-1.5 px-2 text-xs'
+              : 'h-auto w-full justify-start gap-2 px-2 py-2 text-left'
+          }
+          aria-label="Open Agent setup"
+          data-testid="agent-setup"
+        >
+          <PlugZap className="size-3.5 shrink-0 text-accent" aria-hidden="true" />
+          <span className={compact ? 'sr-only' : 'min-w-0'}>
+            <span className="block text-xs font-semibold">Agent setup</span>
+            <span className="block text-[11px] font-normal text-muted-foreground">
+              {savedPrompt === null ? 'Save for prompt handoff' : 'Saved prompt ready'}
+            </span>
+          </span>
+          {compact ? <span className="text-xs">Agent</span> : null}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-2" align="end" data-testid="agent-setup-content">
+        <div className="mb-2 px-1">
           <h3 id="agent-setup-title" className="text-xs font-semibold text-foreground">
             Agent setup
           </h3>
@@ -540,73 +668,73 @@ function AgentSetupSection({
             Use this Contexture document from Codex or another MCP-capable agent.
           </p>
         </div>
-      </div>
 
-      <div className="space-y-1.5">
-        <AgentCopyRow
-          label="Codex install command"
-          value={CODEX_MCP_INSTALL_COMMAND}
-          copied={copied === 'install'}
-          onCopy={() => onCopy('install', CODEX_MCP_INSTALL_COMMAND)}
-          copyLabel="Copy Codex MCP install command"
-          testId="agent-setup-install"
-        />
-
-        {savedPrompt === null ? (
-          <div
-            className="rounded border border-dashed border-border/80 bg-background/60 p-2 text-[11px] leading-snug text-muted-foreground"
-            data-testid="agent-setup-unsaved"
-          >
-            <p>
-              Save this document to create a stable .contexture.json path before handing it to an
-              agent.
-            </p>
-            {onRequestSave ? (
-              <Button
-                type="button"
-                size="sm"
-                variant="secondary"
-                className="mt-2 h-7 text-xs"
-                onClick={onRequestSave}
-              >
-                Save first
-              </Button>
-            ) : null}
-          </div>
-        ) : (
+        <div className="space-y-1.5">
           <AgentCopyRow
-            label="Saved-document prompt"
-            value={savedPrompt}
-            copied={copied === 'prompt'}
-            onCopy={() => onCopy('prompt', savedPrompt)}
-            copyLabel="Copy saved-document prompt"
-            testId="agent-setup-prompt"
+            label="Codex install command"
+            value={CODEX_MCP_INSTALL_COMMAND}
+            copied={copied === 'install'}
+            onCopy={() => onCopy('install', CODEX_MCP_INSTALL_COMMAND)}
+            copyLabel="Copy Codex MCP install command"
+            testId="agent-setup-install"
           />
-        )}
 
-        <AgentCopyRow
-          label="Smoke test"
-          value={smokeTest}
-          copied={copied === 'smoke'}
-          onCopy={() => onCopy('smoke', smokeTest)}
-          copyLabel="Copy MCP smoke test"
-          testId="agent-setup-smoke"
-        />
-      </div>
+          {savedPrompt === null ? (
+            <div
+              className="rounded border border-dashed border-border/80 bg-background/60 p-2 text-[11px] leading-snug text-muted-foreground"
+              data-testid="agent-setup-unsaved"
+            >
+              <p>
+                Save this document to create a stable .contexture.json path before handing it to an
+                agent.
+              </p>
+              {onRequestSave ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  className="mt-2 h-7 text-xs"
+                  onClick={onRequestSave}
+                >
+                  Save first
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <AgentCopyRow
+              label="Saved-document prompt"
+              value={savedPrompt}
+              copied={copied === 'prompt'}
+              onCopy={() => onCopy('prompt', savedPrompt)}
+              copyLabel="Copy saved-document prompt"
+              testId="agent-setup-prompt"
+            />
+          )}
 
-      <ul className="mt-2 flex flex-wrap gap-1 text-[10px]" aria-label="Contexture MCP tools">
-        {CONTEXTURE_MCP_TOOLS.map((tool) => (
-          <li key={tool}>
-            <code className="rounded border border-border/70 bg-background/70 px-1.5 py-0.5 font-mono text-muted-foreground">
-              {tool}
-            </code>
-          </li>
-        ))}
-      </ul>
-      <p className="sr-only" aria-live="polite">
-        {copiedLabel}
-      </p>
-    </section>
+          <AgentCopyRow
+            label="Smoke test"
+            value={smokeTest}
+            copied={copied === 'smoke'}
+            onCopy={() => onCopy('smoke', smokeTest)}
+            copyLabel="Copy MCP smoke test"
+            testId="agent-setup-smoke"
+          />
+        </div>
+
+        <ul className="mt-2 flex flex-wrap gap-1 text-[10px]" aria-label="Contexture MCP tools">
+          {CONTEXTURE_MCP_TOOLS.map((tool) => (
+            <li key={tool}>
+              <code className="rounded border border-border/70 bg-background/70 px-1.5 py-0.5 font-mono text-muted-foreground">
+                {tool}
+              </code>
+            </li>
+          ))}
+        </ul>
+        <p className="sr-only" aria-live="polite">
+          {copiedLabel}
+        </p>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -644,12 +772,12 @@ function AgentCopyRow({
           {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
         </Button>
       </div>
-      <textarea
-        readOnly
-        value={value}
-        aria-label={label}
-        className="min-h-10 w-full resize-none rounded border border-border/50 bg-muted/20 p-1.5 font-mono text-[11px] leading-snug text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      />
+      <pre
+        data-testid={`${testId}-value`}
+        className="max-h-20 overflow-auto whitespace-pre-wrap break-all rounded border border-border/50 bg-muted/20 p-1.5 font-mono text-[11px] leading-snug text-foreground"
+      >
+        {value}
+      </pre>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/ui/context-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/context-menu.tsx
@@ -142,7 +142,11 @@ const ContextMenuLabel = React.forwardRef<
 >(({ className, inset, ...props }, ref) => (
   <ContextMenuPrimitive.Label
     ref={ref}
-    className={cn('px-2 py-1.5 text-sm font-semibold text-foreground', inset && 'pl-8', className)}
+    className={cn(
+      'px-2 py-1.5 text-sm font-semibold text-accent-foreground',
+      inset && 'pl-8',
+      className,
+    )}
     {...props}
   />
 ));

--- a/apps/desktop/src/renderer/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/dialog.tsx
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-accent-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -34,9 +34,9 @@
   --secondary-foreground: oklch(0.13 0.03 270);
   --muted: oklch(0.95 0.01 270);
   --muted-foreground: oklch(0.5 0.03 270);
-  --accent: oklch(0.75 0.15 195);
+  --accent: oklch(0.93 0.025 270);
   --accent-foreground: oklch(0.13 0.03 270);
-  --icon-btn-hover: oklch(0.93 0.04 270);
+  --icon-btn-hover: var(--accent);
   --destructive: oklch(0.55 0.2 25);
   --destructive-foreground: oklch(1 0 0);
   --border: oklch(0.9 0.01 270);
@@ -94,9 +94,9 @@
   --secondary-foreground: oklch(0.93 0.01 270);
   --muted: oklch(0.2 0.02 270);
   --muted-foreground: oklch(0.6 0.02 270);
-  --accent: oklch(0.75 0.15 195);
+  --accent: oklch(0.24 0.025 270);
   --accent-foreground: oklch(0.93 0.01 270);
-  --icon-btn-hover: oklch(0.25 0.04 270);
+  --icon-btn-hover: var(--accent);
   --destructive: oklch(0.6 0.2 25);
   --destructive-foreground: oklch(1 0 0);
   --border: oklch(0.25 0.02 270);

--- a/apps/desktop/tests/components/App.schema-outputs.test.tsx
+++ b/apps/desktop/tests/components/App.schema-outputs.test.tsx
@@ -4,6 +4,7 @@ import { useGraphSelectionStore } from '@renderer/store/selection';
 import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import { useUndoStore } from '@renderer/store/undo';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const unsub = () => undefined;
@@ -66,8 +67,9 @@ describe('App schema outputs', () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('schema-output-ai-tool-schemas')).toBeInTheDocument();
+      expect(screen.getByTestId('schema-output-config')).toBeInTheDocument();
     });
+    fireEvent.click(screen.getByTestId('schema-output-config'));
     fireEvent.click(screen.getByTestId('schema-output-ai-tool-schemas'));
 
     await waitFor(() => {
@@ -88,13 +90,15 @@ describe('App schema outputs', () => {
 
     render(<App />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('schema-output-form-validators')).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByTestId('schema-output-form-validators'));
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId('schema-output-selector'));
+    fireEvent.click(await screen.findByTestId('schema-output-form-validators'));
 
-    const code = screen.getByTestId('schema-code').textContent ?? '';
-    expect(code).toContain("import { Lead } from './schema.schema';");
-    expect(code).not.toContain('<unsaved>');
+    await waitFor(() => {
+      expect(screen.getByTestId('schema-code').textContent ?? '').toContain(
+        "import { Lead } from './schema.schema';",
+      );
+    });
+    expect(screen.getByTestId('schema-code').textContent ?? '').not.toContain('<unsaved>');
   });
 });

--- a/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
+++ b/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
@@ -58,6 +58,78 @@ describe('SchemaPanel', () => {
     expect(onCopy).toHaveBeenCalledWith(source);
   });
 
+  it('shows Agent setup with the packaged Codex MCP install command', () => {
+    render(<SchemaPanel {...DEFAULT_PROPS} zodSource="zod" />);
+
+    expect(screen.getByTestId('agent-setup')).toHaveTextContent('Agent setup');
+    expect(screen.getByLabelText('Codex install command')).toHaveValue(
+      'codex mcp add contexture -- /Applications/Contexture.app/Contents/MacOS/Contexture --mcp',
+    );
+    expect(screen.getByTestId('agent-setup')).toHaveTextContent('inspect_contexture');
+    expect(screen.getByTestId('agent-setup')).toHaveTextContent('validate_contexture');
+    expect(screen.getByTestId('agent-setup')).toHaveTextContent('apply_contexture_op');
+    expect(screen.getByTestId('agent-setup')).toHaveTextContent('emit_contexture');
+    expect(screen.getByTestId('agent-setup')).toHaveTextContent('check_contexture_drift');
+  });
+
+  it('copies the Agent setup install command with announced feedback', () => {
+    const onCopy = vi.fn();
+    render(<SchemaPanel {...DEFAULT_PROPS} zodSource="zod" onCopy={onCopy} />);
+
+    fireEvent.click(screen.getByTestId('agent-setup-install-copy'));
+    expect(onCopy).toHaveBeenCalledWith(
+      'codex mcp add contexture -- /Applications/Contexture.app/Contents/MacOS/Contexture --mcp',
+    );
+    expect(screen.getByText('Copied install command')).toBeInTheDocument();
+  });
+
+  it('uses the saved document path in the Agent setup prompt and smoke test', () => {
+    const onCopy = vi.fn();
+    render(
+      <SchemaPanel
+        {...DEFAULT_PROPS}
+        zodSource="zod"
+        documentFilePath="/repo/garden.contexture.json"
+        onCopy={onCopy}
+      />,
+    );
+
+    expect(screen.getByLabelText('Saved-document prompt')).toHaveValue(
+      'Use the Contexture MCP server to inspect /repo/garden.contexture.json, then validate, emit, and check drift before finishing.',
+    );
+    expect(screen.getByLabelText('Smoke test')).toHaveValue(
+      'Ask Codex: "List the contexture MCP tools, then inspect /repo/garden.contexture.json."',
+    );
+
+    fireEvent.click(screen.getByTestId('agent-setup-prompt-copy'));
+    expect(onCopy).toHaveBeenCalledWith(
+      'Use the Contexture MCP server to inspect /repo/garden.contexture.json, then validate, emit, and check drift before finishing.',
+    );
+  });
+
+  it('shows a save-first Agent setup state before the document has a path', () => {
+    const onRequestSave = vi.fn();
+    render(
+      <SchemaPanel
+        {...DEFAULT_PROPS}
+        zodSource="zod"
+        documentFilePath={null}
+        onRequestSave={onRequestSave}
+      />,
+    );
+
+    expect(screen.getByTestId('agent-setup-unsaved')).toHaveTextContent(
+      'Save this document to create a stable .contexture.json path before handing it to an agent.',
+    );
+    expect(screen.queryByLabelText('Saved-document prompt')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Smoke test')).toHaveValue(
+      'Ask Codex: "List the contexture MCP tools."',
+    );
+
+    fireEvent.click(screen.getByText('Save first'));
+    expect(onRequestSave).toHaveBeenCalledTimes(1);
+  });
+
   it('renders an error message when `error` is non-null and hides the code/copy controls', () => {
     render(
       <SchemaPanel {...DEFAULT_PROPS} error="Unknown field kind: 'frobnicate'" onCopy={vi.fn()} />,

--- a/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
+++ b/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { SchemaPanel } from '@renderer/components/schema/SchemaPanel';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -62,20 +62,22 @@ describe('SchemaPanel', () => {
     render(<SchemaPanel {...DEFAULT_PROPS} zodSource="zod" />);
 
     expect(screen.getByTestId('agent-setup')).toHaveTextContent('Agent setup');
-    expect(screen.getByLabelText('Codex install command')).toHaveValue(
+    fireEvent.click(screen.getByTestId('agent-setup'));
+    expect(screen.getByTestId('agent-setup-install-value')).toHaveTextContent(
       'codex mcp add contexture -- /Applications/Contexture.app/Contents/MacOS/Contexture --mcp',
     );
-    expect(screen.getByTestId('agent-setup')).toHaveTextContent('inspect_contexture');
-    expect(screen.getByTestId('agent-setup')).toHaveTextContent('validate_contexture');
-    expect(screen.getByTestId('agent-setup')).toHaveTextContent('apply_contexture_op');
-    expect(screen.getByTestId('agent-setup')).toHaveTextContent('emit_contexture');
-    expect(screen.getByTestId('agent-setup')).toHaveTextContent('check_contexture_drift');
+    expect(screen.getByTestId('agent-setup-content')).toHaveTextContent('inspect_contexture');
+    expect(screen.getByTestId('agent-setup-content')).toHaveTextContent('validate_contexture');
+    expect(screen.getByTestId('agent-setup-content')).toHaveTextContent('apply_contexture_op');
+    expect(screen.getByTestId('agent-setup-content')).toHaveTextContent('emit_contexture');
+    expect(screen.getByTestId('agent-setup-content')).toHaveTextContent('check_contexture_drift');
   });
 
   it('copies the Agent setup install command with announced feedback', () => {
     const onCopy = vi.fn();
     render(<SchemaPanel {...DEFAULT_PROPS} zodSource="zod" onCopy={onCopy} />);
 
+    fireEvent.click(screen.getByTestId('agent-setup'));
     fireEvent.click(screen.getByTestId('agent-setup-install-copy'));
     expect(onCopy).toHaveBeenCalledWith(
       'codex mcp add contexture -- /Applications/Contexture.app/Contents/MacOS/Contexture --mcp',
@@ -94,10 +96,11 @@ describe('SchemaPanel', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Saved-document prompt')).toHaveValue(
+    fireEvent.click(screen.getByTestId('agent-setup'));
+    expect(screen.getByTestId('agent-setup-prompt-value')).toHaveTextContent(
       'Use the Contexture MCP server to inspect /repo/garden.contexture.json, then validate, emit, and check drift before finishing.',
     );
-    expect(screen.getByLabelText('Smoke test')).toHaveValue(
+    expect(screen.getByTestId('agent-setup-smoke-value')).toHaveTextContent(
       'Ask Codex: "List the contexture MCP tools, then inspect /repo/garden.contexture.json."',
     );
 
@@ -118,11 +121,12 @@ describe('SchemaPanel', () => {
       />,
     );
 
+    fireEvent.click(screen.getByTestId('agent-setup'));
     expect(screen.getByTestId('agent-setup-unsaved')).toHaveTextContent(
       'Save this document to create a stable .contexture.json path before handing it to an agent.',
     );
     expect(screen.queryByLabelText('Saved-document prompt')).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Smoke test')).toHaveValue(
+    expect(screen.getByTestId('agent-setup-smoke-value')).toHaveTextContent(
       'Ask Codex: "List the contexture MCP tools."',
     );
 
@@ -139,6 +143,24 @@ describe('SchemaPanel', () => {
     expect(err.textContent).toContain("Unknown field kind: 'frobnicate'");
     expect(screen.queryByTestId('schema-copy')).not.toBeInTheDocument();
     expect(screen.queryByTestId('schema-code')).not.toBeInTheDocument();
+  });
+
+  it('keeps Agent setup visible when generated preview emission fails', () => {
+    render(
+      <SchemaPanel
+        {...DEFAULT_PROPS}
+        error="Unknown field kind: 'frobnicate'"
+        documentFilePath="/repo/garden.contexture.json"
+        onCopy={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('schema-error')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-setup')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('agent-setup'));
+    expect(screen.getByTestId('agent-setup-prompt-value')).toHaveTextContent(
+      'Use the Contexture MCP server to inspect /repo/garden.contexture.json, then validate, emit, and check drift before finishing.',
+    );
   });
 
   it('prefers the empty state over the error state when the schema is empty', () => {
@@ -184,36 +206,42 @@ describe('SchemaPanel', () => {
     expect(increase).toBeDisabled();
   });
 
-  describe('grouped output selector', () => {
+  describe('output selector', () => {
+    async function chooseOutput(testId: string): Promise<void> {
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId('schema-output-selector'));
+      await user.click(await screen.findByTestId(testId));
+    }
+
     it('shows Zod active by default without rendering a tab strip', () => {
       const zodSrc = "import { z } from 'zod';\n";
       render(<SchemaPanel {...DEFAULT_PROPS} zodSource={zodSrc} />);
-      const zodOutput = screen.getByTestId('schema-output-zod');
       expect(screen.getByTestId('schema-output-selector')).toBeInTheDocument();
       expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
-      expect(zodOutput).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByTestId('schema-output-selector')).toHaveTextContent('Zod schema');
       expect(screen.queryByTestId('schema-group-ai')).not.toBeInTheDocument();
       expect(screen.queryByTestId('schema-group-forms')).not.toBeInTheDocument();
     });
 
-    it('switches to JSON Schema source when the JSON output is clicked', () => {
+    it('switches to JSON Schema source when the JSON output is selected', async () => {
       const zodSrc = "import { z } from 'zod';\n";
       const jsonSrc = '{\n  "$schema": "https://json-schema.org/draft/2020-12/schema"\n}';
       render(<SchemaPanel {...DEFAULT_PROPS} zodSource={zodSrc} jsonSource={jsonSrc} />);
 
-      fireEvent.click(screen.getByTestId('schema-output-json-schema'));
+      await chooseOutput('schema-output-json-schema');
       expect(screen.getByTestId('schema-code').textContent).toContain('$schema');
     });
 
-    it('switches to Convex source when the Convex output is clicked', () => {
+    it('switches to Convex source when the Convex output is selected', async () => {
       const convexSrc = 'import { defineSchema } from "convex/server";\n';
       render(<SchemaPanel {...DEFAULT_PROPS} zodSource="zod" convexSource={convexSrc} />);
 
-      fireEvent.click(screen.getByTestId('schema-output-convex'));
+      await chooseOutput('schema-output-convex');
       expect(screen.getByTestId('schema-code').textContent).toContain('defineSchema');
     });
 
-    it('shows non-empty AI and Forms outputs grouped away from Core', () => {
+    it('shows non-empty AI and Forms outputs grouped away from Core in the selector', async () => {
+      const user = userEvent.setup();
       render(
         <SchemaPanel
           {...DEFAULT_PROPS}
@@ -226,6 +254,7 @@ describe('SchemaPanel', () => {
         />,
       );
 
+      await user.click(screen.getByTestId('schema-output-selector'));
       expect(screen.getByTestId('schema-group-core')).toHaveTextContent('Zod schema');
       expect(screen.getByTestId('schema-group-ai')).toHaveTextContent('Tool schemas');
       expect(screen.getByTestId('schema-group-forms')).toHaveTextContent('Form validators');
@@ -234,7 +263,7 @@ describe('SchemaPanel', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('shows disabled optional outputs as enableable choices', () => {
+    it('shows disabled optional outputs as explicit configuration actions', () => {
       const onEnableOutput = vi.fn();
       render(
         <SchemaPanel
@@ -248,46 +277,35 @@ describe('SchemaPanel', () => {
         />,
       );
 
+      fireEvent.click(screen.getByTestId('schema-output-config'));
       expect(screen.getByTestId('schema-group-ai')).toHaveTextContent('Tool schemas');
       expect(screen.getByTestId('schema-group-forms')).toHaveTextContent('Form validators');
       fireEvent.click(screen.getByTestId('schema-output-ai-tool-schemas'));
       expect(onEnableOutput).toHaveBeenCalledWith('ai-tool-schemas');
-      expect(screen.getByTestId('schema-output-ai-tool-schemas')).toHaveAttribute(
-        'aria-selected',
-        'false',
-      );
     });
 
-    it('provides lightweight tooltip help on output choices', async () => {
+    it('describes disabled optional outputs in the configuration popover', () => {
       render(
         <SchemaPanel
           {...DEFAULT_PROPS}
           zodSource="zod"
           additionalSources={[
             { type: 'ai-tool-schemas', enabled: false, source: '' },
-            { type: 'form-validators', source: 'export function validate() {}\n' },
+            { type: 'form-validators', enabled: false, source: '' },
           ]}
         />,
       );
 
-      fireEvent.focus(screen.getByTestId('schema-output-ai-tool-schemas'));
-      await waitFor(() => {
-        expect(
-          screen.getAllByText(/Enable Tool schemas: JSON Schema tool definitions/i).length,
-        ).toBeGreaterThan(0);
-      });
-
-      fireEvent.blur(screen.getByTestId('schema-output-ai-tool-schemas'));
-      fireEvent.focus(screen.getByTestId('schema-output-form-validators'));
-      await waitFor(() => {
-        expect(
-          screen.getAllByText(/Type-safe validation helpers backed by generated Zod schemas/i)
-            .length,
-        ).toBeGreaterThan(0);
-      });
+      fireEvent.click(screen.getByTestId('schema-output-config'));
+      expect(screen.getByTestId('schema-output-ai-tool-schemas')).toHaveTextContent(
+        /JSON Schema tool definitions/i,
+      );
+      expect(screen.getByTestId('schema-output-form-validators')).toHaveTextContent(
+        /Type-safe validation helpers backed by generated Zod schemas/i,
+      );
     });
 
-    it('switches to an enabled AI source and shows its friendly filename', () => {
+    it('switches to an enabled AI source and shows its friendly filename', async () => {
       render(
         <SchemaPanel
           {...DEFAULT_PROPS}
@@ -296,21 +314,21 @@ describe('SchemaPanel', () => {
         />,
       );
 
-      fireEvent.click(screen.getByTestId('schema-output-mcp-definitions'));
+      await chooseOutput('schema-output-mcp-definitions');
       expect(screen.getByTestId('schema-code').textContent).toContain('"servers"');
       expect(screen.getByTestId('schema-filename').textContent).toContain(
         '.contexture/mcp-definitions.json',
       );
     });
 
-    it('copies the active output source when Copy is clicked', () => {
+    it('copies the active output source when Copy is clicked', async () => {
       const jsonSrc = '{ "$schema": "..." }';
       const onCopy = vi.fn();
       render(
         <SchemaPanel {...DEFAULT_PROPS} zodSource="zod" jsonSource={jsonSrc} onCopy={onCopy} />,
       );
 
-      fireEvent.click(screen.getByTestId('schema-output-json-schema'));
+      await chooseOutput('schema-output-json-schema');
       fireEvent.click(screen.getByTestId('schema-copy'));
       expect(onCopy).toHaveBeenCalledWith(jsonSrc);
     });
@@ -335,11 +353,11 @@ describe('SchemaPanel', () => {
       await user.tab();
       expect(screen.getByTestId('schema-open-generated')).toHaveFocus();
 
-      fireEvent.click(screen.getByTestId('schema-output-json-schema'));
+      await chooseOutput('schema-output-json-schema');
       fireEvent.click(screen.getByTestId('schema-open-generated'));
       expect(onOpenGeneratedFile).toHaveBeenLastCalledWith('/repo/garden.schema.json');
 
-      fireEvent.click(screen.getByTestId('schema-output-mcp-definitions'));
+      await chooseOutput('schema-output-mcp-definitions');
       fireEvent.click(screen.getByTestId('schema-open-generated'));
       expect(onOpenGeneratedFile).toHaveBeenLastCalledWith(
         '/repo/.contexture/mcp-definitions.json',
@@ -359,7 +377,7 @@ describe('SchemaPanel', () => {
       expect(screen.queryByTestId('schema-open-generated')).not.toBeInTheDocument();
     });
 
-    it('shows the JSON Schema filename when on the JSON output', () => {
+    it('shows the JSON Schema filename when on the JSON output', async () => {
       render(
         <SchemaPanel
           {...DEFAULT_PROPS}
@@ -368,11 +386,11 @@ describe('SchemaPanel', () => {
           schemaFileName="allotment.schema.ts"
         />,
       );
-      fireEvent.click(screen.getByTestId('schema-output-json-schema'));
+      await chooseOutput('schema-output-json-schema');
       expect(screen.getByTestId('schema-filename').textContent).toContain('allotment.schema.json');
     });
 
-    it('shows the Convex filename when on the Convex output', () => {
+    it('shows the Convex filename when on the Convex output', async () => {
       render(
         <SchemaPanel
           {...DEFAULT_PROPS}
@@ -381,15 +399,15 @@ describe('SchemaPanel', () => {
           schemaFileName="allotment.schema.ts"
         />,
       );
-      fireEvent.click(screen.getByTestId('schema-output-convex'));
+      await chooseOutput('schema-output-convex');
       expect(screen.getByTestId('schema-filename').textContent).toContain('convex/schema.ts');
     });
 
-    it('derives JSON filename via .ts → .json fallback when name has no .schema.ts suffix', () => {
+    it('derives JSON filename via .ts → .json fallback when name has no .schema.ts suffix', async () => {
       render(<SchemaPanel {...DEFAULT_PROPS} zodSource="a" jsonSource="b" />);
       // Default schemaFileName is 'schema.ts' — no '.schema.ts' segment, so the
       // fallback .ts → .json replacement must fire.
-      fireEvent.click(screen.getByTestId('schema-output-json-schema'));
+      await chooseOutput('schema-output-json-schema');
       expect(screen.getByTestId('schema-filename').textContent).toContain('schema.json');
     });
   });

--- a/apps/desktop/tests/setup.ts
+++ b/apps/desktop/tests/setup.ts
@@ -3,6 +3,9 @@ import { vi } from 'vitest';
 
 // Mock scrollIntoView for jsdom
 Element.prototype.scrollIntoView = vi.fn();
+Element.prototype.hasPointerCapture = vi.fn(() => false);
+Element.prototype.setPointerCapture = vi.fn();
+Element.prototype.releasePointerCapture = vi.fn();
 
 // Mock ResizeObserver for jsdom
 global.ResizeObserver = vi.fn().mockImplementation(() => ({


### PR DESCRIPTION
## Summary
- Add a new `Agent setup` section to the desktop Schema panel with copyable Codex MCP install guidance, saved-document prompts, smoke-test text, and the exposed MCP tool list.
- Wire the panel to the app save flow so unsaved documents can prompt the user to save before handing the IR to an agent.
- Add a first-pass `contexture-integration` skill draft for repo-level Contexture wiring workflows.
- Cover the new saved/unsaved and copy behavior with focused SchemaPanel tests.

## Testing
- `bunx biome check --write apps/desktop/src/renderer/src/App.tsx apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx apps/desktop/tests/components/schema/SchemaPanel.test.tsx .agents/skills/contexture-integration/SKILL.md`
- `bun run test -- tests/components/schema/SchemaPanel.test.tsx tests/components/App.schema-outputs.test.tsx`
- `bun run typecheck:web`