### PR TITLE
chore: bump desktop to 0.15.11

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.10",
+      "version": "0.15.11",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",


### PR DESCRIPTION
## Summary
- bump @contexture/desktop from 0.15.10 to 0.15.11
- update bun.lock workspace metadata

## Verification
- bun run check apps/desktop/package.json bun.lock
- pre-commit hook: turbo typecheck
- pre-commit hook: turbo test