### PR TITLE
fix(desktop): show union variant edges in graph

### DIFF
--- a/apps/desktop/src/renderer/src/components/detail/EdgeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/EdgeDetail.tsx
@@ -1,11 +1,9 @@
 /**
- * EdgeDetail — read-only ref metadata for a selected edge.
+ * EdgeDetail — read-only graph-edge metadata for a selected edge.
  *
- * Edges are purely derived from the IR (a field's `ref` target) — there
- * is no "edge entity" to mutate directly. Editing the source field
- * belongs in `FieldDetail`, so this panel just surfaces the source
- * type, source field, and target type plus a "edit field" affordance
- * that flips the selection to the driving field.
+ * Edges are purely derived from the IR — field refs come from object
+ * fields, and union-variant edges come from discriminated-union
+ * `variants`. There is no edge entity to mutate directly.
  */
 import type { RefEdgeData } from '../graph/schema-to-graph';
 
@@ -15,10 +13,15 @@ export interface EdgeDetailProps {
 }
 
 export function EdgeDetail({ data, onEditField }: EdgeDetailProps) {
+  const isUnionVariant = data.relation === 'unionVariant';
+  const editableSourceField = isUnionVariant ? undefined : data.sourceField;
+
   return (
     <div className="space-y-2 p-3 text-xs">
       <div className="flex items-center justify-between">
-        <span className="text-sm font-semibold">Ref edge</span>
+        <span className="text-sm font-semibold">
+          {isUnionVariant ? 'Union variant edge' : 'Ref edge'}
+        </span>
         {data.crossBoundary && (
           <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
             cross-boundary
@@ -27,14 +30,18 @@ export function EdgeDetail({ data, onEditField }: EdgeDetailProps) {
       </div>
       <dl className="space-y-1">
         <Row term="Source type" detail={data.sourceType} />
-        <Row term="Source field" detail={data.sourceField} />
+        {isUnionVariant ? (
+          <Row term="Discriminator" detail={data.discriminator ?? ''} />
+        ) : (
+          <Row term="Source field" detail={data.sourceField ?? ''} />
+        )}
         <Row term="Target" detail={data.targetType} />
       </dl>
-      {onEditField && (
+      {editableSourceField && onEditField && (
         <button
           type="button"
           className="text-xs underline text-muted-foreground hover:text-foreground"
-          onClick={() => onEditField(data.sourceType, data.sourceField)}
+          onClick={() => onEditField(data.sourceType, editableSourceField)}
         >
           Edit field
         </button>

--- a/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
@@ -6,7 +6,7 @@
  * the canvas uses so new users can decode the diagram at a glance.
  *
  * Matches the four `TypeDef` kinds (object / enum / discriminatedUnion
- * / raw) and the two `RefEdge` modes (same-schema ref vs cross-boundary
+ * / raw) and the edge modes (field ref, union variant, cross-boundary
  * import). Colours are pulled from `globals.css` so theme changes flow
  * through without edits here.
  */
@@ -23,6 +23,11 @@ const EDGE_ITEMS: readonly EdgeItem[] = [
   {
     label: 'Ref',
     color: 'var(--graph-edge-ref)',
+  },
+  {
+    label: 'Union variant',
+    color: 'var(--graph-edge-union)',
+    dash: '2,4',
   },
   {
     label: 'Import (cross-boundary)',

--- a/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
@@ -4,14 +4,11 @@
  * clips the node body.
  *
  * Styling:
- *   - Local ref (`crossBoundary: false`): solid edge in the property
- *     accent, thicker when selected or adjacent to the selected node.
- *   - Cross-boundary (stdlib / imported) ref: dashed, muted stroke so
- *     the boundary between the user's schema and an imported namespace
- *     reads at a glance.
- *   - A tiny label near the midpoint shows the source field name
- *     (`plot.crop`, etc.) so the user can tell which field carries the
- *     ref without selecting the edge.
+ *   - Field refs use the property accent and label the source field.
+ *   - Union variants use the discriminated-union accent and a dotted
+ *     stroke so inheritance-like membership does not read as a field.
+ *   - Cross-boundary refs are dashed and muted so imported namespaces read
+ *     at a glance.
  */
 import {
   BaseEdge,
@@ -52,6 +49,7 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
   });
 
   const crossBoundary = data?.crossBoundary === true;
+  const isUnionVariant = data?.relation === 'unionVariant';
   const isAdjacent = adjacentEdgeIds.has(id);
   // Dim edges that touch neither the selected node nor an adjacent one.
   const isDimmed =
@@ -63,10 +61,14 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
   const stroke =
     selected || isAdjacent
       ? 'var(--graph-node-selected)'
-      : crossBoundary
-        ? 'var(--graph-edge-import, var(--muted-foreground))'
-        : 'var(--graph-edge-property)';
+      : isUnionVariant
+        ? 'var(--graph-edge-union, var(--chart-4))'
+        : crossBoundary
+          ? 'var(--graph-edge-import, var(--muted-foreground))'
+          : 'var(--graph-edge-ref, var(--graph-edge-property))';
   const strokeWidth = selected || isAdjacent ? 2 : 1.25;
+  const strokeDasharray = isUnionVariant ? '2 4' : crossBoundary ? '6 4' : undefined;
+  const label = isUnionVariant ? 'variant' : data?.sourceField;
 
   return (
     <>
@@ -76,13 +78,13 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
         style={{
           stroke,
           strokeWidth,
-          strokeDasharray: crossBoundary ? '6 4' : undefined,
+          strokeDasharray,
           opacity: isDimmed ? 0.2 : 1,
           transition: 'opacity 0.15s ease, stroke 0.1s ease',
           fill: 'none',
         }}
       />
-      {data && (
+      {label && (
         <EdgeLabelRenderer>
           <div
             style={{
@@ -101,8 +103,9 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
             }}
             data-testid="ref-edge"
             data-cross-boundary={crossBoundary ? 'true' : 'false'}
+            data-relation={data?.relation ?? 'fieldRef'}
           >
-            {data.sourceField}
+            {label}
           </div>
         </EdgeLabelRenderer>
       )}

--- a/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
+++ b/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
@@ -8,8 +8,10 @@
  * nodes are marked as imported) lives in one tested function.
  *
  * Edge policy:
- *   - Only `object` TypeDefs contribute edges — their `ref` fields and
- *     `ref`-typed array elements point at target types.
+ *   - `object` TypeDefs contribute field-ref edges — their `ref` fields
+ *     and `ref`-typed array elements point at target types.
+ *   - `discriminatedUnion` TypeDefs contribute variant edges to each
+ *     object type listed in `variants`.
  *   - Qualified refs (`alias.Name`) always point at the imported
  *     namespace; the target node id is the same alias-qualified name so
  *     the renderer can choose to hide/show or badge external targets.
@@ -48,9 +50,11 @@ export interface FieldRow {
 }
 
 export interface RefEdgeData extends Record<string, unknown> {
+  relation: 'fieldRef' | 'unionVariant';
   sourceType: string;
-  sourceField: string;
+  sourceField?: string;
   targetType: string;
+  discriminator?: string;
   /** True when the target is an imported (out-of-file) type. */
   crossBoundary: boolean;
 }
@@ -74,22 +78,49 @@ export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphRe
     localNodeFor(t, positions?.[t.name] ?? DEFAULT_POSITION),
   );
 
-  // Collect edges + shadow nodes for qualified refs that point outside
-  // the local schema.
+  // Collect edges + shadow nodes for targets that point outside the local
+  // schema. Discriminated-union variants should normally be local, but the
+  // fallback keeps invalid/in-progress schemas renderable while validation
+  // reports the semantic issue elsewhere.
   const edges: Edge<RefEdgeData>[] = [];
   const externalNodeIds = new Set<string>();
 
+  const ensureExternalNode = (target: string): boolean => {
+    const crossBoundary = target.includes('.') || !localNames.has(target);
+    if (crossBoundary && !externalNodeIds.has(target)) {
+      externalNodeIds.add(target);
+      nodes.push(externalNodeFor(target, positions?.[target] ?? DEFAULT_POSITION));
+    }
+    return crossBoundary;
+  };
+
   for (const type of schema.types) {
+    if (type.kind === 'discriminatedUnion') {
+      for (const variant of type.variants) {
+        const crossBoundary = ensureExternalNode(variant);
+        edges.push({
+          id: `${type.name}.variant->${variant}`,
+          source: type.name,
+          target: variant,
+          type: 'ref',
+          data: {
+            relation: 'unionVariant',
+            sourceType: type.name,
+            targetType: variant,
+            discriminator: type.discriminator,
+            crossBoundary,
+          },
+        });
+      }
+      continue;
+    }
+
     if (type.kind !== 'object') continue;
     for (const field of type.fields) {
       const target = unwrapRefTarget(field.type);
       if (!target) continue;
 
-      const crossBoundary = target.includes('.') || !localNames.has(target);
-      if (crossBoundary && !externalNodeIds.has(target)) {
-        externalNodeIds.add(target);
-        nodes.push(externalNodeFor(target, positions?.[target] ?? DEFAULT_POSITION));
-      }
+      const crossBoundary = ensureExternalNode(target);
 
       edges.push({
         id: `${type.name}.${field.name}->${target}`,
@@ -97,6 +128,7 @@ export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphRe
         target,
         type: 'ref',
         data: {
+          relation: 'fieldRef',
           sourceType: type.name,
           sourceField: field.name,
           targetType: target,

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -70,8 +70,10 @@
   --graph-edge-subclass: oklch(0.50 0.02 270);
   --graph-edge-restriction: oklch(0.65 0.15 280);
   /* Zod-era edge tokens. `ref` is the default relationship edge;
-     `import` is the dashed cross-boundary (stdlib / cross-project) edge. */
+     `union` is the discriminated-union variant edge; `import` is the
+     dashed cross-boundary (stdlib / cross-project) edge. */
   --graph-edge-ref: oklch(0.65 0.12 280);
+  --graph-edge-union: oklch(0.55 0.17 155);
   --graph-edge-import: oklch(0.55 0.04 240);
   /* Background dot colour — deliberately subdued so the grid reads as
      texture, not noise. */
@@ -130,6 +132,7 @@
   --graph-edge-restriction: oklch(0.65 0.15 280);
   /* Zod-era edge tokens (dark). */
   --graph-edge-ref: oklch(0.65 0.08 280);
+  --graph-edge-union: oklch(0.65 0.16 155);
   --graph-edge-import: oklch(0.7 0.04 240);
   /* Subdued dot grid on dark canvases too. */
   --graph-dot: oklch(0.7 0.02 270 / 0.14);

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -54,6 +54,7 @@ describe('DetailPanel', () => {
 
   it('renders EdgeDetail when an edge is selected', () => {
     const edge: RefEdgeData = {
+      relation: 'fieldRef',
       sourceType: 'Plot',
       sourceField: 'harvest',
       targetType: 'Harvest',

--- a/apps/desktop/tests/components/detail/EdgeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/EdgeDetail.test.tsx
@@ -11,6 +11,7 @@ describe('EdgeDetail', () => {
 
   it('renders source type, source field, and target type', () => {
     const data: RefEdgeData = {
+      relation: 'fieldRef',
       sourceType: 'Plot',
       sourceField: 'harvest',
       targetType: 'Harvest',
@@ -25,6 +26,7 @@ describe('EdgeDetail', () => {
 
   it('badges cross-boundary edges', () => {
     const data: RefEdgeData = {
+      relation: 'fieldRef',
       sourceType: 'User',
       sourceField: 'email',
       targetType: 'common.Email',
@@ -36,6 +38,7 @@ describe('EdgeDetail', () => {
 
   it('invokes onEditField with source when the affordance is clicked', () => {
     const data: RefEdgeData = {
+      relation: 'fieldRef',
       sourceType: 'Plot',
       sourceField: 'harvest',
       targetType: 'Harvest',
@@ -45,5 +48,20 @@ describe('EdgeDetail', () => {
     render(<EdgeDetail data={data} onEditField={onEditField} />);
     fireEvent.click(screen.getByText('Edit field'));
     expect(onEditField).toHaveBeenCalledWith('Plot', 'harvest');
+  });
+
+  it('renders union variant edges without field-edit affordances', () => {
+    const data: RefEdgeData = {
+      relation: 'unionVariant',
+      sourceType: 'SourceReference',
+      targetType: 'MusicianReference',
+      discriminator: 'kind',
+      crossBoundary: false,
+    };
+    render(<EdgeDetail data={data} onEditField={vi.fn()} />);
+    expect(screen.getByText('Union variant edge')).toBeInTheDocument();
+    expect(screen.getByText('Discriminator')).toBeInTheDocument();
+    expect(screen.getByText('kind')).toBeInTheDocument();
+    expect(screen.queryByText('Edit field')).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/tests/graph/schema-to-graph.test.ts
+++ b/apps/desktop/tests/graph/schema-to-graph.test.ts
@@ -135,6 +135,62 @@ describe('buildGraph', () => {
     expect(edges).toEqual([expect.objectContaining({ source: 'Plot', target: 'Harvest' })]);
   });
 
+  it('emits variant edges from discriminated unions to their object variants', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'discriminatedUnion',
+          name: 'ArtworkSourceReference',
+          discriminator: 'kind',
+          variants: ['MusicianReference', 'GearReference'],
+        },
+        {
+          kind: 'object',
+          name: 'MusicianReference',
+          fields: [{ name: 'kind', type: { kind: 'literal', value: 'musician' } }],
+        },
+        {
+          kind: 'object',
+          name: 'GearReference',
+          fields: [{ name: 'kind', type: { kind: 'literal', value: 'gear' } }],
+        },
+      ],
+    };
+
+    const { nodes, edges } = buildGraph({ schema });
+
+    expect(nodes.map((n) => n.id)).toEqual([
+      'ArtworkSourceReference',
+      'MusicianReference',
+      'GearReference',
+    ]);
+    expect(edges).toEqual([
+      expect.objectContaining({
+        id: 'ArtworkSourceReference.variant->MusicianReference',
+        source: 'ArtworkSourceReference',
+        target: 'MusicianReference',
+        type: 'ref',
+        data: expect.objectContaining({
+          relation: 'unionVariant',
+          discriminator: 'kind',
+          crossBoundary: false,
+        }),
+      }),
+      expect.objectContaining({
+        id: 'ArtworkSourceReference.variant->GearReference',
+        source: 'ArtworkSourceReference',
+        target: 'GearReference',
+        type: 'ref',
+        data: expect.objectContaining({
+          relation: 'unionVariant',
+          discriminator: 'kind',
+          crossBoundary: false,
+        }),
+      }),
+    ]);
+  });
+
   it('applies sidecar positions and falls back to 0,0 for missing keys', () => {
     const schema: Schema = {
       version: '1',


### PR DESCRIPTION
## Summary
- draw discriminated-union variant edges from union nodes to each variant object
- style variant edges distinctly with a green dotted line and legend entry
- update edge details/tests so variant edges show discriminator metadata instead of field-edit actions

## Verification
- bun run test -- tests/graph/schema-to-graph.test.ts
- bun run test -- tests/components/detail/EdgeDetail.test.tsx tests/components/detail/DetailPanel.test.tsx
- bun run ci