### PR TITLE
fix(desktop): surface file access denials

### DIFF
--- a/apps/desktop/src/main/ipc/shell.ts
+++ b/apps/desktop/src/main/ipc/shell.ts
@@ -6,6 +6,9 @@ import { IpcString, parseIpcPayload } from './validation';
 
 export type CliRunner = (args: readonly string[]) => Promise<void>;
 
+const MACOS_FILE_ACCESS_SETTINGS_URL =
+  'x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles';
+
 export async function openInEditor(path: string, runCli: CliRunner): Promise<void> {
   const safePath = assertSafeShellPath(path);
   try {
@@ -47,5 +50,10 @@ export function registerShellIpc(): void {
   });
   ipcMain.handle('shell:open-in-editor', async (_evt, path: unknown) => {
     await openInEditor(parseIpcPayload('shell:open-in-editor', IpcString, path), spawnCode);
+  });
+  ipcMain.handle('shell:open-file-access-settings', async () => {
+    if (process.platform === 'darwin') {
+      await shell.openExternal(MACOS_FILE_ACCESS_SETTINGS_URL);
+    }
   });
 }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -109,6 +109,8 @@ export interface ContextureShellAPI {
   reveal: (path: string) => Promise<void>;
   /** Open a folder or file in VS Code via the `vscode://` URL scheme. */
   openInEditor: (path: string) => Promise<void>;
+  /** Open the OS privacy settings page for file/folder access. */
+  openFileAccessSettings: () => Promise<void>;
 }
 
 export interface ContextureDriftAPI {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -123,6 +123,9 @@ const shell = {
   /** Open a folder (or file) in VS Code via the `vscode://` URL scheme. */
   openInEditor: (path: string): Promise<void> =>
     ipcRenderer.invoke('shell:open-in-editor', path) as Promise<void>,
+  /** Open the OS privacy settings page for file/folder access. */
+  openFileAccessSettings: (): Promise<void> =>
+    ipcRenderer.invoke('shell:open-file-access-settings') as Promise<void>,
 };
 
 const drift = {

--- a/apps/desktop/src/renderer/src/components/dialogs/DocumentDialogs.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/DocumentDialogs.tsx
@@ -44,6 +44,8 @@ export function DocumentDialogs({ onForceSave }: DocumentDialogsProps): React.JS
   const clearUnknownFormat = useDocumentStore((s) => s.clearUnknownFormat);
   const saveWithErrorsPrompt = useDocumentStore((s) => s.saveWithErrorsPrompt);
   const clearSaveWithErrors = useDocumentStore((s) => s.clearSaveWithErrors);
+  const fileAccessError = useDocumentStore((s) => s.fileAccessError);
+  const clearFileAccessError = useDocumentStore((s) => s.clearFileAccessError);
 
   return (
     <>
@@ -97,6 +99,37 @@ export function DocumentDialogs({ onForceSave }: DocumentDialogsProps): React.JS
           )}
           <DialogFooter>
             <Button onClick={clearUnknownFormat}>OK</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={fileAccessError !== null}
+        onOpenChange={(open) => {
+          if (!open) clearFileAccessError();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Folder access needed</DialogTitle>
+            <DialogDescription>{fileAccessError?.message}</DialogDescription>
+          </DialogHeader>
+          {fileAccessError?.path && (
+            <p className="text-xs font-mono text-muted-foreground break-all">
+              {fileAccessError.path}
+            </p>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={clearFileAccessError}>
+              OK
+            </Button>
+            <Button
+              onClick={() => {
+                void window.contexture?.shell.openFileAccessSettings();
+              }}
+            >
+              Open Privacy Settings
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/desktop/src/renderer/src/hooks/useFileMenu.ts
+++ b/apps/desktop/src/renderer/src/hooks/useFileMenu.ts
@@ -113,17 +113,25 @@ export function useFileMenu(options: UseFileMenuOptions = {}): UseFileMenuReturn
 
   const handleOpen = useCallback(async (): Promise<void> => {
     if (!fileApi) return;
-    const opened = await fileApi.openDialog();
-    if (!opened) return;
-    applyLoaded(opened);
+    try {
+      const opened = await fileApi.openDialog();
+      if (!opened) return;
+      applyLoaded(opened);
+    } catch (err) {
+      useDocumentStore.getState().showFileAccessError(fileAccessErrorFrom(err));
+    }
   }, [fileApi, applyLoaded]);
 
   const handleOpenPath = useCallback(
     async (path: string): Promise<void> => {
       if (!fileApi) return;
-      const opened = await fileApi.openRecent(path);
-      if (!opened) return;
-      applyLoaded(opened);
+      try {
+        const opened = await fileApi.openRecent(path);
+        if (!opened) return;
+        applyLoaded(opened);
+      } catch (err) {
+        useDocumentStore.getState().showFileAccessError(fileAccessErrorFrom(err, path));
+      }
     },
     [fileApi, applyLoaded],
   );
@@ -233,4 +241,26 @@ async function writeBundle(
   const chat = options.getChat?.() ?? DEFAULT_CHAT;
   await fileApi.save({ irPath, schema, layout: doc.layout, chat });
   doc.markBundleSaved(irPath);
+}
+
+function fileAccessErrorFrom(
+  err: unknown,
+  fallbackPath?: string,
+): { message: string; path?: string } {
+  const rawMessage = err instanceof Error ? err.message : String(err);
+  const pathMatch = rawMessage.match(/(?:path: '([^']+)'|open '([^']+)'|access '([^']+)')/);
+  const path = pathMatch?.[1] ?? pathMatch?.[2] ?? pathMatch?.[3] ?? fallbackPath;
+
+  if (rawMessage.includes('EPERM') || rawMessage.includes('operation not permitted')) {
+    return {
+      message:
+        'macOS denied access to part of this Contexture bundle. Grant Contexture access to the folder, or move the file and its .contexture folder to a location the app can read.',
+      ...(path ? { path } : {}),
+    };
+  }
+
+  return {
+    message: rawMessage || 'The file could not be opened.',
+    ...(path ? { path } : {}),
+  };
 }

--- a/apps/desktop/src/renderer/src/store/document.ts
+++ b/apps/desktop/src/renderer/src/store/document.ts
@@ -33,6 +33,11 @@ export interface SaveWithErrorsPrompt {
   messages: string[];
 }
 
+export interface FileAccessError {
+  message: string;
+  path?: string;
+}
+
 export const DEFAULT_LAYOUT: Layout = { version: '1', positions: {} };
 
 interface DocumentState {
@@ -51,6 +56,8 @@ interface DocumentState {
   unknownFormatPath: string | null;
   /** Non-null while the save-with-errors dialog is visible. */
   saveWithErrorsPrompt: SaveWithErrorsPrompt | null;
+  /** Non-null while a filesystem permission/open error dialog is visible. */
+  fileAccessError: FileAccessError | null;
 
   setFilePath: (path: string | null) => void;
   setMode: (mode: DocumentMode) => void;
@@ -73,6 +80,9 @@ interface DocumentState {
 
   showSaveWithErrors: (prompt: SaveWithErrorsPrompt) => void;
   clearSaveWithErrors: () => void;
+
+  showFileAccessError: (error: FileAccessError) => void;
+  clearFileAccessError: () => void;
 }
 
 export const useDocumentStore = create<DocumentState>((set) => ({
@@ -83,6 +93,7 @@ export const useDocumentStore = create<DocumentState>((set) => ({
   importWarnings: [],
   unknownFormatPath: null,
   saveWithErrorsPrompt: null,
+  fileAccessError: null,
 
   setFilePath: (filePath) => set({ filePath }),
   setMode: (mode) => set({ mode }),
@@ -127,4 +138,7 @@ export const useDocumentStore = create<DocumentState>((set) => ({
 
   showSaveWithErrors: (saveWithErrorsPrompt) => set({ saveWithErrorsPrompt }),
   clearSaveWithErrors: () => set({ saveWithErrorsPrompt: null }),
+
+  showFileAccessError: (fileAccessError) => set({ fileAccessError }),
+  clearFileAccessError: () => set({ fileAccessError: null }),
 }));

--- a/apps/desktop/tests/components/dialogs/DocumentDialogs.test.tsx
+++ b/apps/desktop/tests/components/dialogs/DocumentDialogs.test.tsx
@@ -14,6 +14,14 @@ beforeEach(() => {
   s.clearImportWarnings();
   s.clearUnknownFormat();
   s.clearSaveWithErrors();
+  s.clearFileAccessError();
+  (window as unknown as { contexture: unknown }).contexture = {
+    shell: {
+      reveal: vi.fn(async () => undefined),
+      openInEditor: vi.fn(async () => undefined),
+      openFileAccessSettings: vi.fn(async () => undefined),
+    },
+  };
 });
 
 afterEach(() => {
@@ -52,6 +60,20 @@ describe('DocumentDialogs', () => {
     });
     expect(screen.getByText(/Not a Contexture file/i)).toBeInTheDocument();
     expect(screen.getByText('/tmp/weird.jsonld')).toBeInTheDocument();
+  });
+
+  it('shows file-access errors and opens privacy settings', () => {
+    render(<DocumentDialogs />);
+    act(() => {
+      useDocumentStore.getState().showFileAccessError({
+        message: 'macOS denied access to part of this Contexture bundle.',
+        path: '/Users/rufus/Downloads/.contexture/layout.json',
+      });
+    });
+    expect(screen.getByText(/Folder access needed/i)).toBeInTheDocument();
+    expect(screen.getByText('/Users/rufus/Downloads/.contexture/layout.json')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /open privacy settings/i }));
+    expect(window.contexture.shell.openFileAccessSettings).toHaveBeenCalled();
   });
 
   it('shows the save-with-errors dialog and fires onForceSave on "Save anyway"', () => {

--- a/apps/desktop/tests/hooks/useFileMenu.test.tsx
+++ b/apps/desktop/tests/hooks/useFileMenu.test.tsx
@@ -34,6 +34,11 @@ function mockFileBridge(): {
       onMenuSaveAs: () => () => undefined,
       pickDirectory: vi.fn(async () => null),
     },
+    shell: {
+      reveal: vi.fn(async () => undefined),
+      openInEditor: vi.fn(async () => undefined),
+      openFileAccessSettings: vi.fn(async () => undefined),
+    },
   };
   return { openDialog, saveAsDialog, save, openRecent, getRecentFiles };
 }
@@ -48,6 +53,7 @@ beforeEach(() => {
   d.clearImportWarnings();
   d.clearUnknownFormat();
   d.clearSaveWithErrors();
+  d.clearFileAccessError();
 });
 
 afterEach(() => {
@@ -103,6 +109,23 @@ describe('useFileMenu', () => {
     expect(useDocumentStore.getState().unknownFormatPath).toBe('/tmp/broken.json');
     // File path shouldn't have been set.
     expect(useDocumentStore.getState().filePath).toBeNull();
+  });
+
+  it('handleOpen surfaces macOS folder permission failures', async () => {
+    const bridge = mockFileBridge();
+    bridge.openDialog.mockRejectedValueOnce(
+      new Error(
+        "EPERM: operation not permitted, open '/Users/rufus/Downloads/.contexture/layout.json'",
+      ),
+    );
+    const { result } = renderHook(() => useFileMenu());
+    await act(async () => {
+      await result.current.handleOpen();
+    });
+    expect(useDocumentStore.getState().fileAccessError).toMatchObject({
+      message: expect.stringMatching(/macOS denied access/i),
+      path: '/Users/rufus/Downloads/.contexture/layout.json',
+    });
   });
 
   it('handleSave writes the bundle when there are no validation errors', async () => {
@@ -300,5 +323,18 @@ describe('useFileMenu', () => {
     });
     expect(bridge.openRecent).toHaveBeenCalledWith('/tmp/recent.contexture.json');
     expect(useDocumentStore.getState().filePath).toBe('/tmp/recent.contexture.json');
+  });
+
+  it('handleOpenPath surfaces recent-file permission failures', async () => {
+    const bridge = mockFileBridge();
+    bridge.openRecent.mockRejectedValueOnce(new Error('EPERM: operation not permitted'));
+    const { result } = renderHook(() => useFileMenu());
+    await act(async () => {
+      await result.current.handleOpenPath('/tmp/recent.contexture.json');
+    });
+    expect(useDocumentStore.getState().fileAccessError).toMatchObject({
+      message: expect.stringMatching(/macOS denied access/i),
+      path: '/tmp/recent.contexture.json',
+    });
   });
 });

--- a/apps/desktop/tests/main/shell-ipc.test.ts
+++ b/apps/desktop/tests/main/shell-ipc.test.ts
@@ -103,4 +103,21 @@ describe('registerShellIpc', () => {
 
     expect(shell.showItemInFolder).toHaveBeenCalledWith('/projects/my-app');
   });
+
+  it('opens macOS file access settings from the privacy shortcut', async () => {
+    registerShellIpc();
+    const settingsHandler = vi.mocked(ipcMain.handle).mock.calls.find(([channel]) => {
+      return channel === 'shell:open-file-access-settings';
+    })?.[1];
+
+    await settingsHandler?.({});
+
+    if (process.platform === 'darwin') {
+      expect(shell.openExternal).toHaveBeenCalledWith(
+        'x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles',
+      );
+    } else {
+      expect(shell.openExternal).not.toHaveBeenCalled();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- show a friendly folder-access dialog when opening a Contexture bundle fails with EPERM
- include the denied path when available and add a shortcut to macOS Privacy settings
- cover open/recent-open error handling and the dialog/IPC bridge with tests

## Tests
- bun run test -- tests/hooks/useFileMenu.test.tsx tests/components/dialogs/DocumentDialogs.test.tsx tests/main/shell-ipc.test.ts
- pre-commit hook: turbo typecheck && turbo test