### PR TITLE
fix: complete Convex-first positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a Turborepo monorepo:
 
 | App / Package | Path | Description | Deployment |
 |---|---|---|---|
-| **Desktop** | [`apps/desktop/`](apps/desktop/) | Electron schema editor | GitHub Releases (tagged) |
+| **Desktop** | [`apps/desktop/`](apps/desktop/) | Electron Convex model editor | GitHub Releases (tagged) |
 | **Web** | [`apps/web/`](apps/web/) | Marketing website (Next.js) | Vercel (auto-deploy on merge to main) |
 | **stdlib** | [`packages/stdlib/`](packages/stdlib/) | Curated types library | — |
 | **runtime** | [`packages/runtime/`](packages/runtime/) | Published as `@contexture/runtime` | npm |

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contexture/desktop",
   "version": "0.15.20",
-  "description": "Visual Zod schema editor with LLM support",
+  "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",
   "author": "Applification Ltd",

--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -45,6 +45,32 @@ test.describe('Home page', () => {
     await expect(aiSection).toBeVisible();
     await expect(aiSection.locator('text=Powered by Claude')).toHaveCount(0);
     await expect(aiSection.locator('text=MCP-native by design')).toBeVisible();
+    await expect(
+      aiSection.locator('text=Add Memberships table with user and team refs'),
+    ).toBeVisible();
+    await expect(aiSection.locator('text=discogsReleaseId')).toHaveCount(0);
+  });
+
+  test('generated-output proof leads with Convex files', async ({ page }) => {
+    await page.goto('/');
+    const proof = page.locator('section', {
+      has: page.locator('h3:has-text("See generated Convex files before they land in git")'),
+    });
+    await expect(proof.locator('div').filter({ hasText: /^convex\/schema\.ts$/ })).toBeVisible();
+    await expect(
+      proof.locator('div').filter({ hasText: /^convex\/validators\.ts$/ }),
+    ).toBeVisible();
+    await expect(proof.locator('text=memberships: defineTable')).toBeVisible();
+    await expect(proof.locator('text=.index("by_user", ["userId"])')).toBeVisible();
+  });
+
+  test('use cases lead with Convex app schemas', async ({ page }) => {
+    await page.goto('/');
+    const useCases = page.locator('section', {
+      has: page.locator('h2:has-text("One Convex model, many consumers")'),
+    });
+    const headings = useCases.locator('.uppercase');
+    await expect(headings.first()).toContainText('Convex app schemas');
   });
 
   test('footer contains expected links', async ({ page }) => {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -113,12 +113,12 @@ const features = [
 const agentSteps = [
   {
     tool: 'inspect_contexture',
-    label: 'Read Release and generated targets',
+    label: 'Read Users and Teams tables',
     status: 'complete',
   },
   {
     tool: 'apply_contexture_op',
-    label: 'Add optional discogsReleaseId field',
+    label: 'Add Memberships table with user and team refs',
     status: 'complete',
   },
   { tool: 'emit_contexture', label: 'Regenerate Convex schema and validators', status: 'complete' },
@@ -128,6 +128,63 @@ const agentSteps = [
     status: 'clean',
   },
 ];
+
+const convexPreviewLines = [
+  { id: 'server-import', text: 'import { defineSchema, defineTable } from "convex/server";' },
+  { id: 'values-import', text: 'import { v } from "convex/values";' },
+  { id: 'spacer-imports', text: '' },
+  { id: 'schema-open', text: 'export default defineSchema({' },
+  { id: 'users-open', text: '  users: defineTable({' },
+  { id: 'users-name', text: '    name: v.string(),' },
+  { id: 'users-email', text: '    email: v.string(),' },
+  { id: 'users-index', text: '  }).index("by_email", ["email"]),' },
+  { id: 'teams-open', text: '  teams: defineTable({' },
+  { id: 'teams-slug', text: '    slug: v.string(),' },
+  { id: 'teams-name', text: '    name: v.string(),' },
+  { id: 'teams-index', text: '  }).index("by_slug", ["slug"]),' },
+  { id: 'memberships-open', text: '  memberships: defineTable({' },
+  { id: 'memberships-user', text: '    userId: v.id("users"),' },
+  { id: 'memberships-team', text: '    teamId: v.id("teams"),' },
+  { id: 'memberships-role', text: '    role: v.union(v.literal("owner"), v.literal("member")),' },
+  { id: 'memberships-close', text: '  })' },
+  { id: 'memberships-user-index', text: '    .index("by_user", ["userId"])' },
+  { id: 'memberships-team-index', text: '    .index("by_team", ["teamId"]),' },
+  { id: 'schema-close', text: '});' },
+];
+
+function ConvexGeneratedPreview() {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border/60 bg-card/70 text-left screenshot-glow">
+      <div className="flex items-center justify-between border-b border-border/60 bg-background/70 px-4 py-3">
+        <div>
+          <div className="font-mono text-xs text-primary dark:text-accent">convex/schema.ts</div>
+          <div className="text-[11px] text-muted-foreground">Read-only generated output</div>
+        </div>
+        <div className="rounded border border-success/20 bg-success/10 px-2 py-1 text-[10px] uppercase tracking-wide text-success">
+          Drift clean
+        </div>
+      </div>
+      <pre className="overflow-x-auto p-4 text-[11px] leading-relaxed text-muted-foreground sm:text-xs">
+        <code>
+          {convexPreviewLines.map((line, index) => (
+            <span key={line.id} className="block">
+              <span className="mr-4 select-none text-muted-foreground/40">
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <span>{line.text || ' '}</span>
+            </span>
+          ))}
+        </code>
+      </pre>
+      <div className="border-t border-border/60 bg-background/50 px-4 py-3">
+        <div className="font-mono text-xs text-primary dark:text-accent">convex/validators.ts</div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Reusable validators emit beside the schema for functions, forms, and app boundaries.
+        </p>
+      </div>
+    </div>
+  );
+}
 
 function AgentConversationDemo() {
   return (
@@ -416,15 +473,8 @@ export default function Home() {
 
           {/* Two-column: generated surface preview + description */}
           <div className="grid sm:grid-cols-5 gap-8 sm:gap-12 items-center">
-            <div className="sm:col-span-2 rounded-xl overflow-hidden border border-border/60 screenshot-glow transition-shadow duration-500">
-              <ThemeImage
-                srcDark="/images/misprint-generated-zod.png"
-                srcLight="/images/misprint-generated-zod-light.png"
-                alt="Contexture generated-output panel previewing code from the selected Convex domain model"
-                width={1600}
-                height={1200}
-                className="w-full h-auto"
-              />
+            <div className="sm:col-span-2">
+              <ConvexGeneratedPreview />
             </div>
             <div className="sm:col-span-3 space-y-6">
               <h3 className="text-2xl font-bold tracking-tight">
@@ -482,21 +532,21 @@ export default function Home() {
           <div className="grid sm:grid-cols-3 gap-4 sm:gap-8">
             <div className="rounded-xl border border-border/60 bg-card/50 p-6 sm:p-8 hover:border-accent/30 transition-colors">
               <div className="text-primary dark:text-accent text-sm font-medium uppercase tracking-wider mb-4">
-                Structured output
-              </div>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                Generate JSON Schema and structured-output definitions from the same Convex model
-                your app imports. Prompt surfaces and app surfaces stay aligned.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/60 bg-card/50 p-6 sm:p-8 hover:border-accent/30 transition-colors">
-              <div className="text-primary dark:text-accent text-sm font-medium uppercase tracking-wider mb-4">
                 Convex app schemas
               </div>
               <p className="text-sm text-muted-foreground leading-relaxed">
                 Emit `convex/schema.ts`, `convex/validators.ts`, and supporting schema files for the
                 product repo. Generated markers and the manifest make review and drift detection
                 part of normal git flow.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-card/50 p-6 sm:p-8 hover:border-accent/30 transition-colors">
+              <div className="text-primary dark:text-accent text-sm font-medium uppercase tracking-wider mb-4">
+                Structured output
+              </div>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Generate JSON Schema and structured-output definitions from the same Convex model
+                your app imports. Prompt surfaces and app surfaces stay aligned.
               </p>
             </div>
             <div className="rounded-xl border border-border/60 bg-card/50 p-6 sm:p-8 hover:border-accent/30 transition-colors">

--- a/docs/adr/0022-contexture-domain-model-control-plane.md
+++ b/docs/adr/0022-contexture-domain-model-control-plane.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-Contexture's codebase has converged on a stronger product shape than "visual Zod schema editor":
+Contexture's codebase has converged on a stronger product shape than the older Zod-first editor category or a generic TypeScript schema tool:
 
 - `@contexture/core` owns a canonical IR, closed-world op vocabulary, validation, emitters, path conventions, and file-backed mutation helpers.
 - The desktop app provides local-first visual and chat-assisted authoring over that IR.
@@ -19,13 +19,13 @@ The product direction should preserve the narrow leverage point: Contexture owns
 
 ## Decision
 
-Contexture is the **domain-model control plane for AI-native TypeScript apps**.
+Contexture is the **domain-model control plane for Convex apps built with agents**.
 
 The product owns:
 
 - Authoring and validating a canonical `.contexture.json` IR.
 - Applying all human, CLI, and agent edits through the closed-world op vocabulary.
-- Emitting typed surfaces from that IR, including Zod, JSON Schema, Convex schema, schema indexes, and future AI-pipeline artefacts such as tool schemas, extractor scaffolds, MCP definitions, and form validators.
+- Emitting typed surfaces from that IR, led by Convex schema and validators, with supporting Zod, JSON Schema, schema indexes, and future AI-pipeline artefacts such as tool schemas, extractor scaffolds, MCP definitions, and form validators.
 - Detecting and reconciling drift in generated artefacts using the emitted hash manifest.
 - Exposing the same model mutation surface to agents through CLI/MCP-style adapters.
 
@@ -55,7 +55,7 @@ The desktop app remains the human visual authoring surface. The CLI and future M
 
 ## Alternatives considered
 
-- **Keep positioning as a visual Zod editor.** Too small: it undersells the existing Convex, JSON Schema, drift, CLI, and agent-safe op architecture.
+- **Keep positioning as a visual Zod editor.** Too small: it undersells the Convex-first model loop, JSON Schema, drift, CLI, and agent-safe op architecture.
 - **Become a full app builder.** Too broad: it would compete with scaffolding, Sandcastle, and coding agents, while weakening Contexture's source-of-truth story.
 - **Become a general agent orchestration product.** Rejected because Sandcastle/missions already cover that adjacent space; Contexture's leverage is a safe domain-model interface those agents can call.
-- **Reopen the JSON-LD/frame pivot.** Rejected for now because the current implementation and product plan have converged on TypeScript/Zod/Convex/AI-pipeline schema design.
+- **Reopen the JSON-LD/frame pivot.** Rejected for now because the current implementation and product plan have converged on Convex-first model design with supporting TypeScript, Zod, JSON Schema, and AI-pipeline outputs.

--- a/docs/adr/0023-features-enter-through-core-domain-modules.md
+++ b/docs/adr/0023-features-enter-through-core-domain-modules.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-Contexture now has a clear product shape: it is the domain-model control plane for AI-native TypeScript apps, with `@contexture/core` as the shared kernel and desktop, CLI, MCP, and provider runtimes as surfaces over that kernel.
+Contexture now has a clear product shape: it is the domain-model control plane for Convex apps built with agents, with `@contexture/core` as the shared kernel and desktop, CLI, MCP, and provider runtimes as surfaces over that kernel.
 
 Recent architecture and security work tightened the trust envelope:
 


### PR DESCRIPTION
## Summary
- update repo metadata and ADR positioning to make Convex apps the lead product lens
- replace the homepage generated-output proof with a Convex schema/validators preview
- align homepage agent demo and use-case ordering around Convex table/ref/index workflows
- add homepage E2E assertions for the Convex-first proof points

## Verification
- pre-commit: biome check --write on staged files
- pre-commit: turbo typecheck
- pre-commit: turbo test
- manual: verified running homepage included memberships table proof, Convex files, no discogsReleaseId, and Convex use case before structured output

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782597780&installation_id=136251083&pr_number=327&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F327&signature=849ae988176ffec9b3890a46bdaadc58f23faba71261d72d7ccb4b3097ae2a89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->