### PR TITLE
feat: tighten Convex validator generation

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/tests/main/document-store.test.ts
+++ b/apps/desktop/tests/main/document-store.test.ts
@@ -206,6 +206,20 @@ describe('DocumentStore', () => {
     expect(convex).toMatch(/defineSchema\s*\(/);
   });
 
+  it('bundle-mode save writes Convex validators.ts next to the schema', async () => {
+    await harness.store.save({
+      irPath,
+      schema: sampleIR,
+      layout: sampleLayout,
+      chat: sampleChat,
+    });
+    const validatorsPath = '/work/convex/validators.ts';
+    expect(harness.fs.exists(validatorsPath)).toBe(true);
+    const validators = await harness.fs.readFile(validatorsPath);
+    expect(validators).toContain('@contexture-generated');
+    expect(validators).toContain(`import { v } from 'convex/values';`);
+  });
+
   it('bundle-mode save writes a schema index re-export next to the IR', async () => {
     await harness.store.save({
       irPath,
@@ -306,6 +320,7 @@ describe('DocumentStore', () => {
         '/work/garden.schema.json',
         '/work/index.ts',
         '/work/convex/schema.ts',
+        '/work/convex/validators.ts',
       ].sort(),
     );
     for (const hash of Object.values(manifest.files)) {

--- a/apps/desktop/tests/model/emit-convex.test.ts
+++ b/apps/desktop/tests/model/emit-convex.test.ts
@@ -1,4 +1,4 @@
-import { emitConvexSchema } from '@contexture/core/emit-convex';
+import { emitConvexSchema, emitConvexValidators } from '@contexture/core/emit-convex';
 import type { Schema } from '@contexture/core/ir';
 import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
@@ -101,7 +101,7 @@ describe('emitConvexSchema', () => {
     expect(parses(out)).toBe(true);
   });
 
-  it('inlines non-table object types referenced from tables as v.object(...)', () => {
+  it('emits non-table object refs as reusable object validators', () => {
     const ir: Schema = {
       version: '1',
       types: [
@@ -122,11 +122,112 @@ describe('emitConvexSchema', () => {
       ],
     };
     const out = emitConvexSchema(ir);
-    expect(out).toMatch(
-      /home:\s*v\.object\(\{\s*city:\s*v\.string\(\),\s*zip:\s*v\.string\(\)\s*\}\)/,
-    );
+    expect(out).toContain(`import { address } from './validators';`);
+    expect(out).toContain('home: address');
     // Only User should be a defineTable entry.
     expect(out).not.toMatch(/Address:\s*defineTable/);
+    expect(parses(out)).toBe(true);
+  });
+
+  it('emits local enum refs as reusable literal unions', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'enum',
+          name: 'Status',
+          values: [{ value: 'draft' }, { value: 'published' }],
+        },
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'status', type: { kind: 'ref', typeName: 'Status' } }],
+        },
+      ],
+    };
+    const out = emitConvexSchema(ir);
+    expect(out).toContain(`import { status } from './validators';`);
+    expect(out).toContain('status: status');
+    expect(out).not.toContain('status: v.any()');
+    expect(parses(out)).toBe(true);
+  });
+
+  it('emits discriminated union refs as reusable unions of object variants', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'ClickEvent',
+          fields: [
+            { name: 'kind', type: { kind: 'literal', value: 'click' } },
+            { name: 'x', type: { kind: 'number' } },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'HoverEvent',
+          fields: [
+            { name: 'kind', type: { kind: 'literal', value: 'hover' } },
+            { name: 'target', type: { kind: 'string' } },
+          ],
+        },
+        {
+          kind: 'discriminatedUnion',
+          name: 'UiEvent',
+          discriminator: 'kind',
+          variants: ['ClickEvent', 'HoverEvent'],
+        },
+        {
+          kind: 'object',
+          name: 'AuditLog',
+          table: true,
+          fields: [{ name: 'event', type: { kind: 'ref', typeName: 'UiEvent' } }],
+        },
+      ],
+    };
+    const out = emitConvexSchema(ir);
+    expect(out).toContain(`import { uiEvent } from './validators';`);
+    expect(out).toContain('event: uiEvent');
+    expect(out).not.toContain('event: v.any()');
+    expect(parses(out)).toBe(true);
+  });
+
+  it('emits nested enum refs inside embedded object arrays', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'enum',
+          name: 'PaletteRole',
+          values: [{ value: 'primary' }, { value: 'accent' }],
+        },
+        {
+          kind: 'object',
+          name: 'PaletteColor',
+          fields: [
+            { name: 'hex', type: { kind: 'string' } },
+            { name: 'role', type: { kind: 'ref', typeName: 'PaletteRole' }, optional: true },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'Artwork',
+          table: true,
+          fields: [
+            {
+              name: 'palette',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'PaletteColor' } },
+            },
+          ],
+        },
+      ],
+    };
+    const out = emitConvexSchema(ir);
+    expect(out).toContain(`import { paletteColor } from './validators';`);
+    expect(out).toContain('palette: v.array(paletteColor)');
+    expect(out).not.toContain('role: v.optional(v.any())');
     expect(parses(out)).toBe(true);
   });
 
@@ -199,5 +300,79 @@ describe('emitConvexSchema', () => {
     };
     // No table-flagged types — emitter should succeed.
     expect(() => emitConvexSchema(ir)).not.toThrow();
+  });
+});
+
+describe('emitConvexValidators', () => {
+  it('exports reusable validators for non-table objects and enums', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'enum',
+          name: 'Status',
+          values: [{ value: 'draft' }, { value: 'published' }],
+        },
+        {
+          kind: 'object',
+          name: 'PostMetadata',
+          fields: [{ name: 'status', type: { kind: 'ref', typeName: 'Status' } }],
+        },
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'metadata', type: { kind: 'ref', typeName: 'PostMetadata' } }],
+        },
+      ],
+    };
+    const out = emitConvexValidators(ir);
+    expect(out).toContain('@contexture-generated');
+    expect(out).toContain("import { v } from 'convex/values';");
+    expect(out).toContain(
+      'export const status = v.union(v.literal("draft"), v.literal("published"));',
+    );
+    expect(out).toContain('export const postMetadata = v.object({ status: status });');
+    expect(out).not.toMatch(/export const post =/);
+    expect(parses(out)).toBe(true);
+  });
+
+  it('exports discriminated unions using their variant validators', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'ClickEvent',
+          fields: [
+            { name: 'kind', type: { kind: 'literal', value: 'click' } },
+            { name: 'x', type: { kind: 'number' } },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'HoverEvent',
+          fields: [
+            { name: 'kind', type: { kind: 'literal', value: 'hover' } },
+            { name: 'target', type: { kind: 'string' } },
+          ],
+        },
+        {
+          kind: 'discriminatedUnion',
+          name: 'UiEvent',
+          discriminator: 'kind',
+          variants: ['ClickEvent', 'HoverEvent'],
+        },
+      ],
+    };
+    const out = emitConvexValidators(ir);
+    expect(out).toContain(
+      'export const clickEvent = v.object({ kind: v.literal("click"), x: v.number() });',
+    );
+    expect(out).toContain(
+      'export const hoverEvent = v.object({ kind: v.literal("hover"), target: v.string() });',
+    );
+    expect(out).toContain('export const uiEvent = v.union(clickEvent, hoverEvent);');
+    expect(parses(out)).toBe(true);
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.6",
+      "version": "0.15.8",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -320,7 +320,7 @@ describe('Contexture MCP server', () => {
       expect(cleanResult.structuredContent).toMatchObject({
         path: irPath,
         clean: true,
-        checked: 5,
+        checked: 6,
         drift: [],
       });
 

--- a/packages/core/src/emit-convex.ts
+++ b/packages/core/src/emit-convex.ts
@@ -1,11 +1,12 @@
 /**
  * Pure IR → Convex schema source emitter.
  *
- * Turns the IR into the contents of `convex/schema.ts`:
+ * Turns the IR into the contents of `convex/schema.ts` and
+ * `convex/validators.ts`:
  * table-flagged `ObjectTypeDef`s become `defineTable(...)` entries on
  * `defineSchema`; indexes chain on via `.index("name", [fields])`.
- * Non-table object types that are referenced via `ref` are inlined as
- * `v.object({...})`.
+ * Non-table object, enum, and discriminated-union types become reusable
+ * exported Convex validators.
  *
  * Convex reserves names starting with `_` (including `_id` and
  * `_creationTime`). The emitter is the final backstop for that rule —
@@ -22,22 +23,27 @@ function banner(sourcePath?: string): string {
 }
 
 type ObjectType = Extract<TypeDef, { kind: 'object' }>;
+type EnumType = Extract<TypeDef, { kind: 'enum' }>;
+type DiscriminatedUnionType = Extract<TypeDef, { kind: 'discriminatedUnion' }>;
+type ConvexReusableType = ObjectType | EnumType | DiscriminatedUnionType;
+
+interface RenderContext {
+  types: Map<string, TypeDef>;
+}
+
+interface RenderOptions {
+  preferNamedRefs: boolean;
+}
 
 export function emitConvexSchema(schema: Schema, sourcePath?: string): string {
   validateReservedNames(schema);
-  const objectByName = new Map<string, ObjectType>();
-  for (const t of schema.types) {
-    if (t.kind === 'object') objectByName.set(t.name, t);
-  }
+  const ctx = buildContext(schema);
 
   const tables = schema.types.filter(
     (t): t is ObjectType => t.kind === 'object' && t.table === true,
   );
-
-  const tableEntries = tables
-    .map((t) => `  ${t.name}: ${renderTable(t, objectByName)},`)
-    .join('\n');
-
+  const validatorImports = collectTableValidatorImports(tables, ctx);
+  const tableEntries = tables.map((t) => `  ${t.name}: ${renderTable(t, ctx)},`).join('\n');
   const body =
     tableEntries.length > 0
       ? `export default defineSchema({\n${tableEntries}\n});\n`
@@ -48,27 +54,52 @@ export function emitConvexSchema(schema: Schema, sourcePath?: string): string {
     '',
     `import { defineSchema, defineTable } from 'convex/server';`,
     `import { v } from 'convex/values';`,
+    renderValidatorImports(validatorImports),
     '',
     body,
-  ].join('\n');
+  ]
+    .filter((line) => line !== null)
+    .join('\n');
 }
 
-function renderTable(t: ObjectType, objects: Map<string, ObjectType>): string {
-  const fields = t.fields.map((f) => `    ${f.name}: ${renderFieldDef(f, objects)},`).join('\n');
+export function emitConvexValidators(schema: Schema, sourcePath?: string): string {
+  const ctx = buildContext(schema);
+  const validators = schema.types
+    .filter(isReusableValidatorType)
+    .map((t) => `export const ${validatorName(t.name)} = ${renderTypeDef(t, ctx)};`)
+    .join('\n');
+
+  const body = validators.length > 0 ? `${validators}\n` : '';
+
+  return [banner(sourcePath), '', `import { v } from 'convex/values';`, '', body].join('\n');
+}
+
+function buildContext(schema: Schema): RenderContext {
+  const typeByName = new Map<string, TypeDef>();
+  for (const t of schema.types) {
+    typeByName.set(t.name, t);
+  }
+  return { types: typeByName };
+}
+
+function renderTable(t: ObjectType, ctx: RenderContext): string {
+  const fields = t.fields
+    .map((f) => `    ${f.name}: ${renderFieldDef(f, ctx, { preferNamedRefs: true })},`)
+    .join('\n');
   const indexChain = (t.indexes ?? [])
     .map((i) => `.index("${i.name}", [${i.fields.map((f) => `"${f}"`).join(', ')}])`)
     .join('');
   return `defineTable({\n${fields}\n  })${indexChain}`;
 }
 
-function renderFieldDef(f: FieldDef, objects: Map<string, ObjectType>): string {
-  let expr = renderType(f.type, objects);
+function renderFieldDef(f: FieldDef, ctx: RenderContext, options: RenderOptions): string {
+  let expr = renderType(f.type, ctx, options);
   if (f.nullable) expr = `v.union(${expr}, v.null())`;
   if (f.optional) expr = `v.optional(${expr})`;
   return expr;
 }
 
-function renderType(t: FieldType, objects: Map<string, ObjectType>): string {
+function renderType(t: FieldType, ctx: RenderContext, options: RenderOptions): string {
   switch (t.kind) {
     case 'string':
       return 'v.string()';
@@ -83,25 +114,91 @@ function renderType(t: FieldType, objects: Map<string, ObjectType>): string {
     case 'literal':
       return `v.literal(${JSON.stringify(t.value)})`;
     case 'ref': {
-      const target = objects.get(t.typeName);
+      const target = ctx.types.get(t.typeName);
       if (!target) {
         // Unknown / qualified ref — fall back to `v.any()` rather than
         // throwing; semantic validation lives elsewhere.
         return 'v.any()';
       }
-      if (target.table === true) {
+      if (target.kind === 'raw') return 'v.any()';
+      if (target.kind === 'object' && target.table === true) {
         return `v.id("${target.name}")`;
       }
-      return renderInlineObject(target, objects);
+      if (!options.preferNamedRefs) return renderTypeDef(target, ctx);
+      return validatorName(target.name);
     }
     case 'array':
-      return `v.array(${renderType(t.element, objects)})`;
+      return `v.array(${renderType(t.element, ctx, options)})`;
   }
 }
 
-function renderInlineObject(t: ObjectType, objects: Map<string, ObjectType>): string {
-  const fields = t.fields.map((f) => `${f.name}: ${renderFieldDef(f, objects)}`).join(', ');
+function isReusableValidatorType(t: TypeDef): t is ConvexReusableType {
+  return t.kind !== 'raw' && !(t.kind === 'object' && t.table === true);
+}
+
+function renderTypeDef(t: ConvexReusableType, ctx: RenderContext): string {
+  if (t.kind === 'object') return renderInlineObject(t, ctx, { preferNamedRefs: true });
+  if (t.kind === 'enum') return renderEnum(t);
+  return renderDiscriminatedUnion(t, ctx);
+}
+
+function renderEnum(t: EnumType): string {
+  if (t.values.length === 1) {
+    const [value] = t.values;
+    if (!value) return 'v.any()';
+    return `v.literal(${JSON.stringify(value.value)})`;
+  }
+  return `v.union(${t.values.map((value) => `v.literal(${JSON.stringify(value.value)})`).join(', ')})`;
+}
+
+function renderDiscriminatedUnion(t: DiscriminatedUnionType, ctx: RenderContext): string {
+  return `v.union(${t.variants.map((name) => renderVariant(name, ctx)).join(', ')})`;
+}
+
+function renderVariant(name: string, ctx: RenderContext): string {
+  const target = ctx.types.get(name);
+  if (!target || target.kind !== 'object') return 'v.any()';
+  if (target.table === true) return renderInlineObject(target, ctx, { preferNamedRefs: true });
+  return validatorName(target.name);
+}
+
+function renderInlineObject(t: ObjectType, ctx: RenderContext, options: RenderOptions): string {
+  const fields = t.fields.map((f) => `${f.name}: ${renderFieldDef(f, ctx, options)}`).join(', ');
   return `v.object({ ${fields} })`;
+}
+
+function validatorName(name: string): string {
+  return `${name.charAt(0).toLowerCase()}${name.slice(1)}`;
+}
+
+function collectTableValidatorImports(tables: ObjectType[], ctx: RenderContext): string[] {
+  const imports = new Set<string>();
+  for (const table of tables) {
+    for (const field of table.fields) {
+      collectValidatorImportsForType(field.type, ctx, imports);
+    }
+  }
+  return [...imports].sort();
+}
+
+function collectValidatorImportsForType(
+  t: FieldType,
+  ctx: RenderContext,
+  imports: Set<string>,
+): void {
+  if (t.kind === 'array') {
+    collectValidatorImportsForType(t.element, ctx, imports);
+    return;
+  }
+  if (t.kind !== 'ref') return;
+  const target = ctx.types.get(t.typeName);
+  if (!target || !isReusableValidatorType(target)) return;
+  imports.add(validatorName(target.name));
+}
+
+function renderValidatorImports(names: string[]): string | null {
+  if (names.length === 0) return null;
+  return `import { ${names.join(', ')} } from './validators';`;
 }
 
 function validateReservedNames(schema: Schema): void {

--- a/packages/core/src/generated-targets.ts
+++ b/packages/core/src/generated-targets.ts
@@ -1,5 +1,5 @@
 import { emitAiToolSchemas } from './emit-ai-tool-schemas';
-import { emitConvexSchema } from './emit-convex';
+import { emitConvexSchema, emitConvexValidators } from './emit-convex';
 import { emitFormValidators } from './emit-form-validators';
 import { emit as emitJsonSchema } from './emit-json-schema';
 import { emitMcpDefinitions } from './emit-mcp-definitions';
@@ -35,6 +35,7 @@ export interface EmitPipelineDeps {
   ) => unknown;
   emitSchemaIndex?: (baseName: string, sourcePath?: string) => string;
   emitConvex?: (schema: Schema, sourcePath?: string) => string;
+  emitConvexValidators?: (schema: Schema, sourcePath?: string) => string;
   emitAiToolSchemas?: (schema: Schema, sourcePath?: string) => unknown;
   emitStructuredOutputSchemas?: (schema: Schema, sourcePath?: string) => unknown;
   emitMcpDefinitions?: (schema: Schema, sourcePath?: string) => unknown;
@@ -155,6 +156,20 @@ export const GENERATED_TARGETS: readonly GeneratedTargetDescriptor[] = [
     enabled: (schema) => coreOutputEnabled(schema, 'convex'),
     enable: (schema) => enableCoreOutput(schema, 'convex'),
     emit: (schema, irPath, deps) => (deps.emitConvex ?? emitConvexSchema)(schema, irPath),
+  },
+  {
+    kind: 'convex-validators',
+    group: 'core',
+    label: 'Convex validators',
+    help: 'Reusable Convex validators for schema fields and function args.',
+    language: 'typescript',
+    previewable: true,
+    displayPath: () => 'convex/validators.ts',
+    path: (paths) => paths.convexValidators,
+    enabled: (schema) => coreOutputEnabled(schema, 'convex'),
+    enable: (schema) => enableCoreOutput(schema, 'convex'),
+    emit: (schema, irPath, deps) =>
+      (deps.emitConvexValidators ?? emitConvexValidators)(schema, irPath),
   },
   {
     kind: 'ai-tool-schemas',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 export * from './chat-history';
 export * from './document-bundle';
 export { emitAiToolSchemas } from './emit-ai-tool-schemas';
-export { emitConvexSchema } from './emit-convex';
+export { emitConvexSchema, emitConvexValidators } from './emit-convex';
 export { emitFormValidators } from './emit-form-validators';
 export { emit as emitJsonSchema } from './emit-json-schema';
 export { emitMcpDefinitions } from './emit-mcp-definitions';

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -8,6 +8,7 @@ export const AI_TOOL_SCHEMAS_FILE = 'ai-tool-schemas.json';
 export const STRUCTURED_OUTPUT_SCHEMAS_FILE = 'structured-output-schemas.json';
 export const MCP_DEFINITIONS_FILE = 'mcp-definitions.json';
 export const FORM_VALIDATORS_FILE = 'form-validators.ts';
+export const CONVEX_VALIDATORS_FILE = 'validators.ts';
 
 export interface BundlePaths {
   ir: string;
@@ -18,6 +19,7 @@ export interface BundlePaths {
   schemaJson: string;
   schemaIndex: string;
   convex: string;
+  convexValidators: string;
   aiToolSchemas: string;
   structuredOutputSchemas: string;
   mcpDefinitions: string;
@@ -29,6 +31,7 @@ export type GeneratedTargetKind =
   | 'json-schema'
   | 'schema-index'
   | 'convex'
+  | 'convex-validators'
   | 'ai-tool-schemas'
   | 'structured-output-schemas'
   | 'mcp-definitions'
@@ -73,6 +76,7 @@ export function bundlePathsFor(irPath: string): BundlePaths {
     schemaJson: `${base}${SCHEMA_JSON_SUFFIX}`,
     schemaIndex: `${dir}/index.ts`,
     convex: `${dir}/convex/schema.ts`,
+    convexValidators: `${dir}/convex/${CONVEX_VALIDATORS_FILE}`,
     aiToolSchemas: `${ctxDir}/${AI_TOOL_SCHEMAS_FILE}`,
     structuredOutputSchemas: `${ctxDir}/${STRUCTURED_OUTPUT_SCHEMAS_FILE}`,
     mcpDefinitions: `${ctxDir}/${MCP_DEFINITIONS_FILE}`,
@@ -87,6 +91,7 @@ export function generatedTargetsFor(irPath: string): GeneratedTarget[] {
     { kind: 'json-schema', path: paths.schemaJson },
     { kind: 'schema-index', path: paths.schemaIndex },
     { kind: 'convex', path: paths.convex },
+    { kind: 'convex-validators', path: paths.convexValidators },
     { kind: 'ai-tool-schemas', path: paths.aiToolSchemas },
     { kind: 'structured-output-schemas', path: paths.structuredOutputSchemas },
     { kind: 'mcp-definitions', path: paths.mcpDefinitions },

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -15,6 +15,7 @@ export {
   baseNameFor,
   bundlePathsFor,
   CHAT_FILE,
+  CONVEX_VALIDATORS_FILE,
   contextureDirFor,
   EMITTED_FILE,
   type GeneratedTarget,

--- a/packages/core/tests/generated-bundle-writer.test.ts
+++ b/packages/core/tests/generated-bundle-writer.test.ts
@@ -80,6 +80,7 @@ describe('generated bundle writer', () => {
         '/proj/packages/contexture/app.schema.json',
         '/proj/packages/contexture/app.schema.ts',
         '/proj/packages/contexture/convex/schema.ts',
+        '/proj/packages/contexture/convex/validators.ts',
         '/proj/packages/contexture/index.ts',
       ].sort(),
     );

--- a/packages/core/tests/paths.test.ts
+++ b/packages/core/tests/paths.test.ts
@@ -12,6 +12,7 @@ describe('Contexture path policy', () => {
     expect(paths.ir).toBe('/repo/packages/contexture/app.contexture.json');
     expect(paths.schemaIndex).toBe('/repo/packages/contexture/index.ts');
     expect(paths.convex).toBe('/repo/packages/contexture/convex/schema.ts');
+    expect(paths.convexValidators).toBe('/repo/packages/contexture/convex/validators.ts');
   });
 
   it('rejects non-IR paths', () => {
@@ -27,6 +28,7 @@ describe('Contexture path policy', () => {
       { kind: 'json-schema', path: '/repo/packages/contexture/app.schema.json' },
       { kind: 'schema-index', path: '/repo/packages/contexture/index.ts' },
       { kind: 'convex', path: '/repo/packages/contexture/convex/schema.ts' },
+      { kind: 'convex-validators', path: '/repo/packages/contexture/convex/validators.ts' },
       {
         kind: 'ai-tool-schemas',
         path: '/repo/packages/contexture/.contexture/ai-tool-schemas.json',

--- a/packages/core/tests/pipeline.test.ts
+++ b/packages/core/tests/pipeline.test.ts
@@ -18,6 +18,7 @@ describe('runEmitPipeline output config', () => {
       '/repo/packages/contexture/app.schema.json',
       '/repo/packages/contexture/index.ts',
       '/repo/packages/contexture/convex/schema.ts',
+      '/repo/packages/contexture/convex/validators.ts',
     ]);
   });
 
@@ -64,6 +65,7 @@ describe('runEmitPipeline output config', () => {
       '/repo/packages/contexture/app.schema.json',
       '/repo/packages/contexture/index.ts',
       '/repo/packages/contexture/convex/schema.ts',
+      '/repo/packages/contexture/convex/validators.ts',
     ]);
   });
 


### PR DESCRIPTION
## Summary
- emit reusable Convex validators for local enum, embedded object, and discriminated union refs
- split Convex generation into `convex/schema.ts` plus reusable `convex/validators.ts`
- have `schema.ts` import table validators while `validators.ts` exports backend-reusable validators for function args
- keep table refs as `v.id(...)` and raw/unresolved refs as conservative `v.any()` fallbacks
- bump `@contexture/desktop` to 0.15.8 and refresh Bun workspace metadata

## Tests
- `bun run test -- tests/model/emit-convex.test.ts`
- `bun run test -- tests/main/document-store.test.ts`
- `bun run test -- tests/paths.test.ts tests/pipeline.test.ts tests/generated-bundle-writer.test.ts`
- `bun run test -- tests/mcp.test.ts`
- commit hook: `turbo typecheck`
- commit hook: `turbo test`
