### PR TITLE
Improve graph enum hover and model shape readability

### DIFF
--- a/apps/desktop/src/renderer/src/components/detail/ModelShapeHints.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/ModelShapeHints.tsx
@@ -16,16 +16,16 @@ export function ModelShapeHints({ hints }: ModelShapeHintsProps) {
   return (
     <section
       aria-label="Model shape"
-      className="space-y-2 rounded border border-border/70 bg-muted/20 p-3 text-xs"
+      className="space-y-2.5 rounded border border-border/70 bg-muted/20 p-3 text-[12px] leading-5"
     >
       <div className="flex items-start gap-2">
         <Lightbulb aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 text-primary" />
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex items-center justify-between gap-2">
-            <h3 className="text-xs font-semibold text-foreground">Model shape</h3>
-            <span className="text-[10px] text-muted-foreground">Advisory</span>
+            <h3 className="text-sm font-semibold text-foreground">Model shape</h3>
+            <span className="text-[11px] text-muted-foreground">Advisory</span>
           </div>
-          <p className="text-[11px] leading-snug text-muted-foreground">
+          <p className="text-xs leading-5 text-muted-foreground">
             Embed for ownership. Extract for identity.
           </p>
         </div>
@@ -35,7 +35,7 @@ export function ModelShapeHints({ hints }: ModelShapeHintsProps) {
 
       {secondary.length > 0 && (
         <details className="group">
-          <summary className="cursor-pointer text-[11px] font-medium text-muted-foreground">
+          <summary className="cursor-pointer text-xs font-medium text-muted-foreground">
             {secondary.length} more {secondary.length === 1 ? 'signal' : 'signals'}
           </summary>
           <div className="mt-2 space-y-2">
@@ -56,7 +56,7 @@ function HintBody({ hint, compact = false }: { hint: ModelingHint; compact?: boo
       <div className="flex flex-wrap items-center gap-1.5">
         <Badge
           variant="outline"
-          className="rounded px-1.5 py-0 text-[10px] font-medium"
+          className="rounded px-1.5 py-0.5 text-[11px] font-medium leading-none"
           style={tone}
         >
           {hint.title}
@@ -65,17 +65,15 @@ function HintBody({ hint, compact = false }: { hint: ModelingHint; compact?: boo
           <Badge
             key={fieldName}
             variant="outline"
-            className="rounded px-1.5 py-0 text-[10px] font-medium"
+            className="rounded px-1.5 py-0.5 text-[11px] font-medium leading-none"
             style={fieldBadgeStyle}
           >
             {fieldName}
           </Badge>
         ))}
       </div>
-      <p className="leading-snug text-muted-foreground">{hint.message}</p>
-      {!compact && (
-        <p className="text-[11px] leading-snug text-muted-foreground">{hint.rationale}</p>
-      )}
+      <p className="text-foreground/85">{hint.message}</p>
+      {!compact && <p className="text-[12px] leading-5 text-muted-foreground">{hint.rationale}</p>}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -144,6 +144,9 @@ function GraphCanvasInner({
         }
       : visible;
     if (!refPreview) return visibleWithFocusedField;
+    if (!visibleWithFocusedField.nodes.some((node) => node.id === refPreview.targetType)) {
+      return visibleWithFocusedField;
+    }
     const previewNodeIds = new Set<string>([refPreview.targetType]);
     const previewEdgeIds = new Set<string>();
     for (const edge of visible.edges) {

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -113,7 +113,7 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
       active: boolean,
       ev: React.SyntheticEvent<HTMLElement>,
     ) => {
-      if (!field.refTarget || field.enumTarget) return;
+      if (!field.refTarget) return;
       const detail: FieldRefPreview = {
         sourceType: data.typeName,
         sourceField: field.name,

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -308,7 +308,7 @@ describe('TypeNode', () => {
     expect(screen.getByText('spring')).toBeInTheDocument();
   });
 
-  it('previews object ref targets on hover and focus without previewing enum refs', () => {
+  it('previews ref targets on hover and focus, including enum refs', () => {
     const data: TypeNodeData = {
       typeName: 'Artwork',
       kind: 'object',
@@ -344,7 +344,7 @@ describe('TypeNode', () => {
     fireEvent.focus(rows[0]);
     fireEvent.mouseEnter(rows[1]);
 
-    expect(handler).toHaveBeenCalledTimes(3);
+    expect(handler).toHaveBeenCalledTimes(4);
     expect(handler.mock.calls.map(([event]) => (event as CustomEvent).detail)).toEqual([
       {
         sourceType: 'Artwork',
@@ -362,6 +362,12 @@ describe('TypeNode', () => {
         sourceType: 'Artwork',
         sourceField: 'dimensions',
         targetType: 'ArtworkDimensions',
+        active: true,
+      },
+      {
+        sourceType: 'Artwork',
+        sourceField: 'medium',
+        targetType: 'ArtworkMedium',
         active: true,
       },
     ]);


### PR DESCRIPTION
## Summary
- Highlight visible enum nodes when hovering enum ref text in graph field rows
- Avoid preview dimming when enum targets are hidden by the graph filter
- Improve Model shape guidance readability in the properties panel

## Verification
- bun run test -- tests/components/graph/TypeNode.test.tsx
- bun run test -- tests/components/detail/TypeDetail.test.tsx tests/components/detail/FieldDetail.test.tsx tests/components/detail/DetailPanel.test.tsx
- bun run typecheck
- pre-commit: turbo typecheck; turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782554348&installation_id=136251083&pr_number=323&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F323&signature=138ec9686f0cd03ce6297605cd3fa5670bc78458b5350024bcd04493d1db0a84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->