### PR TITLE
Emit app schemas into a schema folder

### DIFF
--- a/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
+++ b/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
@@ -348,14 +348,14 @@ describe('SchemaPanel', () => {
       );
 
       fireEvent.click(screen.getByTestId('schema-open-generated'));
-      expect(onOpenGeneratedFile).toHaveBeenLastCalledWith('/repo/garden.schema.ts');
+      expect(onOpenGeneratedFile).toHaveBeenLastCalledWith('/repo/schema/garden.schema.ts');
       screen.getByTestId('schema-copy').focus();
       await user.tab();
       expect(screen.getByTestId('schema-open-generated')).toHaveFocus();
 
       await chooseOutput('schema-output-json-schema');
       fireEvent.click(screen.getByTestId('schema-open-generated'));
-      expect(onOpenGeneratedFile).toHaveBeenLastCalledWith('/repo/garden.schema.json');
+      expect(onOpenGeneratedFile).toHaveBeenLastCalledWith('/repo/schema/garden.schema.json');
 
       await chooseOutput('schema-output-mcp-definitions');
       fireEvent.click(screen.getByTestId('schema-open-generated'));

--- a/apps/desktop/tests/main/document-store.test.ts
+++ b/apps/desktop/tests/main/document-store.test.ts
@@ -25,8 +25,8 @@ const irPath = '/work/garden.contexture.json';
 // package API).
 const layoutPath = '/work/.contexture/layout.json';
 const chatPath = '/work/.contexture/chat.json';
-const schemaTsPath = '/work/garden.schema.ts';
-const schemaJsonPath = '/work/garden.schema.json';
+const schemaTsPath = '/work/schema/garden.schema.ts';
+const schemaJsonPath = '/work/schema/garden.schema.json';
 
 const sampleIR: Schema = {
   version: '1',
@@ -220,14 +220,14 @@ describe('DocumentStore', () => {
     expect(validators).toContain(`import { v } from 'convex/values';`);
   });
 
-  it('bundle-mode save writes a schema index re-export next to the IR', async () => {
+  it('bundle-mode save writes a schema index re-export in the schema directory', async () => {
     await harness.store.save({
       irPath,
       schema: sampleIR,
       layout: sampleLayout,
       chat: sampleChat,
     });
-    const indexPath = '/work/index.ts';
+    const indexPath = '/work/schema/index.ts';
     expect(harness.fs.exists(indexPath)).toBe(true);
     const source = await harness.fs.readFile(indexPath);
     expect(source).toContain('@contexture-generated');
@@ -316,9 +316,9 @@ describe('DocumentStore', () => {
     // (it's the source of truth) so it is not in the manifest.
     expect(Object.keys(manifest.files).sort()).toEqual(
       [
-        '/work/garden.schema.ts',
-        '/work/garden.schema.json',
-        '/work/index.ts',
+        '/work/schema/garden.schema.ts',
+        '/work/schema/garden.schema.json',
+        '/work/schema/index.ts',
         '/work/convex/schema.ts',
         '/work/convex/validators.ts',
       ].sort(),
@@ -362,7 +362,7 @@ describe('DocumentStore', () => {
     expect(fs.exists('/work/.contexture/layout.json')).toBe(true);
     expect(fs.exists('/work/.contexture/chat.json')).toBe(true);
     expect(fs.exists('/work/.contexture/emitted.json')).toBe(true);
-    expect(fs.exists('/work/index.ts')).toBe(true);
+    expect(fs.exists('/work/schema/index.ts')).toBe(true);
   });
 
   it('saving a bare legacy IR refuses to overwrite existing generated targets', async () => {

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -275,7 +275,7 @@ describe('@contexture/cli', () => {
       '--json',
     ]);
     expect(result.exitCode).toBe(0);
-    await expect(readFile(join(dir, 'bare.schema.ts'), 'utf8')).resolves.toContain('body');
+    await expect(readFile(join(dir, 'schema/bare.schema.ts'), 'utf8')).resolves.toContain('body');
     await expect(readFile(join(dir, '.contexture/emitted.json'), 'utf8')).resolves.toContain(
       'bare.schema.ts',
     );

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -391,7 +391,7 @@ describe('Contexture MCP server', () => {
         opKind: 'add_field',
       });
       await expect(
-        readFile(irPath.replace(/\.contexture\.json$/, '.schema.ts'), 'utf8'),
+        readFile(join(irPath, '..', 'schema', 'bare.schema.ts'), 'utf8'),
       ).resolves.toContain('body');
     });
   });
@@ -464,7 +464,7 @@ describe('Contexture MCP server', () => {
       });
       expect(emitResult.structuredContent).toMatchObject({
         path: irPath,
-        emitted: expect.arrayContaining([irPath.replace(/\.contexture\.json$/, '.schema.ts')]),
+        emitted: expect.arrayContaining([join(irPath, '..', 'schema', 'bare.schema.ts')]),
       });
       await expect(
         readFile(join(irPath, '..', '.contexture/emitted.json'), 'utf8'),
@@ -487,7 +487,7 @@ describe('Contexture MCP server', () => {
         opKind: 'add_field',
       });
       await expect(
-        readFile(irPath.replace(/\.contexture\.json$/, '.schema.ts'), 'utf8'),
+        readFile(join(irPath, '..', 'schema', 'bare.schema.ts'), 'utf8'),
       ).resolves.toContain('body');
     });
   });

--- a/packages/core/src/generated-bundle-writer.ts
+++ b/packages/core/src/generated-bundle-writer.ts
@@ -2,7 +2,7 @@ import { DEFAULT_CHAT_HISTORY, saveChatHistory } from './chat-history';
 import type { Schema } from './ir';
 import { DEFAULT_LAYOUT, saveLayout } from './layout';
 import { save } from './load';
-import { type BundlePaths, bundlePathsFor, contextureDirFor } from './paths';
+import { type BundlePaths, bundlePathsFor } from './paths';
 import {
   type EmitPipelineDeps,
   type EmittedManifest,
@@ -155,9 +155,6 @@ export async function writeGeneratedBundle(
     const collisions = await checkGeneratedTargetCollisions(bundle.emitted, fs);
     if (collisions.length > 0) throw new GeneratedBundleDriftError(collisions);
   }
-  await fs.mkdirp?.(contextureDirFor(irPath));
-  await fs.mkdirp?.(dirname(bundle.paths.convex));
-
   const defaultSidecars = await missingDefaultSidecars(bundle.paths, fs, sidecars);
   const files = [
     ...(includeIr ? [{ path: bundle.paths.ir, content: `${save(schema)}\n` }] : []),
@@ -166,6 +163,12 @@ export async function writeGeneratedBundle(
     ...bundle.emitted,
     bundle.manifestFile,
   ];
+
+  if (fs.mkdirp) {
+    for (const dir of new Set(files.map((file) => dirname(file.path)))) {
+      await fs.mkdirp(dir);
+    }
+  }
 
   await writeFilesAtomic(fs, files);
   return { ...bundle, files };

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -9,6 +9,7 @@ export const STRUCTURED_OUTPUT_SCHEMAS_FILE = 'structured-output-schemas.json';
 export const MCP_DEFINITIONS_FILE = 'mcp-definitions.json';
 export const FORM_VALIDATORS_FILE = 'form-validators.ts';
 export const CONVEX_VALIDATORS_FILE = 'validators.ts';
+export const SCHEMA_DIR = 'schema';
 
 export interface BundlePaths {
   ir: string;
@@ -43,9 +44,9 @@ export interface GeneratedTarget {
 }
 
 export function contextureDirFor(irPath: string): string {
-  const slash = irPath.lastIndexOf('/');
-  const dir = slash === -1 ? '' : irPath.slice(0, slash);
-  return `${dir}/.contexture`;
+  const normalized = normalizeContexturePath(irPath);
+  const irDir = dirname(normalized);
+  return `${bundleLayoutFor(irDir).projectDir}/.contexture`;
 }
 
 export function baseNameFor(irPath: string): string {
@@ -64,23 +65,25 @@ export function assertContextureIrPath(path: string): string {
 
 export function bundlePathsFor(irPath: string): BundlePaths {
   const resolvedIrPath = assertContextureIrPath(irPath);
-  const base = resolvedIrPath.slice(0, -IR_SUFFIX.length);
+  const baseName = baseNameFor(resolvedIrPath);
   const ctxDir = contextureDirFor(resolvedIrPath);
-  const dir = ctxDir.slice(0, -'/.contexture'.length);
+  const irDir = dirname(resolvedIrPath);
+  const layout = bundleLayoutFor(irDir);
+  const schemaBase = `${layout.schemaDir}/${baseName}`;
   return {
     ir: resolvedIrPath,
     layout: `${ctxDir}/${LAYOUT_FILE}`,
     chat: `${ctxDir}/${CHAT_FILE}`,
     emitted: `${ctxDir}/${EMITTED_FILE}`,
-    schemaTs: `${base}${SCHEMA_TS_SUFFIX}`,
-    schemaJson: `${base}${SCHEMA_JSON_SUFFIX}`,
-    schemaIndex: `${dir}/index.ts`,
-    convex: `${dir}/convex/schema.ts`,
-    convexValidators: `${dir}/convex/${CONVEX_VALIDATORS_FILE}`,
+    schemaTs: `${schemaBase}${SCHEMA_TS_SUFFIX}`,
+    schemaJson: `${schemaBase}${SCHEMA_JSON_SUFFIX}`,
+    schemaIndex: `${layout.schemaDir}/index.ts`,
+    convex: `${layout.projectDir}/convex/schema.ts`,
+    convexValidators: `${layout.projectDir}/convex/${CONVEX_VALIDATORS_FILE}`,
     aiToolSchemas: `${ctxDir}/${AI_TOOL_SCHEMAS_FILE}`,
     structuredOutputSchemas: `${ctxDir}/${STRUCTURED_OUTPUT_SCHEMAS_FILE}`,
     mcpDefinitions: `${ctxDir}/${MCP_DEFINITIONS_FILE}`,
-    formValidators: `${dir}/${FORM_VALIDATORS_FILE}`,
+    formValidators: `${layout.schemaDir}/${FORM_VALIDATORS_FILE}`,
   };
 }
 
@@ -127,4 +130,40 @@ function normalizeContexturePath(path: string): string {
 
   if (prefix) return `${prefix}${parts.join('/')}`;
   return parts.length > 0 ? parts.join('/') : '.';
+}
+
+interface BundleLayout {
+  projectDir: string;
+  schemaDir: string;
+}
+
+function bundleLayoutFor(irDir: string): BundleLayout {
+  const parent = dirname(irDir);
+
+  if (leafName(irDir) === 'contexture' && isWorkspaceCollectionDir(leafName(parent))) {
+    return {
+      projectDir: irDir,
+      schemaDir: irDir,
+    };
+  }
+
+  return {
+    projectDir: irDir,
+    schemaDir: `${irDir}/${SCHEMA_DIR}`,
+  };
+}
+
+function isWorkspaceCollectionDir(name: string): boolean {
+  return name === 'apps' || name === 'packages';
+}
+
+function dirname(path: string): string {
+  const slash = path.lastIndexOf('/');
+  if (slash <= 0) return slash === 0 ? '/' : '.';
+  return path.slice(0, slash);
+}
+
+function leafName(path: string): string {
+  const slash = path.lastIndexOf('/');
+  return slash === -1 ? path : path.slice(slash + 1);
 }

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -24,6 +24,7 @@ export {
   generatedTargetsFor,
   IR_SUFFIX,
   LAYOUT_FILE,
+  SCHEMA_DIR,
   SCHEMA_JSON_SUFFIX,
   SCHEMA_TS_SUFFIX,
 } from './paths';

--- a/packages/core/tests/document-bundle.test.ts
+++ b/packages/core/tests/document-bundle.test.ts
@@ -71,7 +71,7 @@ describe('document bundle policy', () => {
     expect(files.has('/repo/.contexture/layout.json')).toBe(true);
     expect(files.has('/repo/.contexture/chat.json')).toBe(true);
     expect(files.has('/repo/.contexture/emitted.json')).toBe(true);
-    expect(files.has('/repo/app.schema.ts')).toBe(true);
+    expect(files.has('/repo/schema/app.schema.ts')).toBe(true);
     expect(files.has('/repo/AGENTS.md')).toBe(false);
     expect(files.has('/repo/CLAUDE.md')).toBe(false);
     expect(files.has('/repo/convex/Plot.ts')).toBe(false);

--- a/packages/core/tests/paths.test.ts
+++ b/packages/core/tests/paths.test.ts
@@ -15,6 +15,18 @@ describe('Contexture path policy', () => {
     expect(paths.convexValidators).toBe('/repo/packages/contexture/convex/validators.ts');
   });
 
+  it('emits app-root schema and framework outputs when the IR lives at the app root', () => {
+    const paths = bundlePathsFor('/repo/apps/misprint/misprint.contexture.json');
+    expect(paths.ir).toBe('/repo/apps/misprint/misprint.contexture.json');
+    expect(paths.schemaTs).toBe('/repo/apps/misprint/schema/misprint.schema.ts');
+    expect(paths.schemaJson).toBe('/repo/apps/misprint/schema/misprint.schema.json');
+    expect(paths.schemaIndex).toBe('/repo/apps/misprint/schema/index.ts');
+    expect(paths.formValidators).toBe('/repo/apps/misprint/schema/form-validators.ts');
+    expect(paths.convex).toBe('/repo/apps/misprint/convex/schema.ts');
+    expect(paths.convexValidators).toBe('/repo/apps/misprint/convex/validators.ts');
+    expect(paths.emitted).toBe('/repo/apps/misprint/.contexture/emitted.json');
+  });
+
   it('rejects non-IR paths', () => {
     expect(() => assertContextureIrPath('/repo/packages/contexture/app.schema.json')).toThrow(
       /Expected a \.contexture\.json path/,

--- a/packages/core/tests/pipeline.test.ts
+++ b/packages/core/tests/pipeline.test.ts
@@ -22,6 +22,18 @@ describe('runEmitPipeline output config', () => {
     ]);
   });
 
+  it('emits schemas and Convex under app-root folders for a root app IR', () => {
+    const { emitted } = runEmitPipeline(baseSchema, '/repo/apps/misprint/misprint.contexture.json');
+
+    expect(emitted.map((file) => file.path)).toEqual([
+      '/repo/apps/misprint/schema/misprint.schema.ts',
+      '/repo/apps/misprint/schema/misprint.schema.json',
+      '/repo/apps/misprint/schema/index.ts',
+      '/repo/apps/misprint/convex/schema.ts',
+      '/repo/apps/misprint/convex/validators.ts',
+    ]);
+  });
+
   it('can disable existing generated targets explicitly', () => {
     const schema: Schema = {
       ...baseSchema,


### PR DESCRIPTION
## Summary
- Keep the app IR as a single root-level `*.contexture.json` file.
- Emit generated app schema artifacts into a root `schema/` folder instead of cluttering the app root.
- Keep Contexture sidecars in root `.contexture/` and Convex output in root `convex/`.
- Preserve existing package-style bundle behavior for `packages/contexture/*.contexture.json`.
- Make bundle writes create every parent directory needed by emitted files.

## Folder structure
For a Next.js/app project with a root IR, Contexture will emit/use:

```txt
misprint/
  misprint.contexture.json

  .contexture/
    layout.json
    chat.json
    emitted.json
    ai-tool-schemas.json           # when enabled
    structured-output-schemas.json # when enabled
    mcp-definitions.json           # when enabled

  schema/
    misprint.schema.ts
    misprint.schema.json
    index.ts
    form-validators.ts             # when enabled

  convex/
    schema.ts
    validators.ts
```

Existing package-style layouts such as `packages/contexture/app.contexture.json` continue to emit beside the IR, preserving the current package bundle behavior.

## Existing root-level IR behavior
If an app currently has `misprint.contexture.json` at the app root, it stays there. On the next save/emit with this change, Contexture writes generated schemas to `schema/` and updates `.contexture/emitted.json` with the new generated paths.

One-time cleanup: after confirming the new `schema/` outputs are present, delete old root generated files such as `index.ts`, `misprint.schema.ts`, and `misprint.schema.json`. The root `.contexture/` and `convex/` folders remain in place.

## Checks
- `bun run test -- tests/paths.test.ts`
- `bun run test -- tests/pipeline.test.ts`
- `bun run test -- tests/document-bundle.test.ts`
- `bun run test -- tests/cli.test.ts tests/mcp.test.ts` in `packages/cli`
- `bun run test -- tests/components/schema/SchemaPanel.test.tsx` in `apps/desktop`
- `bun run test -- tests/main/document-store.test.ts` in `apps/desktop`
- `bun run test` in `packages/core`
- `bun run lint`
- `bun run typecheck`
- pre-commit `turbo typecheck`
- pre-commit `turbo test`
