### PR TITLE
feat(desktop): add model sync change log

### DIFF
--- a/apps/desktop/src/main/app-main.ts
+++ b/apps/desktop/src/main/app-main.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { electronApp, is, optimizer } from '@electron-toolkit/utils';
 import { registerDriftIpc } from './ipc/drift';
 import { registerFileIpc } from './ipc/file';
+import { registerModelSyncIpc } from './ipc/model-sync';
 import { registerReconcileIpc } from './ipc/reconcile';
 import { registerSchemaAgentIpc } from './ipc/schema-agent';
 import { registerShellIpc } from './ipc/shell';
@@ -92,6 +93,7 @@ app.whenReady().then(() => {
   registerReconcileIpc();
   registerSchemaAgentIpc(mainWindow);
   registerDriftIpc(mainWindow);
+  registerModelSyncIpc(mainWindow);
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/apps/desktop/src/main/documents/model-sync-watcher.ts
+++ b/apps/desktop/src/main/documents/model-sync-watcher.ts
@@ -1,0 +1,170 @@
+/**
+ * Source-model sync watcher for the open `.contexture.json`.
+ *
+ * This is deliberately separate from generated drift detection:
+ * - model sync watches the IR source of truth and keeps the canvas current;
+ * - generated drift watches emitted targets and feeds Reconcile.
+ */
+import { type FSWatcher, promises as fsPromises, watch } from 'node:fs';
+import {
+  load as loadIR,
+  loadModelChangeLog,
+  type ModelChangeLogEntry,
+  type ModelChangeSource,
+  type Schema,
+  schemaHash,
+} from '@contexture/core';
+import { hashContent } from '@contexture/core/pipeline';
+
+export type ModelSyncStatus = 'changed' | 'invalid_json' | 'invalid_ir' | 'unreadable' | 'deleted';
+
+export interface ModelSyncEvent {
+  irPath: string;
+  status: ModelSyncStatus;
+  source: ModelChangeSource | 'unknown';
+  observedAt: number;
+  revision: string;
+  content?: string;
+  schema?: Schema;
+  error?: string;
+  change?: ModelChangeLogEntry;
+}
+
+export interface ModelSyncWatcher {
+  start(): void;
+  stop(): void;
+  check(): Promise<void>;
+  acknowledgeSelfWrite(revision: string): void;
+}
+
+export interface ModelSyncWatcherOptions {
+  irPath: string;
+  onEvent: (event: ModelSyncEvent) => void;
+  debounceMs?: number;
+  readFile?: (path: string) => Promise<string>;
+}
+
+export function createModelSyncWatcher(opts: ModelSyncWatcherOptions): ModelSyncWatcher {
+  const {
+    irPath,
+    onEvent,
+    debounceMs = 300,
+    readFile = (path) => fsPromises.readFile(path, 'utf8'),
+  } = opts;
+
+  let watcher: FSWatcher | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  let lastSeenRevision: string | null = null;
+  let lastSelfWriteRevision: string | null = null;
+  let lastEventKey: string | null = null;
+
+  async function classify(): Promise<ModelSyncEvent> {
+    let raw: string;
+    try {
+      raw = await readFile(irPath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      return {
+        irPath,
+        status: code === 'ENOENT' ? 'deleted' : 'unreadable',
+        source: 'unknown',
+        observedAt: Date.now(),
+        revision: code === 'ENOENT' ? 'deleted' : 'unreadable',
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    const revision = hashContent(raw);
+    try {
+      const { schema } = loadIR(raw);
+      const matchingChange = await findMatchingChange(irPath, schema, readFile);
+      return {
+        irPath,
+        status: 'changed',
+        source: matchingChange?.source ?? 'external',
+        observedAt: Date.now(),
+        revision,
+        content: raw,
+        schema,
+        ...(matchingChange ? { change: matchingChange } : {}),
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        irPath,
+        status: message.startsWith('Invalid JSON:') ? 'invalid_json' : 'invalid_ir',
+        source: 'external',
+        observedAt: Date.now(),
+        revision,
+        content: raw,
+        error: message,
+      };
+    }
+  }
+
+  async function doCheck(): Promise<void> {
+    const event = await classify();
+    if (stopped) return;
+    if (event.revision === lastSeenRevision) return;
+
+    lastSeenRevision = event.revision;
+    if (event.revision === lastSelfWriteRevision) {
+      lastSelfWriteRevision = null;
+      return;
+    }
+
+    const key = `${event.status}:${event.revision}:${event.error ?? ''}`;
+    if (key === lastEventKey) return;
+    lastEventKey = key;
+    onEvent(event);
+  }
+
+  function scheduleCheck(): void {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      void doCheck();
+    }, debounceMs);
+  }
+
+  return {
+    start() {
+      stopped = false;
+      void classify().then((event) => {
+        if (!stopped) lastSeenRevision = event.revision;
+      });
+      try {
+        watcher = watch(irPath, () => scheduleCheck());
+      } catch {
+        // The file may be created later. Focus/manual checks still work.
+      }
+    },
+    stop() {
+      stopped = true;
+      watcher?.close();
+      watcher = null;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      lastSeenRevision = null;
+      lastSelfWriteRevision = null;
+      lastEventKey = null;
+    },
+    check: doCheck,
+    acknowledgeSelfWrite(revision) {
+      lastSelfWriteRevision = revision;
+    },
+  };
+}
+
+async function findMatchingChange(
+  irPath: string,
+  schema: Schema,
+  readFile: (path: string) => Promise<string>,
+): Promise<ModelChangeLogEntry | null> {
+  const { log } = await loadModelChangeLog(irPath, { readFile });
+  const afterHash = schemaHash(schema);
+  return log.entries.find((entry) => entry.afterHash === afterHash) ?? null;
+}

--- a/apps/desktop/src/main/ipc/file.ts
+++ b/apps/desktop/src/main/ipc/file.ts
@@ -15,7 +15,7 @@
 
 import { join } from 'node:path';
 import type { ChatHistory, Layout } from '@contexture/core';
-import { IRSchema, type Schema } from '@contexture/core';
+import { hashContent, IRSchema, type Schema, save as saveIR } from '@contexture/core';
 import { app, type BrowserWindow, dialog, type FileFilter, ipcMain } from 'electron';
 import { z } from 'zod';
 import {
@@ -25,6 +25,7 @@ import {
 } from '../documents/document-store';
 import { nodeFsAdapter } from '../documents/node-fs-adapter';
 import { assertSafeContextureIrPath } from '../security';
+import { acknowledgeModelSyncSelfWrite } from './model-sync';
 import { IpcString, parseIpcPayload } from './validation';
 
 // Electron's FileFilter.extensions is a list of bare extensions (no dot,
@@ -93,6 +94,7 @@ export function setDocumentStoreForTesting(s: DocumentStore | null): void {
 
 /** Build the five-file bundle for `input` and write it atomically. */
 export async function handleSave(input: HandleSaveInput): Promise<void> {
+  acknowledgeModelSyncSelfWrite(input.irPath, hashContent(`${saveIR(input.schema)}\n`));
   await getStore().save(input);
 }
 

--- a/apps/desktop/src/main/ipc/model-sync.ts
+++ b/apps/desktop/src/main/ipc/model-sync.ts
@@ -1,0 +1,119 @@
+/**
+ * Model sync IPC bridges the main-side `.contexture.json` watcher to the
+ * renderer. This is source-model sync, not generated-target drift.
+ */
+
+import {
+  appendModelChangeLogEntry,
+  buildModelChangeLogEntry,
+  IRSchema,
+  loadModelChangeLog,
+} from '@contexture/core';
+import type { BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
+import { z } from 'zod';
+import {
+  createModelSyncWatcher,
+  type ModelSyncEvent,
+  type ModelSyncWatcher,
+} from '../documents/model-sync-watcher';
+import { nodeFsAdapter } from '../documents/node-fs-adapter';
+import { assertSafeContextureIrPath } from '../security';
+import { IpcString, parseIpcPayload } from './validation';
+
+let activeWatcher: ModelSyncWatcher | null = null;
+let activeIrPath: string | null = null;
+
+const WatchPayloadSchema = z
+  .object({
+    irPath: IpcString,
+  })
+  .strict();
+
+const SelfWritePayloadSchema = z
+  .object({
+    irPath: IpcString,
+    revision: IpcString,
+  })
+  .strict();
+
+const AppendChangePayloadSchema = z
+  .object({
+    irPath: IpcString,
+    source: z.enum(['desktop', 'schema_agent', 'reconcile', 'external']),
+    reason: z.enum(['op_applied', 'replace_schema', 'external_sync_accepted']),
+    before: IRSchema,
+    after: IRSchema,
+    opKind: z.string().optional(),
+    actor: z.string().optional(),
+  })
+  .strict();
+
+export function registerModelSyncIpc(mainWindow: BrowserWindow): void {
+  ipcMain.handle('model-sync:watch', (_evt, payload: unknown) => {
+    const parsed = parseIpcPayload('model-sync:watch', WatchPayloadSchema, payload);
+    const irPath = assertSafeContextureIrPath(parsed.irPath);
+    activeWatcher?.stop();
+    activeIrPath = irPath;
+    activeWatcher = createModelSyncWatcher({
+      irPath,
+      onEvent: (event) => sendEvent(mainWindow, event),
+    });
+    activeWatcher.start();
+    return { ok: true };
+  });
+
+  ipcMain.handle('model-sync:unwatch', () => {
+    activeWatcher?.stop();
+    activeWatcher = null;
+    activeIrPath = null;
+    return { ok: true };
+  });
+
+  ipcMain.handle('model-sync:check', async () => {
+    if (!activeWatcher) return { ok: false };
+    await activeWatcher.check();
+    return { ok: true };
+  });
+
+  ipcMain.handle('model-sync:acknowledge-self-write', (_evt, payload: unknown) => {
+    const parsed = parseIpcPayload(
+      'model-sync:acknowledge-self-write',
+      SelfWritePayloadSchema,
+      payload,
+    );
+    acknowledgeModelSyncSelfWrite(parsed.irPath, parsed.revision);
+    return { ok: true };
+  });
+
+  ipcMain.handle('model-sync:change-log', async (_evt, payload: unknown) => {
+    const parsed = parseIpcPayload('model-sync:change-log', WatchPayloadSchema, payload);
+    const irPath = assertSafeContextureIrPath(parsed.irPath);
+    return loadModelChangeLog(irPath, nodeFsAdapter);
+  });
+
+  ipcMain.handle('model-sync:append-change', async (_evt, payload: unknown) => {
+    const parsed = parseIpcPayload('model-sync:append-change', AppendChangePayloadSchema, payload);
+    const irPath = assertSafeContextureIrPath(parsed.irPath);
+    const entry = buildModelChangeLogEntry({
+      irPath,
+      source: parsed.source,
+      reason: parsed.reason,
+      before: parsed.before,
+      after: parsed.after,
+      ...(parsed.opKind ? { opKind: parsed.opKind } : {}),
+      ...(parsed.actor ? { actor: parsed.actor } : {}),
+    });
+    await appendModelChangeLogEntry({ irPath, fs: nodeFsAdapter, entry });
+    return { ok: true, entry };
+  });
+}
+
+export function acknowledgeModelSyncSelfWrite(irPath: string, revision: string): void {
+  if (activeIrPath !== irPath) return;
+  activeWatcher?.acknowledgeSelfWrite(revision);
+}
+
+function sendEvent(mainWindow: BrowserWindow, event: ModelSyncEvent): void {
+  mainWindow.webContents.send('model-sync:event', event);
+}

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -129,6 +129,38 @@ export interface DriftDetectedPayload {
   files?: Array<{ path: string; status: 'drifted' | 'unreadable' }>;
 }
 
+export type ModelSyncStatus = 'changed' | 'invalid_json' | 'invalid_ir' | 'unreadable' | 'deleted';
+
+export interface ModelSyncEventPayload {
+  irPath: string;
+  status: ModelSyncStatus;
+  source: 'desktop' | 'mcp' | 'cli' | 'schema_agent' | 'reconcile' | 'external' | 'unknown';
+  observedAt: number;
+  revision: string;
+  content?: string;
+  schema?: unknown;
+  error?: string;
+  change?: unknown;
+}
+
+export interface ContextureModelSyncAPI {
+  watch: (payload: { irPath: string }) => Promise<{ ok: boolean }>;
+  unwatch: () => Promise<{ ok: boolean }>;
+  check: () => Promise<{ ok: boolean }>;
+  acknowledgeSelfWrite: (payload: { irPath: string; revision: string }) => Promise<{ ok: boolean }>;
+  getChangeLog: (payload: { irPath: string }) => Promise<unknown>;
+  appendChange: (payload: {
+    irPath: string;
+    source: 'desktop' | 'schema_agent' | 'reconcile' | 'external';
+    reason: 'op_applied' | 'replace_schema' | 'external_sync_accepted';
+    before: unknown;
+    after: unknown;
+    opKind?: string;
+    actor?: string;
+  }) => Promise<unknown>;
+  onEvent: (listener: (payload: ModelSyncEventPayload) => void) => Unsubscribe;
+}
+
 export interface ContextureReconcileAPI {
   readGeneratedTarget: (payload: { irPath: string; targetPath: string }) => Promise<string | null>;
   writeGeneratedTarget: (payload: {
@@ -163,6 +195,7 @@ export interface ContextureAPI {
   file: ContextureFileAPI;
   shell: ContextureShellAPI;
   drift: ContextureDriftAPI;
+  modelSync: ContextureModelSyncAPI;
   reconcile: ContextureReconcileAPI;
   update: ContextureUpdateAPI;
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -144,6 +144,29 @@ const drift = {
     subscribe('drift:resolved', (() => listener()) as (p: unknown) => void),
 };
 
+const modelSync = {
+  watch: (payload: { irPath: string }): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('model-sync:watch', payload) as Promise<{ ok: boolean }>,
+  unwatch: (): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('model-sync:unwatch') as Promise<{ ok: boolean }>,
+  check: (): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('model-sync:check') as Promise<{ ok: boolean }>,
+  acknowledgeSelfWrite: (payload: { irPath: string; revision: string }): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('model-sync:acknowledge-self-write', payload) as Promise<{ ok: boolean }>,
+  getChangeLog: (payload: { irPath: string }): Promise<unknown> =>
+    ipcRenderer.invoke('model-sync:change-log', payload),
+  appendChange: (payload: {
+    irPath: string;
+    source: 'desktop' | 'schema_agent' | 'reconcile' | 'external';
+    reason: 'op_applied' | 'replace_schema' | 'external_sync_accepted';
+    before: unknown;
+    after: unknown;
+    opKind?: string;
+    actor?: string;
+  }): Promise<unknown> => ipcRenderer.invoke('model-sync:append-change', payload),
+  onEvent: (listener: (payload: unknown) => void) => subscribe('model-sync:event', listener),
+};
+
 const reconcile = {
   readGeneratedTarget: (payload: { irPath: string; targetPath: string }): Promise<string | null> =>
     ipcRenderer.invoke('reconcile:read-generated-target', payload) as Promise<string | null>,
@@ -182,7 +205,7 @@ const update = {
   },
 };
 
-const contexture = { schemaAgent, file, shell, drift, reconcile, update };
+const contexture = { schemaAgent, file, shell, drift, modelSync, reconcile, update };
 
 if (process.contextIsolated) {
   try {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -31,6 +31,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import type { PanelImperativeHandle } from 'react-resizable-panels';
 import { useSchemaAgentChat } from './chat/useSchemaAgentChat';
 import { ActivityBar } from './components/activity-bar/ActivityBar';
+import { ChangesPanel } from './components/changes/ChangesPanel';
 import { ChatPanel } from './components/chat/ChatPanel';
 import { DetailPanel } from './components/detail/DetailPanel';
 import { DocumentDialogs } from './components/dialogs/DocumentDialogs';
@@ -38,6 +39,7 @@ import { ReconcileModal } from './components/dialogs/ReconcileModal';
 import { GraphBackground } from './components/graph/GraphBackground';
 import { type CanvasPosition, GraphCanvas } from './components/graph/GraphCanvas';
 import { DriftBanner } from './components/hud/DriftBanner';
+import { ModelSyncBanner } from './components/hud/ModelSyncBanner';
 import { SchemaPanel, type SchemaPanelSource } from './components/schema/SchemaPanel';
 import { StatusBar } from './components/status-bar/StatusBar';
 import { GraphControlsPanel } from './components/toolbar/GraphControlsPanel';
@@ -55,10 +57,13 @@ import { Popover, PopoverContent, PopoverTrigger } from './components/ui/popover
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './components/ui/resizable';
 import { useDrift } from './hooks/useDrift';
 import { useFileMenu } from './hooks/useFileMenu';
+import { useModelChangeLogRecorder } from './hooks/useModelChangeLogRecorder';
+import { useModelSync } from './hooks/useModelSync';
 import { useProjectAutoSave } from './hooks/useProjectAutoSave';
 import { useSessionPersistence } from './hooks/useSessionPersistence';
 import allotment from './samples/allotment.contexture.json' with { type: 'json' };
 import { useDocumentStore } from './store/document';
+import { useModelSyncStore } from './store/model-sync';
 import { useGraphSelectionStore } from './store/selection';
 import { useUIChromeStore } from './store/ui-chrome';
 import { useUndoStore } from './store/undo';
@@ -79,6 +84,7 @@ export default function App(): React.JSX.Element {
   const [showGraphControls, setShowGraphControls] = useState(false);
   const [recentFiles, setRecentFiles] = useState<string[]>([]);
   const selectedNodeId = useGraphSelectionStore((s) => s.state.primaryNodeId);
+  const highlightedNodeIds = useModelSyncStore((s) => s.highlightedNodeIds);
   const activeTab = useUIChromeStore((s) => s.sidebarTab);
   const setActiveTab = useUIChromeStore((s) => s.setSidebarTab);
   const sidebarVisible = useUIChromeStore((s) => s.sidebarVisible);
@@ -150,6 +156,8 @@ export default function App(): React.JSX.Element {
   const chat = useSchemaAgentChat({ api: schemaAgentApi });
 
   useDrift();
+  useModelSync();
+  useModelChangeLogRecorder();
 
   const fileMenu = useFileMenu({
     getChat: chat.toHistory,
@@ -279,6 +287,7 @@ export default function App(): React.JSX.Element {
         <ResizablePanel id="graph-panel" defaultSize="70%" minSize="30%">
           <div className="flex flex-col w-full h-full">
             <DriftBanner />
+            <ModelSyncBanner />
             <div className="relative flex-1 min-h-0">
               {hasSchema && (
                 <div className="absolute top-2 left-2 z-10">
@@ -300,7 +309,11 @@ export default function App(): React.JSX.Element {
                 </div>
               )}
               {hasSchema ? (
-                <GraphCanvas positions={positions} onPositionsChange={setPositions} />
+                <GraphCanvas
+                  positions={positions}
+                  onPositionsChange={setPositions}
+                  highlightedNodeIds={highlightedNodeIds}
+                />
               ) : (
                 <EmptyState
                   onLoadSample={loadSample}
@@ -360,6 +373,9 @@ export default function App(): React.JSX.Element {
                   onRequestSave={() => void fileMenu.handleSave()}
                   schemaFileName={schemaFileName}
                 />
+              </div>
+              <div className={activeTab !== 'changes' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
+                <ChangesPanel />
               </div>
             </div>
             <ActivityBar activeTab={activeTab} onTabChange={setActiveTab} />

--- a/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
+++ b/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
@@ -302,7 +302,9 @@ export function useSchemaAgentChat({
 
   useEffect(() => {
     return api.onToolRequest(({ id, op }) => {
-      const result: ApplyResult = useUndoStore.getState().apply(op as Op);
+      const result: ApplyResult = useUndoStore
+        .getState()
+        .apply(op as Op, { source: 'schema_agent' });
       api.replyTool(id, result);
     });
   }, [api]);

--- a/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
+++ b/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
@@ -1,5 +1,5 @@
 import type { SidebarTab } from '@renderer/store/ui-chrome';
-import { FileBracesCorner, MessageSquare, MousePointer2 } from 'lucide-react';
+import { FileBracesCorner, History, MessageSquare, MousePointer2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ActivityBarProps {
@@ -11,6 +11,7 @@ const TABS: Array<{ id: SidebarTab; icon: React.ReactNode; label: string }> = [
   { id: 'properties', icon: <MousePointer2 className="size-4" />, label: 'Properties' },
   { id: 'chat', icon: <MessageSquare className="size-4" />, label: 'Chat' },
   { id: 'schema', icon: <FileBracesCorner className="size-4" />, label: 'Schema' },
+  { id: 'changes', icon: <History className="size-4" />, label: 'Changes' },
 ];
 
 export function ActivityBar({ activeTab, onTabChange }: ActivityBarProps): React.JSX.Element {

--- a/apps/desktop/src/renderer/src/components/changes/ChangesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/changes/ChangesPanel.tsx
@@ -1,0 +1,333 @@
+import type { ModelChangeLogEntry } from '@contexture/core';
+import { AlertTriangle, History, LocateFixed, Search } from 'lucide-react';
+import { useEffect, useMemo } from 'react';
+import { type ChangeSourceFilter, useChangesStore } from '../../store/changes';
+import { useDocumentStore } from '../../store/document';
+import { sourceLabel } from '../../store/model-sync';
+import { useGraphSelectionStore } from '../../store/selection';
+import { Button } from '../ui/button';
+import { Checkbox } from '../ui/checkbox';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../ui/empty';
+import { Input } from '../ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+
+const SOURCE_FILTERS: Array<{ value: ChangeSourceFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'desktop', label: 'Desktop' },
+  { value: 'agent', label: 'Agent' },
+  { value: 'mcp', label: 'MCP' },
+  { value: 'cli', label: 'CLI' },
+  { value: 'reconcile', label: 'Reconcile' },
+  { value: 'external', label: 'External' },
+];
+
+export function ChangesPanel(): React.JSX.Element {
+  const filePath = useDocumentStore((s) => s.filePath);
+  const selectedNodeId = useGraphSelectionStore((s) => s.state.primaryNodeId);
+  const focus = useGraphSelectionStore((s) => s.focus);
+  const click = useGraphSelectionStore((s) => s.click);
+  const status = useChangesStore((s) => s.status);
+  const entries = useChangesStore((s) => s.entries);
+  const warnings = useChangesStore((s) => s.warnings);
+  const error = useChangesStore((s) => s.error);
+  const query = useChangesStore((s) => s.query);
+  const sourceFilter = useChangesStore((s) => s.sourceFilter);
+  const currentSelectionOnly = useChangesStore((s) => s.currentSelectionOnly);
+  const selectedId = useChangesStore((s) => s.selectedId);
+  const load = useChangesStore((s) => s.load);
+  const resetForNoDocument = useChangesStore((s) => s.resetForNoDocument);
+  const setQuery = useChangesStore((s) => s.setQuery);
+  const setSourceFilter = useChangesStore((s) => s.setSourceFilter);
+  const setCurrentSelectionOnly = useChangesStore((s) => s.setCurrentSelectionOnly);
+  const selectChange = useChangesStore((s) => s.select);
+
+  useEffect(() => {
+    if (!filePath || !window.contexture?.modelSync) {
+      resetForNoDocument();
+      return;
+    }
+    load({ irPath: filePath, api: window.contexture.modelSync });
+  }, [filePath, load, resetForNoDocument]);
+
+  const filtered = useMemo(
+    () =>
+      entries.filter((entry) => {
+        if (sourceFilter === 'agent') {
+          if (entry.source !== 'schema_agent' && entry.source !== 'mcp') return false;
+        } else if (sourceFilter !== 'all' && entry.source !== sourceFilter) {
+          return false;
+        }
+        if (currentSelectionOnly && selectedNodeId) {
+          if (!entryTouchesType(entry, selectedNodeId)) return false;
+        }
+        const haystack = [
+          entry.summary,
+          entry.actor,
+          entry.opKind,
+          sourceLabel(entry.source),
+          ...entry.addedTypes,
+          ...entry.changedTypes,
+          ...entry.removedTypes,
+          ...entry.renamedTypes.flatMap((rename) => [rename.from, rename.to]),
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase();
+        return haystack.includes(query.trim().toLowerCase());
+      }),
+    [currentSelectionOnly, entries, query, selectedNodeId, sourceFilter],
+  );
+
+  const selected = filtered.find((entry) => entry.id === selectedId) ?? filtered[0] ?? null;
+
+  function focusAffected(entry: ModelChangeLogEntry): void {
+    const target = primaryAffectedType(entry);
+    if (!target) return;
+    click(target, 'replace');
+    focus(target);
+  }
+
+  if (status === 'error') {
+    return (
+      <PanelEmpty
+        icon={<AlertTriangle />}
+        title="Change log unavailable"
+        description={
+          error ??
+          'Contexture could not read .contexture/change-log.json. The model is still usable.'
+        }
+      />
+    );
+  }
+
+  if (!filePath) {
+    return (
+      <PanelEmpty
+        icon={<History />}
+        title="No model changes yet"
+        description="Changes to this Contexture model will appear here after the file is saved."
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="border-b border-border p-3 space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold">Model changes</h2>
+          {status === 'loading' && (
+            <span className="text-[10px] text-muted-foreground">Loading...</span>
+          )}
+        </div>
+        <div className="relative">
+          <Search className="absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search changes"
+            className="h-8 pl-7 text-xs"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Select
+            value={sourceFilter}
+            onValueChange={(value) => setSourceFilter(value as ChangeSourceFilter)}
+          >
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue aria-label="Source" />
+            </SelectTrigger>
+            <SelectContent>
+              {SOURCE_FILTERS.map((filter) => (
+                <SelectItem key={filter.value} value={filter.value}>
+                  {filter.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {selectedNodeId && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Checkbox
+                id="changes-current-selection"
+                checked={currentSelectionOnly}
+                onCheckedChange={(checked) => setCurrentSelectionOnly(checked === true)}
+              />
+              <label htmlFor="changes-current-selection">Current selection</label>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {entries.length === 0 ? (
+        <PanelEmpty
+          icon={<History />}
+          title="No model changes yet"
+          description="Changes to this Contexture model will appear here after the file is edited, reconciled, or updated by an agent."
+        />
+      ) : filtered.length === 0 ? (
+        <PanelEmpty
+          icon={<Search />}
+          title="No matching changes"
+          description="Adjust the search or filters."
+        />
+      ) : (
+        <div className="grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)_auto]">
+          <div className="min-h-0 overflow-y-auto border-b border-border">
+            {warnings.length > 0 && (
+              <div className="border-b border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
+                {warnings[0]}
+              </div>
+            )}
+            {filtered.map((entry) => (
+              <button
+                type="button"
+                key={entry.id}
+                onClick={() => selectChange(entry.id)}
+                className={`w-full border-b border-border px-3 py-2 text-left text-xs hover:bg-muted/60 ${
+                  selected?.id === entry.id ? 'bg-muted' : ''
+                }`}
+              >
+                <div className="font-medium text-foreground">{entryTitle(entry)}</div>
+                <div className="mt-0.5 truncate text-muted-foreground">
+                  {sourceLabel(entry.source)}
+                  {entry.actor ? ` · ${entry.actor}` : ''}
+                  {' · '}
+                  <time title={entry.createdAt}>{timeLabel(entry.createdAt)}</time>
+                  {' · '}
+                  {entry.changeCount} {entry.changeCount === 1 ? 'affected type' : 'affected types'}
+                </div>
+                {entry.summary && (
+                  <div className="mt-1 truncate text-muted-foreground/80">{entry.summary}</div>
+                )}
+              </button>
+            ))}
+          </div>
+
+          {selected && (
+            <div className="max-h-80 overflow-y-auto p-3 text-xs">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <div className="font-semibold text-foreground">{entryTitle(selected)}</div>
+                  <div className="mt-0.5 text-muted-foreground">
+                    {sourceLabel(selected.source)} ·{' '}
+                    <time title={selected.createdAt}>{timeLabel(selected.createdAt)}</time>
+                  </div>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 gap-1.5 px-2 text-xs"
+                  onClick={() => focusAffected(selected)}
+                  disabled={!primaryAffectedType(selected)}
+                >
+                  <LocateFixed className="size-3" />
+                  Focus affected
+                </Button>
+              </div>
+
+              <section className="mt-3 space-y-1.5">
+                <h3 className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Affected model
+                </h3>
+                <div className="flex flex-wrap gap-1">
+                  {affectedTypes(selected).map((typeName) => (
+                    <button
+                      type="button"
+                      key={typeName}
+                      onClick={() => {
+                        click(typeName, 'replace');
+                        focus(typeName);
+                      }}
+                      className="rounded border border-border px-1.5 py-0.5 text-[10px] hover:bg-muted"
+                    >
+                      {typeName}
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              <section className="mt-3 space-y-1">
+                <h3 className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Change summary
+                </h3>
+                <p className="text-muted-foreground">{selected.summary ?? 'Model changed'}</p>
+                <p className="text-muted-foreground/70">
+                  Generated file drift is handled in Reconcile.
+                </p>
+              </section>
+
+              <details className="mt-3">
+                <summary className="cursor-pointer text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Raw log entry
+                </summary>
+                <pre className="mt-2 max-h-40 overflow-auto rounded border border-border bg-muted/40 p-2 text-[10px]">
+                  {JSON.stringify(selected, null, 2)}
+                </pre>
+              </details>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PanelEmpty({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}): React.JSX.Element {
+  return (
+    <Empty className="h-full border-0 p-4">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">{icon}</EmptyMedia>
+        <EmptyTitle className="text-sm font-medium">{title}</EmptyTitle>
+        <EmptyDescription className="text-xs">{description}</EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  );
+}
+
+function entryTitle(entry: ModelChangeLogEntry): string {
+  const affected = primaryAffectedType(entry);
+  return `${operationLabel(entry)}${affected ? ` · ${affected}` : ''}`;
+}
+
+function operationLabel(entry: ModelChangeLogEntry): string {
+  if (entry.renamedTypes.length > 0) return 'Renamed';
+  if (entry.addedTypes.length > 0) return 'Added';
+  if (entry.removedTypes.length > 0) return 'Deleted';
+  if (entry.reason === 'external_sync_accepted') return 'Accepted external change';
+  if (entry.reason === 'replace_schema') return 'Replaced';
+  return 'Updated';
+}
+
+function affectedTypes(entry: ModelChangeLogEntry): string[] {
+  return [
+    ...entry.addedTypes,
+    ...entry.changedTypes,
+    ...entry.removedTypes,
+    ...entry.renamedTypes.flatMap((rename) => [rename.from, rename.to]),
+  ];
+}
+
+function primaryAffectedType(entry: ModelChangeLogEntry): string | null {
+  return affectedTypes(entry)[0] ?? null;
+}
+
+function entryTouchesType(entry: ModelChangeLogEntry, typeName: string): boolean {
+  return affectedTypes(entry).includes(typeName);
+}
+
+function timeLabel(raw: string): string {
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return raw;
+  const now = new Date();
+  if (date.toDateString() === now.toDateString()) {
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -180,7 +180,7 @@ export function ReconcileModal(): React.JSX.Element {
     undo.begin();
     for (let i = 0; i < proposedOps.length; i += 1) {
       if (!selectedIndices.has(i)) continue;
-      const r = undo.apply(proposedOps[i].op);
+      const r = undo.apply(proposedOps[i].op, { source: 'reconcile' });
       if ('error' in r) {
         undo.rollback();
         setError(r.error);

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -63,6 +63,7 @@ export interface CanvasPosition {
 export interface GraphCanvasProps {
   positions?: Record<string, CanvasPosition>;
   onPositionsChange?: (next: Record<string, CanvasPosition>) => void;
+  highlightedNodeIds?: string[];
 }
 
 const NODE_TYPES = { type: TypeNode, group: GroupNode } as const;
@@ -76,7 +77,11 @@ export function GraphCanvas(props: GraphCanvasProps): React.JSX.Element {
   );
 }
 
-function GraphCanvasInner({ positions, onPositionsChange }: GraphCanvasProps): React.JSX.Element {
+function GraphCanvasInner({
+  positions,
+  onPositionsChange,
+  highlightedNodeIds = [],
+}: GraphCanvasProps): React.JSX.Element {
   const schema = useSyncExternalStore(useUndoStore.subscribe, () => useUndoStore.getState().schema);
   const dispatch = useCallback((op: Op) => {
     useUndoStore.getState().apply(op);
@@ -93,10 +98,18 @@ function GraphCanvasInner({ positions, onPositionsChange }: GraphCanvasProps): R
   const setSidebarTab = useUIChromeStore((s) => s.setSidebarTab);
   const setSidebarVisible = useUIChromeStore((s) => s.setSidebarVisible);
 
-  const { nodes: builtNodes, edges: builtEdges }: BuildGraphResult = useMemo(
-    () => buildGraph({ schema, positions }),
-    [schema, positions],
-  );
+  const { nodes: builtNodes, edges: builtEdges }: BuildGraphResult = useMemo(() => {
+    const highlighted = new Set(highlightedNodeIds);
+    const graph = buildGraph({ schema, positions });
+    return {
+      ...graph,
+      nodes: graph.nodes.map((node) =>
+        node.type === 'type'
+          ? { ...node, data: { ...node.data, syncHighlighted: highlighted.has(node.id) } }
+          : node,
+      ),
+    };
+  }, [schema, positions, highlightedNodeIds]);
 
   const [nodes, setNodes] = useState<Node[]>(builtNodes);
   const [edges, setEdges] = useState<Edge[]>(builtEdges);

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -68,6 +68,7 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
   const isSelected = primaryNodeId === id;
   const isAdjacent = !isSelected && adjacentNodeIds.has(id);
   const isDimmed = primaryNodeId !== null && !isSelected && !isAdjacent;
+  const isSyncHighlighted = data.syncHighlighted === true && !isSelected && !isAdjacent;
 
   const onFieldClick = useCallback(
     (fieldName: string, ev: React.MouseEvent<HTMLElement>) => {
@@ -108,6 +109,10 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         borderColor,
         boxShadow: '0 2px 10px oklch(0 0 0 / 0.18), 0 0 1px oklch(0 0 0 / 0.15)',
         background: isSelected ? 'var(--graph-node-selected-bg)' : 'transparent',
+        outline: isSyncHighlighted
+          ? '2px solid color-mix(in oklch, var(--chart-2) 78%, var(--background))'
+          : undefined,
+        outlineOffset: isSyncHighlighted ? 3 : undefined,
         opacity: isDimmed ? 0.22 : data.imported ? 0.75 : 1,
         transition: 'opacity 0.15s ease, border-color 0.1s ease',
       }}

--- a/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
+++ b/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
@@ -40,6 +40,7 @@ export interface TypeNodeData extends Record<string, unknown> {
   enumValues?: ReadonlyArray<EnumValueRow>;
   fields: ReadonlyArray<FieldRow>;
   imported: boolean;
+  syncHighlighted?: boolean;
   /** True when the source `ObjectTypeDef` carries `table: true`. */
   table?: boolean;
 }

--- a/apps/desktop/src/renderer/src/components/hud/ModelSyncBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/hud/ModelSyncBanner.tsx
@@ -1,0 +1,61 @@
+import { AlertTriangle, GitCompareArrows } from 'lucide-react';
+import { applyPendingModelSyncEvent } from '../../hooks/useModelSync';
+import { sourceLabel, useModelSyncStore } from '../../store/model-sync';
+import { Button } from '../ui/button';
+
+export function ModelSyncBanner(): React.JSX.Element | null {
+  const status = useModelSyncStore((s) => s.status);
+  const notice = useModelSyncStore((s) => s.notice);
+  const pendingEvent = useModelSyncStore((s) => s.pendingEvent);
+  const invalidEvent = useModelSyncStore((s) => s.invalidEvent);
+  const clearAttention = useModelSyncStore((s) => s.clearAttention);
+
+  if (status === 'external_changes' && pendingEvent && notice) {
+    return (
+      <div
+        role="alert"
+        data-testid="model-sync-banner"
+        className="flex items-center gap-2 px-3 py-2 bg-sky-50 dark:bg-sky-950/40 border-b border-sky-200 dark:border-sky-800 text-sky-900 dark:text-sky-100 text-xs"
+      >
+        <GitCompareArrows className="size-3.5 shrink-0" />
+        <span className="flex-1">
+          External model changes are ready. {sourceLabel(notice.source)} changed{' '}
+          <code className="font-mono">{pendingEvent.irPath.split('/').pop()}</code> while the
+          current canvas has unsaved work.
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-6 px-2 text-xs"
+          onClick={applyPendingModelSyncEvent}
+        >
+          Apply external changes
+        </Button>
+        <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={clearAttention}>
+          Keep current canvas
+        </Button>
+      </div>
+    );
+  }
+
+  if (status === 'invalid_model' && invalidEvent) {
+    return (
+      <div
+        role="alert"
+        data-testid="model-sync-banner"
+        className="flex items-center gap-2 px-3 py-2 bg-destructive/10 border-b border-destructive/30 text-destructive text-xs"
+      >
+        <AlertTriangle className="size-3.5 shrink-0" />
+        <span className="flex-1">
+          Model needs attention. The canvas is showing the last valid model.
+          {invalidEvent.error ? ` ${invalidEvent.error}` : ''}
+        </span>
+        <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={clearAttention}>
+          Dismiss
+        </Button>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -11,6 +11,7 @@ import { getAnalyticsOptOut, setAnalyticsOptOut } from '@renderer/lib/analytics'
 import { estimateTokenCount } from '@renderer/services/tokens';
 import { type ValidationError, validate } from '@renderer/services/validation';
 import { useDocumentStore } from '@renderer/store/document';
+import { sourceLabel, useModelSyncStore } from '@renderer/store/model-sync';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { useUndoStore } from '@renderer/store/undo';
 import { STDLIB_REGISTRY } from '@shared/stdlib-registry';
@@ -24,6 +25,8 @@ export function StatusBar(): React.JSX.Element {
   const schema = useSyncExternalStore(useUndoStore.subscribe, () => useUndoStore.getState().schema);
   const filePath = useDocumentStore((s) => s.filePath);
   const isDirty = useDocumentStore((s) => s.isDirty);
+  const syncStatus = useModelSyncStore((s) => s.status);
+  const syncNotice = useModelSyncStore((s) => s.notice);
   const click = useGraphSelectionStore((s) => s.click);
 
   const typeCount = schema.types.length;
@@ -98,7 +101,7 @@ export function StatusBar(): React.JSX.Element {
                   isDirty ? 'fill-warning text-warning' : 'fill-success/70 text-success/70',
                 )}
               />
-              <span>{isDirty ? 'Unsaved changes' : 'Saved'}</span>
+              <span>{saveStateLabel(isDirty, syncStatus, syncNotice)}</span>
             </span>
           </TooltipTrigger>
           <TooltipContent side="top">
@@ -122,6 +125,19 @@ export function StatusBar(): React.JSX.Element {
         </span>
 
         <span>{tokenDisplay}</span>
+
+        {syncNotice && syncStatus === 'synced' && (
+          <span className="text-sky-700 dark:text-sky-300">
+            Synced from {sourceLabel(syncNotice.source)} · {syncNotice.changeCount}{' '}
+            {syncNotice.changeCount === 1 ? 'change' : 'changes'}
+          </span>
+        )}
+
+        {syncStatus === 'external_changes' && (
+          <span className="text-sky-700 dark:text-sky-300">External changes pending</span>
+        )}
+
+        {syncStatus === 'invalid_model' && <span className="text-destructive">Invalid model</span>}
 
         <div className="flex-1" />
 
@@ -185,4 +201,16 @@ export function StatusBar(): React.JSX.Element {
       </TooltipProvider>
     </div>
   );
+}
+
+function saveStateLabel(
+  isDirty: boolean,
+  syncStatus: ReturnType<typeof useModelSyncStore.getState>['status'],
+  syncNotice: ReturnType<typeof useModelSyncStore.getState>['notice'],
+): string {
+  if (syncStatus === 'syncing') return 'Syncing...';
+  if (syncStatus === 'synced' && syncNotice) return 'Synced';
+  if (syncStatus === 'external_changes') return 'External changes';
+  if (syncStatus === 'invalid_model') return 'Invalid model';
+  return isDirty ? 'Unsaved changes' : 'Saved';
 }

--- a/apps/desktop/src/renderer/src/hooks/useFileMenu.ts
+++ b/apps/desktop/src/renderer/src/hooks/useFileMenu.ts
@@ -71,7 +71,9 @@ export function useFileMenu(options: UseFileMenuOptions = {}): UseFileMenuReturn
 
   const handleNew = useCallback((): void => {
     optionsRef.current.onNew?.();
-    useUndoStore.getState().apply({ kind: 'replace_schema', schema: { version: '1', types: [] } });
+    useUndoStore
+      .getState()
+      .apply({ kind: 'replace_schema', schema: { version: '1', types: [] } }, { log: false });
     useDocumentStore.getState().resetForNewBundle();
   }, []);
 
@@ -87,7 +89,7 @@ export function useFileMenu(options: UseFileMenuOptions = {}): UseFileMenuReturn
       const doc = useDocumentStore.getState();
       try {
         const { schema, warnings: irWarnings } = load(opened.content);
-        useUndoStore.getState().apply({ kind: 'replace_schema', schema });
+        useUndoStore.getState().apply({ kind: 'replace_schema', schema }, { log: false });
         doc.acceptOpenedBundle({ filePath: opened.irPath, layout: opened.layout });
 
         optionsRef.current.onBundleLoaded?.({

--- a/apps/desktop/src/renderer/src/hooks/useModelChangeLogRecorder.ts
+++ b/apps/desktop/src/renderer/src/hooks/useModelChangeLogRecorder.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { changeLogEntryFromAppendResult, useChangesStore } from '../store/changes';
 import { useDocumentStore } from '../store/document';
 import { subscribeUndoMutations } from '../store/undo';
 
@@ -10,15 +11,22 @@ export function useModelChangeLogRecorder(): void {
       if (!filePath) return;
       const api = window.contexture?.modelSync;
       if (!api) return;
-      void api.appendChange({
-        irPath: filePath,
-        source: event.meta.source ?? 'desktop',
-        reason: event.op.kind === 'replace_schema' ? 'replace_schema' : 'op_applied',
-        before: event.before,
-        after: event.after,
-        opKind: event.op.kind,
-        ...(event.meta.actor ? { actor: event.meta.actor } : {}),
-      });
+      void api
+        .appendChange({
+          irPath: filePath,
+          source: event.meta.source ?? 'desktop',
+          reason: event.op.kind === 'replace_schema' ? 'replace_schema' : 'op_applied',
+          before: event.before,
+          after: event.after,
+          opKind: event.op.kind,
+          ...(event.meta.actor ? { actor: event.meta.actor } : {}),
+        })
+        .then((result) => {
+          const entry = changeLogEntryFromAppendResult(result);
+          if (!entry || entry.irPath !== useDocumentStore.getState().filePath) return;
+          useChangesStore.getState().recordEntry(entry);
+        })
+        .catch(() => undefined);
     });
   }, []);
 }

--- a/apps/desktop/src/renderer/src/hooks/useModelChangeLogRecorder.ts
+++ b/apps/desktop/src/renderer/src/hooks/useModelChangeLogRecorder.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useDocumentStore } from '../store/document';
+import { subscribeUndoMutations } from '../store/undo';
+
+export function useModelChangeLogRecorder(): void {
+  useEffect(() => {
+    return subscribeUndoMutations((event) => {
+      if (event.meta.log === false) return;
+      const filePath = useDocumentStore.getState().filePath;
+      if (!filePath) return;
+      const api = window.contexture?.modelSync;
+      if (!api) return;
+      void api.appendChange({
+        irPath: filePath,
+        source: event.meta.source ?? 'desktop',
+        reason: event.op.kind === 'replace_schema' ? 'replace_schema' : 'op_applied',
+        before: event.before,
+        after: event.after,
+        opKind: event.op.kind,
+        ...(event.meta.actor ? { actor: event.meta.actor } : {}),
+      });
+    });
+  }, []);
+}

--- a/apps/desktop/src/renderer/src/hooks/useModelSync.ts
+++ b/apps/desktop/src/renderer/src/hooks/useModelSync.ts
@@ -1,0 +1,137 @@
+/**
+ * Mounts source-model sync for the currently open `.contexture.json`.
+ *
+ * This keeps external MCP/CLI/raw-file edits distinct from generated drift:
+ * valid clean source changes update the canvas; unsafe changes become a
+ * model-sync attention state.
+ */
+import { IRSchema, summarizeModelChange } from '@contexture/core';
+import { useEffect } from 'react';
+import { useDocumentStore } from '../store/document';
+import {
+  affectedNodeIds,
+  noticeFromChange,
+  noticeFromSummary,
+  type RendererModelSyncEvent,
+  useModelSyncStore,
+} from '../store/model-sync';
+import { useUndoStore } from '../store/undo';
+
+const IR_SUFFIX = '.contexture.json';
+const HIGHLIGHT_LIMIT = 8;
+const HIGHLIGHT_MS = 5000;
+const SYNC_NOTICE_MS = 5000;
+
+export function useModelSync(): void {
+  const filePath = useDocumentStore((s) => s.filePath);
+  const mode = useDocumentStore((s) => s.mode);
+
+  useEffect(() => {
+    const api = window.contexture?.modelSync;
+    if (!api) return;
+
+    if (mode !== 'bundle' || !filePath || !filePath.endsWith(IR_SUFFIX)) {
+      void api.unwatch();
+      useModelSyncStore.getState().clearAttention();
+      return;
+    }
+
+    void api.watch({ irPath: filePath });
+
+    const unEvent = api.onEvent((event) => handleModelSyncEvent(event as RendererModelSyncEvent));
+
+    function onFocus(): void {
+      void api?.check();
+    }
+    window.addEventListener('focus', onFocus);
+
+    return () => {
+      void api.unwatch();
+      unEvent();
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [filePath, mode]);
+}
+
+export function applyPendingModelSyncEvent(): void {
+  const pending = useModelSyncStore.getState().pendingEvent;
+  if (!pending) return;
+  applyExternalModelEvent(pending);
+}
+
+function handleModelSyncEvent(event: RendererModelSyncEvent): void {
+  if (event.status !== 'changed') {
+    useModelSyncStore.getState().setInvalid(event);
+    return;
+  }
+
+  const parsed = IRSchema.safeParse(event.schema);
+  if (!parsed.success) {
+    useModelSyncStore.getState().setInvalid({
+      ...event,
+      status: 'invalid_ir',
+      error: parsed.error.message,
+    });
+    return;
+  }
+
+  const current = useUndoStore.getState().schema;
+  const summary = event.change ? null : summarizeModelChange(current, parsed.data);
+  const notice = event.change
+    ? noticeFromChange(event.change)
+    : noticeFromSummary(
+        event.source,
+        event.observedAt,
+        summary ?? summarizeModelChange(current, parsed.data),
+      );
+
+  const doc = useDocumentStore.getState();
+  const undo = useUndoStore.getState();
+  if (doc.isDirty || undo.txDepth > 0) {
+    useModelSyncStore.getState().setPending(event, notice);
+    return;
+  }
+
+  applyExternalModelEvent(event, notice);
+}
+
+function applyExternalModelEvent(
+  event: RendererModelSyncEvent,
+  preparedNotice?: ReturnType<typeof noticeFromChange>,
+): void {
+  const parsed = IRSchema.safeParse(event.schema);
+  if (!parsed.success) {
+    useModelSyncStore.getState().setInvalid({
+      ...event,
+      status: 'invalid_ir',
+      error: parsed.error.message,
+    });
+    return;
+  }
+  const current = useUndoStore.getState().schema;
+  const notice =
+    preparedNotice ??
+    (event.change
+      ? noticeFromChange(event.change)
+      : noticeFromSummary(
+          event.source,
+          event.observedAt,
+          summarizeModelChange(current, parsed.data),
+        ));
+
+  useModelSyncStore.getState().setSyncing();
+  useUndoStore.getState().apply({ kind: 'replace_schema', schema: parsed.data }, { log: false });
+  useDocumentStore.getState().markClean();
+
+  const highlighted = affectedNodeIds(notice);
+  const shouldHighlight = highlighted.length > 0 && highlighted.length <= HIGHLIGHT_LIMIT;
+  useModelSyncStore.getState().setSynced(notice, shouldHighlight ? highlighted : []);
+
+  window.setTimeout(() => useModelSyncStore.getState().clearHighlights(), HIGHLIGHT_MS);
+  window.setTimeout(() => {
+    const state = useModelSyncStore.getState();
+    if (state.status === 'synced' && state.notice?.observedAt === notice.observedAt) {
+      useModelSyncStore.getState().clearAttention();
+    }
+  }, SYNC_NOTICE_MS);
+}

--- a/apps/desktop/src/renderer/src/hooks/useModelSync.ts
+++ b/apps/desktop/src/renderer/src/hooks/useModelSync.ts
@@ -5,7 +5,8 @@
  * valid clean source changes update the canvas; unsafe changes become a
  * model-sync attention state.
  */
-import { IRSchema, summarizeModelChange } from '@contexture/core';
+import { summarizeModelChange } from '@contexture/core/change-log';
+import { IRSchema } from '@contexture/core/ir';
 import { useEffect } from 'react';
 import { useDocumentStore } from '../store/document';
 import {

--- a/apps/desktop/src/renderer/src/hooks/useSessionPersistence.ts
+++ b/apps/desktop/src/renderer/src/hooks/useSessionPersistence.ts
@@ -56,7 +56,9 @@ export function useSessionPersistence({
       const session = JSON.parse(raw) as StoredSession;
       if (!session.schema || session.schema.types.length === 0) return;
       const layout = session.layout ?? { version: '1', positions: {} };
-      useUndoStore.getState().apply({ kind: 'replace_schema', schema: session.schema });
+      useUndoStore
+        .getState()
+        .apply({ kind: 'replace_schema', schema: session.schema }, { log: false });
       useDocumentStore.getState().acceptRestoredSession({ layout });
       onRestoreRef.current(layout);
     } catch {

--- a/apps/desktop/src/renderer/src/store/changes.ts
+++ b/apps/desktop/src/renderer/src/store/changes.ts
@@ -1,0 +1,95 @@
+import type { ModelChangeLogEntry, ModelChangeSource } from '@contexture/core';
+import { create } from 'zustand';
+
+export type ChangeSourceFilter = 'all' | ModelChangeSource | 'agent';
+
+interface ChangeLogLoadResult {
+  entries: ModelChangeLogEntry[];
+  warnings: string[];
+  error: null;
+}
+
+interface ChangesState {
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  entries: ModelChangeLogEntry[];
+  warnings: string[];
+  error: string | null;
+  query: string;
+  sourceFilter: ChangeSourceFilter;
+  currentSelectionOnly: boolean;
+  selectedId: string | null;
+
+  load: (input: { irPath: string; api: NonNullable<Window['contexture']['modelSync']> }) => void;
+  resetForNoDocument: () => void;
+  setQuery: (query: string) => void;
+  setSourceFilter: (sourceFilter: ChangeSourceFilter) => void;
+  setCurrentSelectionOnly: (currentSelectionOnly: boolean) => void;
+  select: (selectedId: string | null) => void;
+}
+
+export const useChangesStore = create<ChangesState>((set, get) => ({
+  status: 'idle',
+  entries: [],
+  warnings: [],
+  error: null,
+  query: '',
+  sourceFilter: 'all',
+  currentSelectionOnly: false,
+  selectedId: null,
+
+  load: ({ irPath, api }) => {
+    set({ status: 'loading', error: null });
+    void api
+      .getChangeLog({ irPath })
+      .then((result) => {
+        const parsed = parseChangeLogLoadResult(result);
+        const currentSelectedId = get().selectedId;
+        const selectedStillExists = parsed.entries.some((entry) => entry.id === currentSelectedId);
+        set({
+          status: 'ready',
+          ...parsed,
+          selectedId: selectedStillExists ? currentSelectedId : (parsed.entries[0]?.id ?? null),
+        });
+      })
+      .catch((err) => {
+        set({
+          status: 'error',
+          entries: [],
+          warnings: [],
+          error: err instanceof Error ? err.message : String(err),
+          selectedId: null,
+        });
+      });
+  },
+  resetForNoDocument: () =>
+    set({
+      status: 'ready',
+      entries: [],
+      warnings: [],
+      error: null,
+      selectedId: null,
+    }),
+  setQuery: (query) => set({ query }),
+  setSourceFilter: (sourceFilter) => set({ sourceFilter }),
+  setCurrentSelectionOnly: (currentSelectionOnly) => set({ currentSelectionOnly }),
+  select: (selectedId) => set({ selectedId }),
+}));
+
+function parseChangeLogLoadResult(value: unknown): ChangeLogLoadResult {
+  if (!value || typeof value !== 'object') return { entries: [], warnings: [], error: null };
+  const record = value as {
+    log?: { entries?: unknown };
+    warnings?: unknown;
+  };
+  const entries = Array.isArray(record.log?.entries)
+    ? record.log.entries.filter(isChangeLogEntry)
+    : [];
+  const warnings = Array.isArray(record.warnings)
+    ? record.warnings.filter((warning): warning is string => typeof warning === 'string')
+    : [];
+  return { entries, warnings, error: null };
+}
+
+function isChangeLogEntry(value: unknown): value is ModelChangeLogEntry {
+  return !!value && typeof value === 'object' && 'id' in value && typeof value.id === 'string';
+}

--- a/apps/desktop/src/renderer/src/store/changes.ts
+++ b/apps/desktop/src/renderer/src/store/changes.ts
@@ -20,6 +20,7 @@ interface ChangesState {
   selectedId: string | null;
 
   load: (input: { irPath: string; api: NonNullable<Window['contexture']['modelSync']> }) => void;
+  recordEntry: (entry: ModelChangeLogEntry) => void;
   resetForNoDocument: () => void;
   setQuery: (query: string) => void;
   setSourceFilter: (sourceFilter: ChangeSourceFilter) => void;
@@ -61,6 +62,13 @@ export const useChangesStore = create<ChangesState>((set, get) => ({
         });
       });
   },
+  recordEntry: (entry) =>
+    set((state) => ({
+      status: state.status === 'idle' ? 'ready' : state.status,
+      entries: [entry, ...state.entries.filter((existing) => existing.id !== entry.id)],
+      error: null,
+      selectedId: state.selectedId ?? entry.id,
+    })),
   resetForNoDocument: () =>
     set({
       status: 'ready',
@@ -92,4 +100,10 @@ function parseChangeLogLoadResult(value: unknown): ChangeLogLoadResult {
 
 function isChangeLogEntry(value: unknown): value is ModelChangeLogEntry {
   return !!value && typeof value === 'object' && 'id' in value && typeof value.id === 'string';
+}
+
+export function changeLogEntryFromAppendResult(value: unknown): ModelChangeLogEntry | null {
+  if (!value || typeof value !== 'object') return null;
+  const entry = (value as { entry?: unknown }).entry;
+  return isChangeLogEntry(entry) ? entry : null;
 }

--- a/apps/desktop/src/renderer/src/store/model-sync.ts
+++ b/apps/desktop/src/renderer/src/store/model-sync.ts
@@ -1,0 +1,147 @@
+import type { ModelChangeLogEntry, ModelChangeSource, ModelChangeSummary } from '@contexture/core';
+import { create } from 'zustand';
+
+export type ModelSyncStatus =
+  | 'idle'
+  | 'syncing'
+  | 'synced'
+  | 'external_changes'
+  | 'model_conflict'
+  | 'invalid_model';
+
+export interface RendererModelSyncEvent {
+  irPath: string;
+  status: 'changed' | 'invalid_json' | 'invalid_ir' | 'unreadable' | 'deleted';
+  source: ModelChangeSource | 'unknown';
+  observedAt: number;
+  revision: string;
+  content?: string;
+  schema?: unknown;
+  error?: string;
+  change?: ModelChangeLogEntry;
+}
+
+export interface ModelSyncNotice {
+  source: ModelChangeSource | 'unknown';
+  changeCount: number;
+  changedTypes: string[];
+  addedTypes: string[];
+  removedTypes: string[];
+  renamedTypes: Array<{ from: string; to: string }>;
+  summary: string;
+  observedAt: number;
+}
+
+interface ModelSyncState {
+  status: ModelSyncStatus;
+  notice: ModelSyncNotice | null;
+  pendingEvent: RendererModelSyncEvent | null;
+  invalidEvent: RendererModelSyncEvent | null;
+  highlightedNodeIds: string[];
+
+  setSyncing: () => void;
+  setSynced: (notice: ModelSyncNotice, highlightedNodeIds: string[]) => void;
+  setPending: (event: RendererModelSyncEvent, notice: ModelSyncNotice) => void;
+  setInvalid: (event: RendererModelSyncEvent) => void;
+  clearAttention: () => void;
+  clearHighlights: () => void;
+}
+
+export const useModelSyncStore = create<ModelSyncState>((set) => ({
+  status: 'idle',
+  notice: null,
+  pendingEvent: null,
+  invalidEvent: null,
+  highlightedNodeIds: [],
+
+  setSyncing: () => set({ status: 'syncing' }),
+  setSynced: (notice, highlightedNodeIds) =>
+    set({
+      status: 'synced',
+      notice,
+      pendingEvent: null,
+      invalidEvent: null,
+      highlightedNodeIds,
+    }),
+  setPending: (pendingEvent, notice) =>
+    set({
+      status: 'external_changes',
+      notice,
+      pendingEvent,
+      invalidEvent: null,
+      highlightedNodeIds: [],
+    }),
+  setInvalid: (invalidEvent) =>
+    set({
+      status: 'invalid_model',
+      pendingEvent: null,
+      invalidEvent,
+      highlightedNodeIds: [],
+    }),
+  clearAttention: () =>
+    set({
+      status: 'idle',
+      notice: null,
+      pendingEvent: null,
+      invalidEvent: null,
+      highlightedNodeIds: [],
+    }),
+  clearHighlights: () => set({ highlightedNodeIds: [] }),
+}));
+
+export function noticeFromSummary(
+  source: ModelChangeSource | 'unknown',
+  observedAt: number,
+  summary: ModelChangeSummary,
+): ModelSyncNotice {
+  return {
+    source,
+    observedAt,
+    changedTypes: summary.changedTypes,
+    addedTypes: summary.addedTypes,
+    removedTypes: summary.removedTypes,
+    renamedTypes: summary.renamedTypes,
+    changeCount: summary.changeCount,
+    summary: summary.summary,
+  };
+}
+
+export function noticeFromChange(change: ModelChangeLogEntry): ModelSyncNotice {
+  return {
+    source: change.source,
+    observedAt: Date.parse(change.createdAt),
+    changedTypes: change.changedTypes,
+    addedTypes: change.addedTypes,
+    removedTypes: change.removedTypes,
+    renamedTypes: change.renamedTypes,
+    changeCount: change.changeCount,
+    summary: change.summary ?? 'Model changed',
+  };
+}
+
+export function sourceLabel(source: ModelChangeSource | 'unknown'): string {
+  switch (source) {
+    case 'desktop':
+      return 'Desktop';
+    case 'schema_agent':
+      return 'Schema agent';
+    case 'mcp':
+      return 'MCP';
+    case 'cli':
+      return 'CLI';
+    case 'reconcile':
+      return 'Reconcile';
+    case 'external':
+      return 'External';
+    case 'unknown':
+      return 'External';
+  }
+}
+
+export function affectedNodeIds(notice: ModelSyncNotice): string[] {
+  return [
+    ...notice.addedTypes,
+    ...notice.changedTypes,
+    ...notice.renamedTypes.map((rename) => rename.to),
+  ];
+}

--- a/apps/desktop/src/renderer/src/store/ui-chrome.ts
+++ b/apps/desktop/src/renderer/src/store/ui-chrome.ts
@@ -8,7 +8,7 @@
 import { create } from 'zustand';
 
 export type Theme = 'dark' | 'light';
-export type SidebarTab = 'properties' | 'chat' | 'schema';
+export type SidebarTab = 'properties' | 'chat' | 'schema' | 'changes';
 
 interface UIChromeStoreShape {
   theme: Theme;

--- a/apps/desktop/src/renderer/src/store/undo.ts
+++ b/apps/desktop/src/renderer/src/store/undo.ts
@@ -29,6 +29,23 @@ import { STDLIB_REGISTRY } from '@shared/stdlib-registry';
 import { create } from 'zustand';
 import { type ApplyResult, apply as applyOp, type Op } from './ops';
 
+export interface UndoMutationMeta {
+  source?: 'desktop' | 'schema_agent' | 'reconcile' | 'external';
+  actor?: string;
+  log?: boolean;
+}
+
+export interface UndoMutationEvent {
+  op: Op;
+  before: Schema;
+  after: Schema;
+  meta: UndoMutationMeta;
+}
+
+export type UndoMutationListener = (event: UndoMutationEvent) => void;
+
+const mutationListeners = new Set<UndoMutationListener>();
+
 export interface UndoableState {
   schema: Schema;
   /** Past snapshots, oldest first. `past[past.length-1]` is the most recent pre-step schema. */
@@ -40,7 +57,7 @@ export interface UndoableState {
   /** Snapshot captured at the outermost `begin()`. null when no tx is open. */
   txStart: Schema | null;
 
-  apply: (op: Op) => ApplyResult;
+  apply: (op: Op, meta?: UndoMutationMeta) => ApplyResult;
   undo: () => void;
   redo: () => void;
   begin: () => void;
@@ -69,7 +86,7 @@ export function createUndoableContextureStore(initial: Schema) {
       canUndo: false,
       canRedo: false,
 
-      apply: (op) => {
+      apply: (op, meta = {}) => {
         const state = get();
         const res = applyOp(state.schema, op, STDLIB_REGISTRY);
         if ('error' in res) return res;
@@ -78,12 +95,14 @@ export function createUndoableContextureStore(initial: Schema) {
           // Inside a transaction: mutate the live schema but defer the
           // history push until `commit()`.
           set({ schema: res.schema });
+          notifyMutation(mutationListeners, { op, before: state.schema, after: res.schema, meta });
           return res;
         }
 
         const past = [...state.past, state.schema];
         const future: Schema[] = [];
         set({ schema: res.schema, past, future, ...recompute(past, future) });
+        notifyMutation(mutationListeners, { op, before: state.schema, after: res.schema, meta });
         return res;
       },
 
@@ -148,6 +167,17 @@ export function createUndoableContextureStore(initial: Schema) {
  * in one transaction.
  */
 export const useUndoStore = createUndoableContextureStore({ version: '1', types: [] });
+
+export function subscribeUndoMutations(listener: UndoMutationListener): () => void {
+  mutationListeners.add(listener);
+  return () => {
+    mutationListeners.delete(listener);
+  };
+}
+
+function notifyMutation(listeners: Set<UndoMutationListener>, event: UndoMutationEvent): void {
+  for (const listener of listeners) listener(event);
+}
 
 // Expose the store on `window` only in test/dev/e2e so Playwright specs can
 // dispatch ops directly without relying on XYFlow pointer events.

--- a/apps/desktop/tests/hooks/useModelChangeLogRecorder.test.tsx
+++ b/apps/desktop/tests/hooks/useModelChangeLogRecorder.test.tsx
@@ -1,0 +1,83 @@
+import { useModelChangeLogRecorder } from '@renderer/hooks/useModelChangeLogRecorder';
+import { useDocumentStore } from '@renderer/store/document';
+import { useUndoStore } from '@renderer/store/undo';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const irPath = '/tmp/garden.contexture.json';
+
+function setupBridge() {
+  const appendChange = vi.fn(async () => ({ ok: true }));
+  (window as unknown as { contexture: unknown }).contexture = {
+    modelSync: {
+      appendChange,
+    },
+  };
+  return { appendChange };
+}
+
+beforeEach(() => {
+  useUndoStore
+    .getState()
+    .apply({ kind: 'replace_schema', schema: { version: '1', types: [] } }, { log: false });
+  useDocumentStore.setState({
+    filePath: irPath,
+    isDirty: false,
+    mode: 'bundle',
+    layout: { version: '1', positions: {} },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('useModelChangeLogRecorder', () => {
+  it('appends a desktop change-log entry for renderer ops', () => {
+    const { appendChange } = setupBridge();
+    renderHook(() => useModelChangeLogRecorder());
+
+    act(() => {
+      useUndoStore.getState().apply({
+        kind: 'add_type',
+        type: { kind: 'object', name: 'Plot', fields: [] },
+      });
+    });
+
+    expect(appendChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        irPath,
+        source: 'desktop',
+        reason: 'op_applied',
+        opKind: 'add_type',
+      }),
+    );
+  });
+
+  it('honors source metadata and log suppression', () => {
+    const { appendChange } = setupBridge();
+    renderHook(() => useModelChangeLogRecorder());
+
+    act(() => {
+      useUndoStore.getState().apply(
+        {
+          kind: 'add_type',
+          type: { kind: 'object', name: 'AgentType', fields: [] },
+        },
+        { source: 'schema_agent' },
+      );
+      useUndoStore
+        .getState()
+        .apply({ kind: 'replace_schema', schema: { version: '1', types: [] } }, { log: false });
+    });
+
+    expect(appendChange).toHaveBeenCalledTimes(1);
+    expect(appendChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'schema_agent',
+        opKind: 'add_type',
+      }),
+    );
+  });
+});

--- a/apps/desktop/tests/hooks/useModelChangeLogRecorder.test.tsx
+++ b/apps/desktop/tests/hooks/useModelChangeLogRecorder.test.tsx
@@ -1,13 +1,33 @@
 import { useModelChangeLogRecorder } from '@renderer/hooks/useModelChangeLogRecorder';
+import { useChangesStore } from '@renderer/store/changes';
 import { useDocumentStore } from '@renderer/store/document';
 import { useUndoStore } from '@renderer/store/undo';
-import { act, cleanup, renderHook } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const irPath = '/tmp/garden.contexture.json';
 
 function setupBridge() {
-  const appendChange = vi.fn(async () => ({ ok: true }));
+  const appendChange = vi.fn(
+    async (payload: { irPath: string; source: string; opKind: string }) => ({
+      ok: true,
+      entry: {
+        id: `change-${payload.opKind}`,
+        irPath: payload.irPath,
+        source: payload.source,
+        reason: 'op_applied',
+        opKind: payload.opKind,
+        changedTypes: [],
+        addedTypes: ['Plot'],
+        removedTypes: [],
+        renamedTypes: [],
+        changeCount: 1,
+        afterHash: 'hash',
+        createdAt: '2026-05-22T07:00:00.000Z',
+        summary: 'Added Plot',
+      },
+    }),
+  );
   (window as unknown as { contexture: unknown }).contexture = {
     modelSync: {
       appendChange,
@@ -25,6 +45,16 @@ beforeEach(() => {
     isDirty: false,
     mode: 'bundle',
     layout: { version: '1', positions: {} },
+  });
+  useChangesStore.setState({
+    status: 'ready',
+    entries: [],
+    warnings: [],
+    error: null,
+    query: '',
+    sourceFilter: 'all',
+    currentSelectionOnly: false,
+    selectedId: null,
   });
 });
 
@@ -79,5 +109,28 @@ describe('useModelChangeLogRecorder', () => {
         opKind: 'add_type',
       }),
     );
+  });
+
+  it('adds successful append results to the visible change store', async () => {
+    setupBridge();
+    renderHook(() => useModelChangeLogRecorder());
+
+    act(() => {
+      useUndoStore.getState().apply({
+        kind: 'add_type',
+        type: { kind: 'object', name: 'Plot', fields: [] },
+      });
+    });
+
+    await waitFor(() => {
+      expect(useChangesStore.getState().entries).toEqual([
+        expect.objectContaining({
+          id: 'change-add_type',
+          irPath,
+          source: 'desktop',
+          opKind: 'add_type',
+        }),
+      ]);
+    });
   });
 });

--- a/apps/desktop/tests/hooks/useModelSync.test.tsx
+++ b/apps/desktop/tests/hooks/useModelSync.test.tsx
@@ -1,4 +1,5 @@
-import { type Schema, save } from '@contexture/core';
+import type { Schema } from '@contexture/core/ir';
+import { save } from '@contexture/core/load';
 import { useModelSync } from '@renderer/hooks/useModelSync';
 import { useDocumentStore } from '@renderer/store/document';
 import { useModelSyncStore } from '@renderer/store/model-sync';

--- a/apps/desktop/tests/hooks/useModelSync.test.tsx
+++ b/apps/desktop/tests/hooks/useModelSync.test.tsx
@@ -1,0 +1,135 @@
+import { type Schema, save } from '@contexture/core';
+import { useModelSync } from '@renderer/hooks/useModelSync';
+import { useDocumentStore } from '@renderer/store/document';
+import { useModelSyncStore } from '@renderer/store/model-sync';
+import { useUndoStore } from '@renderer/store/undo';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const irPath = '/tmp/garden.contexture.json';
+
+const initial: Schema = { version: '1', types: [] };
+const external: Schema = {
+  version: '1',
+  types: [{ kind: 'object', name: 'Plot', fields: [] }],
+};
+
+function setupBridge() {
+  let listener: ((payload: unknown) => void) | null = null;
+  const watch = vi.fn(async () => ({ ok: true }));
+  const unwatch = vi.fn(async () => ({ ok: true }));
+  (window as unknown as { contexture: unknown }).contexture = {
+    modelSync: {
+      watch,
+      unwatch,
+      check: vi.fn(async () => ({ ok: true })),
+      acknowledgeSelfWrite: vi.fn(async () => ({ ok: true })),
+      getChangeLog: vi.fn(async () => ({ log: { version: '1', entries: [] }, warnings: [] })),
+      onEvent: (fn: (payload: unknown) => void) => {
+        listener = fn;
+        return () => {
+          listener = null;
+        };
+      },
+    },
+  };
+  return {
+    watch,
+    emit(payload: unknown) {
+      listener?.(payload);
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  useUndoStore.getState().apply({ kind: 'replace_schema', schema: initial });
+  useDocumentStore.setState({
+    filePath: irPath,
+    isDirty: false,
+    mode: 'bundle',
+    layout: { version: '1', positions: {} },
+  });
+  useModelSyncStore.getState().clearAttention();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('useModelSync', () => {
+  it('starts watching the open IR path', () => {
+    const bridge = setupBridge();
+
+    renderHook(() => useModelSync());
+
+    expect(bridge.watch).toHaveBeenCalledWith({ irPath });
+  });
+
+  it('auto-applies clean valid external changes', () => {
+    const bridge = setupBridge();
+    renderHook(() => useModelSync());
+
+    act(() => {
+      bridge.emit({
+        irPath,
+        status: 'changed',
+        source: 'mcp',
+        observedAt: 1,
+        revision: 'rev',
+        content: `${save(external)}\n`,
+        schema: external,
+      });
+    });
+
+    expect(useUndoStore.getState().schema).toEqual(external);
+    expect(useDocumentStore.getState().isDirty).toBe(false);
+    expect(useModelSyncStore.getState()).toMatchObject({
+      status: 'synced',
+      highlightedNodeIds: ['Plot'],
+    });
+  });
+
+  it('queues valid external changes while the local model is dirty', () => {
+    const bridge = setupBridge();
+    useDocumentStore.getState().markDirty();
+    renderHook(() => useModelSync());
+
+    act(() => {
+      bridge.emit({
+        irPath,
+        status: 'changed',
+        source: 'cli',
+        observedAt: 1,
+        revision: 'rev',
+        content: `${save(external)}\n`,
+        schema: external,
+      });
+    });
+
+    expect(useUndoStore.getState().schema).toEqual(initial);
+    expect(useModelSyncStore.getState().status).toBe('external_changes');
+    expect(useModelSyncStore.getState().pendingEvent).toMatchObject({ source: 'cli' });
+  });
+
+  it('keeps the last valid model visible for invalid source changes', () => {
+    const bridge = setupBridge();
+    renderHook(() => useModelSync());
+
+    act(() => {
+      bridge.emit({
+        irPath,
+        status: 'invalid_json',
+        source: 'external',
+        observedAt: 1,
+        revision: 'bad',
+        error: 'Invalid JSON',
+      });
+    });
+
+    expect(useUndoStore.getState().schema).toEqual(initial);
+    expect(useModelSyncStore.getState().status).toBe('invalid_model');
+  });
+});

--- a/apps/desktop/tests/main/model-sync-watcher.test.ts
+++ b/apps/desktop/tests/main/model-sync-watcher.test.ts
@@ -1,0 +1,114 @@
+import {
+  buildModelChangeLogEntry,
+  changeLogPathFor,
+  hashContent,
+  type Schema,
+  save,
+} from '@contexture/core';
+import { createModelSyncWatcher, type ModelSyncEvent } from '@main/documents/model-sync-watcher';
+import { describe, expect, it, vi } from 'vitest';
+
+const irPath = '/work/garden.contexture.json';
+
+const before: Schema = {
+  version: '1',
+  types: [{ kind: 'object', name: 'Plot', fields: [] }],
+};
+
+const after: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Plot',
+      fields: [{ name: 'name', type: { kind: 'string' } }],
+    },
+  ],
+};
+
+function readFrom(files: Map<string, string>) {
+  return async (path: string): Promise<string> => {
+    const content = files.get(path);
+    if (content === undefined) {
+      const err = new Error(`ENOENT: ${path}`) as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return content;
+  };
+}
+
+describe('createModelSyncWatcher', () => {
+  it('emits valid external IR changes', async () => {
+    const files = new Map([[irPath, `${save(after)}\n`]]);
+    const onEvent = vi.fn<(event: ModelSyncEvent) => void>();
+    const watcher = createModelSyncWatcher({ irPath, readFile: readFrom(files), onEvent });
+
+    await watcher.check();
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        irPath,
+        status: 'changed',
+        source: 'external',
+        schema: after,
+      }),
+    );
+  });
+
+  it('suppresses acknowledged self-writes', async () => {
+    const raw = `${save(after)}\n`;
+    const files = new Map([[irPath, raw]]);
+    const onEvent = vi.fn<(event: ModelSyncEvent) => void>();
+    const watcher = createModelSyncWatcher({ irPath, readFile: readFrom(files), onEvent });
+
+    watcher.acknowledgeSelfWrite(hashContent(raw));
+    await watcher.check();
+
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it('reports invalid JSON without throwing', async () => {
+    const files = new Map([[irPath, '{not json']]);
+    const onEvent = vi.fn<(event: ModelSyncEvent) => void>();
+    const watcher = createModelSyncWatcher({ irPath, readFile: readFrom(files), onEvent });
+
+    await watcher.check();
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'invalid_json',
+        source: 'external',
+        error: expect.stringContaining('Invalid JSON'),
+      }),
+    );
+  });
+
+  it('uses change-log entries to attribute the source', async () => {
+    const entry = buildModelChangeLogEntry({
+      id: 'mcp-change',
+      irPath,
+      source: 'mcp',
+      reason: 'op_applied',
+      before,
+      after,
+      opKind: 'add_field',
+    });
+    const files = new Map([
+      [irPath, `${save(after)}\n`],
+      [changeLogPathFor(irPath), JSON.stringify({ version: '1', entries: [entry] })],
+    ]);
+    const onEvent = vi.fn<(event: ModelSyncEvent) => void>();
+    const watcher = createModelSyncWatcher({ irPath, readFile: readFrom(files), onEvent });
+
+    await watcher.check();
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'changed',
+        source: 'mcp',
+        change: expect.objectContaining({ id: 'mcp-change', opKind: 'add_field' }),
+      }),
+    );
+  });
+});

--- a/docs/sync-experience-implementation-plan.md
+++ b/docs/sync-experience-implementation-plan.md
@@ -1,0 +1,559 @@
+# Contexture Sync Experience Implementation Plan
+
+## Goal
+
+Make the desktop canvas stay trustworthy when the open `.contexture.json` is
+changed outside the renderer by MCP, CLI, external agents, or raw file edits.
+
+Contexture should remain the domain-model control plane:
+
+- The `.contexture.json` IR is the source of truth.
+- Desktop reflects the latest valid model without surprising the user.
+- Invalid or conflicting source changes are explicit and recoverable.
+- Generated-target drift remains a separate concern from model sync.
+
+## Current Architecture Findings
+
+- `DocumentStore` owns open/save/save-as for the bundle in
+  `apps/desktop/src/main/documents/document-store.ts`.
+- `useProjectAutoSave` writes schema, layout, chat, generated targets, and the
+  emitted manifest 500ms after renderer schema edits.
+- `createDriftWatcher` watches generated target paths from
+  `.contexture/emitted.json`, but there is no equivalent watcher for the IR
+  source file.
+- `useDrift` bridges generated drift to the renderer and runs a manual check on
+  window focus.
+- `StatusBar` currently exposes saved/unsaved, validation, counts, and token
+  estimates. It has no sync state slot yet.
+- `DriftBanner` is specifically about generated files modified outside
+  Contexture. That language should not be reused for source IR sync.
+- Schema-agent chat applies Ops in the renderer through `schema-agent:tool-request`
+  and sends `schema-agent:set-ir` before a turn. External MCP/CLI Ops mutate the
+  file directly through `createFileBackedForward`, bypassing the open renderer.
+- Provider thread desync already exists as a concept, but external model changes
+  are not currently wired to mark active chat context stale.
+
+## UX Direction
+
+Valid external model changes should feel almost invisible. Unsafe changes should
+be explicit, recoverable, and attributable.
+
+Primary interaction levels:
+
+1. Clean auto-sync
+   - Auto-load valid external IR changes when there are no local model edits.
+   - Show a temporary status event such as `Synced from MCP · 3 changes`.
+   - Preserve selection when possible. Follow renames when detectable. Clear
+     selection if the selected type was deleted.
+
+2. Review banner
+   - Show a top-of-canvas banner when valid external changes arrive while local
+     model state is dirty, a chat turn is active, or applying would be unsafe.
+   - Copy: `External model changes are ready`
+   - Supporting copy: `MCP changed .contexture.json while you have unsaved edits.`
+   - Actions: `Review`, `Apply external changes`, `Keep current canvas`
+
+3. Blocking attention
+   - Use a dialog only for invalid JSON, invalid IR, semantic failure, or a true
+     local/external conflict.
+   - Copy: `Model needs attention`
+   - Body: `.contexture.json changed outside Contexture, but the file is not valid Contexture IR. The canvas is still showing the last valid model.`
+   - Actions: `Open file`, `Reload last valid`, `Retry`
+
+4. Generated drift remains separate
+   - Model sync labels: `Synced`, `External changes`, `Model conflict`,
+     `Invalid model`.
+   - Generated drift labels: `Generated files drifted`, `Review generated changes`,
+     `Re-emit`.
+
+## Canvas Change Highlight Recommendation
+
+Use limited highlighting as an orientation aid, not as the primary signal.
+
+- Highlight only small clean auto-syncs, roughly 1 to 8 changed visible nodes.
+- Use a temporary non-layout-affecting outline/ring for changed nodes.
+- Do not recolor nodes permanently and do not reuse selection/adjacency styling.
+- Do not add badges unless node chrome already has stable space, because resizing
+  nodes would move the graph and create confusion.
+- Do not highlight field-level changes inside node bodies. Surface field changes
+  in a change summary or already-open detail panel.
+- Respect `prefers-reduced-motion`: no pulse, only a static temporary outline.
+- For large syncs, metadata-only changes, conflicts, invalid IR, or active manual
+  selection where selection clarity would suffer, prefer the status event and
+  change summary only.
+
+The status event and change summary are the accessible source of truth. Canvas
+highlighting is supplemental.
+
+## Proposed State Model
+
+Add a renderer sync store separate from generated drift:
+
+```ts
+type DocumentSyncState =
+  | "saved"
+  | "unsaved_changes"
+  | "syncing"
+  | "synced"
+  | "external_changes"
+  | "model_conflict"
+  | "invalid_model";
+```
+
+Suggested event payload:
+
+```ts
+interface ModelSyncEvent {
+  source: "desktop" | "mcp" | "cli" | "external" | "unknown";
+  status:
+    | "changed"
+    | "invalid_json"
+    | "invalid_ir"
+    | "semantic_error"
+    | "unreadable"
+    | "deleted";
+  irPath: string;
+  content?: string;
+  observedAt: number;
+  revision: string;
+}
+```
+
+Renderer-derived summary:
+
+```ts
+interface ModelChangeSummary {
+  source: ModelSyncEvent["source"];
+  changedTypes: string[];
+  addedTypes: string[];
+  removedTypes: string[];
+  renamedTypes: Array<{ from: string; to: string }>;
+  visibleChangedNodeIds: string[];
+  changeCount: number;
+}
+```
+
+The initial implementation can derive summaries by comparing the last rendered
+schema to the newly loaded schema. Exact Op history can be added later.
+
+## Implementation Slices
+
+### 1. Main-side IR watcher
+
+Create a source-model watcher alongside, but separate from, `drift-watcher`.
+
+Suggested files:
+
+- Add `apps/desktop/src/main/documents/model-sync-watcher.ts`
+- Add `apps/desktop/src/main/ipc/model-sync.ts`
+- Register it from `apps/desktop/src/main/app-main.ts`
+- Expose it through `apps/desktop/src/preload/index.ts` and `index.d.ts`
+
+Responsibilities:
+
+- Watch the open `.contexture.json`.
+- Debounce changes, default around 200-300ms.
+- Read the file and classify as valid, invalid JSON/IR, unreadable, or deleted.
+- Emit renderer events on meaningful external changes.
+- Provide `watch`, `unwatch`, `check`, and `acknowledgeSelfWrite` style APIs.
+
+Self-write suppression is required because `useProjectAutoSave` writes the same
+file. The least surprising implementation is to track the last saved revision:
+
+- Main `file:save` returns or internally records a content hash/revision for the
+  IR it just wrote.
+- The model-sync watcher compares the observed on-disk hash with the most recent
+  self-write hash for the open path.
+- Matching self-writes do not produce external sync events.
+- Non-matching writes are treated as external.
+
+Tests:
+
+- Detects valid external IR changes.
+- Does not report `file:save` or autosave self-writes.
+- Reports invalid JSON without crashing.
+- Reports deleted/unreadable IR.
+- Debounces rapid writes into one event.
+
+### 2. Renderer sync store and hook
+
+Create renderer state for source model sync.
+
+Suggested files:
+
+- Add `apps/desktop/src/renderer/src/store/model-sync.ts`
+- Add `apps/desktop/src/renderer/src/hooks/useModelSync.ts`
+- Mount `useModelSync()` in `App.tsx` near `useDrift()`
+
+Responsibilities:
+
+- Start/stop the main watcher for the open bundle path.
+- On valid external change:
+  - If there are no unsaved local model edits and no active turn, parse and apply
+    via `replace_schema`.
+  - Mark document clean for the loaded external revision.
+  - Record a temporary `synced` status event.
+  - Build a `ModelChangeSummary` for status text and optional highlights.
+- On local dirty state:
+  - Store pending external content.
+  - Set state to `external_changes`.
+  - Show a review banner.
+- On invalid state:
+  - Keep the last valid model visible.
+  - Set state to `invalid_model`.
+  - Expose details for a blocking dialog or banner.
+
+Important implementation detail:
+
+`useFileMenu` currently marks every schema-reference change dirty. Loading an
+external schema through `replace_schema` would trip this. Add a domain-level
+method such as `useUndoStore.replaceExternal(schema)` or use an explicit sync
+accept path that resets document dirtiness after the store update.
+
+Tests:
+
+- Clean external valid IR updates the undo store and document status.
+- Dirty local document does not auto-apply external content.
+- Invalid external IR keeps the old schema visible.
+- Pending external content can be applied by user action.
+- Window focus triggers a sync check, mirroring `useDrift`.
+
+### 3. Status bar sync surface
+
+Extend `StatusBar` with a sync status slot.
+
+Suggested behavior:
+
+- Base state remains `Saved` / `Unsaved changes`.
+- Temporary external success state can override the text for a few seconds:
+  `Synced from MCP · 3 changes`.
+- Persistent attention states appear on the right near validation:
+  `External changes pending`, `Model conflict`, `Invalid model`.
+- The status item should open a compact change summary popover when available.
+
+Tests:
+
+- Shows `Synced from MCP · N changes` for recent clean auto-sync.
+- Shows `External changes pending` for dirty local state.
+- Shows `Invalid model` for invalid source file.
+- Keyboard users can open and close the status details popover.
+
+### 4. Source sync banner and invalid model dialog
+
+Add a source-model sync banner distinct from `DriftBanner`.
+
+Suggested files:
+
+- Add `apps/desktop/src/renderer/src/components/hud/ModelSyncBanner.tsx`
+- Render it above the graph near `DriftBanner`, with model sync taking precedence
+  when source IR changed.
+
+Banner states:
+
+- `external_changes`: valid changes are waiting behind local dirty state.
+- `model_conflict`: local and external changes need explicit choice.
+
+Dialog state:
+
+- `invalid_model`: on-disk IR cannot be parsed or validated.
+
+Tests:
+
+- Banner copy does not mention generated drift.
+- `Review` opens summary.
+- `Apply external changes` applies pending content.
+- `Keep current canvas` leaves pending content unapplied and non-destructive.
+- Invalid model dialog offers `Open file`, `Reload last valid`, and `Retry`.
+
+### 5. Limited canvas highlight
+
+Add optional sync highlight state to graph rendering.
+
+Suggested approach:
+
+- Store `highlightedNodeIds` and expiry in `model-sync` store.
+- Pass them into `GraphCanvas`.
+- Pass a boolean through `TypeNodeData` or node `data`.
+- In `TypeNode`, add a temporary outline/ring style that does not change node
+  dimensions.
+- Clear highlights on timeout, selection interaction, navigation, or a new sync
+  event.
+
+Rules:
+
+- Only highlight clean auto-syncs with 1-8 changed visible nodes.
+- Do not highlight when sync state is conflict/invalid.
+- Do not animate if `prefers-reduced-motion: reduce`.
+- Selection and adjacency visuals win over sync highlight.
+
+Tests:
+
+- Small clean sync adds temporary `data-sync-highlighted="true"` or equivalent.
+- Large sync does not highlight nodes.
+- Highlight does not change node dimensions.
+- Selection style remains dominant.
+
+### 6. Provider/chat desync handling
+
+External model changes should make active provider context stale.
+
+Implementation options:
+
+- Add a preload/schema-agent method such as `schemaAgent.markExternalModelChange`.
+- Or have the renderer clear/mark local chat state desynced when `useModelSync`
+  applies or queues an external model event.
+
+Behavior:
+
+- If a chat turn is active, do not auto-apply external source changes. Queue and
+  show a banner.
+- If an external change is applied after a thread exists, mark the thread stale
+  before the next send.
+- Copy: `Model changed outside this chat. Start a new turn from the latest model.`
+
+Tests:
+
+- External sync during streaming queues instead of applying.
+- External sync after a provider thread marks chat desynced or clears resumable
+  thread state.
+- Next send pushes the latest IR before provider execution.
+
+### 7. Native notifications excluded
+
+Native notifications are out of scope.
+
+Do not add push or OS-level notifications for model sync. The desktop app should
+communicate sync state through the status bar, source sync banner, invalid model
+dialog, canvas highlight, and durable change log.
+
+## Source Attribution
+
+Best effort for v1:
+
+- MCP writes: if the packaged desktop MCP server can share process state with the
+  desktop window, tag as `mcp`.
+- CLI writes: tag as `cli` when the CLI writes a change-log entry; otherwise
+  treat as `external`.
+- Raw file edits: `external`.
+
+## Durable Change Log
+
+Promote source attribution into a durable sidecar change log, not a short-lived
+`last-change.json` marker.
+
+Suggested file:
+
+- `.contexture/change-log.json`
+
+Suggested core API:
+
+- `appendModelChangeLogEntry(input)`
+- `loadModelChangeLog(irPath)`
+- `pruneModelChangeLog(irPath, limit)`
+
+Suggested entry shape:
+
+```ts
+interface ModelChangeLog {
+  version: "1";
+  entries: ModelChangeLogEntry[];
+}
+
+interface ModelChangeLogEntry {
+  id: string;
+  irPath: string;
+  source: "desktop" | "mcp" | "cli" | "schema_agent" | "external";
+  reason:
+    | "op_applied"
+    | "replace_schema"
+    | "raw_file_change"
+    | "external_sync_accepted"
+    | "generated_emit";
+  opKind?: string;
+  changedTypes: string[];
+  addedTypes: string[];
+  removedTypes: string[];
+  renamedTypes: Array<{ from: string; to: string }>;
+  changeCount: number;
+  beforeHash?: string;
+  afterHash: string;
+  createdAt: string;
+  actor?: string;
+  summary?: string;
+}
+```
+
+Write entries from every intentional model mutation surface:
+
+- Desktop direct manipulation and detail-panel Ops.
+- Schema-agent Ops applied through the renderer.
+- MCP `apply_contexture_op`.
+- CLI mutation commands and `apply`.
+- Reconcile applying IR Ops.
+- External raw file changes accepted by the sync flow.
+
+Do not write entries for pure generated-target emits unless the source IR also
+changed. If an emit needs a record, use `reason: "generated_emit"` and keep it
+visually separate from model mutation entries.
+
+The desktop watcher should use the change log to enrich sync events:
+
+- Match on `afterHash` to attribute source accurately.
+- Use changed type hints for status text, summaries, and limited canvas
+  highlights.
+- Fall back to renderer-derived schema diff when no matching entry exists.
+
+Renderer UI:
+
+- Add a persistent right-sidebar activity tab named `Changes`.
+- Add the tab to the existing activity bar next to `Properties`, `Chat`, and
+  `Schema`, using a Lucide `History` or `ListTree` icon.
+- The status bar may link to the latest change, but it is not the primary home
+  for durable history.
+- Do not use a modal for the normal change-log flow.
+- The panel title is `Model changes`.
+- The list is newest-first and compact enough to scan beside the canvas.
+- Each row shows an operation summary, source, actor, time, affected type names
+  or count, and a short system-generated summary when useful.
+- Selecting a change opens an in-panel detail view.
+- The change log is read-only in v1; undo/rollback remains the job of the undo
+  stack and future reconcile flows.
+
+Recommended row copy:
+
+- Primary line: `Add type · Booking`
+- Secondary line: `Desktop · Rufus · 14:32 · 2 affected types`
+- Optional summary: `Added Booking and linked it to Customer`
+
+Recommended source labels:
+
+- `Desktop`
+- `Schema agent`
+- `MCP`
+- `CLI`
+- `Reconcile`
+- `External`
+
+Recommended operation labels:
+
+- `Added`
+- `Updated`
+- `Deleted`
+- `Renamed`
+- `Replaced`
+- `Accepted external change`
+
+Use neutral source badges. Reserve warning/destructive colors for unreadable log
+states or destructive operations. Do not rely on color alone.
+
+Detail view:
+
+- Header: operation summary, timestamp, source, actor.
+- `Affected model`: clickable types/fields.
+- `Change summary`: normalized semantic summary.
+- `Raw log entry`: collapsed disclosure for debugging.
+- Optional semantic diff when structured before/after data exists.
+- Prefer semantic model diffs over source-code diffs.
+- Avoid using the generated-target reconcile diff component unless the entry is
+  specifically an accepted external/reconcile change.
+
+Canvas behavior from the change log:
+
+- Provide a `Focus affected` button in the detail view.
+- Clicking an affected type selects/reveals that node using existing graph focus
+  behavior.
+- If multiple nodes are affected, fit them in view and select the primary node.
+- Do not create persistent glows or trails from historical changes.
+
+Filtering/search:
+
+- V1 search should match summary, type names, actor, and source.
+- V1 source filter: `All`, `Desktop`, `Agent`, `MCP`, `CLI`, `Reconcile`,
+  `External`.
+- Show a `Current selection` toggle when a canvas node is selected.
+- Defer date range, operation-kind filter, actor filter, saved filters, and
+  day/session grouping until the log proves it needs them.
+
+Empty and error states:
+
+- Empty title: `No model changes yet`
+- Empty description: `Changes to this Contexture model will appear here after the file is edited, reconciled, or updated by an agent.`
+- No-results title: `No matching changes`
+- No-results description: `Adjust the search or filters.`
+- Unreadable title: `Change log unavailable`
+- Unreadable description: `Contexture could not read .contexture/change-log.json. The model is still usable.`
+- Unreadable action: `Retry`
+- Malformed entries: show valid entries and an inline warning row,
+  `1 change could not be displayed`, with `Show details`.
+- Distinction copy when useful: `Generated file drift is handled in Reconcile.`
+
+Accessibility:
+
+- The activity tab is a labelled button with `aria-label="Changes"`.
+- The list is keyboard navigable; Enter opens the selected change detail.
+- `Focus affected` is a real button, not row-only behavior.
+- Icon-only controls have tooltips and accessible names.
+- Source and operation are represented by text, not color alone.
+- Preserve visible focus rings.
+- Respect `prefers-reduced-motion`; canvas focus should not rely on animated
+  pulses.
+- Time text exposes absolute timestamps via `title` or accessible label.
+
+Retention:
+
+- Keep the most recent 200 entries by default.
+- Prune on append.
+- Preserve IDs and timestamps so entries are stable for UI selection.
+
+Tests:
+
+- MCP and CLI mutations append change-log entries with source and `afterHash`.
+- Renderer-applied schema-agent Ops append entries without double-counting
+  autosave.
+- Raw file changes accepted through sync append `external_sync_accepted`.
+- The watcher enriches a sync event from a matching `afterHash`.
+- The `Changes` activity tab renders entries, details, filters, empty/error
+  states, and affected-node focus.
+
+## Suggested Delivery Order
+
+1. Main-side IR watcher with self-write suppression and tests.
+2. Renderer model-sync store/hook that auto-applies clean valid external changes.
+3. Durable `.contexture/change-log.json` writer/reader in core plus
+   MCP/CLI/desktop write sites.
+4. Status bar sync messages, latest change summary, and pending/invalid states.
+5. Source sync banner and invalid model dialog.
+6. Chat/provider stale handling.
+7. Limited canvas node highlights for small syncs.
+8. Read-only `Changes` sidebar tab with search, source filter, details, and
+   affected-node focus.
+
+## Acceptance Checklist
+
+- Valid external `.contexture.json` changes auto-update the canvas when the local
+  model is clean.
+- Autosave and manual save do not trigger false external sync events.
+- Invalid on-disk IR never blanks the canvas; the last valid model remains visible.
+- Dirty local model state prevents silent external apply and shows a reviewable
+  source-model banner.
+- Model sync and generated drift use separate stores, labels, banners, and actions.
+- Rapid external Op sequences batch into one visual update and one status event.
+- Provider/chat context is marked stale or prevented from continuing against an
+  old model snapshot.
+- Optional canvas highlight is temporary, non-resizing, accessible, and limited to
+  small clean syncs.
+- Durable `.contexture/change-log.json` records intentional model mutations from
+  desktop, schema agent, MCP, CLI, reconcile, and accepted raw external changes.
+- Users can inspect recent model changes at any time from a persistent `Changes`
+  sidebar tab.
+- Each change row shows source, actor, time, operation, affected model elements,
+  and a short summary.
+- Selecting a change shows details with affected model elements and a collapsed
+  raw JSON disclosure.
+- `Focus affected` reveals affected canvas nodes without making historical
+  highlighting the primary UI.
+- The change-log surface remains separate from chat history and generated-target
+  drift/reconcile.
+- Focus checks catch changes made while Contexture was backgrounded.
+- Tests cover main watcher, renderer hook, status/banner behavior, change log
+  behavior, and highlight rules.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -616,7 +616,7 @@ async function run(argv: string[]): Promise<void> {
       else process.stderr.write(`${error.error.message}\n`);
       return;
     }
-    const forward = createFileBackedForward(writableIrPath);
+    const forward = createFileBackedForward(writableIrPath, { changeSource: 'cli' });
     type ForwardResult = Awaited<ReturnType<typeof forward>>;
     let result: ForwardResult;
     try {
@@ -640,7 +640,7 @@ async function run(argv: string[]): Promise<void> {
   }
 
   const writableIrPath = assertContextureIrPath(irPath);
-  const forward = createFileBackedForward(writableIrPath);
+  const forward = createFileBackedForward(writableIrPath, { changeSource: 'cli' });
   const tools = new Map(createOpTools(forward).map((tool) => [tool.name, tool]));
   const { tool: toolName, input } = commandToToolInput(command, args);
   const tool = tools.get(toolName);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./change-log": "./src/change-log.ts",
     "./emit-ai-tool-schemas": "./src/emit-ai-tool-schemas.ts",
     "./emit-convex": "./src/emit-convex.ts",
     "./emit-form-validators": "./src/emit-form-validators.ts",

--- a/packages/core/src/change-log.ts
+++ b/packages/core/src/change-log.ts
@@ -1,0 +1,376 @@
+import type { Schema, TypeDef } from './ir';
+import { save } from './load';
+import { bundlePathsFor } from './paths';
+import { hashContent } from './pipeline';
+
+export type ModelChangeSource =
+  | 'desktop'
+  | 'mcp'
+  | 'cli'
+  | 'schema_agent'
+  | 'reconcile'
+  | 'external';
+
+export type ModelChangeReason =
+  | 'op_applied'
+  | 'replace_schema'
+  | 'raw_file_change'
+  | 'external_sync_accepted'
+  | 'generated_emit';
+
+export interface ModelChangeRename {
+  from: string;
+  to: string;
+}
+
+export interface ModelChangeLogEntry {
+  id: string;
+  irPath: string;
+  source: ModelChangeSource;
+  reason: ModelChangeReason;
+  opKind?: string;
+  changedTypes: string[];
+  addedTypes: string[];
+  removedTypes: string[];
+  renamedTypes: ModelChangeRename[];
+  changeCount: number;
+  beforeHash?: string;
+  afterHash: string;
+  createdAt: string;
+  actor?: string;
+  summary?: string;
+}
+
+export interface ModelChangeLog {
+  version: '1';
+  entries: ModelChangeLogEntry[];
+}
+
+export interface ModelChangeLogFs {
+  readFile(path: string): Promise<string>;
+  writeFile(path: string, content: string): Promise<void>;
+}
+
+export interface ModelChangeSummary {
+  changedTypes: string[];
+  addedTypes: string[];
+  removedTypes: string[];
+  renamedTypes: ModelChangeRename[];
+  changeCount: number;
+  summary: string;
+}
+
+export interface BuildModelChangeLogEntryInput {
+  irPath: string;
+  source: ModelChangeSource;
+  reason: ModelChangeReason;
+  before?: Schema;
+  after: Schema;
+  opKind?: string;
+  actor?: string;
+  createdAt?: string;
+  id?: string;
+  summary?: string;
+}
+
+export interface AppendModelChangeLogEntryInput {
+  irPath: string;
+  fs: ModelChangeLogFs;
+  entry: ModelChangeLogEntry;
+  limit?: number;
+}
+
+export interface LoadModelChangeLogResult {
+  log: ModelChangeLog;
+  warnings: string[];
+}
+
+export const DEFAULT_CHANGE_LOG_LIMIT = 200;
+
+export function changeLogPathFor(irPath: string): string {
+  return bundlePathsFor(irPath).changeLog;
+}
+
+export function schemaHash(schema: Schema): string {
+  return hashContent(save(schema));
+}
+
+export function summarizeModelChange(
+  before: Schema | undefined,
+  after: Schema,
+): ModelChangeSummary {
+  if (!before) {
+    const addedTypes = after.types.map((type) => type.name);
+    return {
+      changedTypes: [],
+      addedTypes,
+      removedTypes: [],
+      renamedTypes: [],
+      changeCount: addedTypes.length,
+      summary: summarizeWords({ addedTypes }),
+    };
+  }
+
+  const beforeByName = new Map(before.types.map((type) => [type.name, type] as const));
+  const afterByName = new Map(after.types.map((type) => [type.name, type] as const));
+  let addedTypes = after.types
+    .filter((type) => !beforeByName.has(type.name))
+    .map((type) => type.name);
+  let removedTypes = before.types
+    .filter((type) => !afterByName.has(type.name))
+    .map((type) => type.name);
+  const renamedTypes = inferRenames(before, after, removedTypes, addedTypes);
+  if (renamedTypes.length > 0) {
+    const renamedFrom = new Set(renamedTypes.map((rename) => rename.from));
+    const renamedTo = new Set(renamedTypes.map((rename) => rename.to));
+    removedTypes = removedTypes.filter((name) => !renamedFrom.has(name));
+    addedTypes = addedTypes.filter((name) => !renamedTo.has(name));
+  }
+
+  const changedTypes = after.types
+    .filter((type) => {
+      const previous = beforeByName.get(type.name);
+      return previous !== undefined && stableStringify(previous) !== stableStringify(type);
+    })
+    .map((type) => type.name);
+
+  const changeCount =
+    changedTypes.length + addedTypes.length + removedTypes.length + renamedTypes.length;
+
+  return {
+    changedTypes,
+    addedTypes,
+    removedTypes,
+    renamedTypes,
+    changeCount,
+    summary: summarizeWords({ changedTypes, addedTypes, removedTypes, renamedTypes }),
+  };
+}
+
+export function buildModelChangeLogEntry(
+  input: BuildModelChangeLogEntryInput,
+): ModelChangeLogEntry {
+  const summary = summarizeModelChange(input.before, input.after);
+  return {
+    id: input.id ?? makeChangeLogId(input.createdAt),
+    irPath: input.irPath,
+    source: input.source,
+    reason: input.reason,
+    ...(input.opKind ? { opKind: input.opKind } : {}),
+    changedTypes: summary.changedTypes,
+    addedTypes: summary.addedTypes,
+    removedTypes: summary.removedTypes,
+    renamedTypes: summary.renamedTypes,
+    changeCount: summary.changeCount,
+    ...(input.before ? { beforeHash: schemaHash(input.before) } : {}),
+    afterHash: schemaHash(input.after),
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    ...(input.actor ? { actor: input.actor } : {}),
+    summary: input.summary ?? summary.summary,
+  };
+}
+
+export async function loadModelChangeLog(
+  irPath: string,
+  fs: Pick<ModelChangeLogFs, 'readFile'>,
+): Promise<LoadModelChangeLogResult> {
+  try {
+    const raw = await fs.readFile(changeLogPathFor(irPath));
+    const parsed = JSON.parse(raw);
+    return parseModelChangeLog(parsed);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { log: emptyModelChangeLog(), warnings: [] };
+    }
+    return {
+      log: emptyModelChangeLog(),
+      warnings: [err instanceof Error ? err.message : String(err)],
+    };
+  }
+}
+
+export async function appendModelChangeLogEntry(
+  input: AppendModelChangeLogEntryInput,
+): Promise<ModelChangeLog> {
+  const loaded = await loadModelChangeLog(input.irPath, input.fs);
+  const next = pruneModelChangeLog(
+    {
+      version: '1',
+      entries: [input.entry, ...loaded.log.entries.filter((entry) => entry.id !== input.entry.id)],
+    },
+    input.limit ?? DEFAULT_CHANGE_LOG_LIMIT,
+  );
+  await input.fs.writeFile(changeLogPathFor(input.irPath), `${JSON.stringify(next, null, 2)}\n`);
+  return next;
+}
+
+export function pruneModelChangeLog(
+  log: ModelChangeLog,
+  limit = DEFAULT_CHANGE_LOG_LIMIT,
+): ModelChangeLog {
+  return { version: '1', entries: log.entries.slice(0, Math.max(0, limit)) };
+}
+
+export function emptyModelChangeLog(): ModelChangeLog {
+  return { version: '1', entries: [] };
+}
+
+function parseModelChangeLog(value: unknown): LoadModelChangeLogResult {
+  const warnings: string[] = [];
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { log: emptyModelChangeLog(), warnings: ['Change log is not an object.'] };
+  }
+  const record = value as { version?: unknown; entries?: unknown };
+  if (record.version !== '1') {
+    warnings.push('Change log version is not supported.');
+  }
+  if (!Array.isArray(record.entries)) {
+    return { log: emptyModelChangeLog(), warnings: [...warnings, 'Change log entries missing.'] };
+  }
+  const entries: ModelChangeLogEntry[] = [];
+  let invalidCount = 0;
+  for (const entry of record.entries) {
+    const parsed = parseEntry(entry);
+    if (parsed) entries.push(parsed);
+    else invalidCount += 1;
+  }
+  if (invalidCount > 0) warnings.push(`${invalidCount} change log entries could not be read.`);
+  return { log: { version: '1', entries }, warnings };
+}
+
+function parseEntry(value: unknown): ModelChangeLogEntry | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.id !== 'string' ||
+    typeof record.irPath !== 'string' ||
+    !isSource(record.source) ||
+    !isReason(record.reason) ||
+    !Array.isArray(record.changedTypes) ||
+    !Array.isArray(record.addedTypes) ||
+    !Array.isArray(record.removedTypes) ||
+    !Array.isArray(record.renamedTypes) ||
+    typeof record.changeCount !== 'number' ||
+    typeof record.afterHash !== 'string' ||
+    typeof record.createdAt !== 'string'
+  ) {
+    return null;
+  }
+  const entry: ModelChangeLogEntry = {
+    id: record.id,
+    irPath: record.irPath,
+    source: record.source,
+    reason: record.reason,
+    changedTypes: record.changedTypes.filter(isString),
+    addedTypes: record.addedTypes.filter(isString),
+    removedTypes: record.removedTypes.filter(isString),
+    renamedTypes: record.renamedTypes.filter(isRename),
+    changeCount: record.changeCount,
+    afterHash: record.afterHash,
+    createdAt: record.createdAt,
+  };
+  if (typeof record.opKind === 'string') entry.opKind = record.opKind;
+  if (typeof record.beforeHash === 'string') entry.beforeHash = record.beforeHash;
+  if (typeof record.actor === 'string') entry.actor = record.actor;
+  if (typeof record.summary === 'string') entry.summary = record.summary;
+  return entry;
+}
+
+function inferRenames(
+  before: Schema,
+  after: Schema,
+  removedTypes: string[],
+  addedTypes: string[],
+): ModelChangeRename[] {
+  if (removedTypes.length === 0 || addedTypes.length === 0) return [];
+  const beforeByName = new Map(before.types.map((type) => [type.name, type] as const));
+  const afterByName = new Map(after.types.map((type) => [type.name, type] as const));
+  const renames: ModelChangeRename[] = [];
+  const remainingAdded = new Set(addedTypes);
+
+  for (const from of removedTypes) {
+    const previous = beforeByName.get(from);
+    if (!previous) continue;
+    const match = [...remainingAdded].find((to) => {
+      const next = afterByName.get(to);
+      return next ? sameExceptName(previous, next) : false;
+    });
+    if (!match) continue;
+    remainingAdded.delete(match);
+    renames.push({ from, to: match });
+  }
+  return renames;
+}
+
+function sameExceptName(left: TypeDef, right: TypeDef): boolean {
+  return stableStringify({ ...left, name: '' }) === stableStringify({ ...right, name: '' });
+}
+
+function summarizeWords(input: {
+  changedTypes?: string[];
+  addedTypes?: string[];
+  removedTypes?: string[];
+  renamedTypes?: ModelChangeRename[];
+}): string {
+  const parts: string[] = [];
+  if (input.addedTypes && input.addedTypes.length > 0) {
+    parts.push(`Added ${renderNames(input.addedTypes)}`);
+  }
+  if (input.changedTypes && input.changedTypes.length > 0) {
+    parts.push(`Updated ${renderNames(input.changedTypes)}`);
+  }
+  if (input.removedTypes && input.removedTypes.length > 0) {
+    parts.push(`Deleted ${renderNames(input.removedTypes)}`);
+  }
+  if (input.renamedTypes && input.renamedTypes.length > 0) {
+    parts.push(
+      `Renamed ${input.renamedTypes.map((rename) => `${rename.from} to ${rename.to}`).join(', ')}`,
+    );
+  }
+  return parts.length > 0 ? parts.join('; ') : 'No visible model changes';
+}
+
+function renderNames(names: string[]): string {
+  if (names.length <= 2) return names.join(' and ');
+  return `${names.slice(0, 2).join(', ')} and ${names.length - 2} more`;
+}
+
+function makeChangeLogId(createdAt?: string): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  return c?.randomUUID ? c.randomUUID() : `change-${createdAt ?? Date.now()}-${Math.random()}`;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function isSource(value: unknown): value is ModelChangeSource {
+  return (
+    value === 'desktop' ||
+    value === 'mcp' ||
+    value === 'cli' ||
+    value === 'schema_agent' ||
+    value === 'reconcile' ||
+    value === 'external'
+  );
+}
+
+function isReason(value: unknown): value is ModelChangeReason {
+  return (
+    value === 'op_applied' ||
+    value === 'replace_schema' ||
+    value === 'raw_file_change' ||
+    value === 'external_sync_accepted' ||
+    value === 'generated_emit'
+  );
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isRename(value: unknown): value is ModelChangeRename {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.from === 'string' && typeof record.to === 'string';
+}

--- a/packages/core/src/change-log.ts
+++ b/packages/core/src/change-log.ts
@@ -1,7 +1,6 @@
 import type { Schema, TypeDef } from './ir';
 import { save } from './load';
 import { bundlePathsFor } from './paths';
-import { hashContent } from './pipeline';
 
 export type ModelChangeSource =
   | 'desktop'
@@ -92,7 +91,7 @@ export function changeLogPathFor(irPath: string): string {
 }
 
 export function schemaHash(schema: Schema): string {
-  return hashContent(save(schema));
+  return hashText(save(schema));
 }
 
 export function summarizeModelChange(
@@ -342,6 +341,22 @@ function makeChangeLogId(createdAt?: string): string {
 
 function stableStringify(value: unknown): string {
   return JSON.stringify(value);
+}
+
+function hashText(text: string): string {
+  const chunks = [0x811c9dc5, 0x01000193, 0x9e3779b9, 0x85ebca6b];
+  for (let i = 0; i < text.length; i += 1) {
+    const code = text.charCodeAt(i);
+    for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex += 1) {
+      const chunk = chunks[chunkIndex];
+      if (chunk === undefined) continue;
+      chunks[chunkIndex] = Math.imul(chunk ^ (code + chunkIndex), 0x01000193);
+    }
+  }
+  return chunks
+    .map((chunk) => (chunk >>> 0).toString(16).padStart(8, '0'))
+    .join('')
+    .repeat(2);
 }
 
 function isSource(value: unknown): value is ModelChangeSource {

--- a/packages/core/src/file-forward.ts
+++ b/packages/core/src/file-forward.ts
@@ -1,5 +1,10 @@
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
+import {
+  appendModelChangeLogEntry,
+  buildModelChangeLogEntry,
+  type ModelChangeSource,
+} from './change-log';
 import { type GeneratedBundleFs, writeGeneratedBundle } from './generated-bundle-writer';
 import { load } from './load';
 import { type ApplyResult, apply, type Op } from './ops';
@@ -41,6 +46,8 @@ export const nodeFileBackedFs: FileBackedFs = {
 export interface FileBackedForwardOptions {
   fs?: FileBackedFs;
   stdlib?: StdlibCatalog;
+  changeSource?: ModelChangeSource;
+  actor?: string;
 }
 
 export function createFileBackedForward(
@@ -58,6 +65,21 @@ export function createFileBackedForward(
     if ('error' in result) return result;
 
     await writeGeneratedBundle({ irPath: resolvedIrPath, schema: result.schema, fs });
+    if (options.changeSource) {
+      await appendModelChangeLogEntry({
+        irPath: resolvedIrPath,
+        fs,
+        entry: buildModelChangeLogEntry({
+          irPath: resolvedIrPath,
+          source: options.changeSource,
+          reason: op.kind === 'replace_schema' ? 'replace_schema' : 'op_applied',
+          before: schema,
+          after: result.schema,
+          opKind: op.kind,
+          ...(options.actor ? { actor: options.actor } : {}),
+        }),
+      });
+    }
     return result;
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './change-log';
 export * from './chat-history';
 export * from './document-bundle';
 export { emitAiToolSchemas } from './emit-ai-tool-schemas';

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -264,7 +264,9 @@ async function applyContextureOp(
 
   let result: Awaited<ReturnType<ReturnType<typeof createFileBackedForward>>>;
   try {
-    result = await createFileBackedForward(path, { stdlib: catalog })(parsed.data);
+    result = await createFileBackedForward(path, { stdlib: catalog, changeSource: 'mcp' })(
+      parsed.data,
+    );
   } catch (err) {
     return {
       path,

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -4,6 +4,7 @@ export const SCHEMA_JSON_SUFFIX = '.schema.json';
 export const LAYOUT_FILE = 'layout.json';
 export const CHAT_FILE = 'chat.json';
 export const EMITTED_FILE = 'emitted.json';
+export const CHANGE_LOG_FILE = 'change-log.json';
 export const AI_TOOL_SCHEMAS_FILE = 'ai-tool-schemas.json';
 export const STRUCTURED_OUTPUT_SCHEMAS_FILE = 'structured-output-schemas.json';
 export const MCP_DEFINITIONS_FILE = 'mcp-definitions.json';
@@ -16,6 +17,7 @@ export interface BundlePaths {
   layout: string;
   chat: string;
   emitted: string;
+  changeLog: string;
   schemaTs: string;
   schemaJson: string;
   schemaIndex: string;
@@ -75,6 +77,7 @@ export function bundlePathsFor(irPath: string): BundlePaths {
     layout: `${ctxDir}/${LAYOUT_FILE}`,
     chat: `${ctxDir}/${CHAT_FILE}`,
     emitted: `${ctxDir}/${EMITTED_FILE}`,
+    changeLog: `${ctxDir}/${CHANGE_LOG_FILE}`,
     schemaTs: `${schemaBase}${SCHEMA_TS_SUFFIX}`,
     schemaJson: `${schemaBase}${SCHEMA_JSON_SUFFIX}`,
     schemaIndex: `${layout.schemaDir}/index.ts`,

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -14,6 +14,7 @@ export {
   assertContextureIrPath,
   baseNameFor,
   bundlePathsFor,
+  CHANGE_LOG_FILE,
   CHAT_FILE,
   CONVEX_VALIDATORS_FILE,
   contextureDirFor,

--- a/packages/core/tests/change-log.test.ts
+++ b/packages/core/tests/change-log.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendModelChangeLogEntry,
+  buildModelChangeLogEntry,
+  changeLogPathFor,
+  loadModelChangeLog,
+  type ModelChangeLogFs,
+  pruneModelChangeLog,
+  type Schema,
+  summarizeModelChange,
+} from '../src';
+
+const irPath = '/work/garden.contexture.json';
+
+const before: Schema = {
+  version: '1',
+  types: [{ kind: 'object', name: 'Plot', fields: [] }],
+};
+
+const after: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Plot',
+      fields: [{ name: 'name', type: { kind: 'string' } }],
+    },
+    { kind: 'object', name: 'Bed', fields: [] },
+  ],
+};
+
+function memFs(
+  seed: Record<string, string> = {},
+): ModelChangeLogFs & { files: Map<string, string> } {
+  const files = new Map(Object.entries(seed));
+  return {
+    files,
+    async readFile(path) {
+      const content = files.get(path);
+      if (content === undefined) {
+        const err = new Error(`ENOENT: ${path}`) as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        throw err;
+      }
+      return content;
+    },
+    async writeFile(path, content) {
+      files.set(path, content);
+    },
+  };
+}
+
+describe('model change log', () => {
+  it('summarizes added and changed types', () => {
+    expect(summarizeModelChange(before, after)).toMatchObject({
+      changedTypes: ['Plot'],
+      addedTypes: ['Bed'],
+      removedTypes: [],
+      renamedTypes: [],
+      changeCount: 2,
+      summary: 'Added Bed; Updated Plot',
+    });
+  });
+
+  it('detects simple renames when the type body is unchanged', () => {
+    const renamed: Schema = {
+      version: '1',
+      types: [{ kind: 'object', name: 'AllotmentPlot', fields: [] }],
+    };
+
+    expect(summarizeModelChange(before, renamed)).toMatchObject({
+      changedTypes: [],
+      addedTypes: [],
+      removedTypes: [],
+      renamedTypes: [{ from: 'Plot', to: 'AllotmentPlot' }],
+      changeCount: 1,
+    });
+  });
+
+  it('appends newest-first entries and prunes to the limit', async () => {
+    const fs = memFs();
+    const first = buildModelChangeLogEntry({
+      id: 'first',
+      irPath,
+      source: 'cli',
+      reason: 'op_applied',
+      before,
+      after,
+      opKind: 'add_field',
+      createdAt: '2026-05-22T10:00:00.000Z',
+    });
+    const second = buildModelChangeLogEntry({
+      id: 'second',
+      irPath,
+      source: 'mcp',
+      reason: 'op_applied',
+      before: after,
+      after: { version: '1', types: after.types.slice(0, 1) },
+      opKind: 'delete_type',
+      createdAt: '2026-05-22T10:01:00.000Z',
+    });
+
+    await appendModelChangeLogEntry({ irPath, fs, entry: first, limit: 2 });
+    await appendModelChangeLogEntry({ irPath, fs, entry: second, limit: 1 });
+
+    const loaded = await loadModelChangeLog(irPath, fs);
+    expect(loaded.warnings).toEqual([]);
+    expect(loaded.log.entries.map((entry) => entry.id)).toEqual(['second']);
+    expect(fs.files.has(changeLogPathFor(irPath))).toBe(true);
+  });
+
+  it('returns warnings but keeps valid entries when the log is partially malformed', async () => {
+    const entry = buildModelChangeLogEntry({
+      id: 'valid',
+      irPath,
+      source: 'desktop',
+      reason: 'op_applied',
+      before,
+      after,
+      createdAt: '2026-05-22T10:00:00.000Z',
+    });
+    const fs = memFs({
+      [changeLogPathFor(irPath)]: JSON.stringify({
+        version: '1',
+        entries: [entry, { id: 'broken' }],
+      }),
+    });
+
+    const loaded = await loadModelChangeLog(irPath, fs);
+    expect(loaded.log.entries.map((candidate) => candidate.id)).toEqual(['valid']);
+    expect(loaded.warnings).toEqual(['1 change log entries could not be read.']);
+  });
+
+  it('prunes without mutating the original log', () => {
+    const log = {
+      version: '1' as const,
+      entries: [
+        buildModelChangeLogEntry({ id: 'a', irPath, source: 'cli', reason: 'op_applied', after }),
+        buildModelChangeLogEntry({ id: 'b', irPath, source: 'cli', reason: 'op_applied', after }),
+      ],
+    };
+
+    expect(pruneModelChangeLog(log, 1).entries.map((entry) => entry.id)).toEqual(['a']);
+    expect(log.entries.map((entry) => entry.id)).toEqual(['a', 'b']);
+  });
+});

--- a/packages/core/tests/file-forward.test.ts
+++ b/packages/core/tests/file-forward.test.ts
@@ -2,7 +2,13 @@ import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { createFileBackedForward, type FileBackedFs, type Schema } from '../src';
+import {
+  changeLogPathFor,
+  createFileBackedForward,
+  type FileBackedFs,
+  type ModelChangeLog,
+  type Schema,
+} from '../src';
 
 const initialSchema: Schema = {
   version: '1',
@@ -36,6 +42,34 @@ describe('createFileBackedForward', () => {
     await expect(
       readFile(join(dir, 'packages/contexture/.contexture/emitted.json'), 'utf8'),
     ).resolves.toContain('app.schema.ts');
+  });
+
+  it('appends change-log entries when a change source is provided', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'contexture-core-'));
+    const irPath = join(dir, 'packages/contexture/app.contexture.json');
+    await mkdir(join(dir, 'packages/contexture/.contexture'), { recursive: true });
+    await writeFile(irPath, `${JSON.stringify(initialSchema, null, 2)}\n`, 'utf8');
+
+    const forward = createFileBackedForward(irPath, { changeSource: 'mcp' });
+    await forward({
+      kind: 'add_field',
+      typeName: 'Post',
+      field: { name: 'title', type: { kind: 'string' } },
+    });
+
+    const log = JSON.parse(await readFile(changeLogPathFor(irPath), 'utf8')) as ModelChangeLog;
+    expect(log.entries).toHaveLength(1);
+    expect(log.entries[0]).toMatchObject({
+      source: 'mcp',
+      reason: 'op_applied',
+      opKind: 'add_field',
+      changedTypes: ['Post'],
+      addedTypes: [],
+      removedTypes: [],
+      changeCount: 1,
+      summary: 'Updated Post',
+    });
+    expect(log.entries[0]?.afterHash).toMatch(/^[a-f0-9]{64}$/);
   });
 
   it('rolls back the IR if a later generated-file write fails', async () => {


### PR DESCRIPTION
## Summary
- add durable `.contexture/change-log.json` support in core and log MCP/CLI/desktop/schema-agent/reconcile model mutations
- add a main-process `.contexture.json` sync watcher with self-write suppression and renderer IPC/preload bindings
- add desktop sync UX: source-model banner, status bar sync states, limited canvas highlights, and persistent `Changes` sidebar tab backed by Zustand
- document the sync implementation plan and UX decisions

## Verification
- `bun run ci`
- pre-commit hook also ran `turbo typecheck` and `turbo test`
