### PR TITLE
Refine graph inline type affordances

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.18",
+  "version": "0.15.19",
   "description": "Visual Zod schema editor with LLM support",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -39,7 +39,11 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { useELKLayout } from '../../hooks/useELKLayout';
 import { useGraphLayoutStore } from '../../store/layout-config';
 import type { Op } from '../../store/ops';
-import { clickModeFromEvent, useGraphSelectionStore } from '../../store/selection';
+import {
+  clickModeFromEvent,
+  type GraphFocusTarget,
+  useGraphSelectionStore,
+} from '../../store/selection';
 import { useUIChromeStore } from '../../store/ui-chrome';
 import { useUndoStore } from '../../store/undo';
 import { RefEdge } from './edges/RefEdge';
@@ -71,6 +75,11 @@ const NODE_TYPES = { type: TypeNode, group: GroupNode } as const;
 const EDGE_TYPES = { ref: RefEdge } as const;
 
 type RefPreview = Omit<FieldRefPreview, 'active'>;
+type FocusedField = { nodeId: string; fieldName: string };
+
+export function focusedFieldFromTarget(target: GraphFocusTarget): FocusedField | null {
+  return target.fieldName ? { nodeId: target.nodeId, fieldName: target.fieldName } : null;
+}
 
 export function GraphCanvas(props: GraphCanvasProps): React.JSX.Element {
   return (
@@ -297,9 +306,13 @@ function GraphCanvasInner({
     const cy = node.position.y + height / 2;
     setCenter(cx, cy, { zoom: 1.1, duration: 400 });
     click(focusTarget.nodeId, 'replace');
-    if (focusTarget.fieldName) {
-      if (focusedFieldClearTimer.current) clearTimeout(focusedFieldClearTimer.current);
-      setFocusedField({ nodeId: focusTarget.nodeId, fieldName: focusTarget.fieldName });
+    const nextFocusedField = focusedFieldFromTarget(focusTarget);
+    if (focusedFieldClearTimer.current) {
+      clearTimeout(focusedFieldClearTimer.current);
+      focusedFieldClearTimer.current = null;
+    }
+    setFocusedField(nextFocusedField);
+    if (nextFocusedField) {
       focusedFieldClearTimer.current = setTimeout(() => setFocusedField(null), 1600);
     }
     consumeFocus();

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -53,7 +53,7 @@ import {
   type KeyEvent as InteractionKeyEvent,
 } from './interactions';
 import { GroupNode } from './nodes/GroupNode';
-import { TypeNode } from './nodes/TypeNode';
+import { type FieldRefPreview, TYPE_NODE_REF_PREVIEW_EVENT, TypeNode } from './nodes/TypeNode';
 import { type BuildGraphResult, buildGraph, type RefEdgeData } from './schema-to-graph';
 
 export interface CanvasPosition {
@@ -69,6 +69,8 @@ export interface GraphCanvasProps {
 
 const NODE_TYPES = { type: TypeNode, group: GroupNode } as const;
 const EDGE_TYPES = { ref: RefEdge } as const;
+
+type RefPreview = Omit<FieldRefPreview, 'active'>;
 
 export function GraphCanvas(props: GraphCanvasProps): React.JSX.Element {
   return (
@@ -94,7 +96,7 @@ function GraphCanvasInner({
   const clearNodes = useGraphSelectionStore((s) => s.clearNodes);
   const selectedNodeId = useGraphSelectionStore((s) => s.state.primaryNodeId);
   const setAdjacencyResolver = useGraphSelectionStore((s) => s.setAdjacencyResolver);
-  const focusNodeId = useGraphSelectionStore((s) => s.state.focusNodeId);
+  const focusTarget = useGraphSelectionStore((s) => s.state.focusTarget);
   const consumeFocus = useGraphSelectionStore((s) => s.consumeFocus);
   const setSidebarTab = useUIChromeStore((s) => s.setSidebarTab);
   const setSidebarVisible = useUIChromeStore((s) => s.setSidebarVisible);
@@ -114,10 +116,52 @@ function GraphCanvasInner({
 
   const graphLayout = useGraphLayoutStore((s) => s.graphLayout);
   const showEnums = graphLayout.showEnums;
-  const { nodes: visibleBuiltNodes, edges: visibleBuiltEdges } = useMemo(
-    () => filterGraphView({ nodes: builtNodes, edges: builtEdges }, { showEnums }),
-    [builtNodes, builtEdges, showEnums],
+  const [refPreview, setRefPreview] = useState<RefPreview | null>(null);
+  const refPreviewClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [focusedField, setFocusedField] = useState<{ nodeId: string; fieldName: string } | null>(
+    null,
   );
+  const focusedFieldClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { nodes: visibleBuiltNodes, edges: visibleBuiltEdges } = useMemo(() => {
+    const visible = filterGraphView({ nodes: builtNodes, edges: builtEdges }, { showEnums });
+    const visibleWithFocusedField = focusedField
+      ? {
+          ...visible,
+          nodes: visible.nodes.map((node) =>
+            node.id === focusedField.nodeId
+              ? { ...node, data: { ...node.data, focusedFieldName: focusedField.fieldName } }
+              : node,
+          ),
+        }
+      : visible;
+    if (!refPreview) return visibleWithFocusedField;
+    const previewNodeIds = new Set<string>([refPreview.targetType]);
+    const previewEdgeIds = new Set<string>();
+    for (const edge of visible.edges) {
+      if (edge.source !== refPreview.targetType && edge.target !== refPreview.targetType) continue;
+      previewEdgeIds.add(edge.id);
+      previewNodeIds.add(edge.source);
+      previewNodeIds.add(edge.target);
+    }
+    return {
+      nodes: visibleWithFocusedField.nodes.map((node) =>
+        previewNodeIds.has(node.id)
+          ? {
+              ...node,
+              data: {
+                ...node.data,
+                previewRole: node.id === refPreview.targetType ? 'primary' : 'adjacent',
+              },
+            }
+          : { ...node, data: { ...node.data, previewDimmed: true } },
+      ),
+      edges: visibleWithFocusedField.edges.map((edge) => {
+        return previewEdgeIds.has(edge.id)
+          ? { ...edge, data: { ...edge.data, previewHighlighted: true } }
+          : { ...edge, data: { ...edge.data, previewDimmed: true } };
+      }),
+    };
+  }, [builtNodes, builtEdges, showEnums, refPreview, focusedField]);
 
   const [nodes, setNodes] = useState<Node[]>(visibleBuiltNodes);
   const [edges, setEdges] = useState<Edge[]>(visibleBuiltEdges);
@@ -237,12 +281,12 @@ function GraphCanvasInner({
     };
   }, [runLayoutNow, fitView]);
 
-  // Search → centre the matched node and select it. `focusNodeId` is
+  // Search → centre the matched node and select it. `focusTarget` is
   // the trigger; we consume the value so repeated picks of the same
   // name still re-centre.
   useEffect(() => {
-    if (!focusNodeId) return;
-    const node = nodesRef.current.find((n) => n.id === focusNodeId);
+    if (!focusTarget) return;
+    const node = nodesRef.current.find((n) => n.id === focusTarget.nodeId);
     if (!node) {
       consumeFocus();
       return;
@@ -252,9 +296,14 @@ function GraphCanvasInner({
     const cx = node.position.x + width / 2;
     const cy = node.position.y + height / 2;
     setCenter(cx, cy, { zoom: 1.1, duration: 400 });
-    click(focusNodeId, 'replace');
+    click(focusTarget.nodeId, 'replace');
+    if (focusTarget.fieldName) {
+      if (focusedFieldClearTimer.current) clearTimeout(focusedFieldClearTimer.current);
+      setFocusedField({ nodeId: focusTarget.nodeId, fieldName: focusTarget.fieldName });
+      focusedFieldClearTimer.current = setTimeout(() => setFocusedField(null), 1600);
+    }
     consumeFocus();
-  }, [focusNodeId, setCenter, click, consumeFocus]);
+  }, [focusTarget, setCenter, click, consumeFocus]);
 
   // Register an adjacency resolver against the current edges so the
   // selection store's `click()` can compute dim-sets without reaching
@@ -357,6 +406,50 @@ function GraphCanvasInner({
     return () => el.removeEventListener('keydown', handler);
   }, [dispatch, undo, redo, selectedNodeId]);
 
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handler = (ev: Event): void => {
+      const detail = (ev as CustomEvent<FieldRefPreview>).detail;
+      if (refPreviewClearTimer.current) {
+        clearTimeout(refPreviewClearTimer.current);
+        refPreviewClearTimer.current = null;
+      }
+      if (detail.active) {
+        setRefPreview((prev) => {
+          if (
+            prev?.sourceType === detail.sourceType &&
+            prev.sourceField === detail.sourceField &&
+            prev.targetType === detail.targetType
+          ) {
+            return prev;
+          }
+          return {
+            sourceType: detail.sourceType,
+            sourceField: detail.sourceField,
+            targetType: detail.targetType,
+          };
+        });
+        return;
+      }
+      refPreviewClearTimer.current = setTimeout(() => {
+        setRefPreview((prev) =>
+          prev?.sourceType === detail.sourceType &&
+          prev.sourceField === detail.sourceField &&
+          prev.targetType === detail.targetType
+            ? null
+            : prev,
+        );
+      }, 80);
+    };
+    el.addEventListener(TYPE_NODE_REF_PREVIEW_EVENT, handler);
+    return () => {
+      if (refPreviewClearTimer.current) clearTimeout(refPreviewClearTimer.current);
+      if (focusedFieldClearTimer.current) clearTimeout(focusedFieldClearTimer.current);
+      el.removeEventListener(TYPE_NODE_REF_PREVIEW_EVENT, handler);
+    };
+  }, []);
+
   return (
     <div
       ref={containerRef}
@@ -389,7 +482,7 @@ function GraphCanvasInner({
             pattern reads as texture not noise on both light and dark. */}
         <Background gap={28} size={0.8} color="var(--graph-dot)" />
         <Controls showInteractive={false} />
-        <GraphLegend />
+        <GraphLegend showEnumNodes={showEnums} />
       </ReactFlow>
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
@@ -5,10 +5,10 @@
  * stays out of the way; expanded view names every visual affordance
  * the canvas uses so new users can decode the diagram at a glance.
  *
- * Matches the four `TypeDef` kinds (object / enum / discriminatedUnion
- * / raw), table subtype marker, and the edge modes (field ref, inferred
- * table id, union variant, cross-boundary import). Colours are pulled
- * from `globals.css` so theme changes flow through without edits here.
+ * Matches the `TypeDef` kinds, inline enum marker, table subtype marker,
+ * and the edge modes (field ref, inferred table id, union variant,
+ * cross-boundary import). Colours are pulled from `globals.css` so theme
+ * changes flow through without edits here.
  */
 import { ChevronDown, ChevronUp, Table2 } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -54,10 +54,6 @@ const NODE_ITEMS: readonly NodeItem[] = [
   { label: 'Object', header: 'var(--graph-node-header-bg)' },
   { label: 'Table', header: 'var(--graph-node-table-header-bg)', table: true },
   {
-    label: 'Enum',
-    header: 'color-mix(in oklch, var(--chart-3) 85%, transparent)',
-  },
-  {
     label: 'Discriminated union',
     header: 'color-mix(in oklch, var(--chart-4) 85%, transparent)',
   },
@@ -76,8 +72,22 @@ const NODE_ITEMS: readonly NodeItem[] = [
   },
 ];
 
-export const GraphLegend = memo(function GraphLegend() {
+export const GraphLegend = memo(function GraphLegend({
+  showEnumNodes = false,
+}: {
+  showEnumNodes?: boolean;
+}) {
   const [expanded, setExpanded] = useState(false);
+  const nodeItems = showEnumNodes
+    ? [
+        ...NODE_ITEMS.slice(0, 2),
+        {
+          label: 'Enum',
+          header: 'color-mix(in oklch, var(--chart-3) 85%, transparent)',
+        },
+        ...NODE_ITEMS.slice(2),
+      ]
+    : NODE_ITEMS;
 
   return (
     <div
@@ -119,8 +129,41 @@ export const GraphLegend = memo(function GraphLegend() {
           </div>
 
           <div className="space-y-1">
+            <span className="text-[9px] text-muted-foreground font-medium uppercase">Fields</span>
+            <div className="flex items-center gap-2">
+              <span className="text-[9px]" style={{ color: 'var(--graph-edge-property)' }}>
+                → Reference
+              </span>
+              <span className="text-foreground">Object ref</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span
+                className="inline-flex min-w-0 items-baseline gap-0.5 text-[9px]"
+                style={{ color: 'var(--graph-edge-property)' }}
+              >
+                <span>→ Source</span>
+                <span style={{ color: 'var(--muted-foreground)', fontWeight: 400 }}>· union</span>
+              </span>
+              <span className="text-foreground">Union ref</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span
+                aria-hidden="true"
+                className="text-[9px]"
+                style={{
+                  color: 'var(--muted-foreground)',
+                  fontFamily: 'var(--font-mono)',
+                }}
+              >
+                Status enum
+              </span>
+              <span className="text-foreground">Inline enum</span>
+            </div>
+          </div>
+
+          <div className="space-y-1">
             <span className="text-[9px] text-muted-foreground font-medium uppercase">Nodes</span>
-            {NODE_ITEMS.map((item) => (
+            {nodeItems.map((item) => (
               <div key={item.label} className="flex items-center gap-2">
                 <div
                   aria-hidden="true"

--- a/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
@@ -56,22 +56,26 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
   const isUnionVariant = data?.relation === 'unionVariant';
   const isTableId = data?.relation === 'tableId';
   const isAdjacent = adjacentEdgeIds.has(id);
+  const isPreviewHighlighted = data?.previewHighlighted === true;
+  const isPreviewDimmed = data?.previewDimmed === true;
   // Dim edges that touch neither the selected node nor an adjacent one.
   const isDimmed =
-    selectedNodeId !== null &&
-    !isAdjacent &&
-    source !== selectedNodeId &&
-    target !== selectedNodeId;
+    (selectedNodeId !== null &&
+      !isAdjacent &&
+      !isPreviewHighlighted &&
+      source !== selectedNodeId &&
+      target !== selectedNodeId) ||
+    isPreviewDimmed;
 
   const stroke =
-    selected || isAdjacent
+    selected || isAdjacent || isPreviewHighlighted
       ? 'var(--graph-node-selected)'
       : isUnionVariant
         ? 'var(--graph-edge-union, var(--chart-4))'
         : crossBoundary
           ? 'var(--graph-edge-import, var(--muted-foreground))'
           : 'var(--graph-edge-ref, var(--graph-edge-property))';
-  const strokeWidth = selected || isAdjacent ? 2 : 1.25;
+  const strokeWidth = selected || isAdjacent || isPreviewHighlighted ? 2 : 1.25;
   const strokeDasharray = isUnionVariant ? '2 4' : isTableId || crossBoundary ? '6 4' : undefined;
   const label = isUnionVariant ? 'variant' : data?.sourceField;
 
@@ -84,7 +88,7 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
           stroke,
           strokeWidth,
           strokeDasharray,
-          opacity: isDimmed ? 0.2 : 1,
+          opacity: isDimmed ? 0.2 : isPreviewHighlighted ? 0.95 : 1,
           transition: 'opacity 0.15s ease, stroke 0.1s ease',
           fill: 'none',
         }}
@@ -103,7 +107,7 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
               fontSize: 9,
               fontFamily: 'var(--font-mono, monospace)',
               pointerEvents: 'none',
-              opacity: isDimmed ? 0.2 : 0.85,
+              opacity: isDimmed ? 0.2 : isPreviewHighlighted ? 1 : 0.85,
               whiteSpace: 'nowrap',
             }}
             data-testid="ref-edge"

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -21,11 +21,11 @@
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
 import { Table2 } from 'lucide-react';
 import type { CSSProperties } from 'react';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { useGraphSelectionStore } from '../../../store/selection';
-import type { TypeNodeData } from '../schema-to-graph';
+import type { EnumTargetRow, TypeNodeData } from '../schema-to-graph';
 
 export interface FieldSelection {
   typeName: string;
@@ -33,6 +33,14 @@ export interface FieldSelection {
 }
 
 export const TYPE_NODE_EVENT = 'contexture:field-select' as const;
+export const TYPE_NODE_REF_PREVIEW_EVENT = 'contexture:field-ref-preview' as const;
+
+export interface FieldRefPreview {
+  sourceType: string;
+  sourceField: string;
+  targetType: string;
+  active: boolean;
+}
 
 type TypeNodeKind = Node<TypeNodeData, 'type'>;
 
@@ -57,9 +65,13 @@ function headerColorFor(kind: TypeNodeData['kind']): string {
 }
 
 const enumValueBadgeStyle: CSSProperties = {
-  background: 'color-mix(in oklch, var(--chart-1) 78%, var(--background))',
-  borderColor: 'color-mix(in oklch, var(--chart-1) 88%, transparent)',
-  color: 'var(--primary-foreground)',
+  background: 'color-mix(in oklch, var(--chart-3) 85%, transparent)',
+  borderColor: 'color-mix(in oklch, var(--chart-3) 85%, transparent)',
+  color: 'var(--graph-node-header-text)',
+};
+
+const enumHoverCardStyle: CSSProperties = {
+  borderTop: '2px solid color-mix(in oklch, var(--chart-3) 85%, transparent)',
 };
 
 export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
@@ -70,24 +82,60 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
 
   const isSelected = primaryNodeId === id;
   const isAdjacent = !isSelected && adjacentNodeIds.has(id);
-  const isDimmed = primaryNodeId !== null && !isSelected && !isAdjacent;
+  const isPreviewPrimary = data.previewRole === 'primary' && !isSelected;
+  const isPreviewAdjacent = data.previewRole === 'adjacent' && !isSelected && !isAdjacent;
+  const isDimmed =
+    (primaryNodeId !== null &&
+      !isSelected &&
+      !isAdjacent &&
+      !isPreviewPrimary &&
+      !isPreviewAdjacent) ||
+    (data.previewDimmed === true && !isSelected && !isPreviewPrimary && !isPreviewAdjacent);
   const isSyncHighlighted = data.syncHighlighted === true && !isSelected && !isAdjacent;
 
   const onFieldClick = useCallback(
-    (fieldName: string, ev: React.MouseEvent<HTMLElement>) => {
+    (field: TypeNodeData['fields'][number], ev: React.MouseEvent<HTMLElement>) => {
       ev.stopPropagation();
+      if (field.refTarget && !field.enumTarget) {
+        click(field.refTarget, 'replace');
+        return;
+      }
       click(data.typeName, 'replace');
-      const detail: FieldSelection = { typeName: data.typeName, fieldName };
+      const detail: FieldSelection = { typeName: data.typeName, fieldName: field.name };
       ev.currentTarget.dispatchEvent(new CustomEvent(TYPE_NODE_EVENT, { bubbles: true, detail }));
     },
     [data.typeName, click],
+  );
+
+  const onRefPreview = useCallback(
+    (
+      field: TypeNodeData['fields'][number],
+      active: boolean,
+      ev: React.SyntheticEvent<HTMLElement>,
+    ) => {
+      if (!field.refTarget || field.enumTarget) return;
+      const detail: FieldRefPreview = {
+        sourceType: data.typeName,
+        sourceField: field.name,
+        targetType: field.refTarget,
+        active,
+      };
+      ev.currentTarget.dispatchEvent(
+        new CustomEvent(TYPE_NODE_REF_PREVIEW_EVENT, { bubbles: true, detail }),
+      );
+    },
+    [data.typeName],
   );
 
   const borderColor = isSelected
     ? 'var(--graph-node-selected)'
     : isAdjacent
       ? 'var(--graph-node-adjacent)'
-      : 'var(--graph-node-border)';
+      : isPreviewPrimary
+        ? 'var(--graph-node-selected)'
+        : isPreviewAdjacent
+          ? 'var(--graph-node-adjacent)'
+          : 'var(--graph-node-border)';
   const borderWidth = isSelected || isAdjacent ? 2 : 1;
   const borderStyle = data.imported ? 'dashed' : 'solid';
   const headerColor = useMemo(
@@ -115,7 +163,8 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         borderStyle,
         borderColor,
         boxShadow: '0 2px 10px oklch(0 0 0 / 0.18), 0 0 1px oklch(0 0 0 / 0.15)',
-        background: isSelected ? 'var(--graph-node-selected-bg)' : 'transparent',
+        background:
+          isSelected || isPreviewPrimary ? 'var(--graph-node-selected-bg)' : 'transparent',
         outline: isSyncHighlighted
           ? '2px solid color-mix(in oklch, var(--chart-2) 78%, var(--background))'
           : undefined,
@@ -187,36 +236,9 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
           {data.typeName}
         </span>
         {data.table ? (
-          <span
-            data-testid="type-node-table-badge"
-            title="Convex table"
-            style={{
-              fontSize: 9,
-              fontWeight: 600,
-              letterSpacing: '0.04em',
-              padding: '1px 5px',
-              borderRadius: 3,
-              border:
-                '1px solid color-mix(in oklch, var(--graph-node-header-text) 28%, transparent)',
-              background: 'color-mix(in oklch, var(--graph-node-header-text) 14%, transparent)',
-              color: 'var(--graph-node-header-text)',
-              opacity: 0.86,
-            }}
-          >
-            table
-          </span>
+          <NodeKindLabel data-testid="type-node-table-label">table</NodeKindLabel>
         ) : (
-          <span
-            style={{
-              fontSize: 9,
-              fontWeight: 500,
-              textTransform: 'uppercase',
-              letterSpacing: '0.08em',
-              opacity: 0.75,
-            }}
-          >
-            {data.kind === 'discriminatedUnion' ? 'union' : data.kind}
-          </span>
+          <NodeKindLabel>{data.kind === 'discriminatedUnion' ? 'union' : data.kind}</NodeKindLabel>
         )}
       </div>
 
@@ -232,7 +254,9 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
               key={f.name}
               field={f}
               selectedTarget={primaryNodeId}
+              searchFocused={data.focusedFieldName === f.name}
               onFieldClick={onFieldClick}
+              onRefPreview={onRefPreview}
             />
           ))}
         </div>
@@ -245,59 +269,123 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
   return (
     <HoverCard openDelay={120} closeDelay={80}>
       <HoverCardTrigger asChild>{node}</HoverCardTrigger>
-      <HoverCardContent side="right" align="start" className="w-72 p-3 text-xs">
-        <div className="space-y-3">
-          <div className="space-y-1">
-            <div className="text-sm font-semibold text-foreground">{data.typeName}</div>
-            <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-              Enum
-            </div>
-            {data.description && (
-              <p className="text-xs leading-snug text-muted-foreground">{data.description}</p>
-            )}
-          </div>
-          <div className="space-y-1.5">
-            <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-              Values
-            </div>
-            <div className="flex flex-wrap gap-1.5">
-              {(data.enumValues ?? []).map((value) => (
-                <Badge
-                  key={value.value}
-                  data-testid="enum-value-badge"
-                  variant="default"
-                  title={value.description}
-                  className="max-w-full rounded border px-1.5 py-0 text-[10px] font-semibold shadow-sm hover:opacity-90"
-                  style={enumValueBadgeStyle}
-                >
-                  <span className="truncate">{value.value}</span>
-                </Badge>
-              ))}
-            </div>
-          </div>
-        </div>
+      <HoverCardContent
+        side="right"
+        align="start"
+        className="w-72 p-3 text-xs"
+        style={enumHoverCardStyle}
+      >
+        <EnumHoverCardContent
+          enumTarget={{
+            name: data.typeName,
+            description: data.description,
+            values: data.enumValues ?? [],
+          }}
+        />
       </HoverCardContent>
     </HoverCard>
   );
 });
 
+function NodeKindLabel({
+  children,
+  ...props
+}: React.PropsWithChildren<React.HTMLAttributes<HTMLSpanElement>>) {
+  return (
+    <span
+      {...props}
+      style={{
+        fontSize: 9,
+        fontWeight: 500,
+        textTransform: 'uppercase',
+        letterSpacing: '0.08em',
+        opacity: 0.75,
+        ...props.style,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function EnumHoverCardContent({ enumTarget }: { enumTarget: EnumTargetRow }) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <div className="text-sm font-semibold text-foreground">{enumTarget.name}</div>
+        <div
+          className="text-[10px] font-medium uppercase tracking-wide"
+          style={{ color: 'color-mix(in oklch, var(--chart-3) 85%, transparent)' }}
+        >
+          Enum
+        </div>
+        {enumTarget.description && (
+          <p className="text-xs leading-snug text-muted-foreground">{enumTarget.description}</p>
+        )}
+      </div>
+      <div className="space-y-1.5">
+        <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          Values
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {enumTarget.values.map((value) => (
+            <Badge
+              key={value.value}
+              data-testid="enum-value-badge"
+              variant="default"
+              title={value.description}
+              className="max-w-full rounded border px-1.5 py-0 text-[10px] font-semibold shadow-sm hover:opacity-90"
+              style={enumValueBadgeStyle}
+            >
+              <span className="truncate">{value.value}</span>
+            </Badge>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function FieldRowButton({
   field,
   selectedTarget,
+  searchFocused,
   onFieldClick,
+  onRefPreview,
 }: {
   field: TypeNodeData['fields'][number];
   selectedTarget: string | null;
-  onFieldClick: (fieldName: string, ev: React.MouseEvent<HTMLElement>) => void;
+  searchFocused: boolean;
+  onFieldClick: (field: TypeNodeData['fields'][number], ev: React.MouseEvent<HTMLElement>) => void;
+  onRefPreview: (
+    field: TypeNodeData['fields'][number],
+    active: boolean,
+    ev: React.SyntheticEvent<HTMLElement>,
+  ) => void;
 }) {
   const refTargetSelected = field.refTarget !== undefined && field.refTarget === selectedTarget;
-  return (
+  const [enumCardOpen, setEnumCardOpen] = useState(false);
+  const enumSummary = field.enumTarget ? `${field.summary.replace(/^→\s*/, '')} enum` : undefined;
+  const isUnionRef = field.refTargetKind === 'discriminatedUnion';
+  const button = (
     <button
       type="button"
       data-testid="type-node-field"
       data-field-name={field.name}
-      onClick={(ev) => onFieldClick(field.name, ev)}
-      className="contexture-type-node-field"
+      onClick={(ev) => onFieldClick(field, ev)}
+      onFocus={field.enumTarget ? () => setEnumCardOpen(true) : undefined}
+      onBlur={field.enumTarget ? () => setEnumCardOpen(false) : undefined}
+      onMouseEnter={(ev) => onRefPreview(field, true, ev)}
+      onMouseLeave={(ev) => onRefPreview(field, false, ev)}
+      onFocusCapture={(ev) => onRefPreview(field, true, ev)}
+      onBlurCapture={(ev) => onRefPreview(field, false, ev)}
+      aria-label={
+        field.enumTarget
+          ? `${field.name}, ${field.enumTarget.name} enum, ${field.enumTarget.values.length} values`
+          : undefined
+      }
+      data-search-focused={searchFocused ? 'true' : 'false'}
+      className="contexture-type-node-field hover:bg-accent/35 focus-visible:bg-accent/45 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
       style={{
         display: 'flex',
         justifyContent: 'space-between',
@@ -306,10 +394,13 @@ function FieldRowButton({
         fontSize: 10,
         gap: 8,
         width: '100%',
-        background: 'transparent',
         border: 'none',
         cursor: 'pointer',
         textAlign: 'left',
+        background: searchFocused ? 'var(--graph-node-selected-bg)' : undefined,
+        boxShadow: searchFocused
+          ? 'inset 3px 0 0 var(--graph-node-selected), inset 0 0 0 1px color-mix(in oklch, var(--graph-node-selected) 34%, transparent)'
+          : undefined,
       }}
     >
       <span style={{ color: 'var(--muted-foreground)', fontWeight: 400 }}>
@@ -318,23 +409,77 @@ function FieldRowButton({
         {field.nullable ? ' | null' : ''}
       </span>
       <span
-        data-testid={field.refTarget ? 'type-node-field-ref-summary' : undefined}
+        data-testid={
+          field.enumTarget
+            ? 'type-node-field-enum-summary'
+            : field.refTarget
+              ? 'type-node-field-ref-summary'
+              : undefined
+        }
         style={{
           color: refTargetSelected
             ? 'var(--graph-node-selected)'
+            : field.enumTarget
+              ? 'var(--muted-foreground)'
+              : field.refTarget
+                ? 'var(--graph-edge-property)'
+                : 'var(--muted-foreground)',
+          fontFamily: field.enumTarget
+            ? 'var(--font-mono)'
             : field.refTarget
-              ? 'var(--graph-edge-property)'
-              : 'var(--muted-foreground)',
-          fontFamily: field.refTarget ? 'inherit' : 'var(--font-mono)',
+              ? 'inherit'
+              : 'var(--font-mono)',
           fontSize: 9,
           fontWeight: refTargetSelected ? 700 : 400,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
+          minWidth: 0,
         }}
       >
-        {field.summary}
+        {field.enumTarget ? (
+          <span
+            data-testid="type-node-field-enum-affordance"
+            style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {enumSummary}
+          </span>
+        ) : isUnionRef ? (
+          <span
+            data-testid="type-node-field-union-affordance"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'baseline',
+              maxWidth: '100%',
+              minWidth: 0,
+              gap: 3,
+            }}
+          >
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {field.summary}
+            </span>
+            <span style={{ color: 'var(--muted-foreground)', fontWeight: 400 }}>· union</span>
+          </span>
+        ) : (
+          field.summary
+        )}
       </span>
     </button>
+  );
+
+  if (!field.enumTarget) return button;
+
+  return (
+    <HoverCard open={enumCardOpen} onOpenChange={setEnumCardOpen} openDelay={120} closeDelay={80}>
+      <HoverCardTrigger asChild>{button}</HoverCardTrigger>
+      <HoverCardContent
+        side="right"
+        align="start"
+        className="w-72 p-3 text-xs"
+        style={enumHoverCardStyle}
+      >
+        <EnumHoverCardContent enumTarget={field.enumTarget} />
+      </HoverCardContent>
+    </HoverCard>
   );
 }

--- a/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
+++ b/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
@@ -41,6 +41,9 @@ export interface TypeNodeData extends Record<string, unknown> {
   fields: ReadonlyArray<FieldRow>;
   imported: boolean;
   syncHighlighted?: boolean;
+  focusedFieldName?: string;
+  previewRole?: 'primary' | 'adjacent';
+  previewDimmed?: boolean;
   /** True when the source `ObjectTypeDef` carries `table: true`. */
   table?: boolean;
 }
@@ -60,6 +63,15 @@ export interface FieldRow {
    * element, is a `ref`). Used to draw `RefEdge`s.
    */
   refTarget?: string;
+  refTargetKind?: TypeDef['kind'];
+  /** Local enum metadata when this field references an enum TypeDef. */
+  enumTarget?: EnumTargetRow;
+}
+
+export interface EnumTargetRow {
+  name: string;
+  description?: string;
+  values: ReadonlyArray<EnumValueRow>;
 }
 
 export interface RefEdgeData extends Record<string, unknown> {
@@ -70,6 +82,8 @@ export interface RefEdgeData extends Record<string, unknown> {
   discriminator?: string;
   /** True when the target is an imported (out-of-file) type. */
   crossBoundary: boolean;
+  previewHighlighted?: boolean;
+  previewDimmed?: boolean;
 }
 
 export interface BuildGraphInput {
@@ -86,10 +100,11 @@ const DEFAULT_POSITION = { x: 0, y: 0 };
 
 export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphResult {
   const localNames = new Set(schema.types.map((t) => t.name));
+  const localTypes = new Map(schema.types.map((type) => [type.name, type]));
   const tableTypes = schema.types.filter(isTableType);
 
   const nodes: Node<TypeNodeData>[] = schema.types.map((t) =>
-    localNodeFor(t, positions?.[t.name] ?? DEFAULT_POSITION),
+    localNodeFor(t, positions?.[t.name] ?? DEFAULT_POSITION, localTypes),
   );
 
   // Collect edges + shadow nodes for targets that point outside the local
@@ -173,7 +188,11 @@ export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphRe
   return { nodes, edges };
 }
 
-function localNodeFor(type: TypeDef, position: { x: number; y: number }): Node<TypeNodeData> {
+function localNodeFor(
+  type: TypeDef,
+  position: { x: number; y: number },
+  localTypes: ReadonlyMap<string, TypeDef>,
+): Node<TypeNodeData> {
   return {
     id: type.name,
     type: 'type',
@@ -183,7 +202,7 @@ function localNodeFor(type: TypeDef, position: { x: number; y: number }): Node<T
       kind: type.kind,
       description: type.description,
       enumValues: type.kind === 'enum' ? type.values.map(enumValueRow) : undefined,
-      fields: type.kind === 'object' ? type.fields.map(fieldRow) : [],
+      fields: type.kind === 'object' ? type.fields.map((field) => fieldRow(field, localTypes)) : [],
       imported: false,
       table: type.kind === 'object' && type.table === true ? true : undefined,
     },
@@ -248,14 +267,24 @@ function enumValueRow(value: { value: string; description?: string }): EnumValue
   };
 }
 
-function fieldRow(field: FieldDef): FieldRow {
+function fieldRow(field: FieldDef, localTypes: ReadonlyMap<string, TypeDef>): FieldRow {
   const target = unwrapRefTarget(field.type);
+  const refTargetType = target ? localTypes.get(target) : undefined;
+  const enumTarget = refTargetType?.kind === 'enum' ? refTargetType : undefined;
   return {
     name: field.name,
     summary: summariseFieldType(field.type),
     optional: field.optional === true,
     nullable: field.nullable === true,
     refTarget: target,
+    refTargetKind: refTargetType?.kind,
+    enumTarget: enumTarget
+      ? {
+          name: enumTarget.name,
+          description: enumTarget.description,
+          values: enumTarget.values.map(enumValueRow),
+        }
+      : undefined,
   };
 }
 

--- a/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
@@ -2,8 +2,8 @@
  * Graph controls popover — view filters + node-spacing slider +
  * re-layout / fit / reset.
  *
- * Keeps the first graph filters deliberately narrow: enums and edge
- * labels are useful, but can add noise in structure-first reading.
+ * Keeps the first graph filters deliberately narrow: expanded enum nodes
+ * and edge labels are useful, but can add noise in structure-first reading.
  *
  * The panel talks to the canvas over two custom DOM events:
  *
@@ -87,7 +87,7 @@ export function GraphControlsPanel({ onClose }: Props): React.JSX.Element {
             checked={graphLayout.showEnums}
             onCheckedChange={(checked) => setGraphLayout({ showEnums: checked === true })}
           />
-          Enums
+          Show enum nodes
         </label>
         <label
           className="flex items-center gap-2 text-xs text-foreground"

--- a/apps/desktop/src/renderer/src/components/toolbar/GraphSearchBar.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphSearchBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Canvas search bar — focuses a type by name.
+ * Canvas search bar — focuses a type or inline enum usage by name.
  *
  * Contexture IRs only have `TypeDef`s (objects / enums / discriminated
  * unions / raw), so we match against `TypeDef.name` and
@@ -10,16 +10,30 @@
  * Escape clears.
  */
 
+import type { FieldType } from '@contexture/core/ir';
 import { useGraphLayoutStore } from '@renderer/store/layout-config';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { useUndoStore } from '@renderer/store/undo';
 import { Search, X } from 'lucide-react';
+import type { CSSProperties } from 'react';
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 
 interface Result {
   name: string;
-  matchType: 'name' | 'description';
+  focusName: string;
+  matchType: 'name' | 'description' | 'enum';
+  kindLabel: 'object' | 'table' | 'enum' | 'union' | 'raw';
+  focusFieldName?: string;
+  detail?: string;
 }
+
+const KIND_BADGE_STYLES: Record<Result['kindLabel'], CSSProperties> = {
+  object: badgeStyle('var(--graph-node-header-bg)'),
+  table: badgeStyle('var(--graph-node-table-accent)'),
+  enum: badgeStyle('var(--chart-3)'),
+  union: badgeStyle('var(--graph-edge-union)'),
+  raw: badgeStyle('var(--muted-foreground)'),
+};
 
 export function GraphSearchBar(): React.JSX.Element {
   const [query, setQuery] = useState('');
@@ -48,12 +62,45 @@ export function GraphSearchBar(): React.JSX.Element {
     const q = query.trim().toLowerCase();
     if (!q) return [];
     const matches: Result[] = [];
+    const hiddenLocalEnums = new Set<string>();
     for (const t of schema.types) {
-      if (!showEnums && t.kind === 'enum') continue;
+      if (!showEnums && t.kind === 'enum') {
+        hiddenLocalEnums.add(t.name);
+        continue;
+      }
       if (t.name.toLowerCase().includes(q)) {
-        matches.push({ name: t.name, matchType: 'name' });
+        matches.push({
+          name: t.name,
+          focusName: t.name,
+          matchType: 'name',
+          kindLabel: kindLabel(t),
+        });
       } else if (t.description?.toLowerCase().includes(q)) {
-        matches.push({ name: t.name, matchType: 'description' });
+        matches.push({
+          name: t.name,
+          focusName: t.name,
+          matchType: 'description',
+          kindLabel: kindLabel(t),
+        });
+      }
+    }
+    if (!showEnums && hiddenLocalEnums.size > 0) {
+      for (const type of schema.types) {
+        if (type.kind !== 'object') continue;
+        for (const field of type.fields) {
+          const target = unwrapRefTarget(field.type);
+          if (!target || !hiddenLocalEnums.has(target)) continue;
+          if (target.toLowerCase().includes(q)) {
+            matches.push({
+              name: target,
+              focusName: type.name,
+              matchType: 'enum',
+              kindLabel: 'enum',
+              focusFieldName: field.name,
+              detail: `${type.name}.${field.name}`,
+            });
+          }
+        }
       }
     }
     return matches.slice(0, 10);
@@ -76,8 +123,8 @@ export function GraphSearchBar(): React.JSX.Element {
     return () => document.removeEventListener('mousedown', handler);
   }, [open]);
 
-  function pick(name: string): void {
-    focus(name);
+  function pick(result: Result): void {
+    focus({ nodeId: result.focusName, fieldName: result.focusFieldName });
     setQuery('');
     setOpen(false);
   }
@@ -96,7 +143,7 @@ export function GraphSearchBar(): React.JSX.Element {
       e.preventDefault();
       setActiveIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === 'Enter') {
-      pick(results[activeIndex].name);
+      pick(results[activeIndex]);
     }
   }
 
@@ -113,9 +160,9 @@ export function GraphSearchBar(): React.JSX.Element {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={onKeyDown}
-          placeholder="Search types…"
+          placeholder="Search types and enums…"
           className="flex-1 min-w-0 bg-transparent text-xs outline-none text-foreground placeholder:text-muted-foreground/50"
-          aria-label="Search types"
+          aria-label="Search types and enums"
         />
         {query && (
           <button
@@ -137,18 +184,27 @@ export function GraphSearchBar(): React.JSX.Element {
           {results.map((r, i) => (
             <button
               type="button"
-              key={r.name}
+              key={`${r.name}-${r.focusName}-${r.detail ?? r.matchType}`}
               onMouseDown={(e) => e.preventDefault()}
-              onClick={() => pick(r.name)}
-              className={`w-full text-left px-3 py-1.5 text-xs transition-colors ${
+              onClick={() => pick(r)}
+              className={`flex w-full min-w-0 items-baseline gap-1.5 px-3 py-1.5 text-left text-xs transition-colors ${
                 i === activeIndex
                   ? 'bg-secondary text-foreground'
                   : 'text-foreground hover:bg-secondary/60'
               }`}
             >
-              {r.name}
+              <span className="min-w-0 flex-1 truncate">{r.name}</span>
+              <span
+                className="shrink-0 rounded border px-1.5 py-0 text-[9px] font-medium uppercase tracking-wide"
+                style={KIND_BADGE_STYLES[r.kindLabel]}
+                title={r.detail}
+              >
+                {r.kindLabel}
+              </span>
               {r.matchType === 'description' && (
-                <span className="text-muted-foreground/60 ml-1.5">(in description)</span>
+                <span className="shrink min-w-0 truncate text-muted-foreground/60">
+                  (in description)
+                </span>
               )}
             </button>
           ))}
@@ -156,4 +212,27 @@ export function GraphSearchBar(): React.JSX.Element {
       )}
     </div>
   );
+}
+
+function unwrapRefTarget(t: FieldType): string | undefined {
+  let cur: FieldType = t;
+  while (cur.kind === 'array' && cur.element) cur = cur.element as typeof cur;
+  return cur.kind === 'ref' ? cur.typeName : undefined;
+}
+
+function kindLabel(type: {
+  kind: 'object' | 'enum' | 'discriminatedUnion' | 'raw';
+  table?: boolean;
+}): Result['kindLabel'] {
+  if (type.kind === 'object') return type.table ? 'table' : 'object';
+  if (type.kind === 'discriminatedUnion') return 'union';
+  return type.kind;
+}
+
+function badgeStyle(color: string): CSSProperties {
+  return {
+    background: `color-mix(in oklch, ${color} 12%, transparent)`,
+    borderColor: `color-mix(in oklch, ${color} 42%, var(--border))`,
+    color: `color-mix(in oklch, ${color} 70%, var(--foreground))`,
+  };
 }

--- a/apps/desktop/src/renderer/src/store/layout-config.ts
+++ b/apps/desktop/src/renderer/src/store/layout-config.ts
@@ -15,7 +15,7 @@ export interface GraphLayout {
 
 export const DEFAULT_LAYOUT: GraphLayout = {
   nodeSpacing: 180,
-  showEnums: true,
+  showEnums: false,
   showEdgeLabels: true,
 };
 

--- a/apps/desktop/src/renderer/src/store/selection.ts
+++ b/apps/desktop/src/renderer/src/store/selection.ts
@@ -29,7 +29,12 @@ export interface GraphSelectionState {
   edgeId: string | null;
   adjacency: AdjacencySet;
   /** Target for "reveal in graph" from search — consumed by the canvas. */
-  focusNodeId: string | null;
+  focusTarget: GraphFocusTarget | null;
+}
+
+export interface GraphFocusTarget {
+  nodeId: string;
+  fieldName?: string;
 }
 
 export type AdjacencyResolver = (nodeId: string) => {
@@ -47,7 +52,7 @@ const INITIAL_STATE: GraphSelectionState = {
   primaryNodeId: null,
   edgeId: null,
   adjacency: EMPTY_ADJACENCY,
-  focusNodeId: null,
+  focusTarget: null,
 };
 
 const DEFAULT_RESOLVER: AdjacencyResolver = () => ({ nodeIds: [], edgeIds: [] });
@@ -70,7 +75,7 @@ interface GraphSelectionStoreShape {
   state: GraphSelectionState;
   click(nodeId: string, mode: ClickMode): void;
   selectEdge(edgeId: string | null): void;
-  focus(nodeId: string): void;
+  focus(target: string | GraphFocusTarget): void;
   /** Called by the canvas once it has centred on the focus target. */
   consumeFocus(): void;
   clear(): void;
@@ -136,12 +141,17 @@ export const useGraphSelectionStore = create<GraphSelectionStoreShape>((set, get
       set((s) => ({ state: { ...s.state, edgeId } }));
     },
 
-    focus(nodeId) {
-      set((s) => ({ state: { ...s.state, focusNodeId: nodeId } }));
+    focus(target) {
+      set((s) => ({
+        state: {
+          ...s.state,
+          focusTarget: typeof target === 'string' ? { nodeId: target } : target,
+        },
+      }));
     },
 
     consumeFocus() {
-      set((s) => ({ state: { ...s.state, focusNodeId: null } }));
+      set((s) => ({ state: { ...s.state, focusTarget: null } }));
     },
 
     clear() {

--- a/apps/desktop/tests/components/graph/GraphLegend.test.tsx
+++ b/apps/desktop/tests/components/graph/GraphLegend.test.tsx
@@ -12,4 +12,17 @@ describe('GraphLegend', () => {
 
     expect(screen.getByText('Table')).toBeInTheDocument();
   });
+
+  it('documents inline enums by default and only shows enum nodes when expanded in controls', () => {
+    const { rerender } = render(<GraphLegend />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand legend' }));
+
+    expect(screen.getByText('Inline enum')).toBeInTheDocument();
+    expect(screen.queryByText('Enum')).not.toBeInTheDocument();
+
+    rerender(<GraphLegend showEnumNodes />);
+
+    expect(screen.getByText('Enum')).toBeInTheDocument();
+  });
 });

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -8,7 +8,11 @@
  * paths that matter: field rows, optional markers, imported styling,
  * and the bubbling `contexture:field-select` CustomEvent.
  */
-import { TYPE_NODE_EVENT, TypeNode } from '@renderer/components/graph/nodes/TypeNode';
+import {
+  TYPE_NODE_EVENT,
+  TYPE_NODE_REF_PREVIEW_EVENT,
+  TypeNode,
+} from '@renderer/components/graph/nodes/TypeNode';
 import type { TypeNodeData } from '@renderer/components/graph/schema-to-graph';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
@@ -104,6 +108,31 @@ describe('TypeNode', () => {
     expect(event.detail).toEqual({ typeName: 'Plot', fieldName: 'name' });
   });
 
+  it('selects referenced object targets when a ref field is clicked', () => {
+    const data: TypeNodeData = {
+      typeName: 'Artwork',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'dimensions',
+          summary: '→ ArtworkDimensions',
+          optional: false,
+          nullable: false,
+          refTarget: 'ArtworkDimensions',
+        },
+      ],
+    };
+    const handler = vi.fn();
+    const { container } = render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+    container.addEventListener(TYPE_NODE_EVENT, handler as EventListener);
+
+    fireEvent.click(screen.getByTestId('type-node-field'));
+
+    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('ArtworkDimensions');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it('marks table-flagged nodes with data-table="true"', () => {
     const data: TypeNodeData = {
       typeName: 'Post',
@@ -123,7 +152,11 @@ describe('TypeNode', () => {
       background: 'var(--graph-node-table-accent)',
     });
     expect(screen.getByTestId('type-node-table-icon')).toBeInTheDocument();
-    expect(screen.getByTestId('type-node-table-badge')).toHaveTextContent('table');
+    expect(screen.getByTestId('type-node-table-label')).toHaveTextContent('table');
+    expect(screen.getByTestId('type-node-table-label')).toHaveStyle({
+      textTransform: 'uppercase',
+      letterSpacing: '0.08em',
+    });
   });
 
   it('does not mark non-table nodes with data-table', () => {
@@ -174,6 +207,166 @@ describe('TypeNode', () => {
     });
   });
 
+  it('renders local enum refs as inline enum affordances with hover details', () => {
+    vi.useFakeTimers();
+    const data: TypeNodeData = {
+      typeName: 'Recipe',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'season',
+          summary: '→ Season',
+          optional: false,
+          nullable: false,
+          refTarget: 'Season',
+          enumTarget: {
+            name: 'Season',
+            description: 'The growing season.',
+            values: [{ value: 'spring', description: 'Planting time.' }, { value: 'summer' }],
+          },
+        },
+      ],
+    };
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId('type-node-field-enum-affordance')).toHaveTextContent('Season enum');
+    expect(screen.getByTestId('type-node-field')).toHaveAccessibleName(
+      'season, Season enum, 2 values',
+    );
+    expect(screen.getByTestId('type-node-field-enum-summary')).toHaveStyle({
+      color: 'var(--muted-foreground)',
+      fontWeight: '400',
+      fontFamily: 'var(--font-mono)',
+    });
+    fireEvent.pointerEnter(screen.getByTestId('type-node-field'));
+    act(() => vi.advanceTimersByTime(120));
+
+    expect(screen.getByText('The growing season.')).toBeInTheDocument();
+    expect(screen.getByText('spring')).toBeInTheDocument();
+    expect(screen.getByText('spring').closest('[title]')).toHaveAttribute(
+      'title',
+      'Planting time.',
+    );
+  });
+
+  it('renders discriminated union refs as relationship refs with a muted suffix', () => {
+    const data: TypeNodeData = {
+      typeName: 'Artwork',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'sourceReference',
+          summary: '→ ArtworkSourceReference',
+          optional: false,
+          nullable: false,
+          refTarget: 'ArtworkSourceReference',
+          refTargetKind: 'discriminatedUnion',
+        },
+      ],
+    };
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId('type-node-field-union-affordance')).toHaveTextContent(
+      '→ ArtworkSourceReference· union',
+    );
+    expect(screen.getByTestId('type-node-field-ref-summary')).toHaveStyle({
+      color: 'var(--graph-edge-property)',
+    });
+    expect(screen.getByText('· union')).toHaveStyle({
+      color: 'var(--muted-foreground)',
+      fontWeight: '400',
+    });
+  });
+
+  it('opens inline enum details on keyboard focus', () => {
+    const data: TypeNodeData = {
+      typeName: 'Recipe',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'season',
+          summary: '→ Season',
+          optional: false,
+          nullable: false,
+          refTarget: 'Season',
+          enumTarget: {
+            name: 'Season',
+            description: 'The growing season.',
+            values: [{ value: 'spring' }],
+          },
+        },
+      ],
+    };
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    fireEvent.focus(screen.getByTestId('type-node-field'));
+
+    expect(screen.getByText('The growing season.')).toBeInTheDocument();
+    expect(screen.getByText('spring')).toBeInTheDocument();
+  });
+
+  it('previews object ref targets on hover and focus without previewing enum refs', () => {
+    const data: TypeNodeData = {
+      typeName: 'Artwork',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'dimensions',
+          summary: '→ ArtworkDimensions',
+          optional: false,
+          nullable: false,
+          refTarget: 'ArtworkDimensions',
+        },
+        {
+          name: 'medium',
+          summary: '→ ArtworkMedium',
+          optional: false,
+          nullable: false,
+          refTarget: 'ArtworkMedium',
+          enumTarget: {
+            name: 'ArtworkMedium',
+            values: [{ value: 'paint' }],
+          },
+        },
+      ],
+    };
+    const handler = vi.fn();
+    const { container } = render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+    container.addEventListener(TYPE_NODE_REF_PREVIEW_EVENT, handler as EventListener);
+    const rows = screen.getAllByTestId('type-node-field');
+
+    fireEvent.mouseEnter(rows[0]);
+    fireEvent.mouseLeave(rows[0]);
+    fireEvent.focus(rows[0]);
+    fireEvent.mouseEnter(rows[1]);
+
+    expect(handler).toHaveBeenCalledTimes(3);
+    expect(handler.mock.calls.map(([event]) => (event as CustomEvent).detail)).toEqual([
+      {
+        sourceType: 'Artwork',
+        sourceField: 'dimensions',
+        targetType: 'ArtworkDimensions',
+        active: true,
+      },
+      {
+        sourceType: 'Artwork',
+        sourceField: 'dimensions',
+        targetType: 'ArtworkDimensions',
+        active: false,
+      },
+      {
+        sourceType: 'Artwork',
+        sourceField: 'dimensions',
+        targetType: 'ArtworkDimensions',
+        active: true,
+      },
+    ]);
+  });
+
   it('shows enum description and values in a hover card', () => {
     vi.useFakeTimers();
     const data: TypeNodeData = {
@@ -191,6 +384,9 @@ describe('TypeNode', () => {
 
     expect(screen.getByText('The growing season.')).toBeInTheDocument();
     expect(screen.getByText('Values')).toBeInTheDocument();
+    expect(screen.getByText('Enum')).toHaveStyle({
+      color: 'color-mix(in oklch, var(--chart-3) 85%, transparent)',
+    });
     expect(screen.getByText('spring')).toBeInTheDocument();
     expect(screen.getByText('summer')).toBeInTheDocument();
     expect(screen.getByText('spring').closest('[title]')).toHaveAttribute(
@@ -199,12 +395,18 @@ describe('TypeNode', () => {
     );
     const badges = screen.getAllByTestId('enum-value-badge');
     expect(badges[0]).toHaveStyle({
-      background: 'color-mix(in oklch, var(--chart-1) 78%, var(--background))',
-      color: 'var(--primary-foreground)',
+      background: 'color-mix(in oklch, var(--chart-3) 85%, transparent)',
+      color: 'var(--graph-node-header-text)',
     });
+    expect(badges[0].getAttribute('style')).toContain(
+      'border-color: color-mix(in oklch, var(--chart-3) 85%, transparent)',
+    );
     expect(badges[1]).toHaveStyle({
-      background: 'color-mix(in oklch, var(--chart-1) 78%, var(--background))',
-      color: 'var(--primary-foreground)',
+      background: 'color-mix(in oklch, var(--chart-3) 85%, transparent)',
+      color: 'var(--graph-node-header-text)',
     });
+    expect(badges[1].getAttribute('style')).toContain(
+      'border-color: color-mix(in oklch, var(--chart-3) 85%, transparent)',
+    );
   });
 });

--- a/apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx
+++ b/apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx
@@ -13,17 +13,17 @@ describe('GraphControlsPanel', () => {
     vi.useRealTimers();
   });
 
-  it('toggles enum and edge-label visibility', () => {
+  it('toggles expanded enum nodes and edge-label visibility', () => {
     render(<GraphControlsPanel onClose={vi.fn()} />);
 
-    expect(screen.getByRole('checkbox', { name: 'Enums' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Show enum nodes' })).not.toBeChecked();
     expect(screen.getByRole('checkbox', { name: 'Edge labels' })).toBeChecked();
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Enums' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Show enum nodes' }));
     fireEvent.click(screen.getByRole('checkbox', { name: 'Edge labels' }));
 
     expect(useGraphLayoutStore.getState().graphLayout).toMatchObject({
-      showEnums: false,
+      showEnums: true,
       showEdgeLabels: false,
     });
   });

--- a/apps/desktop/tests/components/toolbar/GraphSearchBar.test.tsx
+++ b/apps/desktop/tests/components/toolbar/GraphSearchBar.test.tsx
@@ -1,0 +1,97 @@
+import type { Schema } from '@contexture/core/ir';
+import { GraphSearchBar } from '@renderer/components/toolbar/GraphSearchBar';
+import { useGraphLayoutStore } from '@renderer/store/layout-config';
+import { useGraphSelectionStore } from '@renderer/store/selection';
+import { useUndoStore } from '@renderer/store/undo';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const schema: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Recipe',
+      fields: [{ name: 'season', type: { kind: 'ref', typeName: 'Season' } }],
+    },
+    {
+      kind: 'object',
+      name: 'Artwork',
+      table: true,
+      fields: [],
+    },
+    {
+      kind: 'discriminatedUnion',
+      name: 'ArtworkSourceReference',
+      discriminator: 'kind',
+      variants: [],
+    },
+    {
+      kind: 'enum',
+      name: 'Season',
+      values: [{ value: 'spring' }, { value: 'summer' }],
+    },
+  ],
+};
+
+describe('GraphSearchBar', () => {
+  beforeEach(() => {
+    useUndoStore.setState({
+      schema,
+      past: [],
+      future: [],
+      txDepth: 0,
+      txStart: null,
+      canUndo: false,
+      canRedo: false,
+    });
+    useGraphLayoutStore.getState().resetToDefaults();
+    useGraphSelectionStore.getState().clear();
+  });
+
+  afterEach(cleanup);
+
+  it('surfaces hidden local enums as inline field usages and focuses the owning type', () => {
+    render(<GraphSearchBar />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search types and enums' }), {
+      target: { value: 'Season' },
+    });
+
+    expect(screen.queryByText('(Recipe.season)')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Season.*enum/ }));
+
+    expect(useGraphSelectionStore.getState().state.focusTarget).toEqual({
+      nodeId: 'Recipe',
+      fieldName: 'season',
+    });
+  });
+
+  it('focuses enum nodes directly when expanded enum nodes are visible', () => {
+    useGraphLayoutStore.getState().setGraphLayout({ showEnums: true });
+    render(<GraphSearchBar />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search types and enums' }), {
+      target: { value: 'Season' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Season.*enum/ }));
+
+    expect(useGraphSelectionStore.getState().state.focusTarget).toEqual({ nodeId: 'Season' });
+  });
+
+  it('shows kind badges for mixed type results', () => {
+    useGraphLayoutStore.getState().setGraphLayout({ showEnums: true });
+    render(<GraphSearchBar />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search types and enums' }), {
+      target: { value: 'Artwork' },
+    });
+
+    expect(screen.getByRole('button', { name: /Artwork.*table/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /ArtworkSourceReference.*union/ }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/tests/graph/graph-canvas-focus.test.ts
+++ b/apps/desktop/tests/graph/graph-canvas-focus.test.ts
@@ -1,0 +1,13 @@
+import { focusedFieldFromTarget } from '@renderer/components/graph/GraphCanvas';
+import { describe, expect, it } from 'vitest';
+
+describe('focusedFieldFromTarget', () => {
+  it('returns inline field focus only when the focus target names a field', () => {
+    expect(focusedFieldFromTarget({ nodeId: 'Recipe', fieldName: 'season' })).toEqual({
+      nodeId: 'Recipe',
+      fieldName: 'season',
+    });
+
+    expect(focusedFieldFromTarget({ nodeId: 'Artwork' })).toBeNull();
+  });
+});

--- a/apps/desktop/tests/graph/schema-to-graph.test.ts
+++ b/apps/desktop/tests/graph/schema-to-graph.test.ts
@@ -53,6 +53,71 @@ describe('buildGraph', () => {
     });
   });
 
+  it('passes local enum metadata into referring object field rows', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Recipe',
+          fields: [{ name: 'season', type: { kind: 'ref', typeName: 'Season' } }],
+        },
+        {
+          kind: 'enum',
+          name: 'Season',
+          description: 'The growing season.',
+          values: [{ value: 'spring', description: 'Planting time.' }, { value: 'summer' }],
+        },
+      ],
+    };
+
+    const { nodes } = buildGraph({ schema });
+    const recipe = nodes.find((node) => node.id === 'Recipe');
+
+    expect(recipe?.data.fields[0]).toMatchObject({
+      name: 'season',
+      summary: '→ Season',
+      refTarget: 'Season',
+      refTargetKind: 'enum',
+      enumTarget: {
+        name: 'Season',
+        description: 'The growing season.',
+        values: [{ value: 'spring', description: 'Planting time.' }, { value: 'summer' }],
+      },
+    });
+  });
+
+  it('passes local ref target kind into object field rows', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Artwork',
+          fields: [
+            { name: 'dimensions', type: { kind: 'ref', typeName: 'ArtworkDimensions' } },
+            { name: 'source', type: { kind: 'ref', typeName: 'ArtworkSourceReference' } },
+          ],
+        },
+        { kind: 'object', name: 'ArtworkDimensions', fields: [] },
+        {
+          kind: 'discriminatedUnion',
+          name: 'ArtworkSourceReference',
+          discriminator: 'kind',
+          variants: ['PosterReference'],
+        },
+      ],
+    };
+
+    const { nodes } = buildGraph({ schema });
+    const artwork = nodes.find((node) => node.id === 'Artwork');
+
+    expect(artwork?.data.fields).toEqual([
+      expect.objectContaining({ name: 'dimensions', refTargetKind: 'object' }),
+      expect.objectContaining({ name: 'source', refTargetKind: 'discriminatedUnion' }),
+    ]);
+  });
+
   it('renders object fields as field rows with summaries', () => {
     const schema: Schema = {
       version: '1',

--- a/apps/desktop/tests/store/selection.test.ts
+++ b/apps/desktop/tests/store/selection.test.ts
@@ -104,16 +104,20 @@ describe('useGraphSelectionStore', () => {
     expect(result.current.state.adjacency.edgeIds.size).toBe(0);
   });
 
-  it('focus(X) sets focusNodeId; focus(null-eq) is a no-op reset via setFocus', () => {
+  it('focus(X) sets focusTarget; consumeFocus resets it', () => {
     const { result } = renderHook(() => useGraphSelectionStore());
     act(() => {
       result.current.focus('A');
     });
-    expect(result.current.state.focusNodeId).toBe('A');
+    expect(result.current.state.focusTarget).toEqual({ nodeId: 'A' });
+    act(() => {
+      result.current.focus({ nodeId: 'B', fieldName: 'kind' });
+    });
+    expect(result.current.state.focusTarget).toEqual({ nodeId: 'B', fieldName: 'kind' });
     act(() => {
       result.current.consumeFocus();
     });
-    expect(result.current.state.focusNodeId).toBeNull();
+    expect(result.current.state.focusTarget).toBeNull();
   });
 
   it('selectEdge() clears node selection and sets edgeId', () => {


### PR DESCRIPTION
## Summary
- hide local enum nodes by default and surface enum details inline from table/object rows
- add hover/click previews for inline object and union references, including persistent selection on click
- improve graph search results with colored kind badges and focused inline enum highlights
- align table header kind text with object/union labels and bump desktop app to 0.15.19

## Checks
- bun run test -- tests/components/graph/TypeNode.test.tsx tests/components/graph/GraphLegend.test.tsx tests/components/toolbar/GraphControlsPanel.test.tsx tests/components/toolbar/GraphSearchBar.test.tsx tests/graph/schema-to-graph.test.ts tests/store/selection.test.ts
- bun run typecheck
- bunx biome check apps/desktop/package.json apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx apps/desktop/src/renderer/src/components/toolbar/GraphSearchBar.tsx apps/desktop/src/renderer/src/store/layout-config.ts apps/desktop/src/renderer/src/store/selection.ts apps/desktop/tests/components/graph/GraphLegend.test.tsx apps/desktop/tests/components/graph/TypeNode.test.tsx apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx apps/desktop/tests/components/toolbar/GraphSearchBar.test.tsx apps/desktop/tests/graph/schema-to-graph.test.ts apps/desktop/tests/store/selection.test.ts
- pre-commit: turbo typecheck && turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782552699&installation_id=136251083&pr_number=322&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F322&signature=668c5ae70b6703c01c0adef285b3e5bf7e72a2a3899cb336bcc3a2ab9cb9e0d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->