### PR TITLE
Add entity pressure modeling hints and ordered Convex index fields

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.15",
+  "version": "0.15.16",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
@@ -15,7 +15,8 @@
  * concern. Splitting them like this keeps the panel test-only on the
  * selection prop surface.
  */
-import { useSyncExternalStore } from 'react';
+import { analyzeModelingHints } from '@contexture/core/modeling-hints';
+import { useMemo, useSyncExternalStore } from 'react';
 import type { Op } from '../../store/ops';
 import { useUndoStore } from '../../store/undo';
 import type { RefEdgeData } from '../graph/schema-to-graph';
@@ -35,6 +36,7 @@ export interface DetailPanelProps {
 
 export function DetailPanel({ selection }: DetailPanelProps) {
   const schema = useSyncExternalStore(useUndoStore.subscribe, () => useUndoStore.getState().schema);
+  const modelingHints = useMemo(() => analyzeModelingHints(schema), [schema]);
   const dispatch = (op: Op) => {
     useUndoStore.getState().apply(op);
   };
@@ -60,10 +62,25 @@ export function DetailPanel({ selection }: DetailPanelProps) {
     if (!field) {
       return <EmptyState message={`No field named "${selection.fieldName}".`} />;
     }
-    return <FieldDetail typeName={type.name} field={field} dispatch={dispatch} />;
+    return (
+      <FieldDetail
+        typeName={type.name}
+        field={field}
+        dispatch={dispatch}
+        modelingHints={modelingHints.filter(
+          (hint) => hint.typeName === type.name && hint.fieldName === field.name,
+        )}
+      />
+    );
   }
 
-  return <TypeDetail type={type} dispatch={dispatch} />;
+  return (
+    <TypeDetail
+      type={type}
+      dispatch={dispatch}
+      modelingHints={modelingHints.filter((hint) => hint.typeName === type.name)}
+    />
+  );
 }
 
 function EmptyState({ message }: { message: string }) {

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -11,18 +11,21 @@
  * nothing here mutates the store directly.
  */
 import type { FieldDef, FieldType } from '@contexture/core/ir';
+import type { ModelingHint } from '@contexture/core/modeling-hints';
 import type { Op } from '../../store/ops';
 import { Checkbox } from '../ui/checkbox';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
+import { ModelShapeHints } from './ModelShapeHints';
 
 export interface FieldDetailProps {
   typeName: string;
   field: FieldDef;
   dispatch: (op: Op) => void;
+  modelingHints?: readonly ModelingHint[];
 }
 
-export function FieldDetail({ typeName, field, dispatch }: FieldDetailProps) {
+export function FieldDetail({ typeName, field, dispatch, modelingHints = [] }: FieldDetailProps) {
   const update = (patch: Partial<FieldDef>) =>
     dispatch({ kind: 'update_field', typeName, fieldName: field.name, patch });
 
@@ -53,6 +56,7 @@ export function FieldDetail({ typeName, field, dispatch }: FieldDetailProps) {
       </div>
 
       <FieldTypeBody fieldType={field.type} onChange={(nextType) => update({ type: nextType })} />
+      <ModelShapeHints hints={modelingHints} />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/detail/ModelShapeHints.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/ModelShapeHints.tsx
@@ -1,0 +1,133 @@
+import type { ModelingHint } from '@contexture/core/modeling-hints';
+import { Lightbulb } from 'lucide-react';
+import type { CSSProperties } from 'react';
+import { Badge } from '../ui/badge';
+
+interface ModelShapeHintsProps {
+  hints: readonly ModelingHint[];
+}
+
+export function ModelShapeHints({ hints }: ModelShapeHintsProps) {
+  if (hints.length === 0) return null;
+
+  const [primary, ...secondary] = [...hints].sort(compareHints);
+  if (!primary) return null;
+
+  return (
+    <section
+      aria-label="Model shape"
+      className="space-y-2 rounded border border-border/70 bg-muted/20 p-3 text-xs"
+    >
+      <div className="flex items-start gap-2">
+        <Lightbulb aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 text-primary" />
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center justify-between gap-2">
+            <h3 className="text-xs font-semibold text-foreground">Model shape</h3>
+            <span className="text-[10px] text-muted-foreground">Advisory</span>
+          </div>
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            Embed for ownership. Extract for identity.
+          </p>
+        </div>
+      </div>
+
+      <HintBody hint={primary} />
+
+      {secondary.length > 0 && (
+        <details className="group">
+          <summary className="cursor-pointer text-[11px] font-medium text-muted-foreground">
+            {secondary.length} more {secondary.length === 1 ? 'signal' : 'signals'}
+          </summary>
+          <div className="mt-2 space-y-2">
+            {secondary.map((hint) => (
+              <HintBody key={hint.id} hint={hint} compact />
+            ))}
+          </div>
+        </details>
+      )}
+    </section>
+  );
+}
+
+function HintBody({ hint, compact = false }: { hint: ModelingHint; compact?: boolean }) {
+  const tone = toneForHint(hint.kind);
+  return (
+    <div className={compact ? 'space-y-1 border-t border-border/70 pt-2' : 'space-y-2'}>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Badge
+          variant="outline"
+          className="rounded px-1.5 py-0 text-[10px] font-medium"
+          style={tone}
+        >
+          {hint.title}
+        </Badge>
+        {hint.fieldNames.map((fieldName) => (
+          <Badge
+            key={fieldName}
+            variant="outline"
+            className="rounded px-1.5 py-0 text-[10px] font-medium"
+            style={fieldBadgeStyle}
+          >
+            {fieldName}
+          </Badge>
+        ))}
+      </div>
+      <p className="leading-snug text-muted-foreground">{hint.message}</p>
+      {!compact && (
+        <p className="text-[11px] leading-snug text-muted-foreground">{hint.rationale}</p>
+      )}
+    </div>
+  );
+}
+
+const fieldBadgeStyle: CSSProperties = {
+  background: 'color-mix(in oklch, var(--graph-edge-ref) 14%, transparent)',
+  borderColor: 'color-mix(in oklch, var(--graph-edge-ref) 42%, transparent)',
+  color: 'var(--characteristic-badge-text)',
+};
+
+function toneForHint(kind: ModelingHint['kind']): CSSProperties {
+  switch (kind) {
+    case 'possible_entity':
+      return {
+        background: 'color-mix(in oklch, var(--primary) 16%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--primary) 46%, transparent)',
+        color: 'var(--primary)',
+      };
+    case 'query_handle':
+      return {
+        background: 'color-mix(in oklch, var(--graph-node-selected) 14%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--graph-node-selected) 55%, var(--foreground))',
+        color: 'color-mix(in oklch, var(--graph-node-selected) 52%, var(--foreground))',
+      };
+    case 'embedded_collection':
+      return {
+        background: 'color-mix(in oklch, var(--graph-edge-union) 14%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--graph-edge-union) 46%, transparent)',
+        color: 'var(--graph-edge-union)',
+      };
+    case 'owned_value_object':
+      return {
+        background: 'color-mix(in oklch, var(--success) 13%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--success) 40%, transparent)',
+        color: 'var(--success)',
+      };
+  }
+}
+
+function compareHints(a: ModelingHint, b: ModelingHint): number {
+  return hintRank(a) - hintRank(b) || a.id.localeCompare(b.id);
+}
+
+function hintRank(hint: ModelingHint): number {
+  switch (hint.kind) {
+    case 'possible_entity':
+      return 0;
+    case 'query_handle':
+      return 1;
+    case 'embedded_collection':
+      return 2;
+    case 'owned_value_object':
+      return 3;
+  }
+}

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -13,15 +13,26 @@
  * `blur` (not `change`) to avoid a history entry per keystroke.
  */
 import type { IndexDef, TypeDef } from '@contexture/core/ir';
-import { Plus, Trash2 } from 'lucide-react';
-import { useId } from 'react';
+import type { ModelingHint } from '@contexture/core/modeling-hints';
+import { ChevronLeft, ChevronRight, Plus, Trash2, X } from 'lucide-react';
+import { useId, useState } from 'react';
 import type { Op } from '../../store/ops';
 import { Button } from '../ui/button';
 import { Checkbox } from '../ui/checkbox';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '../ui/command';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import { Textarea } from '../ui/textarea';
+import { ModelShapeHints } from './ModelShapeHints';
 
 const CONVEX_RESERVED_PREFIX_MSG = "Convex reserves names starting with '_'";
 
@@ -33,9 +44,10 @@ export interface TypeDetailProps {
   type: TypeDef;
   /** Dispatch an op. In production this is `useUndoStore.getState().apply`. */
   dispatch: (op: Op) => void;
+  modelingHints?: readonly ModelingHint[];
 }
 
-export function TypeDetail({ type, dispatch }: TypeDetailProps) {
+export function TypeDetail({ type, dispatch, modelingHints = [] }: TypeDetailProps) {
   const isTable = type.kind === 'object' && type.table === true;
   const nameReserved = isTable && isConvexReservedName(type.name);
 
@@ -48,6 +60,7 @@ export function TypeDetail({ type, dispatch }: TypeDetailProps) {
 
       <NameField type={type} dispatch={dispatch} reserved={nameReserved} />
       <DescriptionField type={type} dispatch={dispatch} />
+      <ModelShapeHints hints={modelingHints} />
 
       {type.kind === 'object' && <ObjectBody type={type} dispatch={dispatch} />}
       {type.kind === 'object' && <ConvexSection type={type} dispatch={dispatch} />}
@@ -225,28 +238,33 @@ function ConvexSection({
           {indexes.length === 0 ? (
             <p className="text-xs text-muted-foreground">No indexes yet.</p>
           ) : (
-            <Table className="text-xs">
-              <TableHeader>
-                <TableRow className="hover:bg-transparent">
-                  <TableHead className="h-7 px-2">Index</TableHead>
-                  <TableHead className="h-7 px-2">Fields</TableHead>
-                  <TableHead className="h-7 w-9 px-1 text-right">
-                    <span className="sr-only">Actions</span>
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {indexes.map((idx) => (
-                  <IndexRow
-                    key={idx.name}
-                    typeName={type.name}
-                    index={idx}
-                    fieldNames={fieldNames}
-                    dispatch={dispatch}
-                  />
-                ))}
-              </TableBody>
-            </Table>
+            <div className="space-y-1.5">
+              <p className="text-[11px] text-muted-foreground">
+                Field order affects Convex query prefixes.
+              </p>
+              <Table className="text-xs">
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead className="h-7 px-2">Index</TableHead>
+                    <TableHead className="h-7 px-2">Fields</TableHead>
+                    <TableHead className="h-7 w-9 px-1 text-right">
+                      <span className="sr-only">Actions</span>
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {indexes.map((idx) => (
+                    <IndexRow
+                      key={idx.name}
+                      typeName={type.name}
+                      index={idx}
+                      fieldNames={fieldNames}
+                      dispatch={dispatch}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           )}
         </div>
       )}
@@ -265,8 +283,34 @@ function IndexRow({
   fieldNames: string[];
   dispatch: (op: Op) => void;
 }) {
-  const fieldGroupId = useStableDomId('index-fields');
-  const fieldRequirementId = `${fieldGroupId}-requirement`;
+  const availableFieldNames = fieldNames.filter((fieldName) => !index.fields.includes(fieldName));
+
+  const updateFields = (fields: string[]) => {
+    dispatch({
+      kind: 'update_index',
+      typeName,
+      name: index.name,
+      patch: { fields },
+    });
+  };
+
+  const appendField = (fieldName: string) => {
+    updateFields([...index.fields, fieldName]);
+  };
+
+  const removeField = (fieldName: string) => {
+    if (index.fields.length <= 1) return;
+    updateFields(index.fields.filter((field) => field !== fieldName));
+  };
+
+  const moveField = (fromIndex: number, toIndex: number) => {
+    if (toIndex < 0 || toIndex >= index.fields.length) return;
+    const nextFields = [...index.fields];
+    const [field] = nextFields.splice(fromIndex, 1);
+    if (!field) return;
+    nextFields.splice(toIndex, 0, field);
+    updateFields(nextFields);
+  };
 
   return (
     <TableRow data-testid="convex-index-row">
@@ -289,47 +333,25 @@ function IndexRow({
         />
       </TableCell>
       <TableCell className="px-2 py-1.5 align-top">
-        <fieldset aria-describedby={fieldRequirementId} className="flex flex-wrap gap-1.5">
-          <legend className="sr-only">Fields for index {index.name}</legend>
-          {fieldNames.map((fname) => {
-            const checked = index.fields.includes(fname);
-            const locked = checked && index.fields.length === 1;
-            const checkboxId = `${fieldGroupId}-${slugForDomId(fname)}`;
-
-            return (
-              <Label
-                key={fname}
-                htmlFor={checkboxId}
-                data-checked={checked || undefined}
-                className="flex min-h-7 items-center gap-1.5 rounded-md border border-border/60 bg-background px-2 text-xs text-muted-foreground transition-colors data-[checked=true]:border-primary/40 data-[checked=true]:bg-primary/10 data-[checked=true]:text-foreground"
-              >
-                <Checkbox
-                  id={checkboxId}
-                  aria-label={`${index.name}: ${fname}`}
-                  aria-describedby={locked ? fieldRequirementId : undefined}
-                  checked={checked}
-                  disabled={locked}
-                  onCheckedChange={(v) => {
-                    const want = v === true;
-                    const nextFields = want
-                      ? [...index.fields, fname]
-                      : index.fields.filter((f) => f !== fname);
-                    dispatch({
-                      kind: 'update_index',
-                      typeName,
-                      name: index.name,
-                      patch: { fields: nextFields },
-                    });
-                  }}
-                />
-                <span className="max-w-24 truncate">{fname}</span>
-              </Label>
-            );
-          })}
-        </fieldset>
-        <p id={fieldRequirementId} className="mt-1 text-[11px] text-muted-foreground">
-          Indexes need at least one field.
-        </p>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {index.fields.map((fieldName, fieldIndex) => (
+            <IndexFieldChip
+              key={fieldName}
+              indexName={index.name}
+              fieldName={fieldName}
+              position={fieldIndex}
+              total={index.fields.length}
+              onMoveEarlier={() => moveField(fieldIndex, fieldIndex - 1)}
+              onMoveLater={() => moveField(fieldIndex, fieldIndex + 1)}
+              onRemove={() => removeField(fieldName)}
+            />
+          ))}
+          <IndexFieldPicker
+            indexName={index.name}
+            availableFieldNames={availableFieldNames}
+            onSelect={appendField}
+          />
+        </div>
       </TableCell>
       <TableCell className="w-9 px-1 py-1.5 text-right align-top">
         <Button
@@ -347,12 +369,132 @@ function IndexRow({
   );
 }
 
-function useStableDomId(prefix: string): string {
-  return `${prefix}-${useId().replace(/:/g, '')}`;
+function IndexFieldChip({
+  indexName,
+  fieldName,
+  position,
+  total,
+  onMoveEarlier,
+  onMoveLater,
+  onRemove,
+}: {
+  indexName: string;
+  fieldName: string;
+  position: number;
+  total: number;
+  onMoveEarlier: () => void;
+  onMoveLater: () => void;
+  onRemove: () => void;
+}) {
+  const displayPosition = position + 1;
+  const onlyField = total === 1;
+
+  return (
+    <span className="inline-flex min-h-7 max-w-full items-center gap-1 rounded-md border border-primary/35 bg-primary/10 px-1.5 text-xs text-foreground">
+      <span className="sr-only">
+        {fieldName}, field {displayPosition} of {total} in index {indexName}
+      </span>
+      <span className="rounded bg-primary/15 px-1 font-mono text-[10px] text-primary">
+        {displayPosition}
+      </span>
+      <span className="max-w-32 truncate font-medium">{fieldName}</span>
+      <span className="ml-0.5 flex items-center gap-0.5">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={`Move ${fieldName} earlier in index ${indexName}`}
+          disabled={position === 0}
+          onClick={onMoveEarlier}
+          className="h-5 w-5 text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft aria-hidden="true" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={`Move ${fieldName} later in index ${indexName}`}
+          disabled={position === total - 1}
+          onClick={onMoveLater}
+          className="h-5 w-5 text-muted-foreground hover:text-foreground"
+        >
+          <ChevronRight aria-hidden="true" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={`Remove ${fieldName} from index ${indexName}`}
+          disabled={onlyField}
+          title={onlyField ? 'Indexes need at least one field.' : undefined}
+          onClick={onRemove}
+          className="h-5 w-5 text-muted-foreground hover:text-destructive"
+        >
+          <X aria-hidden="true" />
+        </Button>
+      </span>
+    </span>
+  );
 }
 
-function slugForDomId(value: string): string {
-  return value.replace(/[^a-zA-Z0-9_-]/g, '-');
+function IndexFieldPicker({
+  indexName,
+  availableFieldNames,
+  onSelect,
+}: {
+  indexName: string;
+  availableFieldNames: string[];
+  onSelect: (fieldName: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const triggerId = useStableDomId('add-index-field');
+  const hasAvailableFields = availableFieldNames.length > 0;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={triggerId}
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!hasAvailableFields}
+          className="h-7 px-2 text-xs"
+          aria-label={`Add field to index ${indexName}`}
+        >
+          <Plus aria-hidden="true" />
+          Add field
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64 p-0">
+        <Command>
+          <CommandInput placeholder="Find a field..." />
+          <CommandList>
+            <CommandEmpty>No fields available.</CommandEmpty>
+            <CommandGroup>
+              {availableFieldNames.map((fieldName) => (
+                <CommandItem
+                  key={fieldName}
+                  value={fieldName}
+                  onSelect={() => {
+                    onSelect(fieldName);
+                    setOpen(false);
+                  }}
+                >
+                  {fieldName}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function useStableDomId(prefix: string): string {
+  return `${prefix}-${useId().replace(/:/g, '')}`;
 }
 
 function nextIndexName(existing: IndexDef[]): string {

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -30,6 +30,36 @@ const plotSchema: Schema = {
   ],
 };
 
+const artworkSchema: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Artwork',
+      table: true,
+      fields: [
+        {
+          name: 'sourceSearchText',
+          description: 'Denormalized lowercase search text.',
+          type: { kind: 'string' },
+        },
+        {
+          name: 'media',
+          type: { kind: 'array', element: { kind: 'ref', typeName: 'ArtworkMedia' } },
+        },
+      ],
+    },
+    {
+      kind: 'object',
+      name: 'ArtworkMedia',
+      fields: [
+        { name: 'storageId', type: { kind: 'string' } },
+        { name: 'alt', type: { kind: 'string' } },
+      ],
+    },
+  ],
+};
+
 describe('DetailPanel', () => {
   beforeEach(() => seed({ version: '1', types: [] }));
   afterEach(cleanup);
@@ -50,6 +80,22 @@ describe('DetailPanel', () => {
     seed(plotSchema);
     render(<DetailPanel selection={{ typeName: 'Plot', fieldName: 'name' }} />);
     expect(screen.getByTestId('field-detail')).toBeInTheDocument();
+  });
+
+  it('derives model shape guidance for the selected type from the schema', () => {
+    seed(artworkSchema);
+    render(<DetailPanel selection={{ typeName: 'ArtworkMedia' }} />);
+    expect(screen.getByText('Model shape')).toBeInTheDocument();
+    expect(screen.getByText('Possible entity')).toBeInTheDocument();
+    expect(screen.getByText(/Keep it embedded/i)).toBeInTheDocument();
+  });
+
+  it('derives field-level query handle guidance for the selected field', () => {
+    seed(artworkSchema);
+    render(<DetailPanel selection={{ typeName: 'Artwork', fieldName: 'sourceSearchText' }} />);
+    expect(screen.getByTestId('field-detail')).toBeInTheDocument();
+    expect(screen.getByText('Query handle')).toBeInTheDocument();
+    expect(screen.getByText(/denormalized/i)).toBeInTheDocument();
   });
 
   it('renders EdgeDetail when an edge is selected', () => {

--- a/apps/desktop/tests/components/detail/FieldDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/FieldDetail.test.tsx
@@ -4,14 +4,17 @@
  */
 
 import type { FieldDef } from '@contexture/core/ir';
+import type { ModelingHint } from '@contexture/core/modeling-hints';
 import { FieldDetail } from '@renderer/components/detail/FieldDetail';
 import type { Op } from '@renderer/store/ops';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-function setup(field: FieldDef) {
+function setup(field: FieldDef, modelingHints: ModelingHint[] = []) {
   const dispatch = vi.fn<(op: Op) => void>();
-  render(<FieldDetail typeName="Plot" field={field} dispatch={dispatch} />);
+  render(
+    <FieldDetail typeName="Plot" field={field} dispatch={dispatch} modelingHints={modelingHints} />,
+  );
   return { dispatch };
 }
 
@@ -121,5 +124,28 @@ describe('FieldDetail', () => {
       fieldName: 'n',
       patch: { optional: true },
     });
+  });
+
+  it('renders field-level query handle guidance when supplied', () => {
+    setup({ name: 'sourceSearchText', type: { kind: 'string' } }, [
+      {
+        id: 'v1:query_handle:Plot:sourceSearchText',
+        kind: 'query_handle',
+        signals: ['query_pressure'],
+        path: 'types.0.fields.0',
+        typeName: 'Plot',
+        fieldName: 'sourceSearchText',
+        title: 'Query handle',
+        message:
+          'This field looks useful for filtering, sorting, indexing, or search. It can stay denormalized on the table as a query handle over embedded data.',
+        rationale:
+          'A top-level query handle can preserve an embedded shape while keeping common queries efficient.',
+        fieldNames: ['sourceSearchText'],
+      },
+    ]);
+
+    expect(screen.getByRole('region', { name: 'Model shape' })).toBeInTheDocument();
+    expect(screen.getByText('Query handle')).toBeInTheDocument();
+    expect(screen.getByText(/stay denormalized/i)).toBeInTheDocument();
   });
 });

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -4,14 +4,15 @@
  */
 
 import type { TypeDef } from '@contexture/core/ir';
+import type { ModelingHint } from '@contexture/core/modeling-hints';
 import { TypeDetail } from '@renderer/components/detail/TypeDetail';
 import type { Op } from '@renderer/store/ops';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-function setup(type: TypeDef) {
+function setup(type: TypeDef, modelingHints: ModelingHint[] = []) {
   const dispatch = vi.fn<(op: Op) => void>();
-  render(<TypeDetail type={type} dispatch={dispatch} />);
+  render(<TypeDetail type={type} dispatch={dispatch} modelingHints={modelingHints} />);
   return { dispatch };
 }
 
@@ -76,6 +77,28 @@ describe('TypeDetail', () => {
         name: 'Plot',
         patch: { description: 'A plot of land.' },
       });
+    });
+
+    it('renders advisory model shape guidance when hints are supplied', () => {
+      setup(type, [
+        {
+          id: 'v1:possible_entity:Plot:name',
+          kind: 'possible_entity',
+          signals: ['identity_pressure'],
+          path: 'types.0',
+          typeName: 'Plot',
+          title: 'Possible entity',
+          message:
+            'This embedded object has identity-like fields. Keep it embedded if it only belongs to Garden.',
+          rationale: 'Identity-like fields often become useful handles.',
+          fieldNames: ['name'],
+        },
+      ]);
+
+      expect(screen.getByRole('region', { name: 'Model shape' })).toBeInTheDocument();
+      expect(screen.getByText('Embed for ownership. Extract for identity.')).toBeInTheDocument();
+      expect(screen.getByText('Possible entity')).toBeInTheDocument();
+      expect(screen.queryByText(/warning/i)).not.toBeInTheDocument();
     });
   });
 
@@ -179,16 +202,15 @@ describe('TypeDetail', () => {
       });
     });
 
-    it('dispatches update_index when a field checkbox toggles', () => {
+    it('dispatches update_index when a field is added from the picker', () => {
       const typeWithIndex: TypeDef = {
         ...base,
         table: true,
         indexes: [{ name: 'by_author', fields: ['author'] }],
       };
       const { dispatch } = setup(typeWithIndex);
-      // The "title" field is not in the index — toggling it on should patch fields.
-      const titleCheckbox = screen.getByLabelText('by_author: title');
-      fireEvent.click(titleCheckbox);
+      fireEvent.click(screen.getByRole('button', { name: /add field to index by_author/i }));
+      fireEvent.click(screen.getByRole('option', { name: 'title' }));
       expect(dispatch).toHaveBeenCalledWith({
         kind: 'update_index',
         typeName: 'Post',
@@ -197,16 +219,66 @@ describe('TypeDetail', () => {
       });
     });
 
-    it('disables the last selected index field with helper text', () => {
+    it('dispatches update_index when a selected field is removed', () => {
+      const typeWithIndex: TypeDef = {
+        ...base,
+        table: true,
+        indexes: [{ name: 'by_author_title', fields: ['author', 'title'] }],
+      };
+      const { dispatch } = setup(typeWithIndex);
+      fireEvent.click(
+        screen.getByRole('button', { name: /remove author from index by_author_title/i }),
+      );
+      expect(dispatch).toHaveBeenCalledWith({
+        kind: 'update_index',
+        typeName: 'Post',
+        name: 'by_author_title',
+        patch: { fields: ['title'] },
+      });
+    });
+
+    it('disables removing the last selected index field', () => {
       const typeWithIndex: TypeDef = {
         ...base,
         table: true,
         indexes: [{ name: 'by_author', fields: ['author'] }],
       };
       setup(typeWithIndex);
-      expect(screen.getByText('Indexes need at least one field.')).toBeInTheDocument();
-      expect(screen.getByLabelText('by_author: author')).toBeDisabled();
-      expect(screen.getByLabelText('by_author: title')).not.toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: /remove author from index by_author/i }),
+      ).toBeDisabled();
+      expect(screen.getByText('Field order affects Convex query prefixes.')).toBeInTheDocument();
+    });
+
+    it('dispatches update_index when a selected field is moved later', () => {
+      const typeWithIndex: TypeDef = {
+        ...base,
+        table: true,
+        indexes: [{ name: 'by_author_title', fields: ['author', 'title'] }],
+      };
+      const { dispatch } = setup(typeWithIndex);
+      fireEvent.click(
+        screen.getByRole('button', { name: /move author later in index by_author_title/i }),
+      );
+      expect(dispatch).toHaveBeenCalledWith({
+        kind: 'update_index',
+        typeName: 'Post',
+        name: 'by_author_title',
+        patch: { fields: ['title', 'author'] },
+      });
+    });
+
+    it('renders selected index fields in index order without showing unselected fields inline', () => {
+      const typeWithIndex: TypeDef = {
+        ...base,
+        table: true,
+        indexes: [{ name: 'by_title', fields: ['title'] }],
+      };
+      setup(typeWithIndex);
+      const row = screen.getByTestId('convex-index-row');
+      expect(row).toHaveTextContent('1');
+      expect(row).toHaveTextContent('title');
+      expect(row).not.toHaveTextContent('author');
     });
 
     it('flags type name starting with "_" as reserved when table:true', () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "./load": "./src/load.ts",
     "./mcp-server": "./src/mcp-server.ts",
     "./migrations": "./src/migrations/index.ts",
+    "./modeling-hints": "./src/modeling-hints.ts",
     "./ops": "./src/ops.ts",
     "./op-tools": "./src/op-tools.ts",
     "./paths": "./src/paths.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './ir';
 export * from './layout';
 export * from './load';
 export * from './migrations';
+export * from './modeling-hints';
 export * from './op-tools';
 export * from './ops';
 export * from './pipeline';

--- a/packages/core/src/modeling-hints.ts
+++ b/packages/core/src/modeling-hints.ts
@@ -1,0 +1,262 @@
+import type { FieldDef, FieldType, Schema, TypeDef } from './ir';
+
+export const MODELING_HINT_ANALYZER_VERSION = 1;
+
+export type ModelingHintKind =
+  | 'owned_value_object'
+  | 'possible_entity'
+  | 'query_handle'
+  | 'embedded_collection';
+
+export type ModelingSignal =
+  | 'identity_pressure'
+  | 'query_pressure'
+  | 'embedded_collection_pressure'
+  | 'lifecycle_pressure'
+  | 'relationship_pressure';
+
+export interface ModelingHint {
+  id: string;
+  kind: ModelingHintKind;
+  signals: ModelingSignal[];
+  path: string;
+  typeName: string;
+  fieldName?: string;
+  title: string;
+  message: string;
+  rationale: string;
+  fieldNames: string[];
+}
+
+type ObjectType = Extract<TypeDef, { kind: 'object' }>;
+
+interface TypeUsage {
+  ownerTypeName: string;
+  fieldName: string;
+  collection: boolean;
+}
+
+const QUERY_HANDLE_NAME = /(^|_)(kind|state|status|slug|key)$|name$|searchtext$|date$|at$|year$/i;
+
+const IDENTITY_FIELD_NAMES = new Set([
+  'id',
+  'name',
+  'slug',
+  'email',
+  'externalId',
+  'storageId',
+  'catalogNumber',
+  'url',
+  'key',
+]);
+
+export function analyzeModelingHints(schema: Schema): ModelingHint[] {
+  const objects = schema.types.filter(isObjectType);
+  const byName = new Map(schema.types.map((type) => [type.name, type]));
+  const usages = collectTypeUsages(objects);
+  const hints: ModelingHint[] = [];
+
+  objects.forEach((type, typeIndex) => {
+    const typePath = `types.${typeIndex}`;
+    const isTable = type.table === true;
+    const typeUsages = usages.get(type.name) ?? [];
+
+    if (!isTable) {
+      const identityFields = type.fields.filter(isIdentityLikeField);
+      if (identityFields.length > 0) {
+        hints.push(
+          possibleEntityHint({
+            type,
+            path: typePath,
+            identityFields,
+            ownerName: ownerLabel(typeUsages),
+          }),
+        );
+      } else if (looksOwnedValueObject(type, typeUsages)) {
+        hints.push(ownedValueObjectHint(type, typePath, ownerLabel(typeUsages)));
+      }
+    }
+
+    type.fields.forEach((field, fieldIndex) => {
+      const fieldPath = `${typePath}.fields.${fieldIndex}`;
+      const refTarget = unwrapRefTarget(field.type);
+      if (field.type.kind === 'array' && refTarget) {
+        const target = byName.get(refTarget);
+        if (target?.kind === 'object') {
+          hints.push(embeddedCollectionHint(type, field, fieldPath, target));
+        }
+      }
+
+      if (isTable && isQueryHandleField(field, type)) {
+        hints.push(queryHandleHint(type, field, fieldPath));
+      }
+    });
+  });
+
+  return hints;
+}
+
+function possibleEntityHint({
+  type,
+  path,
+  identityFields,
+  ownerName,
+}: {
+  type: ObjectType;
+  path: string;
+  identityFields: FieldDef[];
+  ownerName?: string;
+}): ModelingHint {
+  const fieldNames = identityFields.map((field) => field.name);
+  const belongsTo = ownerName
+    ? ` if it only belongs to ${ownerName}`
+    : ' if it only belongs to its parent record';
+  return {
+    id: hintId('possible_entity', type.name, undefined, fieldNames),
+    kind: 'possible_entity',
+    signals: ['identity_pressure'],
+    path,
+    typeName: type.name,
+    title: 'Possible entity',
+    message: `This embedded object has identity-like fields. Keep it embedded${belongsTo}. Consider a table if users need to browse, edit, reuse, or link it independently.`,
+    rationale:
+      'Identity-like fields often become useful handles when a concept gains its own lifecycle.',
+    fieldNames,
+  };
+}
+
+function ownedValueObjectHint(
+  type: ObjectType,
+  path: string,
+  ownerName: string | undefined,
+): ModelingHint {
+  const parent = ownerName ? ` to ${ownerName}` : ' to its parent record';
+  return {
+    id: hintId('owned_value_object', type.name),
+    kind: 'owned_value_object',
+    signals: [],
+    path,
+    typeName: type.name,
+    title: 'Owned value object',
+    message: `This object appears to belong entirely${parent}. Embedding is a good fit while it has no independent identity or lifecycle.`,
+    rationale:
+      'Owned structure can stay close to the parent record instead of becoming a table too early.',
+    fieldNames: [],
+  };
+}
+
+function embeddedCollectionHint(
+  ownerType: ObjectType,
+  field: FieldDef,
+  path: string,
+  elementType: ObjectType,
+): ModelingHint {
+  return {
+    id: hintId('embedded_collection', ownerType.name, field.name, [elementType.name]),
+    kind: 'embedded_collection',
+    signals: ['embedded_collection_pressure', 'relationship_pressure'],
+    path,
+    typeName: ownerType.name,
+    fieldName: field.name,
+    title: 'Embedded collection',
+    message: `This field stores a collection of ${elementType.name} objects. Keep it embedded if the items only belong to ${ownerType.name}. Consider a table if items need independent lifecycle, reuse, or querying.`,
+    rationale:
+      'Arrays are a good fit for owned child data, but shared or independently queried items often want table identity.',
+    fieldNames: [field.name],
+  };
+}
+
+function queryHandleHint(type: ObjectType, field: FieldDef, path: string): ModelingHint {
+  return {
+    id: hintId('query_handle', type.name, field.name),
+    kind: 'query_handle',
+    signals: ['query_pressure'],
+    path,
+    typeName: type.name,
+    fieldName: field.name,
+    title: 'Query handle',
+    message:
+      'This field looks useful for filtering, sorting, indexing, or search. It can stay denormalized on the table as a query handle over embedded data.',
+    rationale:
+      'A top-level query handle can preserve an embedded shape while keeping common queries efficient.',
+    fieldNames: [field.name],
+  };
+}
+
+function collectTypeUsages(objects: ObjectType[]): Map<string, TypeUsage[]> {
+  const usages = new Map<string, TypeUsage[]>();
+  for (const owner of objects) {
+    for (const field of owner.fields) {
+      const target = unwrapRefTarget(field.type);
+      if (!target) continue;
+      const existing = usages.get(target) ?? [];
+      existing.push({
+        ownerTypeName: owner.name,
+        fieldName: field.name,
+        collection: field.type.kind === 'array',
+      });
+      usages.set(target, existing);
+    }
+  }
+  return usages;
+}
+
+function looksOwnedValueObject(type: ObjectType, usages: TypeUsage[]): boolean {
+  if (type.fields.length === 0) return false;
+  if (usages.length > 1) return false;
+  return type.fields.every((field) => {
+    const target = unwrapRefTarget(field.type);
+    if (target) return true;
+    return !isIdentityLikeField(field) && field.type.kind !== 'array';
+  });
+}
+
+function isQueryHandleField(field: FieldDef, type: ObjectType): boolean {
+  if ((type.indexes ?? []).some((index) => index.fields.includes(field.name))) return true;
+  if (QUERY_HANDLE_NAME.test(field.name)) return true;
+  const description = field.description?.toLowerCase() ?? '';
+  return (
+    description.includes('denormalized') ||
+    description.includes('filter') ||
+    description.includes('search') ||
+    description.includes('index')
+  );
+}
+
+function isIdentityLikeField(field: FieldDef): boolean {
+  const fieldName = field.name;
+  if (IDENTITY_FIELD_NAMES.has(fieldName)) return true;
+  if (/(^|[a-z])(Id|Name|StorageId)$/.test(fieldName)) return true;
+  if (field.type.kind === 'string') {
+    return (
+      field.type.format === 'email' || field.type.format === 'url' || field.type.format === 'uuid'
+    );
+  }
+  return false;
+}
+
+function unwrapRefTarget(type: FieldType): string | undefined {
+  let current = type;
+  while (current.kind === 'array') current = current.element;
+  return current.kind === 'ref' ? current.typeName : undefined;
+}
+
+function ownerLabel(usages: TypeUsage[]): string | undefined {
+  if (usages.length !== 1) return undefined;
+  return usages[0]?.ownerTypeName;
+}
+
+function isObjectType(type: TypeDef): type is ObjectType {
+  return type.kind === 'object';
+}
+
+function hintId(
+  kind: ModelingHintKind,
+  typeName: string,
+  fieldName?: string,
+  fieldNames = [] as string[],
+): string {
+  return [`v${MODELING_HINT_ANALYZER_VERSION}`, kind, typeName, fieldName, ...fieldNames]
+    .filter((part): part is string => Boolean(part))
+    .join(':');
+}

--- a/packages/core/tests/modeling-hints.test.ts
+++ b/packages/core/tests/modeling-hints.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { Schema } from '../src/ir';
+import { analyzeModelingHints } from '../src/modeling-hints';
+
+const misprintSlice: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Artwork',
+      table: true,
+      fields: [
+        { name: 'slug', type: { kind: 'string' } },
+        {
+          name: 'sourceKind',
+          description: 'Denormalized source category for filtering artwork lists.',
+          type: { kind: 'string' },
+        },
+        {
+          name: 'sourceSearchText',
+          description: 'Denormalized lowercase search text assembled from source metadata.',
+          type: { kind: 'string' },
+        },
+        {
+          name: 'media',
+          type: { kind: 'array', element: { kind: 'ref', typeName: 'ArtworkMedia' } },
+        },
+        {
+          name: 'palette',
+          type: { kind: 'array', element: { kind: 'ref', typeName: 'ArtworkPaletteColor' } },
+        },
+      ],
+      indexes: [{ name: 'by_source_kind', fields: ['sourceKind'] }],
+    },
+    {
+      kind: 'object',
+      name: 'ArtworkMedia',
+      fields: [
+        { name: 'storageId', type: { kind: 'string' } },
+        { name: 'url', type: { kind: 'string', format: 'url' } },
+        { name: 'alt', type: { kind: 'string' } },
+      ],
+    },
+    {
+      kind: 'object',
+      name: 'ArtworkPaletteColor',
+      fields: [
+        { name: 'hex', type: { kind: 'string' } },
+        { name: 'sortOrder', type: { kind: 'number' } },
+        { name: 'notes', type: { kind: 'string' }, optional: true },
+      ],
+    },
+  ],
+};
+
+describe('analyzeModelingHints', () => {
+  it('identifies identity pressure on embedded objects without making validation issues', () => {
+    const hints = analyzeModelingHints(misprintSlice);
+
+    expect(hints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'possible_entity',
+          typeName: 'ArtworkMedia',
+          title: 'Possible entity',
+          signals: ['identity_pressure'],
+          fieldNames: ['storageId', 'url'],
+        }),
+      ]),
+    );
+  });
+
+  it('identifies query handles on table fields including denormalized search fields', () => {
+    const hints = analyzeModelingHints(misprintSlice);
+    const queryHandles = hints
+      .filter((hint) => hint.kind === 'query_handle')
+      .map((hint) => hint.fieldName);
+
+    expect(queryHandles).toEqual(
+      expect.arrayContaining(['slug', 'sourceKind', 'sourceSearchText']),
+    );
+    expect(hints.find((hint) => hint.fieldName === 'sourceSearchText')?.message).toMatch(
+      /denormalized/i,
+    );
+  });
+
+  it('identifies embedded collections and explains when the shape can remain embedded', () => {
+    const hints = analyzeModelingHints(misprintSlice);
+
+    expect(hints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'embedded_collection',
+          typeName: 'Artwork',
+          fieldName: 'media',
+          signals: ['embedded_collection_pressure', 'relationship_pressure'],
+        }),
+      ]),
+    );
+    expect(hints.find((hint) => hint.fieldName === 'media')?.message).toMatch(/Keep it embedded/i);
+  });
+
+  it('emits positive owned value object guidance for embedded owned structure', () => {
+    const hints = analyzeModelingHints(misprintSlice);
+
+    expect(hints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'owned_value_object',
+          typeName: 'ArtworkPaletteColor',
+          title: 'Owned value object',
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a pure core modeling-hints analyzer for identity, query, embedded-collection, and owned-value-object pressure
- Surface advisory Model shape guidance in the desktop inspector for selected types and fields
- Replace the Convex index checkbox wall with ordered selected-field chips plus an add-field picker
- Cover the new behavior with focused core and desktop tests

## Testing
- Focused Vitest coverage for the new modeling-hints analyzer and detail-panel rendering
- Desktop typecheck passed
- Biome check/format passed