### PR TITLE
fix: tighten generated schema emitters

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.11",
+  "version": "0.15.12",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/tests/model/emit-convex.test.ts
+++ b/apps/desktop/tests/model/emit-convex.test.ts
@@ -36,7 +36,7 @@ describe('emitConvexSchema', () => {
       ],
     };
     const out = emitConvexSchema(ir);
-    expect(out).toMatch(/Post:\s*defineTable\(\{/);
+    expect(out).toMatch(/post:\s*defineTable\(\{/);
     expect(out).toContain('title: v.string()');
     expect(out).toContain('views: v.number()');
     expect(out).toContain('published: v.boolean()');
@@ -97,7 +97,7 @@ describe('emitConvexSchema', () => {
       ],
     };
     const out = emitConvexSchema(ir);
-    expect(out).toContain('author: v.id("Author")');
+    expect(out).toContain('author: v.id("author")');
     expect(parses(out)).toBe(true);
   });
 
@@ -126,6 +126,7 @@ describe('emitConvexSchema', () => {
     expect(out).toContain('home: address');
     // Only User should be a defineTable entry.
     expect(out).not.toMatch(/Address:\s*defineTable/);
+    expect(out).toMatch(/user:\s*defineTable/);
     expect(parses(out)).toBe(true);
   });
 
@@ -256,6 +257,52 @@ describe('emitConvexSchema', () => {
     expect(parses(out)).toBe(true);
   });
 
+  it('emits lower camel case Convex table names', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Artwork', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'ArtworkRevision',
+          table: true,
+          fields: [{ name: 'artworkId', type: { kind: 'ref', typeName: 'Artwork' } }],
+        },
+      ],
+    };
+
+    const out = emitConvexSchema(ir);
+
+    expect(out).toContain('artwork: defineTable({');
+    expect(out).toContain('artworkRevision: defineTable({');
+    expect(out).toContain('artworkId: v.id("artwork")');
+    expect(out).not.toContain('Artwork: defineTable({');
+    expect(parses(out)).toBe(true);
+  });
+
+  it('uses explicit Convex table names for schema keys and refs', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Artwork', table: true, tableName: 'artworks', fields: [] },
+        {
+          kind: 'object',
+          name: 'ArtworkRevision',
+          table: true,
+          tableName: 'artworkRevisions',
+          fields: [{ name: 'artworkId', type: { kind: 'ref', typeName: 'Artwork' } }],
+        },
+      ],
+    };
+
+    const out = emitConvexSchema(ir);
+
+    expect(out).toContain('artworks: defineTable({');
+    expect(out).toContain('artworkRevisions: defineTable({');
+    expect(out).toContain('artworkId: v.id("artworks")');
+    expect(parses(out)).toBe(true);
+  });
+
   it('throws when a table name starts with "_"', () => {
     const ir: Schema = {
       version: '1',
@@ -334,6 +381,53 @@ describe('emitConvexValidators', () => {
     );
     expect(out).toContain('export const postMetadata = v.object({ status: status });');
     expect(out).not.toMatch(/export const post =/);
+    expect(parses(out)).toBe(true);
+  });
+
+  it('emits reusable validators before validators that reference them', () => {
+    const ir: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Artwork',
+          fields: [
+            { name: 'medium', type: { kind: 'ref', typeName: 'ArtworkMedium' } },
+            {
+              name: 'palette',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'PaletteColor' } },
+            },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'PaletteColor',
+          fields: [{ name: 'role', type: { kind: 'ref', typeName: 'PaletteRole' } }],
+        },
+        {
+          kind: 'enum',
+          name: 'ArtworkMedium',
+          values: [{ value: 'print' }, { value: 'poster' }],
+        },
+        {
+          kind: 'enum',
+          name: 'PaletteRole',
+          values: [{ value: 'primary' }, { value: 'accent' }],
+        },
+      ],
+    };
+
+    const out = emitConvexValidators(ir);
+
+    expect(out.indexOf('export const artworkMedium')).toBeLessThan(
+      out.indexOf('export const artwork ='),
+    );
+    expect(out.indexOf('export const paletteRole')).toBeLessThan(
+      out.indexOf('export const paletteColor'),
+    );
+    expect(out.indexOf('export const paletteColor')).toBeLessThan(
+      out.indexOf('export const artwork ='),
+    );
     expect(parses(out)).toBe(true);
   });
 

--- a/apps/desktop/tests/model/emit-zod.test.ts
+++ b/apps/desktop/tests/model/emit-zod.test.ts
@@ -74,7 +74,7 @@ describe('emit (Zod)', () => {
         title: z.string().min(1).max(120),
         views: z.number().int().min(0),
         published: z.boolean().default(false),
-        createdAt: z.date(),
+        createdAt: z.number(),
         kind: z.literal('post'),
         author: Email,
         linked: Ref,
@@ -206,6 +206,52 @@ describe('emit (Zod)', () => {
     };
     const src = emit(schema, 'x.contexture.json');
     expect(src).toContain(`on: Post,`);
+  });
+
+  it('emits local dependencies before consumers', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Artwork',
+          fields: [
+            { name: 'medium', type: { kind: 'ref', typeName: 'ArtworkMedium' } },
+            {
+              name: 'palette',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'PaletteColor' } },
+            },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'PaletteColor',
+          fields: [{ name: 'role', type: { kind: 'ref', typeName: 'PaletteRole' } }],
+        },
+        {
+          kind: 'enum',
+          name: 'ArtworkMedium',
+          values: [{ value: 'print' }, { value: 'poster' }],
+        },
+        {
+          kind: 'enum',
+          name: 'PaletteRole',
+          values: [{ value: 'primary' }, { value: 'accent' }],
+        },
+      ],
+    };
+
+    const src = emit(schema, 'x.contexture.json');
+
+    expect(src.indexOf('export const ArtworkMedium')).toBeLessThan(
+      src.indexOf('export const Artwork ='),
+    );
+    expect(src.indexOf('export const PaletteRole')).toBeLessThan(
+      src.indexOf('export const PaletteColor'),
+    );
+    expect(src.indexOf('export const PaletteColor')).toBeLessThan(
+      src.indexOf('export const Artwork ='),
+    );
   });
 
   it('emits an import for a stdlib qualified ref and uses the bare name', () => {
@@ -397,7 +443,7 @@ describe('emit (Zod)', () => {
         `  title: z.string(),\n` +
         `  views: z.number(),\n` +
         `  published: z.boolean(),\n` +
-        `  createdAt: z.date(),\n` +
+        `  createdAt: z.number(),\n` +
         `});`,
     );
   });

--- a/apps/desktop/tests/model/ir.test.ts
+++ b/apps/desktop/tests/model/ir.test.ts
@@ -115,7 +115,7 @@ describe('IRSchema', () => {
     expect(nested.element.kind).toBe('array');
   });
 
-  it('accepts FieldDef optional/nullable/default/description', () => {
+  it('accepts FieldDef optional/nullable/default/description/serverDerived', () => {
     const input = {
       version: '1',
       types: [
@@ -130,6 +130,7 @@ describe('IRSchema', () => {
               optional: true,
               nullable: true,
               default: 'anon',
+              serverDerived: true,
             },
           ],
         },
@@ -144,6 +145,7 @@ describe('IRSchema', () => {
       optional: true,
       nullable: true,
       default: 'anon',
+      serverDerived: true,
     });
   });
 
@@ -271,7 +273,7 @@ describe('IRSchema', () => {
     expect(path).toContain('types.0.fields.0.type');
   });
 
-  it('accepts an object TypeDef with table:true and indexes', () => {
+  it('accepts an object TypeDef with table:true, tableName, and indexes', () => {
     const input = {
       version: '1',
       types: [
@@ -279,6 +281,7 @@ describe('IRSchema', () => {
           kind: 'object',
           name: 'Post',
           table: true,
+          tableName: 'posts',
           indexes: [
             { name: 'by_author', fields: ['author'] },
             { name: 'by_author_and_date', fields: ['author', 'publishedAt'] },
@@ -294,6 +297,7 @@ describe('IRSchema', () => {
     const td = parsed.types[0];
     if (td.kind !== 'object') throw new Error('expected object');
     expect(td.table).toBe(true);
+    expect(td.tableName).toBe('posts');
     expect(td.indexes).toEqual([
       { name: 'by_author', fields: ['author'] },
       { name: 'by_author_and_date', fields: ['author', 'publishedAt'] },

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.11",
+      "version": "0.15.12",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",

--- a/packages/core/src/emit-convex.ts
+++ b/packages/core/src/emit-convex.ts
@@ -43,7 +43,7 @@ export function emitConvexSchema(schema: Schema, sourcePath?: string): string {
     (t): t is ObjectType => t.kind === 'object' && t.table === true,
   );
   const validatorImports = collectTableValidatorImports(tables, ctx);
-  const tableEntries = tables.map((t) => `  ${t.name}: ${renderTable(t, ctx)},`).join('\n');
+  const tableEntries = tables.map((t) => `  ${tableName(t)}: ${renderTable(t, ctx)},`).join('\n');
   const body =
     tableEntries.length > 0
       ? `export default defineSchema({\n${tableEntries}\n});\n`
@@ -64,8 +64,7 @@ export function emitConvexSchema(schema: Schema, sourcePath?: string): string {
 
 export function emitConvexValidators(schema: Schema, sourcePath?: string): string {
   const ctx = buildContext(schema);
-  const validators = schema.types
-    .filter(isReusableValidatorType)
+  const validators = sortReusableValidators(schema.types.filter(isReusableValidatorType), ctx)
     .map((t) => `export const ${validatorName(t.name)} = ${renderTypeDef(t, ctx)};`)
     .join('\n');
 
@@ -122,7 +121,7 @@ function renderType(t: FieldType, ctx: RenderContext, options: RenderOptions): s
       }
       if (target.kind === 'raw') return 'v.any()';
       if (target.kind === 'object' && target.table === true) {
-        return `v.id("${target.name}")`;
+        return `v.id("${tableName(target)}")`;
       }
       if (!options.preferNamedRefs) return renderTypeDef(target, ctx);
       return validatorName(target.name);
@@ -168,7 +167,79 @@ function renderInlineObject(t: ObjectType, ctx: RenderContext, options: RenderOp
 }
 
 function validatorName(name: string): string {
+  return lowerFirst(name);
+}
+
+function tableName(type: ObjectType): string {
+  return type.tableName ?? lowerFirst(type.name);
+}
+
+function lowerFirst(name: string): string {
   return `${name.charAt(0).toLowerCase()}${name.slice(1)}`;
+}
+
+function sortReusableValidators(
+  types: ConvexReusableType[],
+  ctx: RenderContext,
+): ConvexReusableType[] {
+  const reusableByName = new Map(types.map((t) => [t.name, t]));
+  const sorted: ConvexReusableType[] = [];
+  const temporary = new Set<string>();
+  const permanent = new Set<string>();
+
+  function visit(t: ConvexReusableType): void {
+    if (permanent.has(t.name)) return;
+    if (temporary.has(t.name)) {
+      return;
+    }
+
+    temporary.add(t.name);
+    for (const depName of reusableDependencyNames(t, ctx)) {
+      const dep = reusableByName.get(depName);
+      if (dep) visit(dep);
+    }
+    temporary.delete(t.name);
+    permanent.add(t.name);
+    sorted.push(t);
+  }
+
+  for (const type of types) visit(type);
+  return sorted;
+}
+
+function reusableDependencyNames(t: ConvexReusableType, ctx: RenderContext): string[] {
+  const dependencies = new Set<string>();
+
+  if (t.kind === 'object') {
+    for (const field of t.fields) {
+      collectReusableDependenciesForType(field.type, ctx, dependencies);
+    }
+  }
+
+  if (t.kind === 'discriminatedUnion') {
+    for (const variantName of t.variants) {
+      const variant = ctx.types.get(variantName);
+      if (variant && isReusableValidatorType(variant)) dependencies.add(variant.name);
+    }
+  }
+
+  dependencies.delete(t.name);
+  return [...dependencies].sort();
+}
+
+function collectReusableDependenciesForType(
+  t: FieldType,
+  ctx: RenderContext,
+  dependencies: Set<string>,
+): void {
+  if (t.kind === 'array') {
+    collectReusableDependenciesForType(t.element, ctx, dependencies);
+    return;
+  }
+  if (t.kind !== 'ref') return;
+  const target = ctx.types.get(t.typeName);
+  if (!target || !isReusableValidatorType(target)) return;
+  dependencies.add(target.name);
 }
 
 function collectTableValidatorImports(tables: ObjectType[], ctx: RenderContext): string[] {
@@ -205,9 +276,10 @@ function validateReservedNames(schema: Schema): void {
   for (const t of schema.types) {
     if (t.kind !== 'object') continue;
     if (t.table !== true) continue;
-    if (t.name.startsWith('_')) {
+    const emittedTableName = tableName(t);
+    if (emittedTableName.startsWith('_')) {
       throw new Error(
-        `emitConvexSchema: table name "${t.name}" is invalid — Convex reserves names starting with "_"`,
+        `emitConvexSchema: table name "${emittedTableName}" is invalid — Convex reserves names starting with "_"`,
       );
     }
     for (const f of t.fields) {

--- a/packages/core/src/emit-form-validators.ts
+++ b/packages/core/src/emit-form-validators.ts
@@ -6,7 +6,7 @@
  * dependencies while still giving React Hook Form, TanStack Form, and custom
  * form code a stable `validate(value)` contract.
  */
-import type { Schema } from './ir';
+import type { Schema, TypeDef } from './ir';
 
 function header(sourcePath?: string): string {
   const base = '// @contexture-generated — do not edit by hand. Regenerated on every IR save.';
@@ -19,6 +19,17 @@ export function emitFormValidators(schema: Schema, baseName: string, sourcePath?
     names.length > 0 ? `import { ${names.join(', ')} } from './${baseName}.schema';\n` : '';
   const validators = names
     .map((name) => `export const ${name}Validator = createFormValidator(${name});\n`)
+    .join('');
+  const createValidators = schema.types
+    .filter(hasServerDerivedFields)
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((type) => {
+      const omitted = type.fields
+        .filter((field) => field.serverDerived === true)
+        .map((field) => `${field.name}: true`)
+        .join(', ');
+      return `export const ${type.name}CreateValidator = createFormValidator(${type.name}.omit({ ${omitted} }));\n`;
+    })
     .join('');
 
   return `${header(sourcePath)}${imports}
@@ -66,5 +77,11 @@ function groupIssues(issues: SafeParseIssue[]): Record<string, string[]> {
   return errors;
 }
 
-${validators}`;
+${validators}${createValidators}`;
+}
+
+type ObjectType = Extract<TypeDef, { kind: 'object' }>;
+
+function hasServerDerivedFields(type: TypeDef): type is ObjectType {
+  return type.kind === 'object' && type.fields.some((field) => field.serverDerived === true);
 }

--- a/packages/core/src/emit-zod.ts
+++ b/packages/core/src/emit-zod.ts
@@ -34,7 +34,9 @@ export function emit(schema: Schema, sourcePath: string, options: EmitOptions = 
   const header = `// @contexture-generated — do not edit by hand. Regenerated on every IR save. Source: ${sourcePath}\n`;
   const zodImport = `import { z } from 'zod';\n`;
   const externalImports = renderExternalImports(ctx);
-  const body = schema.types.map((t) => emitTypeDef(t, ctx)).join('');
+  const body = sortTypeDefs(schema.types, ctx)
+    .map((t) => emitTypeDef(t, ctx))
+    .join('');
   return header + zodImport + externalImports + body;
 }
 
@@ -51,6 +53,8 @@ interface EmitContext {
   usedByAlias: Map<string, Set<string>>;
   /** `raw` types with an external import hint, keyed by name. */
   rawExternal: Map<string, { from: string; name: string }>;
+  /** Local types by name, used to order declarations before consumers. */
+  types: Map<string, TypeDef>;
 }
 
 function buildContext(schema: Schema, options: EmitOptions): EmitContext {
@@ -64,6 +68,7 @@ function buildContext(schema: Schema, options: EmitOptions): EmitContext {
   const stdlibNs = new Set(options.stdlibNamespaces ?? []);
   const usedByAlias = new Map<string, Set<string>>();
   const rawExternal = new Map<string, { from: string; name: string }>();
+  const types = new Map(schema.types.map((type) => [type.name, type]));
 
   const walkField = (t: FieldType) => {
     if (t.kind === 'ref') {
@@ -101,7 +106,7 @@ function buildContext(schema: Schema, options: EmitOptions): EmitContext {
     }
   });
 
-  return { aliases, imports, usedByAlias, rawExternal };
+  return { aliases, imports, usedByAlias, rawExternal, types };
 }
 
 function renderExternalImports(ctx: EmitContext): string {
@@ -199,7 +204,7 @@ function emitFieldType(t: FieldType, ctx: EmitContext): string {
     case 'boolean':
       return `z.boolean()`;
     case 'date':
-      return `z.date()`;
+      return `z.number()`;
     case 'literal':
       return `z.literal(${renderLiteral(t.value)})`;
     case 'ref': {
@@ -215,4 +220,60 @@ function emitFieldType(t: FieldType, ctx: EmitContext): string {
       return s;
     }
   }
+}
+
+function sortTypeDefs(types: TypeDef[], ctx: EmitContext): TypeDef[] {
+  const localByName = new Map(types.map((type) => [type.name, type]));
+  const sorted: TypeDef[] = [];
+  const temporary = new Set<string>();
+  const permanent = new Set<string>();
+
+  function visit(type: TypeDef): void {
+    if (permanent.has(type.name)) return;
+    if (temporary.has(type.name)) return;
+
+    temporary.add(type.name);
+    for (const depName of localDependencyNames(type, ctx)) {
+      const dep = localByName.get(depName);
+      if (dep) visit(dep);
+    }
+    temporary.delete(type.name);
+    permanent.add(type.name);
+    sorted.push(type);
+  }
+
+  for (const type of types) visit(type);
+  return sorted;
+}
+
+function localDependencyNames(type: TypeDef, ctx: EmitContext): string[] {
+  const dependencies = new Set<string>();
+
+  if (type.kind === 'object') {
+    for (const field of type.fields) {
+      collectLocalDependenciesForType(field.type, ctx, dependencies);
+    }
+  }
+
+  if (type.kind === 'discriminatedUnion') {
+    for (const variantName of type.variants) {
+      if (ctx.types.has(variantName)) dependencies.add(variantName);
+    }
+  }
+
+  dependencies.delete(type.name);
+  return [...dependencies].sort();
+}
+
+function collectLocalDependenciesForType(
+  t: FieldType,
+  ctx: EmitContext,
+  dependencies: Set<string>,
+): void {
+  if (t.kind === 'array') {
+    collectLocalDependenciesForType(t.element, ctx, dependencies);
+    return;
+  }
+  if (t.kind !== 'ref') return;
+  if (ctx.types.has(t.typeName)) dependencies.add(t.typeName);
 }

--- a/packages/core/src/ir.ts
+++ b/packages/core/src/ir.ts
@@ -84,6 +84,7 @@ export const FieldDefSchema = z.object({
   optional: z.boolean().optional(),
   nullable: z.boolean().optional(),
   default: z.unknown().optional(),
+  serverDerived: z.boolean().optional(),
 });
 
 export type FieldDef = z.infer<typeof FieldDefSchema>;
@@ -101,6 +102,7 @@ const ObjectTypeDefSchema = z.object({
   description: z.string().optional(),
   fields: z.array(FieldDefSchema),
   table: z.boolean().optional(),
+  tableName: z.string().min(1).optional(),
   indexes: z.array(IndexDefSchema).optional(),
 });
 

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -15,7 +15,7 @@
  * import validation. Callers without stdlib context (e.g. core unit tests)
  * pass nothing and get import-only resolution.
  */
-import type { FieldType, ImportDecl, Schema } from './ir';
+import type { FieldType, ImportDecl, Schema, TypeDef } from './ir';
 
 /**
  * Stdlib namespace catalog. The renderer / main process build one from
@@ -38,7 +38,8 @@ export type SemanticIssueCode =
   | 'discriminator_variant_not_object'
   | 'discriminator_missing_on_variant'
   | 'enum_empty'
-  | 'enum_duplicate_value';
+  | 'enum_duplicate_value'
+  | 'duplicate_convex_table_name';
 
 export interface SemanticIssue {
   code: SemanticIssueCode;
@@ -54,9 +55,38 @@ export function checkSemantic(schema: Schema, catalog?: StdlibCatalog): Semantic
     ...checkImports(schema, catalog),
     ...checkRefs(schema, catalog),
     ...checkDuplicateTypeNames(schema),
+    ...checkDuplicateConvexTableNames(schema),
     ...checkDiscriminatedUnions(schema),
     ...checkEnums(schema),
   ];
+}
+
+type ObjectType = Extract<TypeDef, { kind: 'object' }>;
+
+function checkDuplicateConvexTableNames(schema: Schema): SemanticIssue[] {
+  const issues: SemanticIssue[] = [];
+  const seen = new Map<string, number>();
+
+  schema.types.forEach((type, i) => {
+    if (type.kind !== 'object' || type.table !== true) return;
+    const name = convexTableName(type);
+    const first = seen.get(name);
+    if (first !== undefined) {
+      issues.push({
+        code: 'duplicate_convex_table_name',
+        path: `types.${i}.tableName`,
+        message: `Convex table name "${name}" is already used by types.${first}.`,
+      });
+      return;
+    }
+    seen.set(name, i);
+  });
+
+  return issues;
+}
+
+function convexTableName(type: ObjectType): string {
+  return type.tableName ?? `${type.name.charAt(0).toLowerCase()}${type.name.slice(1)}`;
 }
 
 function checkImports(schema: Schema, catalog?: StdlibCatalog): SemanticIssue[] {

--- a/packages/core/tests/emit-form-validators.test.ts
+++ b/packages/core/tests/emit-form-validators.test.ts
@@ -30,4 +30,29 @@ describe('emitFormValidators', () => {
     expect(source).toContain('export const PlanValidator = createFormValidator(Plan);');
     expect(source).toContain('safeParse');
   });
+
+  it('emits create validators that omit server-derived fields', () => {
+    const source = emitFormValidators(
+      {
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'Artwork',
+            fields: [
+              { name: 'title', type: { kind: 'string' } },
+              { name: 'sourceSearchText', type: { kind: 'string' }, serverDerived: true },
+            ],
+          },
+        ],
+      },
+      'artwork',
+      '/repo/packages/contexture/artwork.json',
+    );
+
+    expect(source).toContain('export const ArtworkValidator = createFormValidator(Artwork);');
+    expect(source).toContain(
+      'export const ArtworkCreateValidator = createFormValidator(Artwork.omit({ sourceSearchText: true }));',
+    );
+  });
 });

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -188,6 +188,20 @@ describe('checkSemantic — duplicates', () => {
     const issues = checkSemantic(schema, STDLIB);
     expect(issues.some((i) => i.code === 'duplicate_type_name')).toBe(true);
   });
+
+  it('rejects duplicate emitted Convex table names', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Artwork', table: true, tableName: 'artworks', fields: [] },
+        { kind: 'object', name: 'Artworks', table: true, fields: [] },
+      ],
+    };
+
+    const issues = checkSemantic(schema, STDLIB);
+
+    expect(issues.some((i) => i.code === 'duplicate_convex_table_name')).toBe(true);
+  });
 });
 
 describe('checkSemantic — discriminated unions', () => {


### PR DESCRIPTION
## Summary
- sort generated Zod and Convex validator declarations before consumers
- align Zod date fields with Convex numeric timestamp validators
- add configurable Convex table names plus duplicate table-name validation
- add server-derived field metadata and create-form validators that omit those fields

## Tests
- bun run ci