### PR TITLE
feat(desktop): edit field optionality in properties

### DIFF
--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -103,7 +103,7 @@ function DescriptionField({ type, dispatch }: TypeDetailProps) {
 
 function ObjectBody({
   type,
-  dispatch: _dispatch,
+  dispatch,
 }: {
   type: Extract<TypeDef, { kind: 'object' }>;
   dispatch: (op: Op) => void;
@@ -121,6 +121,7 @@ function ObjectBody({
         <TableHeader>
           <TableRow className="hover:bg-transparent">
             <TableHead className="h-7 px-2">Name</TableHead>
+            <TableHead className="h-7 w-20 px-2 text-center">Optional</TableHead>
             <TableHead className="h-7 px-2 text-right">Type</TableHead>
           </TableRow>
         </TableHeader>
@@ -137,7 +138,23 @@ function ObjectBody({
               >
                 <TableCell className="px-2 py-1.5 font-medium">
                   {f.name}
-                  {f.optional ? '?' : ''}
+                  <span aria-hidden="true" className="inline-block w-[1ch] text-muted-foreground">
+                    {f.optional ? '?' : ''}
+                  </span>
+                </TableCell>
+                <TableCell className="px-2 py-1.5 text-center">
+                  <Checkbox
+                    aria-label={`${f.name} optional`}
+                    checked={f.optional === true}
+                    onCheckedChange={(v) =>
+                      dispatch({
+                        kind: 'update_field',
+                        typeName: type.name,
+                        fieldName: f.name,
+                        patch: { optional: v === true },
+                      })
+                    }
+                  />
                 </TableCell>
                 <TableCell className="px-2 py-1.5 text-right text-muted-foreground">
                   {summariseKind(f.type.kind)}

--- a/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border-2 border-foreground/45 bg-background ring-offset-background transition-colors hover:border-foreground/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border-2 border-foreground/50 bg-background ring-offset-background transition-colors hover:border-foreground/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-foreground/75 dark:hover:border-foreground/95 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
       className,
     )}
     {...props}

--- a/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border-2 border-foreground/50 bg-background ring-offset-background transition-colors hover:border-foreground/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-foreground/75 dark:hover:border-foreground/95 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border-2 border-muted-foreground/80 bg-card ring-offset-background transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-muted-foreground dark:bg-foreground/10 dark:hover:border-foreground data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
       className,
     )}
     {...props}

--- a/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border-2 border-muted-foreground/80 bg-card ring-offset-background transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-muted-foreground dark:bg-foreground/10 dark:hover:border-foreground data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border-2 border-muted-foreground/80 bg-card ring-offset-background transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/55 dark:bg-foreground/10 dark:ring-1 dark:ring-white/15 dark:hover:border-white/85 dark:hover:ring-white/25 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
       className,
     )}
     {...props}

--- a/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border-2 border-foreground/45 bg-background ring-offset-background transition-colors hover:border-foreground/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
       className,
     )}
     {...props}

--- a/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border-2 border-muted-foreground/80 bg-card ring-offset-background transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/55 dark:bg-foreground/10 dark:ring-1 dark:ring-white/15 dark:hover:border-white/85 dark:hover:ring-white/25 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border-2 border-muted-foreground/80 bg-card ring-offset-background transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/80 dark:bg-foreground/10 dark:ring-1 dark:ring-white/30 dark:hover:border-white dark:hover:ring-white/45 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
       className,
     )}
     {...props}

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -37,6 +37,23 @@ describe('TypeDetail', () => {
       expect(rows[1]).toHaveTextContent('area?');
     });
 
+    it('renders field optionality as editable checkboxes', () => {
+      setup(type);
+      expect(screen.getByLabelText('name optional')).not.toBeChecked();
+      expect(screen.getByLabelText('area optional')).toBeChecked();
+    });
+
+    it('dispatches update_field when field optionality toggles', () => {
+      const { dispatch } = setup(type);
+      fireEvent.click(screen.getByLabelText('name optional'));
+      expect(dispatch).toHaveBeenCalledWith({
+        kind: 'update_field',
+        typeName: 'Plot',
+        fieldName: 'name',
+        patch: { optional: true },
+      });
+    });
+
     it('dispatches rename_type when the name input blurs with a new value', () => {
       const { dispatch } = setup(type);
       const input = screen.getByLabelText('Name') as HTMLInputElement;


### PR DESCRIPTION
## Summary
- add an Optional checkbox column to the object fields properties table
- keep the optional marker layout stable when toggling required/optional
- cover optionality display and update dispatch in TypeDetail tests

## Tests
- bun run test -- tests/components/detail/TypeDetail.test.tsx
- commit hook: turbo typecheck
- commit hook: turbo test