### PR TITLE
fix(desktop): package MCP CLI binary

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.13",
+  "version": "0.15.14",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",
@@ -19,9 +19,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "build:win": "bun run build && bun run build:mcp-cli && electron-builder --win --config",
-    "build:mac": "bun run build && bun run build:mcp-cli && electron-builder --mac --config",
-    "build:linux": "bun run build && bun run build:mcp-cli && electron-builder --linux --config",
+    "build:win": "bun run build && electron-builder --win --config",
+    "build:mac": "bun run build && electron-builder --mac --config",
+    "build:linux": "bun run build && electron-builder --linux --config",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/apps/desktop/scripts/build-mcp-cli.cjs
+++ b/apps/desktop/scripts/build-mcp-cli.cjs
@@ -2,24 +2,40 @@ const { spawnSync } = require('node:child_process');
 const { mkdirSync } = require('node:fs');
 const path = require('node:path');
 
-const appDir = path.resolve(__dirname, '..');
-const workspaceRoot = path.resolve(appDir, '../..');
-const outDir = path.join(appDir, 'build', 'bin');
-const executableName = process.platform === 'win32' ? 'contexture-mcp.exe' : 'contexture-mcp';
-const outFile = path.join(outDir, executableName);
-const entrypoint = path.join(workspaceRoot, 'packages', 'cli', 'src', 'mcp.ts');
+function buildMcpCli(options = {}) {
+  const appDir = options.appDir ?? path.resolve(__dirname, '..');
+  const workspaceRoot = options.workspaceRoot ?? path.resolve(appDir, '../..');
+  const outDir = path.join(appDir, 'build', 'bin');
+  const executableName =
+    (options.platform ?? process.platform) === 'win32' ? 'contexture-mcp.exe' : 'contexture-mcp';
+  const outFile = path.join(outDir, executableName);
+  const entrypoint = path.join(workspaceRoot, 'packages', 'cli', 'src', 'mcp.ts');
+  const mkdir = options.mkdirSync ?? mkdirSync;
+  const spawn = options.spawnSync ?? spawnSync;
 
-mkdirSync(outDir, { recursive: true });
+  mkdir(outDir, { recursive: true });
 
-const result = spawnSync('bun', ['build', '--compile', '--outfile', outFile, entrypoint], {
-  cwd: workspaceRoot,
-  stdio: 'inherit',
-});
+  const result = spawn('bun', ['build', '--compile', '--outfile', outFile, entrypoint], {
+    cwd: workspaceRoot,
+    stdio: 'inherit',
+  });
 
-if (result.error) {
-  throw result.error;
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`Failed to build contexture-mcp: bun exited with status ${result.status ?? 1}`);
+  }
 }
 
-if (result.status !== 0) {
-  process.exit(result.status ?? 1);
+if (require.main === module) {
+  try {
+    buildMcpCli();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
 }
+
+module.exports = { buildMcpCli };

--- a/apps/desktop/scripts/electron-builder-before-pack.cjs
+++ b/apps/desktop/scripts/electron-builder-before-pack.cjs
@@ -1,5 +1,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const { buildMcpCli } = require('./build-mcp-cli.cjs');
 
 function findWorkspaceRoot(startDir) {
   let current = startDir;
@@ -87,38 +88,53 @@ function readPackageJson(packageDir) {
   return JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
 }
 
-exports.default = async function beforePack(context) {
-  const appDir = context.packager.projectDir;
-  const workspaceRoot = findWorkspaceRoot(appDir);
-  const claudeAgentSdkDir = fs.realpathSync(
-    path.join(appDir, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
-  );
-  const claudeAgentSdkPackageJsonPath = path.join(claudeAgentSdkDir, 'package.json');
-  const claudeAgentSdkPackageJson = JSON.parse(fs.readFileSync(claudeAgentSdkPackageJsonPath, 'utf8'));
-  const sdkRange = claudeAgentSdkPackageJson.dependencies?.['@anthropic-ai/sdk'];
+function createBeforePack(options = {}) {
+  const buildPackagedMcpCli = options.buildMcpCli ?? buildMcpCli;
 
-  if (!sdkRange) {
-    return;
-  }
+  return async function beforePack(context) {
+    buildPackagedMcpCli();
 
-  const sdkDir = fs.realpathSync(
-    findResolvedPackage(appDir, '@anthropic-ai/sdk') ?? findInstalledPackage(workspaceRoot, '@anthropic-ai/sdk', sdkRange),
-  );
-  const sdkPackageJson = readPackageJson(sdkDir);
-  const linkDir = path.join(claudeAgentSdkDir, 'node_modules', '@anthropic-ai');
-  const linkPath = path.join(linkDir, 'sdk');
+    const appDir = context.packager.projectDir;
+    const workspaceRoot = findWorkspaceRoot(appDir);
+    const claudeAgentSdkDir = fs.realpathSync(
+      path.join(appDir, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
+    );
+    const claudeAgentSdkPackageJsonPath = path.join(claudeAgentSdkDir, 'package.json');
+    const claudeAgentSdkPackageJson = JSON.parse(
+      fs.readFileSync(claudeAgentSdkPackageJsonPath, 'utf8'),
+    );
+    const sdkRange = claudeAgentSdkPackageJson.dependencies?.['@anthropic-ai/sdk'];
 
-  claudeAgentSdkPackageJson.dependencies['@anthropic-ai/sdk'] = sdkPackageJson.version;
-  fs.writeFileSync(claudeAgentSdkPackageJsonPath, `${JSON.stringify(claudeAgentSdkPackageJson, null, 2)}\n`);
+    if (!sdkRange) {
+      return;
+    }
 
-  fs.mkdirSync(linkDir, { recursive: true });
+    const sdkDir = fs.realpathSync(
+      findResolvedPackage(appDir, '@anthropic-ai/sdk') ??
+        findInstalledPackage(workspaceRoot, '@anthropic-ai/sdk', sdkRange),
+    );
+    const sdkPackageJson = readPackageJson(sdkDir);
+    const linkDir = path.join(claudeAgentSdkDir, 'node_modules', '@anthropic-ai');
+    const linkPath = path.join(linkDir, 'sdk');
 
-  if (fs.existsSync(linkPath)) {
-    return;
-  }
+    claudeAgentSdkPackageJson.dependencies['@anthropic-ai/sdk'] = sdkPackageJson.version;
+    fs.writeFileSync(
+      claudeAgentSdkPackageJsonPath,
+      `${JSON.stringify(claudeAgentSdkPackageJson, null, 2)}\n`,
+    );
 
-  const linkType = process.platform === 'win32' ? 'junction' : 'dir';
-  const linkTarget = linkType === 'junction' ? sdkDir : path.relative(linkDir, sdkDir);
+    fs.mkdirSync(linkDir, { recursive: true });
 
-  fs.symlinkSync(linkTarget, linkPath, linkType);
-};
+    if (fs.existsSync(linkPath)) {
+      return;
+    }
+
+    const linkType = process.platform === 'win32' ? 'junction' : 'dir';
+    const linkTarget = linkType === 'junction' ? sdkDir : path.relative(linkDir, sdkDir);
+
+    fs.symlinkSync(linkTarget, linkPath, linkType);
+  };
+}
+
+exports.createBeforePack = createBeforePack;
+exports.default = createBeforePack();

--- a/apps/desktop/tests/main/packaging-scripts.test.ts
+++ b/apps/desktop/tests/main/packaging-scripts.test.ts
@@ -1,0 +1,85 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+const { buildMcpCli } =
+  require('../../scripts/build-mcp-cli.cjs') as typeof import('../../scripts/build-mcp-cli.cjs');
+const { createBeforePack } =
+  require('../../scripts/electron-builder-before-pack.cjs') as typeof import('../../scripts/electron-builder-before-pack.cjs');
+
+describe('desktop packaging scripts', () => {
+  it('builds the packaged MCP command into electron-builder extraResources', () => {
+    const calls: unknown[][] = [];
+    const mkdirCalls: unknown[][] = [];
+
+    buildMcpCli({
+      appDir: '/repo/apps/desktop',
+      workspaceRoot: '/repo',
+      platform: 'darwin',
+      mkdirSync: (...args: unknown[]) => {
+        mkdirCalls.push(args);
+      },
+      spawnSync: (...args: unknown[]) => {
+        calls.push(args);
+        return { status: 0 };
+      },
+    });
+
+    expect(mkdirCalls).toEqual([['/repo/apps/desktop/build/bin', { recursive: true }]]);
+    expect(calls).toEqual([
+      [
+        'bun',
+        [
+          'build',
+          '--compile',
+          '--outfile',
+          '/repo/apps/desktop/build/bin/contexture-mcp',
+          '/repo/packages/cli/src/mcp.ts',
+        ],
+        { cwd: '/repo', stdio: 'inherit' },
+      ],
+    ]);
+  });
+
+  it('runs the MCP build during electron-builder beforePack', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'contexture-before-pack-'));
+    const appDir = join(root, 'apps', 'desktop');
+    const claudeAgentSdkDir = join(appDir, 'node_modules', '@anthropic-ai', 'claude-agent-sdk');
+    const sdkDir = join(appDir, 'node_modules', '@anthropic-ai', 'sdk');
+    const claudeAgentSdkPackageJsonPath = join(claudeAgentSdkDir, 'package.json');
+
+    await mkdir(claudeAgentSdkDir, { recursive: true });
+    await mkdir(sdkDir, { recursive: true });
+    await writeFile(join(root, 'package.json'), JSON.stringify({ workspaces: ['apps/*'] }));
+    await writeFile(
+      claudeAgentSdkPackageJsonPath,
+      JSON.stringify({
+        name: '@anthropic-ai/claude-agent-sdk',
+        dependencies: { '@anthropic-ai/sdk': '^0.95.0' },
+      }),
+    );
+    await writeFile(
+      join(sdkDir, 'package.json'),
+      JSON.stringify({ name: '@anthropic-ai/sdk', version: '0.95.1', main: 'index.js' }),
+    );
+    await writeFile(join(sdkDir, 'index.js'), '');
+
+    let built = false;
+    const beforePack = createBeforePack({
+      buildMcpCli: () => {
+        built = true;
+      },
+    });
+
+    await beforePack({ packager: { projectDir: appDir } });
+
+    expect(built).toBe(true);
+    await expect(readFile(claudeAgentSdkPackageJsonPath, 'utf8')).resolves.toContain(
+      '"@anthropic-ai/sdk": "0.95.1"',
+    );
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.13",
+      "version": "0.15.14",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",


### PR DESCRIPTION
## Summary
- bump @contexture/desktop to 0.15.14
- build the standalone contexture-mcp binary from electron-builder beforePack so release packaging includes Resources/bin/contexture-mcp
- keep local desktop package scripts on the same packaging path and add regression coverage for the packaging scripts

## Verification
- bun run test -- tests/main/packaging-scripts.test.ts
- bun run typecheck
- bunx biome check bun.lock apps/desktop/package.json apps/desktop/scripts/build-mcp-cli.cjs apps/desktop/scripts/electron-builder-before-pack.cjs apps/desktop/tests/main/packaging-scripts.test.ts
- bun run build:mcp-cli
- MCP stdio smoke against ./build/bin/contexture-mcp
- commit hook: turbo typecheck && turbo test