### PR TITLE
fix(desktop): refresh drift manifest on regenerate

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.12",
+  "version": "0.15.13",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/main/ipc/reconcile.ts
+++ b/apps/desktop/src/main/ipc/reconcile.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
+import { bundlePathsFor, type EmittedManifest, hashContent } from '@contexture/core';
 import { ipcMain } from 'electron';
 import { z } from 'zod';
 import { assertGeneratedTargetForIr } from '../security';
@@ -46,8 +47,33 @@ export async function writeGeneratedTarget(input: unknown): Promise<void> {
     input,
   );
   const target = assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath);
+  const manifestPath = bundlePathsFor(parsed.irPath).emitted;
   await mkdir(dirname(target), { recursive: true });
   await writeFile(target, parsed.contents, 'utf8');
+  await writeGeneratedManifestHash(manifestPath, target, parsed.contents);
+}
+
+async function writeGeneratedManifestHash(
+  manifestPath: string,
+  targetPath: string,
+  contents: string,
+): Promise<void> {
+  const manifest = await readGeneratedManifest(manifestPath);
+  manifest.files[targetPath] = hashContent(contents);
+  await mkdir(dirname(manifestPath), { recursive: true });
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+}
+
+async function readGeneratedManifest(manifestPath: string): Promise<EmittedManifest> {
+  try {
+    const parsed = JSON.parse(await readFile(manifestPath, 'utf8')) as Partial<EmittedManifest>;
+    return {
+      version: '1',
+      files: parsed.files && typeof parsed.files === 'object' ? parsed.files : {},
+    };
+  } catch {
+    return { version: '1', files: {} };
+  }
 }
 
 export function registerReconcileIpc(): void {

--- a/apps/desktop/tests/main/reconcile-ipc.test.ts
+++ b/apps/desktop/tests/main/reconcile-ipc.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { type EmittedManifest, hashContent } from '@contexture/core';
 import { readGeneratedTarget, writeGeneratedTarget } from '@main/ipc/reconcile';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -21,6 +22,28 @@ describe('reconcile generated-target IPC helpers', () => {
     await expect(readGeneratedTarget({ irPath, targetPath })).resolves.toBe('before\n');
     await writeGeneratedTarget({ irPath, targetPath, contents: 'after\n' });
     await expect(readFile(targetPath, 'utf8')).resolves.toBe('after\n');
+  });
+
+  it('updates the emitted manifest hash when regenerating a target', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'contexture-reconcile-'));
+    const ctxDir = join(dir, 'packages/contexture');
+    const contextureDir = join(ctxDir, '.contexture');
+    await mkdir(contextureDir, { recursive: true });
+    const irPath = join(ctxDir, 'garden.contexture.json');
+    const targetPath = join(ctxDir, 'garden.schema.ts');
+    const manifestPath = join(contextureDir, 'emitted.json');
+    await writeFile(irPath, '{"version":"1","types":[]}\n', 'utf8');
+    await writeFile(targetPath, 'before\n', 'utf8');
+    await writeFile(
+      manifestPath,
+      `${JSON.stringify({ version: '1', files: { [targetPath]: hashContent('before\n') } }, null, 2)}\n`,
+      'utf8',
+    );
+
+    await writeGeneratedTarget({ irPath, targetPath, contents: 'after\n' });
+
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as EmittedManifest;
+    expect(manifest.files[targetPath]).toBe(hashContent('after\n'));
   });
 
   it('rejects writes outside the generated bundle', async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.12",
+      "version": "0.15.13",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",


### PR DESCRIPTION
## Summary
- Bump the Contexture desktop app version from 0.15.12 to 0.15.13.
- Update the generated-target regenerate path so it refreshes the corresponding hash in .contexture/emitted.json.
- Add regression coverage for manifest updates during reconcile regeneration.

## Why
The published app had the Zod declaration-ordering fix, but stale generated files could remain stuck in drift: Regenerate from IR overwrote the target file without updating the emitted manifest, so the drift watcher kept comparing the new file to the old hash and re-alerting.

## Verification
- bun run --filter @contexture/desktop test -- tests/main/reconcile-ipc.test.ts tests/components/dialogs/ReconcileModal.test.tsx tests/main/drift-watcher.test.ts
- bun run --filter @contexture/desktop typecheck
- pre-commit: turbo typecheck && turbo test