### PR TITLE
Distinguish table nodes in graph visualization

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -65,9 +65,11 @@ All colors use OKLCH for perceptual uniformity. The palette is built around deep
 | `--graph-bg`                | `oklch(0.95 0.01 270)`           | `oklch(0.18 0.02 270)`           | Canvas background            |
 | `--graph-node-class`        | `oklch(0.45 0.15 270)`           | `oklch(0.65 0.12 280)`           | Class node color             |
 | `--graph-node-header-bg`    | `oklch(0.45 0.15 270 / 0.9)`     | `oklch(0.45 0.15 270 / 0.9)`     | Node header background       |
+| `--graph-node-table-header-bg` | `oklch(0.42 0.12 205 / 0.92)` | `oklch(0.42 0.12 205 / 0.92)` | Convex table node header     |
 | `--graph-node-header-text`  | `oklch(1 0 0)`                   | `oklch(1 0 0)`                   | Node header text             |
 | `--graph-node-body-bg`      | `oklch(0.95 0.01 270 / 0.85)`    | `oklch(0.18 0.02 270 / 0.92)`    | Node body background         |
 | `--graph-node-border`       | `oklch(0.45 0.15 270 / 0.25)`    | `oklch(0.25 0.02 270)`           | Node default border          |
+| `--graph-node-table-accent` | `oklch(0.66 0.13 195)`           | `oklch(0.68 0.11 195)`           | Convex table node rail       |
 | `--graph-node-selected`     | `oklch(0.75 0.15 195)`           | `oklch(0.75 0.15 195)`           | Selected node border (cyan)  |
 | `--graph-node-selected-bg`  | `oklch(0.75 0.15 195 / 0.1)`     | `oklch(0.75 0.15 195 / 0.1)`     | Selected node fill           |
 | `--graph-node-adjacent`     | `oklch(0.75 0.15 195 / 0.45)`    | `oklch(0.75 0.15 195 / 0.45)`    | Adjacent node border         |

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -44,6 +44,7 @@ import { useUIChromeStore } from '../../store/ui-chrome';
 import { useUndoStore } from '../../store/undo';
 import { RefEdge } from './edges/RefEdge';
 import { GraphLegend } from './GraphLegend';
+import { filterGraphView } from './graph-view';
 import {
   type ConnectPayload,
   handleConnect,
@@ -111,12 +112,21 @@ function GraphCanvasInner({
     };
   }, [schema, positions, highlightedNodeIds]);
 
-  const [nodes, setNodes] = useState<Node[]>(builtNodes);
-  const [edges, setEdges] = useState<Edge[]>(builtEdges);
+  const graphLayout = useGraphLayoutStore((s) => s.graphLayout);
+  const showEnums = graphLayout.showEnums;
+  const { nodes: visibleBuiltNodes, edges: visibleBuiltEdges } = useMemo(
+    () => filterGraphView({ nodes: builtNodes, edges: builtEdges }, { showEnums }),
+    [builtNodes, builtEdges, showEnums],
+  );
+
+  const [nodes, setNodes] = useState<Node[]>(visibleBuiltNodes);
+  const [edges, setEdges] = useState<Edge[]>(visibleBuiltEdges);
   const nodesRef = useRef(nodes);
   const edgesRef = useRef(edges);
+  const builtNodesRef = useRef(builtNodes);
   nodesRef.current = nodes;
   edgesRef.current = edges;
+  builtNodesRef.current = builtNodes;
 
   // When the IR changes, merge new structure onto the current local
   // positions so node drag state isn't blown away on every keystroke.
@@ -135,21 +145,26 @@ function GraphCanvasInner({
     // Merge: keep existing in-memory positions (user drags) + data
     // updates from the rebuilt nodes.
     const liveById = new Map(nodesRef.current.map((n) => [n.id, n]));
-    const merged = builtNodes.map((n) => {
+    const merged = visibleBuiltNodes.map((n) => {
       const live = liveById.get(n.id);
       return live ? { ...n, position: live.position } : n;
     });
     setNodes(merged);
-    setEdges(builtEdges);
+    setEdges(visibleBuiltEdges);
 
     if (structureChanged) layoutPendingRef.current = true;
-  }, [builtNodes, builtEdges]);
+  }, [builtNodes, visibleBuiltNodes, visibleBuiltEdges]);
+
+  useEffect(() => {
+    if (showEnums || !selectedNodeId) return;
+    const selectedNode = builtNodes.find((node) => node.id === selectedNodeId);
+    if (selectedNode?.data.kind === 'enum' && !selectedNode.data.imported) clearNodes();
+  }, [builtNodes, clearNodes, selectedNodeId, showEnums]);
 
   // ELK once the nodes have measured DOM dimensions.
   const { runLayout } = useELKLayout();
   const { fitView, setCenter } = useReactFlow();
   const nodesInitialized = useNodesInitialized({ includeHiddenNodes: false });
-  const graphLayout = useGraphLayoutStore((s) => s.graphLayout);
   const graphLayoutRef = useRef(graphLayout);
   graphLayoutRef.current = graphLayout;
   // Keep refs for callbacks triggered outside React (custom events).
@@ -179,9 +194,14 @@ function GraphCanvasInner({
           return p ? { ...n, position: p } : n;
         }),
       );
+      const visibleNodeIds = new Set(nodesRef.current.map((n) => n.id));
       const next: Record<string, CanvasPosition> = respectSidecar
         ? { ...(positionsRef.current ?? {}) }
-        : {};
+        : Object.fromEntries(
+            builtNodesRef.current
+              .filter((n) => !visibleNodeIds.has(n.id))
+              .map((n) => [n.id, positionsRef.current?.[n.id] ?? n.position]),
+          );
       positionById.forEach((p, id) => {
         next[id] = p;
       });

--- a/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
@@ -6,11 +6,11 @@
  * the canvas uses so new users can decode the diagram at a glance.
  *
  * Matches the four `TypeDef` kinds (object / enum / discriminatedUnion
- * / raw) and the edge modes (field ref, inferred table id, union variant,
- * cross-boundary import). Colours are pulled from `globals.css` so theme
- * changes flow through without edits here.
+ * / raw), table subtype marker, and the edge modes (field ref, inferred
+ * table id, union variant, cross-boundary import). Colours are pulled
+ * from `globals.css` so theme changes flow through without edits here.
  */
-import { ChevronDown, ChevronUp } from 'lucide-react';
+import { ChevronDown, ChevronUp, Table2 } from 'lucide-react';
 import { memo, useState } from 'react';
 
 interface EdgeItem {
@@ -45,12 +45,14 @@ interface NodeItem {
   label: string;
   /** Header swatch colour — matches `headerColorFor` in `TypeNode`. */
   header: string;
+  table?: boolean;
   /** Border style. Imported refs render dashed; everything else solid. */
   style?: 'solid' | 'dashed';
 }
 
 const NODE_ITEMS: readonly NodeItem[] = [
   { label: 'Object', header: 'var(--graph-node-header-bg)' },
+  { label: 'Table', header: 'var(--graph-node-table-header-bg)', table: true },
   {
     label: 'Enum',
     header: 'color-mix(in oklch, var(--chart-3) 85%, transparent)',
@@ -122,7 +124,7 @@ export const GraphLegend = memo(function GraphLegend() {
               <div key={item.label} className="flex items-center gap-2">
                 <div
                   aria-hidden="true"
-                  className="shrink-0 rounded"
+                  className="relative shrink-0 overflow-hidden rounded"
                   style={{
                     width: 18,
                     height: 12,
@@ -130,7 +132,24 @@ export const GraphLegend = memo(function GraphLegend() {
                     border: `1px ${item.style ?? 'solid'} var(--graph-node-border)`,
                     boxShadow: `inset 0 3px 0 ${item.header}`,
                   }}
-                />
+                >
+                  {item.table ? (
+                    <>
+                      <span
+                        className="absolute inset-y-0 left-0"
+                        style={{
+                          width: 3,
+                          background: 'var(--graph-node-table-accent)',
+                        }}
+                      />
+                      <Table2
+                        size={8}
+                        strokeWidth={2.2}
+                        className="absolute right-0.5 top-0.5 text-white"
+                      />
+                    </>
+                  ) : null}
+                </div>
                 <span className="text-foreground">{item.label}</span>
               </div>
             ))}

--- a/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
@@ -21,6 +21,7 @@ import {
   useInternalNode,
 } from '@xyflow/react';
 import { memo } from 'react';
+import { useGraphLayoutStore } from '../../../store/layout-config';
 import { useGraphSelectionStore } from '../../../store/selection';
 import type { RefEdgeData } from '../schema-to-graph';
 import { getFloatingEdgeParams } from './floating-edge-utils';
@@ -33,6 +34,7 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
   const targetNode = useInternalNode(target);
   const selectedNodeId = useGraphSelectionStore((s) => s.state.primaryNodeId);
   const adjacentEdgeIds = useGraphSelectionStore((s) => s.state.adjacency.edgeIds);
+  const showEdgeLabels = useGraphLayoutStore((s) => s.graphLayout.showEdgeLabels);
 
   if (!sourceNode || !targetNode) return null;
 
@@ -87,7 +89,7 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
           fill: 'none',
         }}
       />
-      {label && (
+      {showEdgeLabels && label && (
         <EdgeLabelRenderer>
           <div
             style={{

--- a/apps/desktop/src/renderer/src/components/graph/graph-view.ts
+++ b/apps/desktop/src/renderer/src/components/graph/graph-view.ts
@@ -1,0 +1,22 @@
+import type { BuildGraphResult } from './schema-to-graph';
+
+export interface GraphViewOptions {
+  showEnums: boolean;
+}
+
+export function filterGraphView(
+  graph: BuildGraphResult,
+  options: GraphViewOptions,
+): BuildGraphResult {
+  if (options.showEnums) return graph;
+  const hiddenNodeIds = new Set(
+    graph.nodes.filter((node) => node.data.kind === 'enum' && !node.data.imported).map((n) => n.id),
+  );
+  if (hiddenNodeIds.size === 0) return graph;
+  return {
+    nodes: graph.nodes.filter((node) => !hiddenNodeIds.has(node.id)),
+    edges: graph.edges.filter(
+      (edge) => !hiddenNodeIds.has(edge.source) && !hiddenNodeIds.has(edge.target),
+    ),
+  };
+}

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -8,6 +8,8 @@
  *     glance without a badge.
  *   - Field rows under the header as a flat list, right-aligned type
  *     summary (ref fields use the edge-property colour for the summary).
+ *   - Table objects add a persistent left rail and header icon so they
+ *     remain distinguishable from value objects without relying on colour.
  *   - Selection, adjacency dimming, and imported-boundary styling all
  *     driven from the UI store.
  *
@@ -17,6 +19,7 @@
  * later slice.
  */
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
+import { Table2 } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import { memo, useCallback, useMemo } from 'react';
 import { Badge } from '@/components/ui/badge';
@@ -87,7 +90,10 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
       : 'var(--graph-node-border)';
   const borderWidth = isSelected || isAdjacent ? 2 : 1;
   const borderStyle = data.imported ? 'dashed' : 'solid';
-  const headerColor = useMemo(() => headerColorFor(data.kind), [data.kind]);
+  const headerColor = useMemo(
+    () => (data.table ? 'var(--graph-node-table-header-bg)' : headerColorFor(data.kind)),
+    [data.kind, data.table],
+  );
   const node = (
     <div
       data-testid="type-node"
@@ -100,6 +106,7 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
       style={{
         minWidth: 180,
         maxWidth: 260,
+        position: 'relative',
         borderRadius: 8,
         overflow: 'hidden',
         backdropFilter: 'blur(8px)',
@@ -117,6 +124,21 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         transition: 'opacity 0.15s ease, border-color 0.1s ease',
       }}
     >
+      {data.table ? (
+        <div
+          aria-hidden="true"
+          data-testid="type-node-table-rail"
+          style={{
+            position: 'absolute',
+            insetBlock: 0,
+            insetInlineStart: 0,
+            width: 4,
+            background: 'var(--graph-node-table-accent)',
+            zIndex: 1,
+          }}
+        />
+      ) : null}
+
       {/* Invisible handles — floating edges use intersection math to find
          the edge crossing point, so actual anchor position doesn't matter. */}
       <Handle
@@ -131,6 +153,7 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
       />
 
       <div
+        data-testid="type-node-header"
         style={{
           padding: '6px 10px',
           fontSize: 12,
@@ -141,8 +164,18 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
           display: 'flex',
           alignItems: 'center',
           gap: 6,
+          paddingLeft: data.table ? 12 : 10,
         }}
       >
+        {data.table ? (
+          <Table2
+            aria-hidden="true"
+            data-testid="type-node-table-icon"
+            size={14}
+            strokeWidth={2.2}
+            style={{ flex: '0 0 auto', opacity: 0.92 }}
+          />
+        ) : null}
         <span
           style={{
             flex: 1,
@@ -160,13 +193,14 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
             style={{
               fontSize: 9,
               fontWeight: 600,
-              textTransform: 'uppercase',
-              letterSpacing: '0.08em',
+              letterSpacing: '0.04em',
               padding: '1px 5px',
               borderRadius: 3,
-              background: 'var(--graph-edge-property)',
+              border:
+                '1px solid color-mix(in oklch, var(--graph-node-header-text) 28%, transparent)',
+              background: 'color-mix(in oklch, var(--graph-node-header-text) 14%, transparent)',
               color: 'var(--graph-node-header-text)',
-              opacity: 0.9,
+              opacity: 0.86,
             }}
           >
             table

--- a/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
@@ -1,11 +1,9 @@
 /**
- * Graph controls popover — node-spacing slider + re-layout / fit / reset.
+ * Graph controls popover — view filters + node-spacing slider +
+ * re-layout / fit / reset.
  *
- * Pre-pivot had a stack of visibility filters (subClassOf, disjointWith,
- * object properties, individuals, restrictions, …). None of those map
- * to Contexture's two-kind edge model (`ref` + future `crossBoundary`),
- * so the filter block is deliberately omitted. If Contexture grows
- * more edge kinds the filter UI can come back alongside them.
+ * Keeps the first graph filters deliberately narrow: enums and edge
+ * labels are useful, but can add noise in structure-first reading.
  *
  * The panel talks to the canvas over two custom DOM events:
  *
@@ -19,6 +17,7 @@
 import { useGraphLayoutStore } from '@renderer/store/layout-config';
 import { Maximize2, RefreshCw, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Slider } from '@/components/ui/slider';
 
 interface Props {
@@ -73,6 +72,34 @@ export function GraphControlsPanel({ onClose }: Props): React.JSX.Element {
             {graphLayout.nodeSpacing}
           </span>
         </div>
+      </div>
+
+      <div className="px-3 py-2 space-y-2 border-b border-border">
+        <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
+          View
+        </p>
+        <label
+          className="flex items-center gap-2 text-xs text-foreground"
+          htmlFor="graph-control-show-enums"
+        >
+          <Checkbox
+            id="graph-control-show-enums"
+            checked={graphLayout.showEnums}
+            onCheckedChange={(checked) => setGraphLayout({ showEnums: checked === true })}
+          />
+          Enums
+        </label>
+        <label
+          className="flex items-center gap-2 text-xs text-foreground"
+          htmlFor="graph-control-show-edge-labels"
+        >
+          <Checkbox
+            id="graph-control-show-edge-labels"
+            checked={graphLayout.showEdgeLabels}
+            onCheckedChange={(checked) => setGraphLayout({ showEdgeLabels: checked === true })}
+          />
+          Edge labels
+        </label>
       </div>
 
       <div className="flex gap-2 px-3 py-2">

--- a/apps/desktop/src/renderer/src/components/toolbar/GraphSearchBar.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphSearchBar.tsx
@@ -10,6 +10,7 @@
  * Escape clears.
  */
 
+import { useGraphLayoutStore } from '@renderer/store/layout-config';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { useUndoStore } from '@renderer/store/undo';
 import { Search, X } from 'lucide-react';
@@ -27,6 +28,7 @@ export function GraphSearchBar(): React.JSX.Element {
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const focus = useGraphSelectionStore((s) => s.focus);
+  const showEnums = useGraphLayoutStore((s) => s.graphLayout.showEnums);
   const schema = useSyncExternalStore(useUndoStore.subscribe, () => useUndoStore.getState().schema);
 
   // Cmd/Ctrl+F focuses the input.
@@ -47,6 +49,7 @@ export function GraphSearchBar(): React.JSX.Element {
     if (!q) return [];
     const matches: Result[] = [];
     for (const t of schema.types) {
+      if (!showEnums && t.kind === 'enum') continue;
       if (t.name.toLowerCase().includes(q)) {
         matches.push({ name: t.name, matchType: 'name' });
       } else if (t.description?.toLowerCase().includes(q)) {
@@ -54,7 +57,7 @@ export function GraphSearchBar(): React.JSX.Element {
       }
     }
     return matches.slice(0, 10);
-  }, [query, schema]);
+  }, [query, schema, showEnums]);
 
   useEffect(() => {
     setActiveIndex(0);

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -59,9 +59,11 @@
   --graph-bg: oklch(0.95 0.01 270);
   --graph-node-class: oklch(0.45 0.15 270);
   --graph-node-header-bg: oklch(0.45 0.15 270 / 0.9);
+  --graph-node-table-header-bg: oklch(0.42 0.12 205 / 0.92);
   --graph-node-header-text: oklch(1 0 0);
   --graph-node-body-bg: oklch(0.95 0.01 270 / 0.85);
   --graph-node-border: oklch(0.45 0.15 270 / 0.25);
+  --graph-node-table-accent: oklch(0.66 0.13 195);
   --graph-node-selected: oklch(0.75 0.15 195);
   --graph-node-selected-bg: oklch(0.75 0.15 195 / 0.1);
   --graph-node-adjacent: oklch(0.75 0.15 195 / 0.45);
@@ -120,9 +122,11 @@
   --graph-bg: oklch(0.18 0.02 270);
   --graph-node-class: oklch(0.65 0.12 280);
   --graph-node-header-bg: oklch(0.45 0.15 270 / 0.9);
+  --graph-node-table-header-bg: oklch(0.42 0.12 205 / 0.92);
   --graph-node-header-text: oklch(1 0 0);
   --graph-node-body-bg: oklch(0.18 0.02 270 / 0.92);
   --graph-node-border: oklch(0.25 0.02 270);
+  --graph-node-table-accent: oklch(0.68 0.11 195);
   --graph-node-selected: oklch(0.75 0.15 195);
   --graph-node-selected-bg: oklch(0.75 0.15 195 / 0.1);
   --graph-node-adjacent: oklch(0.75 0.15 195 / 0.45);

--- a/apps/desktop/src/renderer/src/store/layout-config.ts
+++ b/apps/desktop/src/renderer/src/store/layout-config.ts
@@ -1,18 +1,22 @@
 /**
  * Graph layout configuration store.
  *
- * Holds ELK tuning knobs exposed by the GraphControls panel. Persisted
- * to the layout sidecar alongside node positions — loading a document
- * hydrates this store, and subsequent mutations are written back.
+ * Holds graph view/layout controls exposed by the GraphControls panel.
+ * Persisted to the layout sidecar alongside node positions — loading a
+ * document hydrates this store, and subsequent mutations are written back.
  */
 import { create } from 'zustand';
 
 export interface GraphLayout {
   nodeSpacing: number;
+  showEnums: boolean;
+  showEdgeLabels: boolean;
 }
 
 export const DEFAULT_LAYOUT: GraphLayout = {
   nodeSpacing: 180,
+  showEnums: true,
+  showEdgeLabels: true,
 };
 
 interface GraphLayoutStoreShape {

--- a/apps/desktop/tests/components/graph/GraphLegend.test.tsx
+++ b/apps/desktop/tests/components/graph/GraphLegend.test.tsx
@@ -1,0 +1,15 @@
+import { GraphLegend } from '@renderer/components/graph/GraphLegend';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+describe('GraphLegend', () => {
+  afterEach(() => cleanup());
+
+  it('documents the table node rail in the expanded node legend', () => {
+    render(<GraphLegend />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand legend' }));
+
+    expect(screen.getByText('Table')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -115,6 +115,15 @@ describe('TypeNode', () => {
     const { container } = render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
     const node = container.querySelector('[data-testid="type-node"]') as HTMLElement;
     expect(node.dataset.table).toBe('true');
+    expect(screen.getByTestId('type-node-header')).toHaveStyle({
+      background: 'var(--graph-node-table-header-bg)',
+    });
+    expect(screen.getByTestId('type-node-table-rail')).toHaveStyle({
+      width: '4px',
+      background: 'var(--graph-node-table-accent)',
+    });
+    expect(screen.getByTestId('type-node-table-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('type-node-table-badge')).toHaveTextContent('table');
   });
 
   it('does not mark non-table nodes with data-table', () => {

--- a/apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx
+++ b/apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx
@@ -1,0 +1,43 @@
+import { GraphControlsPanel } from '@renderer/components/toolbar/GraphControlsPanel';
+import { DEFAULT_LAYOUT, useGraphLayoutStore } from '@renderer/store/layout-config';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('GraphControlsPanel', () => {
+  beforeEach(() => {
+    useGraphLayoutStore.getState().resetToDefaults();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('toggles enum and edge-label visibility', () => {
+    render(<GraphControlsPanel onClose={vi.fn()} />);
+
+    expect(screen.getByRole('checkbox', { name: 'Enums' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Edge labels' })).toBeChecked();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Enums' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Edge labels' }));
+
+    expect(useGraphLayoutStore.getState().graphLayout).toMatchObject({
+      showEnums: false,
+      showEdgeLabels: false,
+    });
+  });
+
+  it('resets visibility controls to defaults', () => {
+    vi.useFakeTimers();
+    useGraphLayoutStore
+      .getState()
+      .setGraphLayout({ showEnums: false, showEdgeLabels: false, nodeSpacing: 240 });
+    render(<GraphControlsPanel onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+    vi.runOnlyPendingTimers();
+
+    expect(useGraphLayoutStore.getState().graphLayout).toEqual(DEFAULT_LAYOUT);
+  });
+});

--- a/apps/desktop/tests/graph/graph-view.test.ts
+++ b/apps/desktop/tests/graph/graph-view.test.ts
@@ -1,0 +1,79 @@
+import { filterGraphView } from '@renderer/components/graph/graph-view';
+import type { BuildGraphResult } from '@renderer/components/graph/schema-to-graph';
+import { describe, expect, it } from 'vitest';
+
+function graph(): BuildGraphResult {
+  return {
+    nodes: [
+      {
+        id: 'Recipe',
+        type: 'type',
+        position: { x: 0, y: 0 },
+        data: { typeName: 'Recipe', kind: 'object', imported: false, fields: [] },
+      },
+      {
+        id: 'Difficulty',
+        type: 'type',
+        position: { x: 100, y: 0 },
+        data: { typeName: 'Difficulty', kind: 'enum', imported: false, fields: [] },
+      },
+      {
+        id: 'common.ExternalEnum',
+        type: 'type',
+        position: { x: 200, y: 0 },
+        data: { typeName: 'common.ExternalEnum', kind: 'enum', imported: true, fields: [] },
+      },
+    ],
+    edges: [
+      {
+        id: 'Recipe.difficulty->Difficulty',
+        source: 'Recipe',
+        target: 'Difficulty',
+        type: 'ref',
+        data: {
+          relation: 'fieldRef',
+          sourceType: 'Recipe',
+          sourceField: 'difficulty',
+          targetType: 'Difficulty',
+          crossBoundary: false,
+        },
+      },
+      {
+        id: 'Recipe.external->common.ExternalEnum',
+        source: 'Recipe',
+        target: 'common.ExternalEnum',
+        type: 'ref',
+        data: {
+          relation: 'fieldRef',
+          sourceType: 'Recipe',
+          sourceField: 'external',
+          targetType: 'common.ExternalEnum',
+          crossBoundary: true,
+        },
+      },
+    ],
+  };
+}
+
+describe('filterGraphView', () => {
+  it('keeps enum nodes and enum edges when enums are visible', () => {
+    const result = filterGraphView(graph(), { showEnums: true });
+
+    expect(result.nodes.map((node) => node.id)).toEqual([
+      'Recipe',
+      'Difficulty',
+      'common.ExternalEnum',
+    ]);
+    expect(result.edges.map((edge) => edge.id)).toEqual([
+      'Recipe.difficulty->Difficulty',
+      'Recipe.external->common.ExternalEnum',
+    ]);
+  });
+
+  it('hides local enum nodes and their incident edges', () => {
+    const result = filterGraphView(graph(), { showEnums: false });
+
+    expect(result.nodes.map((node) => node.id)).toEqual(['Recipe', 'common.ExternalEnum']);
+    expect(result.edges.map((edge) => edge.id)).toEqual(['Recipe.external->common.ExternalEnum']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a persistent table rail and header icon for table-flagged graph nodes
- add a table entry to the graph legend using the same visual marker
- document the new table accent graph token and cover the rendering with component tests

## Verification
- bun run test -- tests/components/graph/TypeNode.test.tsx tests/components/graph/GraphLegend.test.tsx
- bun run lint
- bun run typecheck:web
- pre-commit hook: turbo typecheck && turbo test