### PR TITLE
feat(desktop): infer table id diagram edges

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.14",
+  "version": "0.15.15",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/components/detail/EdgeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/EdgeDetail.tsx
@@ -1,9 +1,10 @@
 /**
  * EdgeDetail — read-only graph-edge metadata for a selected edge.
  *
- * Edges are purely derived from the IR — field refs come from object
- * fields, and union-variant edges come from discriminated-union
- * `variants`. There is no edge entity to mutate directly.
+ * Edges are derived from the IR — field refs come from object fields,
+ * inferred table-id edges come from a diagram-only field convention, and
+ * union-variant edges come from discriminated-union `variants`. There is
+ * no edge entity to mutate directly.
  */
 import type { RefEdgeData } from '../graph/schema-to-graph';
 
@@ -14,13 +15,18 @@ export interface EdgeDetailProps {
 
 export function EdgeDetail({ data, onEditField }: EdgeDetailProps) {
   const isUnionVariant = data.relation === 'unionVariant';
+  const isTableId = data.relation === 'tableId';
   const editableSourceField = isUnionVariant ? undefined : data.sourceField;
 
   return (
     <div className="space-y-2 p-3 text-xs">
       <div className="flex items-center justify-between">
         <span className="text-sm font-semibold">
-          {isUnionVariant ? 'Union variant edge' : 'Ref edge'}
+          {isUnionVariant
+            ? 'Union variant edge'
+            : isTableId
+              ? 'Inferred table id edge'
+              : 'Ref edge'}
         </span>
         {data.crossBoundary && (
           <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">

--- a/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
@@ -6,9 +6,9 @@
  * the canvas uses so new users can decode the diagram at a glance.
  *
  * Matches the four `TypeDef` kinds (object / enum / discriminatedUnion
- * / raw) and the edge modes (field ref, union variant, cross-boundary
- * import). Colours are pulled from `globals.css` so theme changes flow
- * through without edits here.
+ * / raw) and the edge modes (field ref, inferred table id, union variant,
+ * cross-boundary import). Colours are pulled from `globals.css` so theme
+ * changes flow through without edits here.
  */
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -23,6 +23,11 @@ const EDGE_ITEMS: readonly EdgeItem[] = [
   {
     label: 'Ref',
     color: 'var(--graph-edge-ref)',
+  },
+  {
+    label: 'Inferred table id',
+    color: 'var(--graph-edge-ref)',
+    dash: '6,4',
   },
   {
     label: 'Union variant',

--- a/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
@@ -5,6 +5,8 @@
  *
  * Styling:
  *   - Field refs use the property accent and label the source field.
+ *   - Inferred table id relationships are dashed because they are a
+ *     diagram-only convention, not an IR ref.
  *   - Union variants use the discriminated-union accent and a dotted
  *     stroke so inheritance-like membership does not read as a field.
  *   - Cross-boundary refs are dashed and muted so imported namespaces read
@@ -50,6 +52,7 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
 
   const crossBoundary = data?.crossBoundary === true;
   const isUnionVariant = data?.relation === 'unionVariant';
+  const isTableId = data?.relation === 'tableId';
   const isAdjacent = adjacentEdgeIds.has(id);
   // Dim edges that touch neither the selected node nor an adjacent one.
   const isDimmed =
@@ -67,7 +70,7 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
           ? 'var(--graph-edge-import, var(--muted-foreground))'
           : 'var(--graph-edge-ref, var(--graph-edge-property))';
   const strokeWidth = selected || isAdjacent ? 2 : 1.25;
-  const strokeDasharray = isUnionVariant ? '2 4' : crossBoundary ? '6 4' : undefined;
+  const strokeDasharray = isUnionVariant ? '2 4' : isTableId || crossBoundary ? '6 4' : undefined;
   const label = isUnionVariant ? 'variant' : data?.sourceField;
 
   return (

--- a/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
+++ b/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
@@ -10,6 +10,10 @@
  * Edge policy:
  *   - `object` TypeDefs contribute field-ref edges — their `ref` fields
  *     and `ref`-typed array elements point at target types.
+ *   - Convex table id fields may contribute diagram-only inferred edges:
+ *     non-ref fields ending in `Id` whose description mentions another
+ *     local table render as dashed relationships without changing IR
+ *     semantics.
  *   - `discriminatedUnion` TypeDefs contribute variant edges to each
  *     object type listed in `variants`.
  *   - Qualified refs (`alias.Name`) always point at the imported
@@ -25,6 +29,8 @@
 
 import type { FieldDef, FieldType, Schema, TypeDef } from '@contexture/core/ir';
 import type { Edge, Node } from '@xyflow/react';
+
+type TableTypeDef = Extract<TypeDef, { kind: 'object' }> & { table: true };
 
 export interface TypeNodeData extends Record<string, unknown> {
   /** Fully-qualified type name (local or `<alias>.<Name>`). */
@@ -56,7 +62,7 @@ export interface FieldRow {
 }
 
 export interface RefEdgeData extends Record<string, unknown> {
-  relation: 'fieldRef' | 'unionVariant';
+  relation: 'fieldRef' | 'tableId' | 'unionVariant';
   sourceType: string;
   sourceField?: string;
   targetType: string;
@@ -79,6 +85,7 @@ const DEFAULT_POSITION = { x: 0, y: 0 };
 
 export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphResult {
   const localNames = new Set(schema.types.map((t) => t.name));
+  const tableTypes = schema.types.filter(isTableType);
 
   const nodes: Node<TypeNodeData>[] = schema.types.map((t) =>
     localNodeFor(t, positions?.[t.name] ?? DEFAULT_POSITION),
@@ -124,21 +131,39 @@ export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphRe
     if (type.kind !== 'object') continue;
     for (const field of type.fields) {
       const target = unwrapRefTarget(field.type);
-      if (!target) continue;
+      if (target) {
+        const crossBoundary = ensureExternalNode(target);
 
-      const crossBoundary = ensureExternalNode(target);
+        edges.push({
+          id: `${type.name}.${field.name}->${target}`,
+          source: type.name,
+          target,
+          type: 'ref',
+          data: {
+            relation: 'fieldRef',
+            sourceType: type.name,
+            sourceField: field.name,
+            targetType: target,
+            crossBoundary,
+          },
+        });
+        continue;
+      }
+
+      const inferredTarget = inferTableIdTarget(type, field, tableTypes);
+      if (!inferredTarget) continue;
 
       edges.push({
-        id: `${type.name}.${field.name}->${target}`,
+        id: `${type.name}.${field.name}~>${inferredTarget.name}`,
         source: type.name,
-        target,
+        target: inferredTarget.name,
         type: 'ref',
         data: {
-          relation: 'fieldRef',
+          relation: 'tableId',
           sourceType: type.name,
           sourceField: field.name,
-          targetType: target,
-          crossBoundary,
+          targetType: inferredTarget.name,
+          crossBoundary: false,
         },
       });
     }
@@ -186,6 +211,33 @@ function unwrapRefTarget(t: FieldType): string | undefined {
   let cur: FieldType = t;
   while (cur.kind === 'array') cur = cur.element;
   return cur.kind === 'ref' ? cur.typeName : undefined;
+}
+
+function inferTableIdTarget(
+  sourceType: TypeDef,
+  field: FieldDef,
+  tableTypes: ReadonlyArray<TableTypeDef>,
+): TableTypeDef | undefined {
+  if (sourceType.kind !== 'object' || sourceType.table !== true) return undefined;
+  if (!field.name.endsWith('Id') || !field.description) return undefined;
+  if (unwrapRefTarget(field.type)) return undefined;
+
+  const description = field.description.toLowerCase();
+  return tableTypes.find((candidate) => {
+    if (candidate.name === sourceType.name) return false;
+    return [candidate.name, candidate.tableName]
+      .filter((name): name is string => name !== undefined)
+      .some((name) => mentionsName(description, name));
+  });
+}
+
+function isTableType(type: TypeDef): type is TableTypeDef {
+  return type.kind === 'object' && type.table === true;
+}
+
+function mentionsName(description: string, name: string): boolean {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').toLowerCase();
+  return new RegExp(`(^|[^a-z0-9])${escapedName}([^a-z0-9]|$)`).test(description);
 }
 
 function enumValueRow(value: { value: string; description?: string }): EnumValueRow {

--- a/apps/desktop/tests/components/detail/EdgeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/EdgeDetail.test.tsx
@@ -50,6 +50,21 @@ describe('EdgeDetail', () => {
     expect(onEditField).toHaveBeenCalledWith('Plot', 'harvest');
   });
 
+  it('renders inferred table id edges as field-backed diagram relationships', () => {
+    const data: RefEdgeData = {
+      relation: 'tableId',
+      sourceType: 'Member',
+      sourceField: 'teamId',
+      targetType: 'Team',
+      crossBoundary: false,
+    };
+    const onEditField = vi.fn();
+    render(<EdgeDetail data={data} onEditField={onEditField} />);
+    expect(screen.getByText('Inferred table id edge')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Edit field'));
+    expect(onEditField).toHaveBeenCalledWith('Member', 'teamId');
+  });
+
   it('renders union variant edges without field-edit affordances', () => {
     const data: RefEdgeData = {
       relation: 'unionVariant',

--- a/apps/desktop/tests/graph/schema-to-graph.test.ts
+++ b/apps/desktop/tests/graph/schema-to-graph.test.ts
@@ -164,6 +164,106 @@ describe('buildGraph', () => {
     expect(edges).toEqual([expect.objectContaining({ source: 'Plot', target: 'Harvest' })]);
   });
 
+  it('emits a diagram-only edge for table Id fields whose description names a table', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Team', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Member',
+          table: true,
+          fields: [
+            {
+              name: 'teamId',
+              description: 'Convex Id of the Team table.',
+              type: { kind: 'string' },
+            },
+          ],
+        },
+      ],
+    };
+
+    const { nodes, edges } = buildGraph({ schema });
+
+    expect(nodes.map((n) => n.id)).toEqual(['Team', 'Member']);
+    expect(edges).toEqual([
+      expect.objectContaining({
+        id: 'Member.teamId~>Team',
+        source: 'Member',
+        target: 'Team',
+        type: 'ref',
+        data: expect.objectContaining({
+          relation: 'tableId',
+          sourceField: 'teamId',
+          targetType: 'Team',
+          crossBoundary: false,
+        }),
+      }),
+    ]);
+  });
+
+  it('uses tableName aliases when inferring diagram-only table Id edges', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Team', table: true, tableName: 'teams', fields: [] },
+        {
+          kind: 'object',
+          name: 'Member',
+          table: true,
+          fields: [
+            {
+              name: 'teamId',
+              description: 'References a document in the teams table.',
+              type: { kind: 'string' },
+            },
+          ],
+        },
+      ],
+    };
+
+    const { edges } = buildGraph({ schema });
+
+    expect(edges).toEqual([expect.objectContaining({ source: 'Member', target: 'Team' })]);
+  });
+
+  it('does not infer table Id edges for non-table objects or fields without table descriptions', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Team', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'DraftMember',
+          fields: [
+            {
+              name: 'teamId',
+              description: 'Convex Id of the Team table.',
+              type: { kind: 'string' },
+            },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'Member',
+          table: true,
+          fields: [
+            {
+              name: 'teamId',
+              description: 'Persisted owner identifier.',
+              type: { kind: 'string' },
+            },
+          ],
+        },
+      ],
+    };
+
+    const { edges } = buildGraph({ schema });
+
+    expect(edges).toEqual([]);
+  });
+
   it('emits variant edges from discriminated unions to their object variants', () => {
     const schema: Schema = {
       version: '1',

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.14",
+      "version": "0.15.15",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",


### PR DESCRIPTION
## Summary
- infer dashed diagram-only edges for Convex table Id fields whose descriptions name another table
- surface inferred table id relationships in the legend and edge detail panel
- bump @contexture/desktop to 0.15.15

## Tests
- bun run test -- tests/graph/schema-to-graph.test.ts
- bun run test -- tests/components/detail/EdgeDetail.test.tsx
- bun run typecheck:web
- bun run lint
- pre-commit: turbo typecheck && turbo test