### PR TITLE
feat(desktop): show enum values on graph hover

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -44,6 +44,7 @@
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.8",
+  "version": "0.15.9",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -189,45 +189,12 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
           }}
         >
           {data.fields.map((f) => (
-            <button
-              type="button"
+            <FieldRowButton
               key={f.name}
-              data-testid="type-node-field"
-              data-field-name={f.name}
-              onClick={(ev) => onFieldClick(f.name, ev)}
-              className="contexture-type-node-field"
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                padding: '2px 10px',
-                fontSize: 10,
-                gap: 8,
-                width: '100%',
-                background: 'transparent',
-                border: 'none',
-                cursor: 'pointer',
-                textAlign: 'left',
-              }}
-            >
-              <span style={{ color: 'var(--muted-foreground)', fontWeight: 400 }}>
-                {f.name}
-                {f.optional ? '?' : ''}
-                {f.nullable ? ' | null' : ''}
-              </span>
-              <span
-                style={{
-                  color: f.refTarget ? 'var(--graph-edge-property)' : 'var(--muted-foreground)',
-                  fontFamily: f.refTarget ? 'inherit' : 'var(--font-mono)',
-                  fontSize: 9,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {f.summary}
-              </span>
-            </button>
+              field={f}
+              selectedTarget={primaryNodeId}
+              onFieldClick={onFieldClick}
+            />
           ))}
         </div>
       )}
@@ -274,3 +241,61 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
     </HoverCard>
   );
 });
+
+function FieldRowButton({
+  field,
+  selectedTarget,
+  onFieldClick,
+}: {
+  field: TypeNodeData['fields'][number];
+  selectedTarget: string | null;
+  onFieldClick: (fieldName: string, ev: React.MouseEvent<HTMLElement>) => void;
+}) {
+  const refTargetSelected = field.refTarget !== undefined && field.refTarget === selectedTarget;
+  return (
+    <button
+      type="button"
+      data-testid="type-node-field"
+      data-field-name={field.name}
+      onClick={(ev) => onFieldClick(field.name, ev)}
+      className="contexture-type-node-field"
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '2px 10px',
+        fontSize: 10,
+        gap: 8,
+        width: '100%',
+        background: 'transparent',
+        border: 'none',
+        cursor: 'pointer',
+        textAlign: 'left',
+      }}
+    >
+      <span style={{ color: 'var(--muted-foreground)', fontWeight: 400 }}>
+        {field.name}
+        {field.optional ? '?' : ''}
+        {field.nullable ? ' | null' : ''}
+      </span>
+      <span
+        data-testid={field.refTarget ? 'type-node-field-ref-summary' : undefined}
+        style={{
+          color: refTargetSelected
+            ? 'var(--graph-node-selected)'
+            : field.refTarget
+              ? 'var(--graph-edge-property)'
+              : 'var(--muted-foreground)',
+          fontFamily: field.refTarget ? 'inherit' : 'var(--font-mono)',
+          fontSize: 9,
+          fontWeight: refTargetSelected ? 700 : 400,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {field.summary}
+      </span>
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -18,6 +18,8 @@
  */
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
 import { memo, useCallback, useMemo } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { useGraphSelectionStore } from '../../../store/selection';
 import type { TypeNodeData } from '../schema-to-graph';
 
@@ -78,8 +80,7 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
   const borderWidth = isSelected || isAdjacent ? 2 : 1;
   const borderStyle = data.imported ? 'dashed' : 'solid';
   const headerColor = useMemo(() => headerColorFor(data.kind), [data.kind]);
-
-  return (
+  const node = (
     <div
       data-testid="type-node"
       data-type-name={data.typeName}
@@ -224,5 +225,43 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         </div>
       )}
     </div>
+  );
+
+  if (data.kind !== 'enum' || data.imported) return node;
+
+  return (
+    <HoverCard openDelay={120} closeDelay={80}>
+      <HoverCardTrigger asChild>{node}</HoverCardTrigger>
+      <HoverCardContent side="right" align="start" className="w-72 p-3 text-xs">
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm font-semibold text-foreground">{data.typeName}</div>
+            <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              Enum
+            </div>
+            {data.description && (
+              <p className="text-xs leading-snug text-muted-foreground">{data.description}</p>
+            )}
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              Values
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {(data.enumValues ?? []).map((value) => (
+                <Badge
+                  key={value.value}
+                  variant="outline"
+                  title={value.description}
+                  className="max-w-full rounded px-1.5 py-0 text-[10px] font-medium"
+                >
+                  <span className="truncate">{value.value}</span>
+                </Badge>
+              ))}
+            </div>
+          </div>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
   );
 });

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -53,32 +53,11 @@ function headerColorFor(kind: TypeNodeData['kind']): string {
   }
 }
 
-const enumValueBadgeStyles: readonly CSSProperties[] = [
-  {
-    background: 'color-mix(in oklch, var(--chart-3) 82%, var(--background))',
-    borderColor: 'color-mix(in oklch, var(--chart-3) 92%, transparent)',
-    color: 'var(--foreground)',
-  },
-  {
-    background: 'color-mix(in oklch, var(--chart-1) 78%, var(--background))',
-    borderColor: 'color-mix(in oklch, var(--chart-1) 88%, transparent)',
-    color: 'var(--foreground)',
-  },
-  {
-    background: 'color-mix(in oklch, var(--chart-4) 78%, var(--background))',
-    borderColor: 'color-mix(in oklch, var(--chart-4) 88%, transparent)',
-    color: 'var(--foreground)',
-  },
-  {
-    background: 'color-mix(in oklch, var(--chart-2) 78%, var(--background))',
-    borderColor: 'color-mix(in oklch, var(--chart-2) 88%, transparent)',
-    color: 'var(--foreground)',
-  },
-];
-
-function enumValueBadgeStyle(index: number): CSSProperties {
-  return enumValueBadgeStyles[index % enumValueBadgeStyles.length] ?? enumValueBadgeStyles[0];
-}
+const enumValueBadgeStyle: CSSProperties = {
+  background: 'color-mix(in oklch, var(--chart-1) 78%, var(--background))',
+  borderColor: 'color-mix(in oklch, var(--chart-1) 88%, transparent)',
+  color: 'var(--foreground)',
+};
 
 export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
   const { data, id } = props;
@@ -276,14 +255,14 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
               Values
             </div>
             <div className="flex flex-wrap gap-1.5">
-              {(data.enumValues ?? []).map((value, index) => (
+              {(data.enumValues ?? []).map((value) => (
                 <Badge
                   key={value.value}
                   data-testid="enum-value-badge"
                   variant="default"
                   title={value.description}
                   className="max-w-full rounded border px-1.5 py-0 text-[10px] font-semibold shadow-sm hover:opacity-90"
-                  style={enumValueBadgeStyle(index)}
+                  style={enumValueBadgeStyle}
                 >
                   <span className="truncate">{value.value}</span>
                 </Badge>

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -17,6 +17,7 @@
  * later slice.
  */
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
+import type { CSSProperties } from 'react';
 import { memo, useCallback, useMemo } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
@@ -50,6 +51,33 @@ function headerColorFor(kind: TypeNodeData['kind']): string {
     default:
       return 'var(--graph-node-header-bg)';
   }
+}
+
+const enumValueBadgeStyles: readonly CSSProperties[] = [
+  {
+    background: 'color-mix(in oklch, var(--chart-3) 82%, var(--background))',
+    borderColor: 'color-mix(in oklch, var(--chart-3) 92%, transparent)',
+    color: 'var(--foreground)',
+  },
+  {
+    background: 'color-mix(in oklch, var(--chart-1) 78%, var(--background))',
+    borderColor: 'color-mix(in oklch, var(--chart-1) 88%, transparent)',
+    color: 'var(--foreground)',
+  },
+  {
+    background: 'color-mix(in oklch, var(--chart-4) 78%, var(--background))',
+    borderColor: 'color-mix(in oklch, var(--chart-4) 88%, transparent)',
+    color: 'var(--foreground)',
+  },
+  {
+    background: 'color-mix(in oklch, var(--chart-2) 78%, var(--background))',
+    borderColor: 'color-mix(in oklch, var(--chart-2) 88%, transparent)',
+    color: 'var(--foreground)',
+  },
+];
+
+function enumValueBadgeStyle(index: number): CSSProperties {
+  return enumValueBadgeStyles[index % enumValueBadgeStyles.length] ?? enumValueBadgeStyles[0];
 }
 
 export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
@@ -248,12 +276,14 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
               Values
             </div>
             <div className="flex flex-wrap gap-1.5">
-              {(data.enumValues ?? []).map((value) => (
+              {(data.enumValues ?? []).map((value, index) => (
                 <Badge
                   key={value.value}
-                  variant="outline"
+                  data-testid="enum-value-badge"
+                  variant="default"
                   title={value.description}
-                  className="max-w-full rounded px-1.5 py-0 text-[10px] font-medium"
+                  className="max-w-full rounded border px-1.5 py-0 text-[10px] font-semibold shadow-sm hover:opacity-90"
+                  style={enumValueBadgeStyle(index)}
                 >
                   <span className="truncate">{value.value}</span>
                 </Badge>

--- a/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
+++ b/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
@@ -31,10 +31,16 @@ export interface TypeNodeData extends Record<string, unknown> {
   typeName: string;
   kind: TypeDef['kind'];
   description?: string;
+  enumValues?: ReadonlyArray<EnumValueRow>;
   fields: ReadonlyArray<FieldRow>;
   imported: boolean;
   /** True when the source `ObjectTypeDef` carries `table: true`. */
   table?: boolean;
+}
+
+export interface EnumValueRow {
+  value: string;
+  description?: string;
 }
 
 export interface FieldRow {
@@ -150,6 +156,7 @@ function localNodeFor(type: TypeDef, position: { x: number; y: number }): Node<T
       typeName: type.name,
       kind: type.kind,
       description: type.description,
+      enumValues: type.kind === 'enum' ? type.values.map(enumValueRow) : undefined,
       fields: type.kind === 'object' ? type.fields.map(fieldRow) : [],
       imported: false,
       table: type.kind === 'object' && type.table === true ? true : undefined,
@@ -179,6 +186,13 @@ function unwrapRefTarget(t: FieldType): string | undefined {
   let cur: FieldType = t;
   while (cur.kind === 'array') cur = cur.element;
   return cur.kind === 'ref' ? cur.typeName : undefined;
+}
+
+function enumValueRow(value: { value: string; description?: string }): EnumValueRow {
+  return {
+    value: value.value,
+    description: value.description,
+  };
 }
 
 function fieldRow(field: FieldDef): FieldRow {

--- a/apps/desktop/src/renderer/src/components/ui/hover-card.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/hover-card.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const HoverCard = HoverCardPrimitive.Root;
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger;
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]',
+        className,
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
+));
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
+
+export { HoverCard, HoverCardContent, HoverCardTrigger };

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -158,8 +158,12 @@ describe('TypeNode', () => {
       'title',
       'Planting time.',
     );
-    expect(screen.getAllByTestId('enum-value-badge')[0]).toHaveStyle({
-      background: 'color-mix(in oklch, var(--chart-3) 82%, var(--background))',
+    const badges = screen.getAllByTestId('enum-value-badge');
+    expect(badges[0]).toHaveStyle({
+      background: 'color-mix(in oklch, var(--chart-1) 78%, var(--background))',
+    });
+    expect(badges[1]).toHaveStyle({
+      background: 'color-mix(in oklch, var(--chart-1) 78%, var(--background))',
     });
   });
 });

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -135,7 +135,7 @@ describe('TypeNode', () => {
     expect(container.querySelectorAll('[data-testid="type-node-field"]')).toHaveLength(0);
   });
 
-  it('shows enum description and values in a hover card', async () => {
+  it('shows enum description and values in a hover card', () => {
     vi.useFakeTimers();
     const data: TypeNodeData = {
       typeName: 'Season',
@@ -158,5 +158,8 @@ describe('TypeNode', () => {
       'title',
       'Planting time.',
     );
+    expect(screen.getAllByTestId('enum-value-badge')[0]).toHaveStyle({
+      background: 'color-mix(in oklch, var(--chart-3) 82%, var(--background))',
+    });
   });
 });

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -10,7 +10,7 @@
  */
 import { TYPE_NODE_EVENT, TypeNode } from '@renderer/components/graph/nodes/TypeNode';
 import type { TypeNodeData } from '@renderer/components/graph/schema-to-graph';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { ReactFlowProvider } from '@xyflow/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -41,7 +41,10 @@ function makeProps(data: TypeNodeData, selected = false) {
 }
 
 describe('TypeNode', () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
 
   it('renders type name, kind, and each field row', () => {
     const data: TypeNodeData = {
@@ -130,5 +133,30 @@ describe('TypeNode', () => {
     };
     const { container } = render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
     expect(container.querySelectorAll('[data-testid="type-node-field"]')).toHaveLength(0);
+  });
+
+  it('shows enum description and values in a hover card', async () => {
+    vi.useFakeTimers();
+    const data: TypeNodeData = {
+      typeName: 'Season',
+      kind: 'enum',
+      description: 'The growing season.',
+      imported: false,
+      enumValues: [{ value: 'spring', description: 'Planting time.' }, { value: 'summer' }],
+      fields: [],
+    };
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    fireEvent.pointerEnter(screen.getByTestId('type-node'));
+    act(() => vi.advanceTimersByTime(120));
+
+    expect(screen.getByText('The growing season.')).toBeInTheDocument();
+    expect(screen.getByText('Values')).toBeInTheDocument();
+    expect(screen.getByText('spring')).toBeInTheDocument();
+    expect(screen.getByText('summer')).toBeInTheDocument();
+    expect(screen.getByText('spring').closest('[title]')).toHaveAttribute(
+      'title',
+      'Planting time.',
+    );
   });
 });

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -10,10 +10,11 @@
  */
 import { TYPE_NODE_EVENT, TypeNode } from '@renderer/components/graph/nodes/TypeNode';
 import type { TypeNodeData } from '@renderer/components/graph/schema-to-graph';
+import { useGraphSelectionStore } from '@renderer/store/selection';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { ReactFlowProvider } from '@xyflow/react';
 import type { ReactNode } from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 function Wrapper({ children }: { children: ReactNode }) {
   return <ReactFlowProvider>{children}</ReactFlowProvider>;
@@ -41,6 +42,10 @@ function makeProps(data: TypeNodeData, selected = false) {
 }
 
 describe('TypeNode', () => {
+  beforeEach(() => {
+    useGraphSelectionStore.getState().clear();
+  });
+
   afterEach(() => {
     vi.useRealTimers();
     cleanup();
@@ -133,6 +138,31 @@ describe('TypeNode', () => {
     };
     const { container } = render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
     expect(container.querySelectorAll('[data-testid="type-node-field"]')).toHaveLength(0);
+  });
+
+  it('highlights a ref summary when its target node is selected', () => {
+    const data: TypeNodeData = {
+      typeName: 'Artwork',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'medium',
+          summary: '→ ArtworkMedium',
+          optional: false,
+          nullable: false,
+          refTarget: 'ArtworkMedium',
+        },
+      ],
+    };
+    useGraphSelectionStore.getState().click('ArtworkMedium', 'replace');
+
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId('type-node-field-ref-summary')).toHaveStyle({
+      color: 'var(--graph-node-selected)',
+      fontWeight: '700',
+    });
   });
 
   it('shows enum description and values in a hover card', () => {

--- a/apps/desktop/tests/graph/schema-to-graph.test.ts
+++ b/apps/desktop/tests/graph/schema-to-graph.test.ts
@@ -21,7 +21,36 @@ describe('buildGraph', () => {
     const { nodes } = buildGraph({ schema });
     expect(nodes).toHaveLength(2);
     expect(nodes[0]).toMatchObject({ id: 'Plot', type: 'type', data: { kind: 'object' } });
-    expect(nodes[1]).toMatchObject({ id: 'Season', type: 'type', data: { kind: 'enum' } });
+    expect(nodes[1]).toMatchObject({
+      id: 'Season',
+      type: 'type',
+      data: {
+        kind: 'enum',
+        enumValues: [{ value: 'spring' }, { value: 'summer' }],
+      },
+    });
+  });
+
+  it('passes enum descriptions and value descriptions into node data', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'enum',
+          name: 'Season',
+          description: 'The growing season.',
+          values: [{ value: 'spring', description: 'Planting time.' }, { value: 'summer' }],
+        },
+      ],
+    };
+
+    const { nodes } = buildGraph({ schema });
+
+    expect(nodes[0].data).toMatchObject({
+      kind: 'enum',
+      description: 'The growing season.',
+      enumValues: [{ value: 'spring', description: 'Planting time.' }, { value: 'summer' }],
+    });
   });
 
   it('renders object fields as field rows with summaries', () => {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.8",
+      "version": "0.15.9",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-hover-card": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
@@ -791,6 +792,8 @@
     "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
 
     "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
+    "@radix-ui/react-hover-card": ["@radix-ui/react-hover-card@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg=="],
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
 

--- a/docs/roadmap/domain-model-control-plane-goals.md
+++ b/docs/roadmap/domain-model-control-plane-goals.md
@@ -7,6 +7,9 @@ layered and independently verifiable, but land the security floor,
 MCP surface, and multi-target emitters together so the generated bundle and
 agent surfaces agree end to end.
 
+For the next product arc after these control-plane foundations, see
+[Faithful Domain-Model Control Plane Plan](faithful-domain-model-control-plane-plan.md).
+
 Historical entries below were originally tracked as separate Codex-sized goals.
 For the current consolidation PR, treat them as evidence and acceptance
 criteria, not as instructions to split the work into separate initiatives.

--- a/docs/roadmap/faithful-domain-model-control-plane-plan.md
+++ b/docs/roadmap/faithful-domain-model-control-plane-plan.md
@@ -1,0 +1,407 @@
+# Faithful Domain-Model Control Plane Plan
+
+- **Status:** Proposed
+- **Date:** 2026-05-20
+- **Related ADRs:** [0022](../adr/0022-contexture-domain-model-control-plane.md), [0023](../adr/0023-features-enter-through-core-domain-modules.md)
+- **Related docs:** [Domain-model goals](domain-model-control-plane-goals.md), [Agent workflow](../agent-contexture-workflow.md), [Remove app scaffolder](../remove-app-scaffolder-plan.md)
+
+## Decision Summary
+
+Contexture should become the most trustworthy way to model the domain of a
+TypeScript app, then expose that model safely to humans, generated outputs, and
+coding agents.
+
+The immediate product arc is:
+
+```txt
+faithful model -> semantic workbench -> excellent app outputs -> agent-safe evolution
+```
+
+This keeps the direction from ADR 0022 intact: Contexture is still the
+domain-model control plane, not an app builder or general agent orchestrator.
+The adjustment is emphasis. Recent work on reusable Convex validators and
+discriminated-union graph edges shows that the product's leverage depends first
+on model fidelity. Agent workflows are compelling only if the underlying model
+is expressive, inspectable, and faithfully emitted into real applications.
+
+The product promise should become:
+
+> Contexture is the trusted domain contract for AI-native TypeScript apps:
+> design the model once, understand its relationships, emit app-ready surfaces,
+> and let agents evolve it through safe operations.
+
+## Why This Shift
+
+The previous roadmap proved the control-plane architecture:
+
+- `.contexture.json` is the canonical IR.
+- All mutations route through a closed-world Op vocabulary.
+- Core emitters, generated target metadata, bundle paths, and manifest-backed
+  drift checks live in `@contexture/core`.
+- CLI and MCP expose the same inspect, validate, mutate, emit, and drift-check
+  loop to agents.
+- The desktop app remains the human visual authoring surface.
+
+The last product improvements sharpen the next layer:
+
+- Convex generation now emits reusable `convex/validators.ts` definitions for
+  non-table objects, enums, and discriminated unions.
+- `convex/schema.ts` imports those validators instead of inlining partial object
+  shapes or falling back to `v.any()` for common app-domain concepts.
+- The desktop graph now renders discriminated-union variant edges as semantic
+  relationships, not invisible metadata hidden in a detail panel.
+
+Those changes are not merely bug fixes. They show the product becoming a
+faithful domain-model workbench for real application shapes. That should be the
+next roadmap's center of gravity.
+
+## Product Pillars
+
+### 1. Model Fidelity Comes First
+
+Contexture should accurately represent real TypeScript application domains,
+including reusable concepts, nested shapes, discriminated unions, enums,
+imports, table references, indexes, raw escape hatches, and target-specific
+constraints.
+
+The goal is not to support every possible TypeScript type. The goal is to make
+the supported Contexture IR feel deliberate, complete, and dependable. Any loose
+fallback should be visible and explainable. Generated `any`-like output should
+mean either "the user intentionally chose `raw`" or "semantic validation found a
+recoverable in-progress state," not "the emitter forgot how to express this."
+
+Feature direction:
+
+- Add golden tests around real app-domain shapes, not only tiny emitter cases.
+- Track where each emitter falls back to weak output such as `v.any()`,
+  permissive JSON Schema, or broad TypeScript types.
+- Make discriminated unions, enums, literals, nested refs, arrays, optionality,
+  nullability, and table refs work consistently across generated targets.
+- Preserve target-specific semantics. A table ref in Convex may emit `v.id`,
+  while the same relationship in JSON Schema or AI tool schemas may need a
+  different representation.
+- Treat reusable generated helpers as first-class outputs when they make app
+  integration cleaner, as with Convex validators.
+
+Completion evidence:
+
+- A representative fixture corpus covers nested refs, discriminated unions,
+  enums, table refs, indexes, raw types, imports, and AI-pipeline outputs.
+- Each generated target has tests that prove the same fixture emits faithful
+  target-specific output.
+- Weak fallbacks are audited, documented in tests, and surfaced in UI or CLI
+  output when they affect generated quality.
+- Real dogfood apps can remove handwritten schema glue because Contexture emits
+  the needed reusable pieces.
+
+### 2. The Desktop App Becomes A Semantic Workbench
+
+The graph is not decorative. It is the user's trust surface for understanding
+what the model means before generated files change.
+
+The desktop app should help a user answer:
+
+- What domain concepts exist?
+- Which concepts refer to, contain, or specialize which others?
+- Which types become tables?
+- Which relationships are indexes, refs, imports, or union variants?
+- Which generated files are affected by this model choice?
+- Where is the model faithful, and where is it using an escape hatch?
+
+Feature direction:
+
+- Render every important semantic relationship in the graph, not only field
+  refs. Union variants are the first example; indexes, imports, output
+  participation, and table boundaries should become similarly legible.
+- Make selection details explain the relationship in domain terms and point to
+  the editable source of truth.
+- Add output-impact previews: selecting a type or edge should show which
+  generated targets consume it.
+- Make drift and weak-fallback warnings visible where the user is already
+  thinking about the model.
+- Keep the UI quiet and operational. The workbench should feel like a precise
+  schema instrument, not a marketing canvas.
+
+Completion evidence:
+
+- The graph has tested builders for every relationship type it claims to show.
+- Detail panels explain relationship source, target, and edit path without
+  introducing fake edge entities.
+- Users can inspect the generated-output impact of a type before emitting.
+- Drift/reconcile state is visible without forcing the user to leave the model
+  context.
+
+### 3. Convex Is The Strategic Beachhead
+
+Convex is currently the clearest proof point for Contexture because it turns the
+domain model into application-critical runtime behavior: tables, validators,
+IDs, indexes, and function argument validation.
+
+Contexture should not become Convex-only. But the Convex path should become
+excellent enough that it proves the broader product thesis:
+
+> If Contexture can faithfully own a Convex app's domain contract, the same IR
+> can safely feed Zod, JSON Schema, MCP definitions, structured outputs, and
+> agent tooling.
+
+Feature direction:
+
+- Continue tightening Convex schema and validator generation.
+- Generate helpers that app code can use directly in queries, mutations,
+  actions, and shared validation code.
+- Make Convex-specific constraints visible at authoring time, not only during
+  emit. Reserved names are one example; table refs, index field validity, and
+  unsupported type forms should follow the same pattern.
+- Dogfood against multiple real Convex products and feed every sharp edge back
+  into fixtures, semantic validation, or generated helpers.
+- Keep Convex output opt-out as a core target, but avoid making other emitters
+  second-class. Convex is the proving ground, not the boundary of the product.
+
+Completion evidence:
+
+- Real Convex apps can use Contexture-generated validators outside
+  `convex/schema.ts`.
+- Contexture catches Convex-specific schema problems before generated code hits
+  app typecheck.
+- Dogfood apps pass `contexture validate`, `contexture emit`,
+  `contexture check-generated`, and their own Convex/app tests.
+- The marketing and docs can show a concrete Convex workflow without implying
+  Contexture only serves Convex users.
+
+### 4. Outputs Become App Integrations, Not Just Files
+
+Generated targets should feel like coherent app integration surfaces. The value
+is not "Contexture writes many files"; the value is "Contexture writes the
+fragile, boring, domain-derived glue correctly and keeps it in sync."
+
+Feature direction:
+
+- Keep every generated output manifest-backed and drift-checked.
+- Provide copyable integration guidance for each enabled output.
+- Make AI-pipeline outputs directly consumable by common SDK patterns:
+  structured outputs, tool schemas, MCP definitions, and form validators.
+- Generate small, reusable helpers where that reduces app glue and preserves
+  target fidelity.
+- Show output configuration as a product choice: enable only what this app
+  actually consumes.
+
+Completion evidence:
+
+- For each generated target, docs answer where it is emitted, who consumes it,
+  how to enable it, and how to verify drift.
+- Desktop output configuration explains the consequences of enabling or
+  disabling a target.
+- Agent prompts and MCP setup guidance include the selected output set and the
+  correct verification loop.
+
+### 5. Agents Evolve The Model Through The Trust Layer
+
+Agent-safe schema evolution remains the distinctive long-term wedge, but it
+should build on model fidelity rather than outrun it.
+
+Agents should not be encouraged to edit generated files or infer the domain by
+reading scattered app code. They should inspect the Contexture IR, propose Ops,
+apply them through the semantic gate, emit, check drift, and then run app tests.
+
+Feature direction:
+
+- Expand MCP and CLI read tools around explanation, not just mutation:
+  `explain_type`, `list_relationships`, `list_outputs`, `summarize_drift`, and
+  `explain_generated_target`.
+- Add provider-neutral proposal flows that return reviewable Ops plus rationale.
+- Make failed Ops teach the agent how to repair the request.
+- Keep schema-only mode strict. Provider runtimes are adapters over the
+  Contexture Op contract, not general repo-writing agents.
+- Let downstream coding agents consume Contexture outputs and guidance, but do
+  not make Contexture own application rewrites.
+
+Completion evidence:
+
+- A coding agent can make a non-trivial model change using MCP without direct
+  repo write access beyond the Contexture bundle.
+- The agent gets useful explanations for validation failures and drift.
+- Proposed Ops are reviewable by humans before application in desktop flows.
+- The same change path works through desktop chat, CLI, and MCP.
+
+## Sequenced Roadmap
+
+### Phase 1 — Fidelity Audit And Fixture Corpus
+
+Create a shared set of domain fixtures that exercise the real shapes Contexture
+wants to own.
+
+Scope:
+
+- Nested reusable objects.
+- Local enums and literal unions.
+- Discriminated unions with object variants.
+- Table objects with refs, arrays, optional fields, nullable fields, and indexes.
+- Raw escape hatches.
+- Imports and cross-boundary refs.
+- Enabled and disabled output targets.
+
+Deliverables:
+
+- A fixture module under the relevant test package.
+- Per-emitter tests that use the same fixtures.
+- A documented list of intentional weak fallbacks.
+- A short "model fidelity" section in contributor docs explaining how new IR
+  features must land across emitters, graph, validation, CLI/MCP, and desktop.
+
+### Phase 2 — Complete Semantic Graph Coverage
+
+Make the graph match the domain semantics users need to reason about.
+
+Scope:
+
+- Keep field-ref and union-variant edges tested.
+- Add graph treatment for indexes, imports, table boundaries, and generated
+  output participation where those relationships help users reason.
+- Add detail-panel explanations and edit affordances for each relationship type.
+- Ensure invalid or in-progress schemas remain renderable while validation
+  reports the issue clearly.
+
+Deliverables:
+
+- Tested graph builder outputs for each semantic relationship.
+- Legend and edge styling that remain readable without becoming noisy.
+- Detail panels that explain source, target, and edit path.
+- Output-impact inspection for selected types.
+
+### Phase 3 — Convex Excellence
+
+Use Convex as the highest-signal integration proving ground.
+
+Scope:
+
+- Keep tightening `convex/schema.ts` and `convex/validators.ts`.
+- Add generated helpers for Convex function args where they remove real app
+  duplication.
+- Promote Convex-specific validation from emitter backstops into semantic
+  validation or UI affordances where possible.
+- Dogfood against real apps before broadening the pattern.
+
+Deliverables:
+
+- Convex fixture coverage for table refs, reusable validators, discriminated
+  unions, indexes, and reserved names.
+- Generated validators that app code can import intentionally.
+- Dogfood notes with sharp edges converted into tests or backlog items.
+
+### Phase 4 — Integration Guidance And Output UX
+
+Make enabled outputs understandable and easy to wire into existing apps.
+
+Scope:
+
+- Improve generated-output configuration in desktop.
+- Add per-output integration guidance for humans and agents.
+- Make MCP setup and workflow prompts include the active IR path and enabled
+  output set.
+- Keep guidance explicit that Contexture owns generated targets, not app code.
+
+Deliverables:
+
+- Desktop copy surfaces for MCP setup, agent workflow, and target-specific
+  integration prompts.
+- Docs for each output target.
+- Tests around generated target metadata so labels, paths, enablement, and
+  help text stay coherent.
+
+### Phase 5 — Agent-Safe Evolution
+
+Build richer agent flows on top of the faithful model and output system.
+
+Scope:
+
+- Add read/explain MCP tools before adding more write power.
+- Improve Op proposal and error-repair flows.
+- Let reconcile proposals become more semantic, but keep generated-file
+  overwrite protection strict.
+- Consider guided fold-back from edited generated files only after drift
+  explanations and model fidelity are strong.
+
+Deliverables:
+
+- MCP tools for type explanation, relationship listing, output listing, and
+  drift summarization.
+- Provider-neutral proposal flows that return Ops plus rationale.
+- Reconcile UI that explains what model concept caused drift before asking the
+  user to regenerate or apply Ops.
+
+## Out Of Scope
+
+This plan does not re-open rejected product directions from ADR 0022.
+
+Contexture should not:
+
+- Scaffold or own full application workspaces.
+- Become a general coding-agent task runner.
+- Manage issues, PRs, missions, or deployment workflows.
+- Mutate arbitrary downstream app files as part of the core product.
+- Treat generated-file edits as a silent source of truth.
+- Reopen JSON-LD, OWL, or ontology tooling without new evidence from real users.
+
+Those adjacent systems can consume Contexture through CLI, MCP, generated
+outputs, prompts, and skills. They should not become Contexture's product
+surface.
+
+## Product Test
+
+When evaluating a future feature, ask these questions in order:
+
+1. Does it make the Contexture IR more faithful to real app-domain concepts?
+2. Does it help humans understand or safely edit that model?
+3. Does it improve generated outputs that real apps consume?
+4. Does it preserve manifest-backed drift and the closed-world Op contract?
+5. Does it help agents operate through Contexture instead of around it?
+
+If the answer starts at question 5 and skips the earlier questions, the feature
+is probably premature. If the feature requires Contexture to own application
+code, issue flow, deployment, or arbitrary repo mutation, it belongs outside the
+core product.
+
+## Near-Term Candidate Slices
+
+These are deliberately vertical slices, not broad refactors.
+
+1. **Model fixture corpus**
+   Add shared fixtures for nested reusable objects, enums, discriminated unions,
+   table refs, imports, raw types, and enabled outputs. Use them across emitters,
+   graph tests, and semantic validation tests.
+
+2. **Weak fallback audit**
+   Inventory every generated fallback to `any`-like behavior, classify it as
+   intentional or a fidelity gap, and add tests for each classification.
+
+3. **Graph output impact**
+   Show which generated targets consume the selected type or relationship.
+   Start read-only and derive it from existing generated-target metadata.
+
+4. **Convex function validator helpers**
+   Extend Convex output beyond schema tables when dogfood apps prove the helper
+   shape. Keep imports explicit and generated files manifest-backed.
+
+5. **MCP explain tools**
+   Add read-only tools that let agents ask what a type is, which relationships
+   it participates in, which outputs consume it, and why drift exists.
+
+6. **Semantic reconcile explanations**
+   Before adding ambitious fold-back, make the reconcile modal explain drift in
+   terms of model concepts and generated targets.
+
+## Success Signal
+
+Contexture is winning when a developer or agent reaches for it before touching
+domain-shaped app code.
+
+The behavioral signal is:
+
+```txt
+I need to change the app's domain.
+I will inspect/change the Contexture IR, emit, check drift, then update app code
+against the generated contract.
+```
+
+The product should make that path feel safer, faster, and more obvious than
+editing scattered schemas by hand.


### PR DESCRIPTION
## Summary
- add a proposed roadmap for the next Contexture product arc
- frame the shift as faithful model -> semantic workbench -> excellent app outputs -> agent-safe evolution
- show enum descriptions and values in a graph hover card, with enum values rendered as badges
- link the new plan from the existing domain-model control-plane goals doc

## Verification
- bun run test -- tests/components/graph/TypeNode.test.tsx tests/graph/schema-to-graph.test.ts
- bun run typecheck (apps/desktop)
- git diff --check
- pre-commit hook ran turbo typecheck and turbo test