### PR TITLE
feat: add reconcile trust workflow

### DIFF
--- a/apps/desktop/src/main/documents/drift-watcher.ts
+++ b/apps/desktop/src/main/documents/drift-watcher.ts
@@ -18,7 +18,13 @@
  */
 import { createHash } from 'node:crypto';
 import { type FSWatcher, promises as fsPromises, watch } from 'node:fs';
-import { bundlePathsFor, generatedTargetsFor } from '@contexture/core';
+import {
+  bundlePathsFor,
+  classifyGeneratedBundleDrift,
+  type GeneratedDriftClassification,
+  generatedTargetsFor,
+  load,
+} from '@contexture/core';
 
 // ─── Pure detector ───────────────────────────────────────────────────
 
@@ -29,8 +35,10 @@ export interface DriftResult {
 
 export interface DriftProblem {
   path: string;
-  status: 'drifted' | 'unreadable';
+  status: GeneratedProblemStatus;
 }
+
+type GeneratedProblemStatus = Exclude<GeneratedDriftClassification, 'clean'> | 'drifted';
 
 export async function detectDrift(
   emittedJsonPath: string,
@@ -107,10 +115,13 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
   let stopped = false;
 
   async function doCheck(): Promise<void> {
-    const results = await detectDrift(emittedJsonPath, readFile, { allowedPaths });
+    const results = await detectCurrentDrift(irPath, emittedJsonPath, readFile, allowedPaths);
     if (stopped || results.length === 0) return;
 
-    const problems = results.filter((r): r is DriftProblem => r.status !== 'match');
+    const problems = results.flatMap((result): DriftProblem[] => {
+      const status = problemStatusFor(result.status);
+      return status ? [{ path: result.path, status }] : [];
+    });
     const nowProblems = problems.map(problemKey);
     const wasProblematic = problemSet.size > 0;
     const isProblematic = problems.length > 0;
@@ -177,4 +188,28 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
 
 function problemKey(problem: DriftProblem): string {
   return `${problem.status}:${problem.path}`;
+}
+
+function problemStatusFor(
+  status: DriftResult['status'] | GeneratedDriftClassification,
+): GeneratedProblemStatus | null {
+  if (status === 'match' || status === 'clean') return null;
+  return status;
+}
+
+async function detectCurrentDrift(
+  irPath: string,
+  emittedJsonPath: string,
+  readFile: (path: string) => Promise<string>,
+  allowedPaths: readonly string[],
+): Promise<Array<{ path: string; status: DriftResult['status'] | GeneratedDriftClassification }>> {
+  try {
+    const { schema } = load(await readFile(irPath));
+    const allowed = new Set(allowedPaths);
+    return (await classifyGeneratedBundleDrift(schema, irPath, { readFile })).filter((result) =>
+      allowed.has(result.path),
+    );
+  } catch {
+    return detectDrift(emittedJsonPath, readFile, { allowedPaths });
+  }
 }

--- a/apps/desktop/src/main/ipc/reconcile.ts
+++ b/apps/desktop/src/main/ipc/reconcile.ts
@@ -34,11 +34,7 @@ export interface AcceptGeneratedTargetInput extends WriteGeneratedTargetInput {
   schema: Schema;
 }
 
-export interface ReconcileWriteResult {
-  convexValidation: ConvexCliValidationResult;
-}
-
-interface ReconcileWriteDeps {
+interface ConvexValidationDeps {
   execFile?: ExecFileLike;
   env?: NodeJS.ProcessEnv;
 }
@@ -72,10 +68,7 @@ export async function readGeneratedTarget(input: unknown): Promise<string | null
   }
 }
 
-export async function writeGeneratedTarget(
-  input: unknown,
-  deps: ReconcileWriteDeps = {},
-): Promise<ReconcileWriteResult> {
+export async function writeGeneratedTarget(input: unknown): Promise<void> {
   const parsed = parseIpcPayload(
     'reconcile:write-generated-target',
     WriteGeneratedTargetInputSchema,
@@ -84,18 +77,9 @@ export async function writeGeneratedTarget(
   const target = assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath);
   const manifestPath = bundlePathsFor(parsed.irPath).emitted;
   await writeGeneratedTargetContents(target, manifestPath, parsed.contents);
-  return {
-    convexValidation: await validateReconciledConvexProject(
-      { irPath: parsed.irPath, targetPath: parsed.targetPath },
-      deps,
-    ),
-  };
 }
 
-export async function acceptGeneratedTarget(
-  input: unknown,
-  deps: ReconcileWriteDeps = {},
-): Promise<ReconcileWriteResult> {
+export async function acceptGeneratedTarget(input: unknown): Promise<void> {
   const parsed = parseIpcPayload(
     'reconcile:accept-generated-target',
     AcceptGeneratedTargetInputSchema,
@@ -114,17 +98,27 @@ export async function acceptGeneratedTarget(
       schema: parsed.schema,
       fs: nodeFsAdapter,
     });
-    return {
-      convexValidation: await validateReconciledConvexProject(
-        { irPath: parsed.irPath, targetPath: parsed.targetPath },
-        deps,
-      ),
-    };
   } catch (err) {
     await restoreOptionalFile(target, previousTarget);
     await restoreOptionalFile(manifestPath, previousManifest);
     throw err;
   }
+}
+
+export async function validateConvexGeneratedTarget(
+  input: unknown,
+  deps: ConvexValidationDeps = {},
+): Promise<ConvexCliValidationResult> {
+  const parsed = parseIpcPayload(
+    'reconcile:validate-convex-generated-target',
+    GeneratedTargetInputSchema,
+    input,
+  );
+  assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath);
+  return validateReconciledConvexProject(
+    { irPath: parsed.irPath, targetPath: parsed.targetPath },
+    deps,
+  );
 }
 
 async function writeGeneratedTargetContents(
@@ -186,5 +180,8 @@ export function registerReconcileIpc(): void {
   );
   ipcMain.handle('reconcile:accept-generated-target', async (_evt, input: unknown) =>
     acceptGeneratedTarget(input),
+  );
+  ipcMain.handle('reconcile:validate-convex-generated-target', async (_evt, input: unknown) =>
+    validateConvexGeneratedTarget(input),
   );
 }

--- a/apps/desktop/src/main/ipc/reconcile.ts
+++ b/apps/desktop/src/main/ipc/reconcile.ts
@@ -1,9 +1,24 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { bundlePathsFor, type EmittedManifest, hashContent } from '@contexture/core';
+import {
+  bundlePathsFor,
+  type EmittedManifest,
+  hashContent,
+  IRSchema,
+  type Schema,
+  save as saveIR,
+  writeGeneratedBundle,
+} from '@contexture/core';
 import { ipcMain } from 'electron';
 import { z } from 'zod';
+import { nodeFsAdapter } from '../documents/node-fs-adapter';
+import {
+  type ConvexCliValidationResult,
+  type ExecFileLike,
+  validateReconciledConvexProject,
+} from '../reconcile/convex-cli-validation';
 import { assertGeneratedTargetForIr } from '../security';
+import { acknowledgeModelSyncSelfWrite } from './model-sync';
 import { IpcString, parseIpcPayload } from './validation';
 
 export interface GeneratedTargetInput {
@@ -13,6 +28,19 @@ export interface GeneratedTargetInput {
 
 export interface WriteGeneratedTargetInput extends GeneratedTargetInput {
   contents: string;
+}
+
+export interface AcceptGeneratedTargetInput extends WriteGeneratedTargetInput {
+  schema: Schema;
+}
+
+export interface ReconcileWriteResult {
+  convexValidation: ConvexCliValidationResult;
+}
+
+interface ReconcileWriteDeps {
+  execFile?: ExecFileLike;
+  env?: NodeJS.ProcessEnv;
 }
 
 const GeneratedTargetInputSchema = z
@@ -25,6 +53,10 @@ const GeneratedTargetInputSchema = z
 const WriteGeneratedTargetInputSchema = GeneratedTargetInputSchema.extend({
   contents: z.string(),
 }).strict();
+
+const AcceptGeneratedTargetInputSchema = WriteGeneratedTargetInputSchema.extend({
+  schema: IRSchema,
+}).strict() as z.ZodType<AcceptGeneratedTargetInput>;
 
 export async function readGeneratedTarget(input: unknown): Promise<string | null> {
   const parsed = parseIpcPayload(
@@ -40,7 +72,10 @@ export async function readGeneratedTarget(input: unknown): Promise<string | null
   }
 }
 
-export async function writeGeneratedTarget(input: unknown): Promise<void> {
+export async function writeGeneratedTarget(
+  input: unknown,
+  deps: ReconcileWriteDeps = {},
+): Promise<ReconcileWriteResult> {
   const parsed = parseIpcPayload(
     'reconcile:write-generated-target',
     WriteGeneratedTargetInputSchema,
@@ -48,9 +83,58 @@ export async function writeGeneratedTarget(input: unknown): Promise<void> {
   );
   const target = assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath);
   const manifestPath = bundlePathsFor(parsed.irPath).emitted;
+  await writeGeneratedTargetContents(target, manifestPath, parsed.contents);
+  return {
+    convexValidation: await validateReconciledConvexProject(
+      { irPath: parsed.irPath, targetPath: parsed.targetPath },
+      deps,
+    ),
+  };
+}
+
+export async function acceptGeneratedTarget(
+  input: unknown,
+  deps: ReconcileWriteDeps = {},
+): Promise<ReconcileWriteResult> {
+  const parsed = parseIpcPayload(
+    'reconcile:accept-generated-target',
+    AcceptGeneratedTargetInputSchema,
+    input,
+  );
+  const target = assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath);
+  const manifestPath = bundlePathsFor(parsed.irPath).emitted;
+  const previousTarget = await readOptionalFile(target);
+  const previousManifest = await readOptionalFile(manifestPath);
+
+  try {
+    await writeGeneratedTargetContents(target, manifestPath, parsed.contents);
+    acknowledgeModelSyncSelfWrite(parsed.irPath, hashContent(`${saveIR(parsed.schema)}\n`));
+    await writeGeneratedBundle({
+      irPath: parsed.irPath,
+      schema: parsed.schema,
+      fs: nodeFsAdapter,
+    });
+    return {
+      convexValidation: await validateReconciledConvexProject(
+        { irPath: parsed.irPath, targetPath: parsed.targetPath },
+        deps,
+      ),
+    };
+  } catch (err) {
+    await restoreOptionalFile(target, previousTarget);
+    await restoreOptionalFile(manifestPath, previousManifest);
+    throw err;
+  }
+}
+
+async function writeGeneratedTargetContents(
+  target: string,
+  manifestPath: string,
+  contents: string,
+): Promise<void> {
   await mkdir(dirname(target), { recursive: true });
-  await writeFile(target, parsed.contents, 'utf8');
-  await writeGeneratedManifestHash(manifestPath, target, parsed.contents);
+  await writeFile(target, contents, 'utf8');
+  await writeGeneratedManifestHash(manifestPath, target, contents);
 }
 
 async function writeGeneratedManifestHash(
@@ -76,11 +160,31 @@ async function readGeneratedManifest(manifestPath: string): Promise<EmittedManif
   }
 }
 
+async function readOptionalFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+async function restoreOptionalFile(path: string, contents: string | null): Promise<void> {
+  if (contents === null) {
+    await nodeFsAdapter.remove(path).catch(() => undefined);
+    return;
+  }
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents, 'utf8');
+}
+
 export function registerReconcileIpc(): void {
   ipcMain.handle('reconcile:read-generated-target', async (_evt, input: unknown) =>
     readGeneratedTarget(input),
   );
   ipcMain.handle('reconcile:write-generated-target', async (_evt, input: unknown) =>
     writeGeneratedTarget(input),
+  );
+  ipcMain.handle('reconcile:accept-generated-target', async (_evt, input: unknown) =>
+    acceptGeneratedTarget(input),
   );
 }

--- a/apps/desktop/src/main/reconcile/convex-cli-validation.ts
+++ b/apps/desktop/src/main/reconcile/convex-cli-validation.ts
@@ -1,0 +1,156 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { bundlePathsFor, generatedTargetForPath } from '@contexture/core/paths';
+
+const execFileAsync = promisify(execFile);
+
+export type ConvexCliValidationResult =
+  | {
+      status: 'skipped';
+      reason: string;
+    }
+  | {
+      status: 'passed';
+      command: string;
+      output?: string;
+    }
+  | {
+      status: 'failed';
+      command: string;
+      error: string;
+      output?: string;
+    };
+
+export type ExecFileLike = (
+  file: string,
+  args: readonly string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    timeout: number;
+    maxBuffer: number;
+  },
+) => Promise<{ stdout?: string | Buffer; stderr?: string | Buffer }>;
+
+interface ValidateConvexCliInput {
+  irPath: string;
+  targetPath: string;
+}
+
+interface ValidateConvexCliDeps {
+  execFile?: ExecFileLike;
+  env?: NodeJS.ProcessEnv;
+}
+
+const COMMAND = ['npx', '--no-install', 'convex', 'dev', '--once'] as const;
+
+export async function validateReconciledConvexProject(
+  input: ValidateConvexCliInput,
+  deps: ValidateConvexCliDeps = {},
+): Promise<ConvexCliValidationResult> {
+  const target = generatedTargetForPath(input.irPath, input.targetPath);
+  if (target?.kind !== 'convex' && target?.kind !== 'convex-validators') {
+    return { status: 'skipped', reason: 'Target is not a Convex generated file.' };
+  }
+
+  const projectDir = dirname(dirname(bundlePathsFor(input.irPath).convex));
+  const configured = await hasConvexCliValidationConfig(projectDir, deps.env ?? process.env);
+  if (!configured.ok) return { status: 'skipped', reason: configured.reason };
+
+  const run = deps.execFile ?? execFileAsync;
+  try {
+    const result = await run(COMMAND[0], COMMAND.slice(1), {
+      cwd: projectDir,
+      env: deps.env ?? process.env,
+      timeout: 60_000,
+      maxBuffer: 1024 * 1024,
+    });
+    return {
+      status: 'passed',
+      command: COMMAND.join(' '),
+      output: compactOutput(result.stdout, result.stderr),
+    };
+  } catch (err) {
+    return {
+      status: 'failed',
+      command: COMMAND.join(' '),
+      error: err instanceof Error ? err.message : String(err),
+      output: outputFromThrownExecError(err),
+    };
+  }
+}
+
+async function hasConvexCliValidationConfig(
+  projectDir: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const packageJson = await readJsonObject(join(projectDir, 'package.json'));
+  if (!packageJson) return { ok: false, reason: 'No project package.json found.' };
+
+  const deps = {
+    ...recordValue(packageJson.dependencies),
+    ...recordValue(packageJson.devDependencies),
+    ...recordValue(packageJson.optionalDependencies),
+  };
+  if (!('convex' in deps)) {
+    return { ok: false, reason: 'Project does not depend on the Convex CLI package.' };
+  }
+
+  if (env.CONVEX_DEPLOYMENT || env.CONVEX_DEPLOY_KEY) return { ok: true };
+
+  const dotenv = await readOptionalText(join(projectDir, '.env.local'));
+  if (dotenv && /^\s*CONVEX_DEPLOYMENT\s*=/m.test(dotenv)) return { ok: true };
+
+  return {
+    ok: false,
+    reason:
+      'Convex deployment is not configured via CONVEX_DEPLOYMENT, CONVEX_DEPLOY_KEY, or .env.local.',
+  };
+}
+
+async function readJsonObject(path: string): Promise<Record<string, unknown> | null> {
+  const text = await readOptionalText(path);
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readOptionalText(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function compactOutput(
+  stdout: string | Buffer | undefined,
+  stderr: string | Buffer | undefined,
+): string | undefined {
+  const output = [stdout, stderr]
+    .filter((part): part is string | Buffer => part !== undefined)
+    .map((part) => String(part).trim())
+    .filter(Boolean)
+    .join('\n');
+  return output || undefined;
+}
+
+function outputFromThrownExecError(err: unknown): string | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const candidate = err as { stdout?: string | Buffer; stderr?: string | Buffer };
+  return compactOutput(candidate.stdout, candidate.stderr);
+}

--- a/apps/desktop/src/main/reconcile/convex-schema-proposals.ts
+++ b/apps/desktop/src/main/reconcile/convex-schema-proposals.ts
@@ -1,0 +1,449 @@
+import type { FieldDef, FieldType, IndexDef, Schema, TypeDef } from '@contexture/core';
+import type { Op } from '@contexture/core/ops';
+import * as ts from 'typescript';
+
+export interface DeterministicReconcileEntry {
+  op: Op;
+  label: string;
+  lossy: boolean;
+  provenance: 'deterministic';
+}
+
+export type ConvexSchemaProposalResult =
+  | { ok: true; ops: DeterministicReconcileEntry[] }
+  | { ok: false; error: string };
+
+type ObjectType = Extract<TypeDef, { kind: 'object' }>;
+
+interface ParsedTable {
+  tableName: string;
+  fields: FieldDef[];
+  indexes: IndexDef[];
+}
+
+interface ParseContext {
+  typeNameForTableName: Map<string, string>;
+}
+
+export function proposeConvexSchemaOps(schema: Schema, source: string): ConvexSchemaProposalResult {
+  const tablesByName = tableTypesByConvexName(schema);
+  const parsed = parseConvexSchema(source, {
+    typeNameForTableName: new Map(
+      [...tablesByName].map(([tableName, type]) => [tableName, type.name]),
+    ),
+  });
+  if (!parsed.ok) return parsed;
+
+  const ops: DeterministicReconcileEntry[] = [];
+
+  for (const table of parsed.tables) {
+    const existing = tablesByName.get(table.tableName);
+    if (!existing) {
+      ops.push({
+        op: {
+          kind: 'add_type',
+          type: {
+            kind: 'object',
+            name: typeNameForTable(table.tableName),
+            table: true,
+            tableName: table.tableName,
+            fields: table.fields,
+            ...(table.indexes.length > 0 ? { indexes: table.indexes } : {}),
+          },
+        },
+        label: `Add Convex table "${table.tableName}"`,
+        lossy: false,
+        provenance: 'deterministic',
+      });
+      continue;
+    }
+
+    addFieldOps(ops, existing, table);
+    addIndexOps(ops, existing, table);
+  }
+
+  return { ok: true, ops };
+}
+
+function addFieldOps(
+  ops: DeterministicReconcileEntry[],
+  existing: ObjectType,
+  table: ParsedTable,
+): void {
+  const existingFields = new Map(existing.fields.map((field) => [field.name, field]));
+  const parsedFieldNames = new Set(table.fields.map((field) => field.name));
+  for (const field of table.fields) {
+    const prior = existingFields.get(field.name);
+    if (!prior) {
+      ops.push({
+        op: { kind: 'add_field', typeName: existing.name, field },
+        label: `Add field "${field.name}" to "${existing.name}"`,
+        lossy: false,
+        provenance: 'deterministic',
+      });
+      continue;
+    }
+    const patch = fieldPatch(prior, field);
+    if (Object.keys(patch).length === 0) continue;
+    ops.push({
+      op: { kind: 'update_field', typeName: existing.name, fieldName: prior.name, patch },
+      label: `Update field "${field.name}" on "${existing.name}"`,
+      lossy: isLossyFieldChange(prior, field),
+      provenance: 'deterministic',
+    });
+  }
+  for (const field of existing.fields) {
+    if (parsedFieldNames.has(field.name)) continue;
+    ops.push({
+      op: { kind: 'remove_field', typeName: existing.name, fieldName: field.name },
+      label: `Remove field "${field.name}" from "${existing.name}"`,
+      lossy: true,
+      provenance: 'deterministic',
+    });
+  }
+}
+
+function addIndexOps(
+  ops: DeterministicReconcileEntry[],
+  existing: ObjectType,
+  table: ParsedTable,
+): void {
+  const existingIndexes = new Map((existing.indexes ?? []).map((index) => [index.name, index]));
+  const parsedIndexNames = new Set(table.indexes.map((index) => index.name));
+  for (const index of table.indexes) {
+    const prior = existingIndexes.get(index.name);
+    if (!prior) {
+      ops.push({
+        op: { kind: 'add_index', typeName: existing.name, index },
+        label: `Add index "${index.name}" to "${existing.name}"`,
+        lossy: false,
+        provenance: 'deterministic',
+      });
+      continue;
+    }
+    if (sameStringArray(prior.fields, index.fields)) continue;
+    ops.push({
+      op: {
+        kind: 'update_index',
+        typeName: existing.name,
+        name: prior.name,
+        patch: { fields: index.fields },
+      },
+      label: `Update index "${index.name}" on "${existing.name}"`,
+      lossy: false,
+      provenance: 'deterministic',
+    });
+  }
+  for (const index of existing.indexes ?? []) {
+    if (parsedIndexNames.has(index.name)) continue;
+    ops.push({
+      op: { kind: 'remove_index', typeName: existing.name, name: index.name },
+      label: `Remove index "${index.name}" from "${existing.name}"`,
+      lossy: false,
+      provenance: 'deterministic',
+    });
+  }
+}
+
+function parseConvexSchema(
+  source: string,
+  ctx: ParseContext,
+): { ok: true; tables: ParsedTable[] } | { ok: false; error: string } {
+  const sf = ts.createSourceFile(
+    'schema.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const diagnostics = (sf as unknown as { parseDiagnostics: ts.Diagnostic[] }).parseDiagnostics;
+  if (diagnostics.length > 0) {
+    return { ok: false, error: 'convex/schema.ts is not valid TypeScript.' };
+  }
+
+  const schemaCall = findDefaultDefineSchemaCall(sf);
+  if (!schemaCall) {
+    return { ok: false, error: 'Could not find `export default defineSchema({ ... })`.' };
+  }
+  const [tablesArg] = schemaCall.arguments;
+  if (!tablesArg || !ts.isObjectLiteralExpression(tablesArg)) {
+    return { ok: false, error: '`defineSchema` must receive an object literal.' };
+  }
+
+  const tables: ParsedTable[] = [];
+  for (const prop of tablesArg.properties) {
+    if (!ts.isPropertyAssignment(prop)) {
+      return { ok: false, error: 'Only table property assignments are supported.' };
+    }
+    const tableName = propertyNameText(prop.name);
+    if (!tableName) return { ok: false, error: 'Only literal Convex table names are supported.' };
+    const table = parseTableExpression(tableName, prop.initializer, ctx);
+    if (!table.ok) return table;
+    tables.push(table.table);
+  }
+
+  return { ok: true, tables };
+}
+
+function findDefaultDefineSchemaCall(sf: ts.SourceFile): ts.CallExpression | null {
+  for (const statement of sf.statements) {
+    if (!ts.isExportAssignment(statement)) continue;
+    const expr = statement.expression;
+    if (!ts.isCallExpression(expr)) continue;
+    if (identifierText(expr.expression) !== 'defineSchema') continue;
+    return expr;
+  }
+  return null;
+}
+
+function parseTableExpression(
+  tableName: string,
+  expr: ts.Expression,
+  ctx: ParseContext,
+): { ok: true; table: ParsedTable } | { ok: false; error: string } {
+  const indexes: IndexDef[] = [];
+  let current = expr;
+
+  while (ts.isCallExpression(current) && ts.isPropertyAccessExpression(current.expression)) {
+    const access = current.expression;
+    if (access.name.text !== 'index') {
+      return { ok: false, error: 'Only `.index(...)` chains are supported on tables.' };
+    }
+    const index = parseIndexCall(current);
+    if (!index.ok) return index;
+    indexes.unshift(index.index);
+    current = access.expression;
+  }
+
+  if (!ts.isCallExpression(current) || identifierText(current.expression) !== 'defineTable') {
+    return { ok: false, error: `Table "${tableName}" must be a defineTable(...) expression.` };
+  }
+  const [fieldsArg] = current.arguments;
+  if (!fieldsArg || !ts.isObjectLiteralExpression(fieldsArg)) {
+    return { ok: false, error: `Table "${tableName}" must define fields with an object literal.` };
+  }
+  const fields = parseFields(fieldsArg, ctx);
+  if (!fields.ok) return fields;
+  return { ok: true, table: { tableName, fields: fields.fields, indexes } };
+}
+
+function parseFields(
+  object: ts.ObjectLiteralExpression,
+  ctx: ParseContext,
+): { ok: true; fields: FieldDef[] } | { ok: false; error: string } {
+  const fields: FieldDef[] = [];
+  for (const prop of object.properties) {
+    if (!ts.isPropertyAssignment(prop)) {
+      return { ok: false, error: 'Only field property assignments are supported.' };
+    }
+    const name = propertyNameText(prop.name);
+    if (!name) return { ok: false, error: 'Only literal field names are supported.' };
+    const parsed = parseFieldType(prop.initializer, ctx);
+    if (!parsed.ok) return parsed;
+    fields.push({ name, ...parsed.field });
+  }
+  return { ok: true, fields };
+}
+
+function parseFieldType(
+  expr: ts.Expression,
+  ctx: ParseContext,
+): { ok: true; field: Omit<FieldDef, 'name'> } | { ok: false; error: string } {
+  if (ts.isCallExpression(expr) && propertyAccessName(expr.expression) === 'optional') {
+    const inner = onlyArgument(expr, 'v.optional');
+    if (!inner.ok) return inner;
+    const parsed = parseFieldType(inner.expr, ctx);
+    if (!parsed.ok) return parsed;
+    return { ok: true, field: { ...parsed.field, optional: true } };
+  }
+
+  if (ts.isCallExpression(expr) && propertyAccessName(expr.expression) === 'union') {
+    const args = [...expr.arguments];
+    const nullIndex = args.findIndex(isVNullCall);
+    if (nullIndex !== -1 && args.length === 2) {
+      const inner = args[nullIndex === 0 ? 1 : 0];
+      if (!inner) return { ok: false, error: 'Unsupported nullable union shape.' };
+      const parsed = parseFieldType(inner, ctx);
+      if (!parsed.ok) return parsed;
+      return { ok: true, field: { ...parsed.field, nullable: true } };
+    }
+    return { ok: false, error: 'Only nullable `v.union(type, v.null())` is supported.' };
+  }
+
+  const type = parseBareFieldType(expr, ctx);
+  if (!type.ok) return type;
+  return { ok: true, field: { type: type.type } };
+}
+
+function parseBareFieldType(
+  expr: ts.Expression,
+  ctx: ParseContext,
+): { ok: true; type: FieldType } | { ok: false; error: string } {
+  if (!ts.isCallExpression(expr)) {
+    if (ts.isIdentifier(expr)) {
+      return { ok: true, type: { kind: 'ref', typeName: typeNameForValidator(expr.text) } };
+    }
+    return { ok: false, error: 'Only Convex `v.*` validators are supported.' };
+  }
+
+  const name = propertyAccessName(expr.expression);
+  switch (name) {
+    case 'string':
+      return { ok: true, type: { kind: 'string' } };
+    case 'number':
+    case 'float64':
+    case 'int64':
+      return { ok: true, type: { kind: 'number' } };
+    case 'boolean':
+      return { ok: true, type: { kind: 'boolean' } };
+    case 'literal': {
+      const [value] = expr.arguments;
+      const literal = literalValue(value);
+      if (literal === null) {
+        return { ok: false, error: 'Only string, number, and boolean literals are supported.' };
+      }
+      return { ok: true, type: { kind: 'literal', value: literal } };
+    }
+    case 'id': {
+      const [tableName] = expr.arguments;
+      if (!tableName || !ts.isStringLiteral(tableName)) {
+        return { ok: false, error: '`v.id(...)` must use a string literal table name.' };
+      }
+      return {
+        ok: true,
+        type: {
+          kind: 'ref',
+          typeName:
+            ctx.typeNameForTableName.get(tableName.text) ?? typeNameForTable(tableName.text),
+        },
+      };
+    }
+    case 'array': {
+      const inner = onlyArgument(expr, 'v.array');
+      if (!inner.ok) return inner;
+      const parsed = parseBareFieldType(inner.expr, ctx);
+      if (!parsed.ok) return parsed;
+      return { ok: true, type: { kind: 'array', element: parsed.type } };
+    }
+    default:
+      if (ts.isIdentifier(expr.expression)) {
+        return {
+          ok: true,
+          type: { kind: 'ref', typeName: typeNameForValidator(expr.expression.text) },
+        };
+      }
+      return { ok: false, error: `Unsupported Convex validator "${name ?? '<unknown>'}".` };
+  }
+}
+
+function parseIndexCall(
+  call: ts.CallExpression,
+): { ok: true; index: IndexDef } | { ok: false; error: string } {
+  const [nameArg, fieldsArg] = call.arguments;
+  if (!nameArg || !ts.isStringLiteral(nameArg)) {
+    return { ok: false, error: 'Index names must be string literals.' };
+  }
+  const fields = parseStringArray(fieldsArg);
+  if (!fields.ok) return fields;
+  return { ok: true, index: { name: nameArg.text, fields: fields.values } };
+}
+
+function onlyArgument(
+  call: ts.CallExpression,
+  label: string,
+): { ok: true; expr: ts.Expression } | { ok: false; error: string } {
+  const [expr] = call.arguments;
+  if (!expr || call.arguments.length !== 1) {
+    return { ok: false, error: `${label} must have exactly one argument.` };
+  }
+  return { ok: true, expr };
+}
+
+function isVNullCall(expr: ts.Expression): boolean {
+  return ts.isCallExpression(expr) && propertyAccessName(expr.expression) === 'null';
+}
+
+function parseStringArray(
+  expr: ts.Expression | undefined,
+): { ok: true; values: string[] } | { ok: false; error: string } {
+  if (!expr || !ts.isArrayLiteralExpression(expr)) {
+    return { ok: false, error: 'Index fields must be an array literal.' };
+  }
+  const values: string[] = [];
+  for (const element of expr.elements) {
+    if (!ts.isStringLiteral(element)) {
+      return { ok: false, error: 'Index fields must be string literals.' };
+    }
+    values.push(element.text);
+  }
+  if (values.length === 0) return { ok: false, error: 'Indexes must include at least one field.' };
+  return { ok: true, values };
+}
+
+function propertyNameText(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  return null;
+}
+
+function propertyAccessName(expr: ts.Expression): string | null {
+  if (!ts.isPropertyAccessExpression(expr)) return null;
+  if (identifierText(expr.expression) !== 'v') return null;
+  return expr.name.text;
+}
+
+function identifierText(expr: ts.Expression): string | null {
+  return ts.isIdentifier(expr) ? expr.text : null;
+}
+
+function literalValue(expr: ts.Expression | undefined): string | number | boolean | null {
+  if (!expr) return null;
+  if (ts.isStringLiteral(expr) || ts.isNumericLiteral(expr)) {
+    return ts.isNumericLiteral(expr) ? Number(expr.text) : expr.text;
+  }
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) return false;
+  return null;
+}
+
+function tableTypesByConvexName(schema: Schema): Map<string, ObjectType> {
+  const tables = new Map<string, ObjectType>();
+  for (const type of schema.types) {
+    if (type.kind !== 'object' || type.table !== true) continue;
+    tables.set(type.tableName ?? lowerFirst(type.name), type);
+  }
+  return tables;
+}
+
+function typeNameForTable(tableName: string): string {
+  return upperFirst(tableName);
+}
+
+function typeNameForValidator(name: string): string {
+  return upperFirst(name);
+}
+
+function fieldPatch(before: FieldDef, after: FieldDef): Partial<FieldDef> {
+  const patch: Partial<FieldDef> = {};
+  if (JSON.stringify(before.type) !== JSON.stringify(after.type)) patch.type = after.type;
+  if ((before.optional ?? false) !== (after.optional ?? false)) patch.optional = after.optional;
+  if ((before.nullable ?? false) !== (after.nullable ?? false)) patch.nullable = after.nullable;
+  return patch;
+}
+
+function isLossyFieldChange(before: FieldDef, after: FieldDef): boolean {
+  return JSON.stringify(before.type) !== JSON.stringify(after.type);
+}
+
+function sameStringArray(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function lowerFirst(name: string): string {
+  return `${name.charAt(0).toLowerCase()}${name.slice(1)}`;
+}
+
+function upperFirst(name: string): string {
+  return `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+}

--- a/apps/desktop/src/main/reconcile/convex-schema-proposals.ts
+++ b/apps/desktop/src/main/reconcile/convex-schema-proposals.ts
@@ -110,6 +110,7 @@ function addIndexOps(
 ): void {
   const existingIndexes = new Map((existing.indexes ?? []).map((index) => [index.name, index]));
   const parsedIndexNames = new Set(table.indexes.map((index) => index.name));
+  const parsedFieldNames = new Set(table.fields.map((field) => field.name));
   for (const index of table.indexes) {
     const prior = existingIndexes.get(index.name);
     if (!prior) {
@@ -136,6 +137,7 @@ function addIndexOps(
   }
   for (const index of existing.indexes ?? []) {
     if (parsedIndexNames.has(index.name)) continue;
+    if (index.fields.some((field) => !parsedFieldNames.has(field))) continue;
     ops.push({
       op: { kind: 'remove_index', typeName: existing.name, name: index.name },
       label: `Remove index "${index.name}" from "${existing.name}"`,

--- a/apps/desktop/src/main/reconcile/proposals.ts
+++ b/apps/desktop/src/main/reconcile/proposals.ts
@@ -1,5 +1,6 @@
 import type { Schema } from '@contexture/core';
 import type { ModelOptions, ProviderRuntime } from '../providers/runtime';
+import { proposeConvexSchemaOps } from './convex-schema-proposals';
 
 export interface ReconcileProposalInput {
   irJson: string;
@@ -7,7 +8,9 @@ export interface ReconcileProposalInput {
   targetKind: string;
 }
 
-export type ReconcileProposalResult = { ok: true; ops: unknown[] } | { ok: false; error: string };
+export type ReconcileProposalResult =
+  | { ok: true; ops: unknown[]; deterministicFallbackReason?: string }
+  | { ok: false; error: string };
 
 export interface GenerateReconcileProposalOptions {
   runtime: ProviderRuntime;
@@ -19,6 +22,13 @@ export interface GenerateReconcileProposalOptions {
 export async function generateReconcileProposal(
   options: GenerateReconcileProposalOptions,
 ): Promise<ReconcileProposalResult> {
+  let deterministicFallbackReason: string | undefined;
+  if (options.payload.targetKind === 'convex') {
+    const deterministic = proposeConvexSchemaOps(options.schema, options.payload.onDiskSource);
+    if (deterministic.ok) return { ok: true, ops: deterministic.ops };
+    deterministicFallbackReason = deterministic.error;
+  }
+
   const status = await options.runtime.getStatus();
   if (!isReadyForGeneration(status.readiness)) {
     return {
@@ -38,10 +48,21 @@ export async function generateReconcileProposal(
       schema: options.schema,
       ...(options.modelOptions ?? {}),
     });
-    return extractOpsArray(text);
+    const extracted = extractOpsArray(text);
+    if (!extracted.ok) return extracted;
+    return {
+      ok: true,
+      ops: extracted.ops.map(withProviderProvenance),
+      ...(deterministicFallbackReason ? { deterministicFallbackReason } : {}),
+    };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
+}
+
+function withProviderProvenance(entry: unknown): unknown {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return entry;
+  return { ...entry, provenance: 'provider' };
 }
 
 function isReadyForGeneration(readiness: string): boolean {
@@ -65,6 +86,9 @@ const TARGET_KIND_DESCRIPTIONS: Record<string, string> = {
   convex:
     'a hand-edited `convex/schema.ts` file (Convex database schema). ' +
     'Focus on `defineTable`, `v.*` validators, and Convex index definitions.',
+  'convex-validators':
+    'a hand-edited `convex/validators.ts` file (reusable Convex validators). ' +
+    'Focus on exported `v.*` validators that mirror IR fields, refs, arrays, optionality, and nullability.',
   zod:
     'a hand-edited `.schema.ts` file (Zod schema mirror). ' +
     'Focus on `z.object`, `z.enum`, `z.discriminatedUnion`, and inferred TypeScript types.',

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -128,7 +128,10 @@ export interface ContextureDriftAPI {
 
 export interface DriftDetectedPayload {
   paths: string[];
-  files?: Array<{ path: string; status: 'drifted' | 'unreadable' }>;
+  files?: Array<{
+    path: string;
+    status: 'drifted' | 'missing' | 'unreadable' | 'modified' | 'stale' | 'externally_regenerated';
+  }>;
 }
 
 export type ModelSyncStatus = 'changed' | 'invalid_json' | 'invalid_ir' | 'unreadable' | 'deleted';
@@ -169,18 +172,34 @@ export interface ContextureReconcileAPI {
     irPath: string;
     targetPath: string;
     contents: string;
-  }) => Promise<void>;
+  }) => Promise<ReconcileWriteResult>;
+  acceptGeneratedTarget: (payload: {
+    irPath: string;
+    targetPath: string;
+    contents: string;
+    schema: unknown;
+  }) => Promise<ReconcileWriteResult>;
   /**
    * Fire a one-shot schema-agent query that proposes IR ops to align
    * the current schema with the user's hand-edited on-disk source. The
    * returned `ops` array is raw — the renderer validates each entry
    * via the op-applier before showing it in the modal.
    */
-  query: (payload: {
-    irJson: string;
-    onDiskSource: string;
-    targetKind: string;
-  }) => Promise<{ ok: boolean; ops?: unknown[]; error?: string }>;
+  query: (payload: { irJson: string; onDiskSource: string; targetKind: string }) => Promise<{
+    ok: boolean;
+    ops?: unknown[];
+    error?: string;
+    deterministicFallbackReason?: string;
+  }>;
+}
+
+export type ConvexCliValidationResult =
+  | { status: 'skipped'; reason: string }
+  | { status: 'passed'; command: string; output?: string }
+  | { status: 'failed'; command: string; error: string; output?: string };
+
+export interface ReconcileWriteResult {
+  convexValidation: ConvexCliValidationResult;
 }
 
 export interface ContextureUpdateAPI {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -172,13 +172,17 @@ export interface ContextureReconcileAPI {
     irPath: string;
     targetPath: string;
     contents: string;
-  }) => Promise<ReconcileWriteResult>;
+  }) => Promise<void>;
   acceptGeneratedTarget: (payload: {
     irPath: string;
     targetPath: string;
     contents: string;
     schema: unknown;
-  }) => Promise<ReconcileWriteResult>;
+  }) => Promise<void>;
+  validateConvexGeneratedTarget: (payload: {
+    irPath: string;
+    targetPath: string;
+  }) => Promise<ConvexCliValidationResult>;
   /**
    * Fire a one-shot schema-agent query that proposes IR ops to align
    * the current schema with the user's hand-edited on-disk source. The
@@ -197,10 +201,6 @@ export type ConvexCliValidationResult =
   | { status: 'skipped'; reason: string }
   | { status: 'passed'; command: string; output?: string }
   | { status: 'failed'; command: string; error: string; output?: string };
-
-export interface ReconcileWriteResult {
-  convexValidation: ConvexCliValidationResult;
-}
 
 export interface ContextureUpdateAPI {
   getState: () => Promise<UpdateState>;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -177,46 +177,31 @@ const reconcile = {
     irPath: string;
     targetPath: string;
     contents: string;
-  }): Promise<{
-    convexValidation: {
-      status: 'skipped' | 'passed' | 'failed';
-      reason?: string;
-      command?: string;
-      error?: string;
-      output?: string;
-    };
-  }> =>
-    ipcRenderer.invoke('reconcile:write-generated-target', payload) as Promise<{
-      convexValidation: {
-        status: 'skipped' | 'passed' | 'failed';
-        reason?: string;
-        command?: string;
-        error?: string;
-        output?: string;
-      };
-    }>,
+  }): Promise<void> =>
+    ipcRenderer.invoke('reconcile:write-generated-target', payload) as Promise<void>,
   acceptGeneratedTarget: (payload: {
     irPath: string;
     targetPath: string;
     contents: string;
     schema: unknown;
+  }): Promise<void> =>
+    ipcRenderer.invoke('reconcile:accept-generated-target', payload) as Promise<void>,
+  validateConvexGeneratedTarget: (payload: {
+    irPath: string;
+    targetPath: string;
   }): Promise<{
-    convexValidation: {
+    status: 'skipped' | 'passed' | 'failed';
+    reason?: string;
+    command?: string;
+    error?: string;
+    output?: string;
+  }> =>
+    ipcRenderer.invoke('reconcile:validate-convex-generated-target', payload) as Promise<{
       status: 'skipped' | 'passed' | 'failed';
       reason?: string;
       command?: string;
       error?: string;
       output?: string;
-    };
-  }> =>
-    ipcRenderer.invoke('reconcile:accept-generated-target', payload) as Promise<{
-      convexValidation: {
-        status: 'skipped' | 'passed' | 'failed';
-        reason?: string;
-        command?: string;
-        error?: string;
-        output?: string;
-      };
     }>,
   /**
    * Fire a one-shot schema-agent query that returns reconcile ops for

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -177,8 +177,47 @@ const reconcile = {
     irPath: string;
     targetPath: string;
     contents: string;
-  }): Promise<void> =>
-    ipcRenderer.invoke('reconcile:write-generated-target', payload) as Promise<void>,
+  }): Promise<{
+    convexValidation: {
+      status: 'skipped' | 'passed' | 'failed';
+      reason?: string;
+      command?: string;
+      error?: string;
+      output?: string;
+    };
+  }> =>
+    ipcRenderer.invoke('reconcile:write-generated-target', payload) as Promise<{
+      convexValidation: {
+        status: 'skipped' | 'passed' | 'failed';
+        reason?: string;
+        command?: string;
+        error?: string;
+        output?: string;
+      };
+    }>,
+  acceptGeneratedTarget: (payload: {
+    irPath: string;
+    targetPath: string;
+    contents: string;
+    schema: unknown;
+  }): Promise<{
+    convexValidation: {
+      status: 'skipped' | 'passed' | 'failed';
+      reason?: string;
+      command?: string;
+      error?: string;
+      output?: string;
+    };
+  }> =>
+    ipcRenderer.invoke('reconcile:accept-generated-target', payload) as Promise<{
+      convexValidation: {
+        status: 'skipped' | 'passed' | 'failed';
+        reason?: string;
+        command?: string;
+        error?: string;
+        output?: string;
+      };
+    }>,
   /**
    * Fire a one-shot schema-agent query that returns reconcile ops for
    * the current IR + on-disk source of any emitted file.
@@ -187,11 +226,17 @@ const reconcile = {
     irJson: string;
     onDiskSource: string;
     targetKind: string;
-  }): Promise<{ ok: boolean; ops?: unknown[]; error?: string }> =>
+  }): Promise<{
+    ok: boolean;
+    ops?: unknown[];
+    error?: string;
+    deterministicFallbackReason?: string;
+  }> =>
     ipcRenderer.invoke('schema-agent:reconcile', payload) as Promise<{
       ok: boolean;
       ops?: unknown[];
       error?: string;
+      deterministicFallbackReason?: string;
     }>,
 };
 

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -38,7 +38,7 @@ import { useUndoStore } from '@renderer/store/undo';
 import { STDLIB_REGISTRY } from '@shared/stdlib-registry';
 import { diffLines } from 'diff';
 import { Loader2, TriangleAlert } from 'lucide-react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -56,6 +56,8 @@ interface EmitResult {
   source: string;
   error: string | null;
 }
+
+type DiffMode = 'file-changes' | 'uncovered-changes';
 
 function safeEmitForTarget(
   schema: Schema,
@@ -144,6 +146,7 @@ function reconcileStatusCopy(status: DriftFileStatus['status'] | null): string {
 }
 
 export function ReconcileModal(): React.JSX.Element {
+  const [diffMode, setDiffMode] = useState<DiffMode>('file-changes');
   const isOpen = useReconcileStore((s) => s.isOpen);
   const status = useReconcileStore((s) => s.status);
   const proposedOps = useReconcileStore((s) => s.proposedOps);
@@ -193,6 +196,22 @@ export function ReconcileModal(): React.JSX.Element {
     if (projection.emit.error) return 0;
     return countResidualLines(projection.emit.source, onDiskSource);
   }, [onDiskSource, projection]);
+
+  const fileChangedLines = useMemo(() => {
+    if (onDiskSource === null) return 0;
+    if (currentEmit.error) return 0;
+    return countResidualLines(currentEmit.source, onDiskSource);
+  }, [onDiskSource, currentEmit]);
+
+  const selectedCount = selectedIndices.size;
+  const totalCount = proposedOps.length;
+  const activeDiff = diffMode === 'file-changes' ? currentEmit : projection.emit;
+  const activeDiffTitle =
+    diffMode === 'file-changes' ? 'Generated file change' : 'Uncovered after selected ops';
+  const activeDiffSubtitle =
+    diffMode === 'file-changes'
+      ? `Current Contexture emit to on-disk ${displayName}`
+      : `Contexture emit with selected ops to on-disk ${displayName}`;
 
   const handleApply = useCallback(() => {
     void (async () => {
@@ -353,15 +372,21 @@ export function ReconcileModal(): React.JSX.Element {
         <DialogHeader>
           <DialogTitle>Reconcile changes</DialogTitle>
           <DialogDescription>
-            <code className="font-mono">{displayName}</code> differs from Contexture's generated
-            output. Regenerate it from the current IR, leave it dirty, or use the proposal tools to
-            fold changes back into the model.
+            <code className="font-mono">{displayName}</code> changed outside Contexture. Review the
+            generated-file change, then choose which proposed model ops should be folded back into
+            the IR.
           </DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col gap-4">
           <div className="rounded-md border bg-muted/20 px-3 py-2 text-sm">
-            {reconcileStatusCopy(driftStatus)}
+            <div>{reconcileStatusCopy(driftStatus)}</div>
+            {status === 'ready' && totalCount > 0 && (
+              <div className="mt-1 text-xs text-muted-foreground">
+                Contexture found {totalCount} proposed model op{totalCount !== 1 ? 's' : ''} ·{' '}
+                {selectedCount} selected
+              </div>
+            )}
           </div>
           {deterministicFallbackReason && (
             <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
@@ -371,7 +396,14 @@ export function ReconcileModal(): React.JSX.Element {
           )}
           <div className="flex flex-col border rounded-md overflow-hidden max-h-64">
             <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/30 text-xs">
-              <span className="font-medium">Proposed ops</span>
+              <div>
+                <span className="font-medium">Proposed model ops</span>
+                {status === 'ready' && totalCount > 0 && (
+                  <span className="ml-2 text-muted-foreground">
+                    {selectedCount} selected of {totalCount}
+                  </span>
+                )}
+              </div>
               {status === 'ready' && proposedOps.length > 0 && (
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <button
@@ -418,34 +450,66 @@ export function ReconcileModal(): React.JSX.Element {
                 </p>
               )}
               {(status === 'ready' || status === 'applying') && proposedOps.length > 0 && (
-                <ul className="space-y-2">
-                  {proposedOps.map((entry, i) => (
-                    <li key={entry.id} className="flex items-start gap-2 text-sm">
-                      <Checkbox
-                        id={`reconcile-op-${entry.id}`}
-                        checked={selectedIndices.has(i)}
-                        onCheckedChange={() => toggleOp(i)}
-                        aria-label={entry.label}
-                        className="mt-0.5"
-                      />
-                      <label
-                        htmlFor={`reconcile-op-${entry.id}`}
-                        className="flex-1 cursor-pointer leading-tight"
-                      >
-                        {entry.label}
-                      </label>
-                      <ProvenanceBadge provenance={entry.provenance} />
-                      {entry.lossy && <LossyBadge />}
-                    </li>
-                  ))}
-                </ul>
+                <div className="space-y-3">
+                  <p className="text-xs text-muted-foreground">
+                    Selected ops will update the IR and re-emit this generated file.
+                  </p>
+                  <ul className="space-y-2">
+                    {proposedOps.map((entry, i) => (
+                      <li key={entry.id} className="flex items-start gap-2 text-sm">
+                        <Checkbox
+                          id={`reconcile-op-${entry.id}`}
+                          checked={selectedIndices.has(i)}
+                          onCheckedChange={() => toggleOp(i)}
+                          aria-label={entry.label}
+                          className="mt-0.5"
+                        />
+                        <label
+                          htmlFor={`reconcile-op-${entry.id}`}
+                          className="flex-1 cursor-pointer leading-tight"
+                        >
+                          {entry.label}
+                        </label>
+                        <ProvenanceBadge provenance={entry.provenance} />
+                        {entry.lossy && <LossyBadge />}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               )}
             </div>
           </div>
 
           <div className="flex flex-col border rounded-md overflow-hidden min-h-[360px]">
-            <div className="px-3 py-2 border-b bg-muted/30 text-xs font-medium">
-              Diff (Contexture emit ↔ on-disk file)
+            <div className="flex flex-wrap items-center justify-between gap-3 px-3 py-2 border-b bg-muted/30">
+              <div>
+                <div className="text-xs font-medium">{activeDiffTitle}</div>
+                <div className="text-xs text-muted-foreground">{activeDiffSubtitle}</div>
+              </div>
+              <div
+                role="tablist"
+                aria-label="Diff view"
+                className="inline-flex h-8 items-center justify-center rounded-md bg-card p-1 text-muted-foreground"
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={diffMode === 'file-changes'}
+                  onClick={() => setDiffMode('file-changes')}
+                  className="inline-flex h-6 items-center justify-center whitespace-nowrap rounded-sm px-2 text-xs font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 aria-selected:bg-muted aria-selected:text-foreground aria-selected:shadow-sm"
+                >
+                  File changes
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={diffMode === 'uncovered-changes'}
+                  onClick={() => setDiffMode('uncovered-changes')}
+                  className="inline-flex h-6 items-center justify-center whitespace-nowrap rounded-sm px-2 text-xs font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 aria-selected:bg-muted aria-selected:text-foreground aria-selected:shadow-sm"
+                >
+                  Uncovered changes
+                </button>
+              </div>
             </div>
             <div className="flex-1 overflow-auto max-h-[60vh]">
               {status === 'loading' && (
@@ -458,15 +522,22 @@ export function ReconcileModal(): React.JSX.Element {
               )}
               {(status === 'ready' || status === 'applying') &&
                 onDiskSource !== null &&
-                (projection.emit.error ? (
+                (activeDiff.error ? (
                   <p className="p-3 text-sm text-destructive">
-                    Cannot emit current schema: {projection.emit.error}
+                    Cannot emit current schema: {activeDiff.error}
                   </p>
+                ) : diffMode === 'uncovered-changes' && residualLines === 0 ? (
+                  <div className="flex h-full min-h-[240px] flex-col items-center justify-center gap-1 p-6 text-center">
+                    <p className="text-sm font-medium">No uncovered changes</p>
+                    <p className="text-sm text-muted-foreground">
+                      The selected ops reproduce the on-disk generated file.
+                    </p>
+                  </div>
                 ) : (
                   <MultiFileDiff
                     oldFile={{
                       name: displayName,
-                      contents: projection.emit.source,
+                      contents: activeDiff.source,
                       lang: displayName.endsWith('.json') ? 'json' : 'ts',
                     }}
                     newFile={{
@@ -481,8 +552,15 @@ export function ReconcileModal(): React.JSX.Element {
             </div>
             {(status === 'ready' || status === 'applying') && onDiskSource !== null && (
               <div className="px-3 py-2 border-t text-xs text-muted-foreground">
-                Residual: {residualLines} changed line{residualLines !== 1 ? 's' : ''} not covered
-                by selected ops
+                {diffMode === 'file-changes'
+                  ? `${fileChangedLines} changed line${
+                      fileChangedLines !== 1 ? 's' : ''
+                    } detected in the generated file.`
+                  : residualLines === 0
+                    ? '0 uncovered lines. The selected ops fully explain the on-disk edit.'
+                    : `${residualLines} uncovered line${
+                        residualLines !== 1 ? 's' : ''
+                      } remain outside the selected ops.`}
               </div>
             )}
           </div>
@@ -511,7 +589,7 @@ export function ReconcileModal(): React.JSX.Element {
             Open in chat
           </Button>
           <Button onClick={handleApply} disabled={applyDisabled}>
-            Apply selected
+            Apply selected ops
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -212,6 +212,10 @@ export function ReconcileModal(): React.JSX.Element {
     diffMode === 'file-changes'
       ? `Current Contexture emit to on-disk ${displayName}`
       : `Contexture emit with selected ops to on-disk ${displayName}`;
+  const activeDiffHelper =
+    diffMode === 'file-changes'
+      ? 'This view always shows the original generated-file edit. Selection only affects Uncovered changes.'
+      : 'This view updates as you select ops, showing only changes not yet explained.';
 
   const handleApply = useCallback(() => {
     void (async () => {
@@ -485,6 +489,7 @@ export function ReconcileModal(): React.JSX.Element {
               <div>
                 <div className="text-xs font-medium">{activeDiffTitle}</div>
                 <div className="text-xs text-muted-foreground">{activeDiffSubtitle}</div>
+                <div className="text-xs text-muted-foreground">{activeDiffHelper}</div>
               </div>
               <div
                 role="tablist"

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -38,7 +38,7 @@ import { useUndoStore } from '@renderer/store/undo';
 import { STDLIB_REGISTRY } from '@shared/stdlib-registry';
 import { diffLines } from 'diff';
 import { Loader2, TriangleAlert } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -144,7 +144,6 @@ function reconcileStatusCopy(status: DriftFileStatus['status'] | null): string {
 }
 
 export function ReconcileModal(): React.JSX.Element {
-  const [convexValidationMessage, setConvexValidationMessage] = useState<string | null>(null);
   const isOpen = useReconcileStore((s) => s.isOpen);
   const status = useReconcileStore((s) => s.status);
   const proposedOps = useReconcileStore((s) => s.proposedOps);
@@ -215,7 +214,6 @@ export function ReconcileModal(): React.JSX.Element {
         return;
       }
 
-      setConvexValidationMessage(null);
       setApplying();
       const undo = useUndoStore.getState();
       undo.begin();
@@ -230,25 +228,12 @@ export function ReconcileModal(): React.JSX.Element {
       }
 
       try {
-        const result = await reconcileApi.acceptGeneratedTarget({
+        await reconcileApi.acceptGeneratedTarget({
           irPath: filePath,
           targetPath,
           contents: projection.emit.source,
           schema: projection.schema,
         });
-        if (result?.convexValidation.status === 'failed') {
-          undo.commit();
-          await window.contexture?.drift.check();
-          setError(convexValidationFailureMessage(result.convexValidation));
-          return;
-        }
-        const validationMessage = convexValidationSuccessMessage(result?.convexValidation);
-        if (validationMessage) {
-          undo.commit();
-          await window.contexture?.drift.check();
-          setConvexValidationMessage(validationMessage);
-          return;
-        }
       } catch (err) {
         undo.rollback();
         const message = err instanceof Error ? err.message : String(err);
@@ -282,20 +267,10 @@ export function ReconcileModal(): React.JSX.Element {
     ) {
       return;
     }
-    setConvexValidationMessage(null);
     void window.contexture?.reconcile
       .writeGeneratedTarget({ irPath: filePath, targetPath, contents: currentEmit.source })
-      .then(async (result) => {
+      .then(async () => {
         await window.contexture?.drift.check();
-        if (result?.convexValidation.status === 'failed') {
-          setError(convexValidationFailureMessage(result.convexValidation));
-          return;
-        }
-        const validationMessage = convexValidationSuccessMessage(result?.convexValidation);
-        if (validationMessage) {
-          setConvexValidationMessage(validationMessage);
-          return;
-        }
         close();
       })
       .catch((err: unknown) => {
@@ -394,12 +369,6 @@ export function ReconcileModal(): React.JSX.Element {
               {deterministicFallbackReason} Assistant fallback proposed the ops below.
             </div>
           )}
-          {convexValidationMessage && (
-            <div className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-900 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-100">
-              {convexValidationMessage}
-            </div>
-          )}
-
           <div className="flex flex-col border rounded-md overflow-hidden max-h-64">
             <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/30 text-xs">
               <span className="font-medium">Proposed ops</span>
@@ -548,22 +517,6 @@ export function ReconcileModal(): React.JSX.Element {
       </DialogContent>
     </Dialog>
   );
-}
-
-type ConvexValidationResult = Awaited<
-  ReturnType<NonNullable<typeof window.contexture>['reconcile']['acceptGeneratedTarget']>
->['convexValidation'];
-
-function convexValidationSuccessMessage(result: ConvexValidationResult | undefined): string | null {
-  if (!result || result.status === 'skipped') return null;
-  return 'Convex CLI accepted the reconciled generated files.';
-}
-
-function convexValidationFailureMessage(
-  result: Extract<ConvexValidationResult, { status: 'failed' }>,
-): string {
-  const output = result.output ? `\n\n${result.output}` : '';
-  return `Convex CLI validation failed after reconcile: ${result.error}${output}`;
 }
 
 function ProvenanceBadge({

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -24,7 +24,7 @@ import { MultiFileDiff } from '@pierre/diffs/react';
 import { useChatThreads } from '@renderer/chat/useChatThreads';
 import { useSchemaAgentReconcile } from '@renderer/hooks/useSchemaAgentReconcile';
 import { useDocumentStore } from '@renderer/store/document';
-import { useDriftStore } from '@renderer/store/drift';
+import { type DriftFileStatus, useDriftStore } from '@renderer/store/drift';
 import { apply } from '@renderer/store/ops';
 import {
   type ReconcileOp,
@@ -38,7 +38,7 @@ import { useUndoStore } from '@renderer/store/undo';
 import { STDLIB_REGISTRY } from '@shared/stdlib-registry';
 import { diffLines } from 'diff';
 import { Loader2, TriangleAlert } from 'lucide-react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -126,7 +126,25 @@ function generatedTargetKindFor(targetPath: string | null, irPath: string | null
   return targetKindFor(targetPath, irPath);
 }
 
+function reconcileStatusCopy(status: DriftFileStatus['status'] | null): string {
+  switch (status) {
+    case 'missing':
+    case 'unreadable':
+      return 'Contexture cannot read this generated file. Re-emitting from the IR can recreate it.';
+    case 'stale':
+      return 'This generated file still matches the last manifest, but not the current IR. Re-emitting from the IR should bring it up to date.';
+    case 'externally_regenerated':
+      return 'This generated file already matches the current IR, but the manifest is out of date.';
+    case 'modified':
+    case 'drifted':
+      return 'This generated file changed outside Contexture. Review it before choosing whether the IR or generated file should win.';
+    default:
+      return 'Review the generated file before choosing whether the IR or generated file should win.';
+  }
+}
+
 export function ReconcileModal(): React.JSX.Element {
+  const [convexValidationMessage, setConvexValidationMessage] = useState<string | null>(null);
   const isOpen = useReconcileStore((s) => s.isOpen);
   const status = useReconcileStore((s) => s.status);
   const proposedOps = useReconcileStore((s) => s.proposedOps);
@@ -134,6 +152,7 @@ export function ReconcileModal(): React.JSX.Element {
   const error = useReconcileStore((s) => s.error);
   const onDiskSource = useReconcileStore((s) => s.onDiskSource);
   const targetPath = useReconcileStore((s) => s.targetPath);
+  const deterministicFallbackReason = useReconcileStore((s) => s.deterministicFallbackReason);
   const close = useReconcileStore((s) => s.close);
   const setLoading = useReconcileStore((s) => s.setLoading);
   const setError = useReconcileStore((s) => s.setError);
@@ -149,9 +168,11 @@ export function ReconcileModal(): React.JSX.Element {
 
   const schema = useUndoStore((s) => s.schema);
   const filePath = useDocumentStore((s) => s.filePath);
+  const driftFiles = useDriftStore((s) => s.files);
 
   const displayName = targetPath ? shortPath(targetPath) : 'generated file';
   const targetKind = generatedTargetKindFor(targetPath, filePath);
+  const driftStatus = driftFiles.find((file) => file.path === targetPath)?.status ?? null;
 
   // Recompute the would-be emit each time the user toggles an op.
   // Cheap (pure function, < 10ms even on large schemas), so a
@@ -175,23 +196,81 @@ export function ReconcileModal(): React.JSX.Element {
   }, [onDiskSource, projection]);
 
   const handleApply = useCallback(() => {
-    setApplying();
-    const undo = useUndoStore.getState();
-    undo.begin();
-    for (let i = 0; i < proposedOps.length; i += 1) {
-      if (!selectedIndices.has(i)) continue;
-      const r = undo.apply(proposedOps[i].op, { source: 'reconcile' });
-      if ('error' in r) {
-        undo.rollback();
-        setError(r.error);
+    void (async () => {
+      if (
+        !filePath ||
+        !targetPath ||
+        targetKind === 'unknown' ||
+        projection.error ||
+        projection.emit.error ||
+        !projection.emit.source
+      ) {
+        setError(projection.error ?? projection.emit.error ?? 'Cannot emit reconciled target.');
         return;
       }
-    }
-    undo.commit();
-    useDriftStore.getState().setResolved();
-    void window.contexture?.drift.dismiss();
-    close();
-  }, [proposedOps, selectedIndices, setApplying, setError, close]);
+
+      const reconcileApi = window.contexture?.reconcile;
+      if (!reconcileApi) {
+        setError('Reconcile IPC bridge is unavailable.');
+        return;
+      }
+
+      setConvexValidationMessage(null);
+      setApplying();
+      const undo = useUndoStore.getState();
+      undo.begin();
+      for (let i = 0; i < proposedOps.length; i += 1) {
+        if (!selectedIndices.has(i)) continue;
+        const r = undo.apply(proposedOps[i].op, { source: 'reconcile' });
+        if ('error' in r) {
+          undo.rollback();
+          setError(r.error);
+          return;
+        }
+      }
+
+      try {
+        const result = await reconcileApi.acceptGeneratedTarget({
+          irPath: filePath,
+          targetPath,
+          contents: projection.emit.source,
+          schema: projection.schema,
+        });
+        if (result?.convexValidation.status === 'failed') {
+          undo.commit();
+          await window.contexture?.drift.check();
+          setError(convexValidationFailureMessage(result.convexValidation));
+          return;
+        }
+        const validationMessage = convexValidationSuccessMessage(result?.convexValidation);
+        if (validationMessage) {
+          undo.commit();
+          await window.contexture?.drift.check();
+          setConvexValidationMessage(validationMessage);
+          return;
+        }
+      } catch (err) {
+        undo.rollback();
+        const message = err instanceof Error ? err.message : String(err);
+        setError(`Failed to accept reconciled generated file: ${message}`);
+        return;
+      }
+
+      undo.commit();
+      await window.contexture?.drift.check();
+      close();
+    })();
+  }, [
+    filePath,
+    targetPath,
+    targetKind,
+    projection,
+    proposedOps,
+    selectedIndices,
+    setApplying,
+    setError,
+    close,
+  ]);
 
   const handleRegenerate = useCallback(() => {
     if (
@@ -203,10 +282,20 @@ export function ReconcileModal(): React.JSX.Element {
     ) {
       return;
     }
+    setConvexValidationMessage(null);
     void window.contexture?.reconcile
       .writeGeneratedTarget({ irPath: filePath, targetPath, contents: currentEmit.source })
-      .then(async () => {
+      .then(async (result) => {
         await window.contexture?.drift.check();
+        if (result?.convexValidation.status === 'failed') {
+          setError(convexValidationFailureMessage(result.convexValidation));
+          return;
+        }
+        const validationMessage = convexValidationSuccessMessage(result?.convexValidation);
+        if (validationMessage) {
+          setConvexValidationMessage(validationMessage);
+          return;
+        }
         close();
       })
       .catch((err: unknown) => {
@@ -259,12 +348,21 @@ export function ReconcileModal(): React.JSX.Element {
     close();
   }, [schema, proposedOps, onDiskSource, displayName, filePath, history, close]);
 
+  const handleOpenFile = useCallback(() => {
+    if (!targetPath) return;
+    void window.contexture?.shell.openInEditor(targetPath);
+  }, [targetPath]);
+
   const handleRetry = useCallback(() => {
     setLoading();
   }, [setLoading]);
 
   const applyDisabled =
-    status !== 'ready' || selectedIndices.size === 0 || proposedOps.length === 0;
+    status !== 'ready' ||
+    selectedIndices.size === 0 ||
+    proposedOps.length === 0 ||
+    !!projection.error ||
+    !!projection.emit.error;
 
   const regenerateDisabled =
     !targetPath || targetKind === 'unknown' || !!currentEmit.error || !currentEmit.source;
@@ -287,6 +385,21 @@ export function ReconcileModal(): React.JSX.Element {
         </DialogHeader>
 
         <div className="flex flex-col gap-4">
+          <div className="rounded-md border bg-muted/20 px-3 py-2 text-sm">
+            {reconcileStatusCopy(driftStatus)}
+          </div>
+          {deterministicFallbackReason && (
+            <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+              Contexture could not safely reverse-map this Convex file deterministically:{' '}
+              {deterministicFallbackReason} Assistant fallback proposed the ops below.
+            </div>
+          )}
+          {convexValidationMessage && (
+            <div className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-900 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-100">
+              {convexValidationMessage}
+            </div>
+          )}
+
           <div className="flex flex-col border rounded-md overflow-hidden max-h-64">
             <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/30 text-xs">
               <span className="font-medium">Proposed ops</span>
@@ -352,6 +465,7 @@ export function ReconcileModal(): React.JSX.Element {
                       >
                         {entry.label}
                       </label>
+                      <ProvenanceBadge provenance={entry.provenance} />
                       {entry.lossy && <LossyBadge />}
                     </li>
                   ))}
@@ -409,6 +523,9 @@ export function ReconcileModal(): React.JSX.Element {
           <Button variant="ghost" onClick={close}>
             Leave dirty
           </Button>
+          <Button variant="outline" onClick={handleOpenFile} disabled={!targetPath}>
+            Open file
+          </Button>
           <Button
             variant="outline"
             onClick={handleRegenerate}
@@ -430,6 +547,46 @@ export function ReconcileModal(): React.JSX.Element {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+type ConvexValidationResult = Awaited<
+  ReturnType<NonNullable<typeof window.contexture>['reconcile']['acceptGeneratedTarget']>
+>['convexValidation'];
+
+function convexValidationSuccessMessage(result: ConvexValidationResult | undefined): string | null {
+  if (!result || result.status === 'skipped') return null;
+  return 'Convex CLI accepted the reconciled generated files.';
+}
+
+function convexValidationFailureMessage(
+  result: Extract<ConvexValidationResult, { status: 'failed' }>,
+): string {
+  const output = result.output ? `\n\n${result.output}` : '';
+  return `Convex CLI validation failed after reconcile: ${result.error}${output}`;
+}
+
+function ProvenanceBadge({
+  provenance,
+}: {
+  provenance: ReconcileOp['provenance'];
+}): React.JSX.Element {
+  const label = provenance === 'deterministic' ? 'Deterministic' : 'Assistant';
+  const tooltip =
+    provenance === 'deterministic'
+      ? 'Contexture inferred this op from supported Convex schema syntax.'
+      : 'This op came from the assistant fallback.';
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge variant="secondary" className="px-1.5 py-0 text-[10px] font-medium">
+            {label}
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/hud/DriftBanner.tsx
@@ -31,14 +31,32 @@ export function DriftBanner(): React.JSX.Element | null {
     const statuses =
       files.length > 0 ? files : driftedPaths.map((path) => ({ path, status: 'drifted' as const }));
     if (statuses.length === 0) return null;
-    const unreadableCount = statuses.filter((file) => file.status === 'unreadable').length;
+    const unavailableCount = statuses.filter(
+      (file) => file.status === 'unreadable' || file.status === 'missing',
+    ).length;
     if (statuses.length === 1) {
       const file = statuses[0];
       if (!file) return null;
-      if (file.status === 'unreadable') {
+      if (file.status === 'unreadable' || file.status === 'missing') {
         return (
           <>
             <code className="font-mono">{shortPath(file.path)}</code> is missing or unreadable.
+          </>
+        );
+      }
+      if (file.status === 'stale') {
+        return (
+          <>
+            <code className="font-mono">{shortPath(file.path)}</code> is stale and needs re-emitting
+            from the current IR.
+          </>
+        );
+      }
+      if (file.status === 'externally_regenerated') {
+        return (
+          <>
+            <code className="font-mono">{shortPath(file.path)}</code> matches the current IR, but
+            the manifest is out of date.
           </>
         );
       }
@@ -48,15 +66,15 @@ export function DriftBanner(): React.JSX.Element | null {
         </>
       );
     }
-    if (unreadableCount > 0) {
+    if (unavailableCount > 0) {
       return (
         <>
-          {statuses.length} generated files need attention, including {unreadableCount} missing or
+          {statuses.length} generated files need attention, including {unavailableCount} missing or
           unreadable.
         </>
       );
     }
-    return <>{statuses.length} generated files were modified outside Contexture.</>;
+    return <>{statuses.length} generated files need reconcile attention.</>;
   }, [files, driftedPaths]);
 
   if (!message) return null;
@@ -65,7 +83,8 @@ export function DriftBanner(): React.JSX.Element | null {
   // dismiss and let the banner re-appear for subsequent files, or use
   // the per-file list that drift detection surfaces.
   const reviewTarget =
-    (files.find((file) => file.status === 'drifted') ?? files[0])?.path ?? driftedPaths[0];
+    (files.find((file) => file.status !== 'missing' && file.status !== 'unreadable') ?? files[0])
+      ?.path ?? driftedPaths[0];
 
   return (
     <div

--- a/apps/desktop/src/renderer/src/hooks/useSchemaAgentReconcile.ts
+++ b/apps/desktop/src/renderer/src/hooks/useSchemaAgentReconcile.ts
@@ -28,6 +28,7 @@ interface RawReconcileEntry {
   op: unknown;
   label: unknown;
   lossy: unknown;
+  provenance?: unknown;
 }
 
 function isRawEntry(value: unknown): value is RawReconcileEntry {
@@ -87,7 +88,12 @@ export function useSchemaAgentReconcile(): void {
 
       const targetKind = targetKindFor(targetPath, irPath);
 
-      let result: { ok: boolean; ops?: unknown[]; error?: string };
+      let result: {
+        ok: boolean;
+        ops?: unknown[];
+        error?: string;
+        deterministicFallbackReason?: string;
+      };
       try {
         result = await reconcileApi.query({
           irJson: JSON.stringify(schema),
@@ -125,11 +131,16 @@ export function useSchemaAgentReconcile(): void {
           op,
           label: entry.label as string,
           lossy: entry.lossy as boolean,
+          provenance: entry.provenance === 'deterministic' ? 'deterministic' : 'provider',
         });
       }
 
       // Empty array is a valid result — schemas already aligned.
-      reconcileStore.setReady(validated, onDiskSource);
+      reconcileStore.setReady(validated, onDiskSource, {
+        ...(result.deterministicFallbackReason
+          ? { deterministicFallbackReason: result.deterministicFallbackReason }
+          : {}),
+      });
     })();
 
     return () => {

--- a/apps/desktop/src/renderer/src/hooks/useSchemaAgentReconcile.ts
+++ b/apps/desktop/src/renderer/src/hooks/useSchemaAgentReconcile.ts
@@ -80,6 +80,7 @@ export function useSchemaAgentReconcile(): void {
       }
 
       const schema = useUndoStore.getState().schema;
+      let validationSchema = schema;
       const reconcileApi = window.contexture?.reconcile;
       if (!reconcileApi) {
         reconcileStore.setError('Reconcile IPC bridge is unavailable.');
@@ -121,11 +122,12 @@ export function useSchemaAgentReconcile(): void {
           continue;
         }
         const op = entry.op as Op;
-        const applyResult: ApplyResult = apply(schema, op, STDLIB_REGISTRY);
+        const applyResult: ApplyResult = apply(validationSchema, op, STDLIB_REGISTRY);
         if ('error' in applyResult) {
           console.warn('[reconcile] dropping invalid op', op, applyResult.error);
           continue;
         }
+        validationSchema = applyResult.schema;
         validated.push({
           id: crypto.randomUUID(),
           op,

--- a/apps/desktop/src/renderer/src/store/drift.ts
+++ b/apps/desktop/src/renderer/src/store/drift.ts
@@ -8,7 +8,7 @@ import { create } from 'zustand';
 
 export interface DriftFileStatus {
   path: string;
-  status: 'drifted' | 'unreadable';
+  status: 'drifted' | 'missing' | 'unreadable' | 'modified' | 'stale' | 'externally_regenerated';
 }
 
 interface DriftState {

--- a/apps/desktop/src/renderer/src/store/reconcile.ts
+++ b/apps/desktop/src/renderer/src/store/reconcile.ts
@@ -42,6 +42,7 @@ export interface ReconcileOp {
   label: string;
   /** True when the op is destructive (delete, rename, type change). Renders a ⚠ badge. */
   lossy: boolean;
+  provenance: 'deterministic' | 'provider';
 }
 
 interface ReconcileState {
@@ -54,11 +55,16 @@ interface ReconcileState {
   targetPath: string | null;
   /** On-disk contents of the target file captured when the modal opened. */
   onDiskSource: string | null;
+  deterministicFallbackReason: string | null;
 
   open: (targetPath: string) => void;
   close: () => void;
   setLoading: () => void;
-  setReady: (ops: ReconcileOp[], onDiskSource: string) => void;
+  setReady: (
+    ops: ReconcileOp[],
+    onDiskSource: string,
+    options?: { deterministicFallbackReason?: string },
+  ) => void;
   setError: (message: string) => void;
   setApplying: () => void;
   toggleOp: (index: number) => void;
@@ -87,6 +93,7 @@ const INITIAL: Omit<
   error: null,
   targetPath: null,
   onDiskSource: null,
+  deterministicFallbackReason: null,
 };
 
 export const useReconcileStore = create<ReconcileState>((set, get) => ({
@@ -101,18 +108,20 @@ export const useReconcileStore = create<ReconcileState>((set, get) => ({
       error: null,
       targetPath,
       onDiskSource: null,
+      deterministicFallbackReason: null,
     }),
 
   close: () => set({ ...INITIAL }),
 
   setLoading: () => set({ status: 'loading', error: null }),
 
-  setReady: (ops, onDiskSource) =>
+  setReady: (ops, onDiskSource, options) =>
     set({
       status: 'ready',
       proposedOps: ops,
       selectedIndices: new Set(ops.map((_, i) => i)),
       onDiskSource,
+      deterministicFallbackReason: options?.deterministicFallbackReason ?? null,
       error: null,
     }),
 

--- a/apps/desktop/tests/components/DriftBanner.test.tsx
+++ b/apps/desktop/tests/components/DriftBanner.test.tsx
@@ -43,10 +43,37 @@ describe('DriftBanner', () => {
     );
   });
 
-  it('reviews a drifted file before an unreadable file', () => {
+  it('shows stale generated files as needing re-emit from the current IR', () => {
+    useDriftStore
+      .getState()
+      .setDetected([{ path: '/repo/packages/contexture/convex/schema.ts', status: 'stale' }]);
+
+    render(<DriftBanner />);
+
+    expect(screen.getByTestId('drift-banner')).toHaveTextContent(
+      'schema.ts is stale and needs re-emitting from the current IR.',
+    );
+  });
+
+  it('shows externally regenerated files as manifest-out-of-date', () => {
+    useDriftStore.getState().setDetected([
+      {
+        path: '/repo/packages/contexture/convex/schema.ts',
+        status: 'externally_regenerated',
+      },
+    ]);
+
+    render(<DriftBanner />);
+
+    expect(screen.getByTestId('drift-banner')).toHaveTextContent(
+      'schema.ts matches the current IR, but the manifest is out of date.',
+    );
+  });
+
+  it('reviews a readable file before an unreadable file', () => {
     useDriftStore.getState().setDetected([
       { path: '/repo/packages/contexture/garden.schema.json', status: 'unreadable' },
-      { path: '/repo/packages/contexture/garden.schema.ts', status: 'drifted' },
+      { path: '/repo/packages/contexture/garden.schema.ts', status: 'stale' },
     ]);
 
     render(<DriftBanner />);

--- a/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
+++ b/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
@@ -1,3 +1,4 @@
+import { emitGeneratedTarget } from '@contexture/core/generated-targets';
 import { useChatThreadStore } from '@renderer/chat/useChatThreads';
 import { ReconcileModal } from '@renderer/components/dialogs/ReconcileModal';
 import { useDocumentStore } from '@renderer/store/document';
@@ -8,7 +9,18 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@pierre/diffs/react', () => ({
-  MultiFileDiff: () => <div data-testid="reconcile-diff" />,
+  MultiFileDiff: ({
+    oldFile,
+    newFile,
+  }: {
+    oldFile: { contents: string };
+    newFile: { contents: string };
+  }) => (
+    <div data-testid="reconcile-diff">
+      <div data-testid="reconcile-diff-old">{oldFile.contents}</div>
+      <div data-testid="reconcile-diff-new">{newFile.contents}</div>
+    </div>
+  ),
 }));
 
 vi.mock('@renderer/hooks/useSchemaAgentReconcile', () => ({
@@ -160,6 +172,53 @@ describe('ReconcileModal', () => {
     fireEvent.click(screen.getByRole('button', { name: /open file/i }));
 
     expect(window.contexture?.shell.openInEditor).toHaveBeenCalledWith(ZOD_PATH);
+  });
+
+  it('opens on file changes and explains the uncovered changes view', async () => {
+    const projectedSchema = {
+      ...SCHEMA,
+      types: [
+        {
+          ...SCHEMA.types[0],
+          fields: [...SCHEMA.types[0].fields, { name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    } as const;
+    const onDiskSource = emitGeneratedTarget(projectedSchema, 'zod', IR_PATH);
+    useDriftStore.getState().setDetected([{ path: ZOD_PATH, status: 'modified' }]);
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setReady(
+      [
+        {
+          id: 'add-title',
+          label: 'Add field title to Plot',
+          lossy: false,
+          provenance: 'deterministic',
+          op: {
+            kind: 'add_field',
+            typeName: 'Plot',
+            field: { name: 'title', type: { kind: 'string' } },
+          },
+        },
+      ],
+      onDiskSource,
+    );
+
+    render(<ReconcileModal />);
+
+    expect(screen.getByText('Generated file change')).toBeVisible();
+    expect(screen.getByText(/Current Contexture emit to on-disk/)).toBeVisible();
+    expect(screen.getByText('Proposed model ops')).toBeVisible();
+    expect(screen.getByText(/1 selected of 1/i)).toBeVisible();
+    expect(screen.getByTestId('reconcile-diff-new')).toHaveTextContent('title');
+
+    fireEvent.click(screen.getByRole('tab', { name: /uncovered changes/i }));
+
+    await waitFor(() => expect(screen.getByText('Uncovered after selected ops')).toBeVisible());
+    expect(screen.getByText(/0 uncovered lines/i)).toBeVisible();
+    expect(screen.getByText(/selected ops fully explain/i)).toBeVisible();
+    expect(screen.getByText(/selected ops reproduce the on-disk generated file/i)).toBeVisible();
+    expect(screen.getByRole('button', { name: /apply selected ops/i })).toBeEnabled();
   });
 
   it('closes after regenerating a configured Convex target without running CLI validation implicitly', async () => {

--- a/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
+++ b/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@renderer/hooks/useSchemaAgentReconcile', () => ({
 
 const IR_PATH = '/repo/packages/contexture/garden.contexture.json';
 const ZOD_PATH = '/repo/packages/contexture/garden.schema.ts';
+const CONVEX_PATH = '/repo/packages/contexture/convex/schema.ts';
 const UNKNOWN_PATH = '/repo/packages/contexture/custom.ts';
 const USER_INDEX_PATH = '/repo/packages/contexture/src/index.ts';
 
@@ -55,6 +56,10 @@ beforeEach(() => {
       },
       reconcile: {
         writeGeneratedTarget: vi.fn().mockResolvedValue(undefined),
+        acceptGeneratedTarget: vi.fn().mockResolvedValue(undefined),
+      },
+      shell: {
+        openInEditor: vi.fn().mockResolvedValue(undefined),
       },
     },
     writable: true,
@@ -100,6 +105,30 @@ describe('ReconcileModal', () => {
     expect(screen.getByRole('button', { name: /regenerate from ir/i })).toBeDisabled();
   });
 
+  it('explains stale generated files as current-IR re-emit work', () => {
+    useDriftStore.getState().setDetected([{ path: ZOD_PATH, status: 'stale' }]);
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setReady([], 'old generated source');
+
+    render(<ReconcileModal />);
+
+    expect(
+      screen.getByText(/still matches the last manifest, but not the current IR/i),
+    ).toBeVisible();
+  });
+
+  it('explains externally regenerated files as manifest work', () => {
+    useDriftStore.getState().setDetected([{ path: ZOD_PATH, status: 'externally_regenerated' }]);
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setReady([], 'current generated source');
+
+    render(<ReconcileModal />);
+
+    expect(
+      screen.getByText(/already matches the current IR, but the manifest is out of date/i),
+    ).toBeVisible();
+  });
+
   it('does not regenerate a user-owned nested index.ts even though it looks like a schema index', () => {
     useReconcileStore.getState().open(USER_INDEX_PATH);
     useReconcileStore.getState().setReady([], 'user-owned index');
@@ -120,5 +149,167 @@ describe('ReconcileModal', () => {
     expect(window.contexture?.reconcile.writeGeneratedTarget).not.toHaveBeenCalled();
     expect(useDriftStore.getState().driftedPaths).toEqual([ZOD_PATH]);
     expect(useReconcileStore.getState().isOpen).toBe(false);
+  });
+
+  it('opens the generated file from the reconcile modal', () => {
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setReady([], 'hand edited source');
+
+    render(<ReconcileModal />);
+    fireEvent.click(screen.getByRole('button', { name: /open file/i }));
+
+    expect(window.contexture?.shell.openInEditor).toHaveBeenCalledWith(ZOD_PATH);
+  });
+
+  it('shows successful Convex CLI validation feedback after regenerating a configured Convex target', async () => {
+    vi.mocked(window.contexture?.reconcile.writeGeneratedTarget).mockResolvedValueOnce({
+      convexValidation: {
+        status: 'passed',
+        command: 'npx --no-install convex dev --once',
+      },
+    });
+    useDriftStore.getState().setDetected([{ path: CONVEX_PATH, status: 'modified' }]);
+    useReconcileStore.getState().open(CONVEX_PATH);
+    useReconcileStore.getState().setReady([], 'hand edited source');
+
+    render(<ReconcileModal />);
+    fireEvent.click(screen.getByRole('button', { name: /regenerate from ir/i }));
+
+    expect(await screen.findByText(/Convex CLI accepted/i)).toBeVisible();
+    expect(useReconcileStore.getState().isOpen).toBe(true);
+  });
+
+  it('writes the reconciled generated target before closing accepted proposals', async () => {
+    useDriftStore.getState().setDetected([{ path: ZOD_PATH, status: 'modified' }]);
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setReady(
+      [
+        {
+          id: 'add-field',
+          label: 'Add field title to Plot',
+          lossy: false,
+          provenance: 'deterministic',
+          op: {
+            kind: 'add_field',
+            typeName: 'Plot',
+            field: { name: 'title', type: { kind: 'string' } },
+          },
+        },
+      ],
+      'hand edited source',
+    );
+
+    render(<ReconcileModal />);
+    fireEvent.click(screen.getByRole('button', { name: /apply selected/i }));
+
+    await waitFor(() =>
+      expect(window.contexture?.reconcile.acceptGeneratedTarget).toHaveBeenCalledOnce(),
+    );
+    const [payload] =
+      vi.mocked(window.contexture?.reconcile.acceptGeneratedTarget).mock.calls[0] ?? [];
+    expect(payload).toMatchObject({ irPath: IR_PATH, targetPath: ZOD_PATH });
+    expect(payload?.contents).toContain('title');
+    expect(JSON.stringify(payload?.schema)).toContain('title');
+    expect(useDriftStore.getState().driftedPaths).toEqual([ZOD_PATH]);
+    expect(window.contexture?.drift.dismiss).not.toHaveBeenCalled();
+    expect(window.contexture?.drift.check).toHaveBeenCalledOnce();
+    expect(useReconcileStore.getState().isOpen).toBe(false);
+  });
+
+  it('shows proposal provenance for deterministic and assistant-backed ops', () => {
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setReady(
+      [
+        {
+          id: 'deterministic-op',
+          label: 'Add field title to Plot',
+          lossy: false,
+          provenance: 'deterministic',
+          op: {
+            kind: 'add_field',
+            typeName: 'Plot',
+            field: { name: 'title', type: { kind: 'string' } },
+          },
+        },
+        {
+          id: 'provider-op',
+          label: 'Add field body to Plot',
+          lossy: false,
+          provenance: 'provider',
+          op: {
+            kind: 'add_field',
+            typeName: 'Plot',
+            field: { name: 'body', type: { kind: 'string' } },
+          },
+        },
+      ],
+      'hand edited source',
+    );
+
+    render(<ReconcileModal />);
+
+    expect(screen.getByText('Deterministic')).toBeVisible();
+    expect(screen.getByText('Assistant')).toBeVisible();
+  });
+
+  it('explains when Convex reverse-mapping used assistant fallback', () => {
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setReady(
+      [
+        {
+          id: 'provider-op',
+          label: 'Add field body to Plot',
+          lossy: false,
+          provenance: 'provider',
+          op: {
+            kind: 'add_field',
+            typeName: 'Plot',
+            field: { name: 'body', type: { kind: 'string' } },
+          },
+        },
+      ],
+      'hand edited source',
+      {
+        deterministicFallbackReason: 'Only `.index(...)` chains are supported on tables.',
+      },
+    );
+
+    render(<ReconcileModal />);
+
+    expect(screen.getByText(/could not safely reverse-map this Convex file/i)).toBeVisible();
+    expect(screen.getByText(/chains are supported on tables/i)).toBeVisible();
+    expect(screen.getByText(/Assistant fallback proposed the ops below/i)).toBeVisible();
+  });
+
+  it('rolls back accepted IR proposals when writing the reconciled target fails', async () => {
+    vi.mocked(window.contexture?.reconcile.acceptGeneratedTarget).mockRejectedValueOnce(
+      new Error('disk full'),
+    );
+    useDriftStore.getState().setDetected([{ path: ZOD_PATH, status: 'modified' }]);
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setReady(
+      [
+        {
+          id: 'add-field',
+          label: 'Add field title to Plot',
+          lossy: false,
+          provenance: 'deterministic',
+          op: {
+            kind: 'add_field',
+            typeName: 'Plot',
+            field: { name: 'title', type: { kind: 'string' } },
+          },
+        },
+      ],
+      'hand edited source',
+    );
+
+    render(<ReconcileModal />);
+    fireEvent.click(screen.getByRole('button', { name: /apply selected/i }));
+
+    await screen.findByText(/failed to accept reconciled generated file: disk full/i);
+    expect(useUndoStore.getState().schema).toEqual(SCHEMA);
+    expect(window.contexture?.drift.check).not.toHaveBeenCalled();
+    expect(useReconcileStore.getState().isOpen).toBe(true);
   });
 });

--- a/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
+++ b/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
@@ -208,6 +208,7 @@ describe('ReconcileModal', () => {
 
     expect(screen.getByText('Generated file change')).toBeVisible();
     expect(screen.getByText(/Current Contexture emit to on-disk/)).toBeVisible();
+    expect(screen.getByText(/Selection only affects Uncovered changes/i)).toBeVisible();
     expect(screen.getByText('Proposed model ops')).toBeVisible();
     expect(screen.getByText(/1 selected of 1/i)).toBeVisible();
     expect(screen.getByTestId('reconcile-diff-new')).toHaveTextContent('title');
@@ -215,6 +216,7 @@ describe('ReconcileModal', () => {
     fireEvent.click(screen.getByRole('tab', { name: /uncovered changes/i }));
 
     await waitFor(() => expect(screen.getByText('Uncovered after selected ops')).toBeVisible());
+    expect(screen.getByText(/updates as you select ops/i)).toBeVisible();
     expect(screen.getByText(/0 uncovered lines/i)).toBeVisible();
     expect(screen.getByText(/selected ops fully explain/i)).toBeVisible();
     expect(screen.getByText(/selected ops reproduce the on-disk generated file/i)).toBeVisible();

--- a/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
+++ b/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
@@ -57,6 +57,7 @@ beforeEach(() => {
       reconcile: {
         writeGeneratedTarget: vi.fn().mockResolvedValue(undefined),
         acceptGeneratedTarget: vi.fn().mockResolvedValue(undefined),
+        validateConvexGeneratedTarget: vi.fn().mockResolvedValue({ status: 'skipped' }),
       },
       shell: {
         openInEditor: vi.fn().mockResolvedValue(undefined),
@@ -161,13 +162,7 @@ describe('ReconcileModal', () => {
     expect(window.contexture?.shell.openInEditor).toHaveBeenCalledWith(ZOD_PATH);
   });
 
-  it('shows successful Convex CLI validation feedback after regenerating a configured Convex target', async () => {
-    vi.mocked(window.contexture?.reconcile.writeGeneratedTarget).mockResolvedValueOnce({
-      convexValidation: {
-        status: 'passed',
-        command: 'npx --no-install convex dev --once',
-      },
-    });
+  it('closes after regenerating a configured Convex target without running CLI validation implicitly', async () => {
     useDriftStore.getState().setDetected([{ path: CONVEX_PATH, status: 'modified' }]);
     useReconcileStore.getState().open(CONVEX_PATH);
     useReconcileStore.getState().setReady([], 'hand edited source');
@@ -175,8 +170,8 @@ describe('ReconcileModal', () => {
     render(<ReconcileModal />);
     fireEvent.click(screen.getByRole('button', { name: /regenerate from ir/i }));
 
-    expect(await screen.findByText(/Convex CLI accepted/i)).toBeVisible();
-    expect(useReconcileStore.getState().isOpen).toBe(true);
+    await waitFor(() => expect(useReconcileStore.getState().isOpen).toBe(false));
+    expect(window.contexture?.reconcile.validateConvexGeneratedTarget).not.toHaveBeenCalled();
   });
 
   it('writes the reconciled generated target before closing accepted proposals', async () => {

--- a/apps/desktop/tests/hooks/useSchemaAgentReconcile.test.tsx
+++ b/apps/desktop/tests/hooks/useSchemaAgentReconcile.test.tsx
@@ -1,0 +1,85 @@
+import { useSchemaAgentReconcile } from '@renderer/hooks/useSchemaAgentReconcile';
+import { useDocumentStore } from '@renderer/store/document';
+import { useReconcileStore } from '@renderer/store/reconcile';
+import { useUndoStore } from '@renderer/store/undo';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const IR_PATH = '/repo/packages/contexture/garden.contexture.json';
+const CONVEX_PATH = '/repo/packages/contexture/convex/schema.ts';
+
+const schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Post',
+      table: true,
+      fields: [{ name: 'title', type: { kind: 'string' } }],
+    },
+  ],
+} as const;
+
+beforeEach(() => {
+  useDocumentStore.setState({ filePath: IR_PATH, mode: 'bundle' });
+  useReconcileStore.getState().reset();
+  useUndoStore.setState({
+    schema,
+    past: [],
+    future: [],
+    txDepth: 0,
+    txStart: null,
+    canUndo: false,
+    canRedo: false,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  useReconcileStore.getState().reset();
+});
+
+describe('useSchemaAgentReconcile', () => {
+  it('validates proposal ops as an ordered sequence', async () => {
+    (window as unknown as { contexture: unknown }).contexture = {
+      reconcile: {
+        readGeneratedTarget: vi.fn().mockResolvedValue('on disk source'),
+        query: vi.fn().mockResolvedValue({
+          ok: true,
+          ops: [
+            {
+              op: {
+                kind: 'add_field',
+                typeName: 'Post',
+                field: { name: 'published', type: { kind: 'boolean' } },
+              },
+              label: 'Add field published to Post',
+              lossy: false,
+              provenance: 'deterministic',
+            },
+            {
+              op: {
+                kind: 'add_index',
+                typeName: 'Post',
+                index: { name: 'by_published', fields: ['published'] },
+              },
+              label: 'Add index by_published to Post',
+              lossy: false,
+              provenance: 'deterministic',
+            },
+          ],
+        }),
+      },
+    };
+    useReconcileStore.getState().open(CONVEX_PATH);
+
+    renderHook(() => useSchemaAgentReconcile());
+
+    await waitFor(() => expect(useReconcileStore.getState().status).toBe('ready'));
+    expect(useReconcileStore.getState().proposedOps.map((entry) => entry.op.kind)).toEqual([
+      'add_field',
+      'add_index',
+    ]);
+  });
+});

--- a/apps/desktop/tests/main/drift-watcher.test.ts
+++ b/apps/desktop/tests/main/drift-watcher.test.ts
@@ -5,6 +5,7 @@
  * fs.watch handler.
  */
 import { createHash } from 'node:crypto';
+import { buildGeneratedBundle, type Schema } from '@contexture/core';
 import { createDriftWatcher, detectDrift } from '@main/documents/drift-watcher';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -37,6 +38,14 @@ function makeReadFile(files: Record<string, string>) {
     if (path in files) return files[path];
     throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
   };
+}
+
+function generatedFilesFor(schema: Schema): Record<string, string> {
+  const bundle = buildGeneratedBundle(schema, IR_PATH);
+  return Object.fromEntries([
+    ...bundle.emitted.map((entry) => [entry.path, entry.content] as const),
+    [bundle.manifestFile.path, bundle.manifestFile.content] as const,
+  ]);
 }
 
 function makeWatcher(
@@ -250,6 +259,71 @@ describe('createDriftWatcher', () => {
       { path: WATCHED, status: 'drifted' },
       { path: SCHEMA_TS, status: 'unreadable' },
     ]);
+  });
+
+  it('calls onStatus with stale when files match the old manifest but not the current IR', async () => {
+    const originalSchema: Schema = {
+      version: '1',
+      types: [{ kind: 'object', name: 'Post', table: true, fields: [] }],
+    };
+    const currentSchema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    const files = {
+      [IR_PATH]: `${JSON.stringify(currentSchema, null, 2)}\n`,
+      ...generatedFilesFor(originalSchema),
+    };
+    const onStatus = vi.fn();
+    const { watcher } = makeWatcher(files, { onStatus });
+
+    await watcher.check();
+
+    expect(onStatus).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ path: WATCHED, status: 'stale' })]),
+    );
+  });
+
+  it('calls onStatus with externally_regenerated when files match current IR but manifest is old', async () => {
+    const originalSchema: Schema = {
+      version: '1',
+      types: [{ kind: 'object', name: 'Post', table: true, fields: [] }],
+    };
+    const currentSchema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    const originalFiles = generatedFilesFor(originalSchema);
+    const currentFiles = generatedFilesFor(currentSchema);
+    const files = {
+      [IR_PATH]: `${JSON.stringify(currentSchema, null, 2)}\n`,
+      ...currentFiles,
+      [EMITTED]: originalFiles[EMITTED] ?? '',
+    };
+    const onStatus = vi.fn();
+    const { watcher } = makeWatcher(files, { onStatus });
+
+    await watcher.check();
+
+    expect(onStatus).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ path: WATCHED, status: 'externally_regenerated' }),
+      ]),
+    );
   });
 
   it('does not call onDrift when the emitted manifest cannot be read', async () => {

--- a/apps/desktop/tests/main/reconcile-ipc.test.ts
+++ b/apps/desktop/tests/main/reconcile-ipc.test.ts
@@ -1,13 +1,37 @@
-import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { type EmittedManifest, hashContent } from '@contexture/core';
-import { readGeneratedTarget, writeGeneratedTarget } from '@main/ipc/reconcile';
+import { dirname, join } from 'node:path';
+import {
+  type EmittedManifest,
+  type GeneratedBundleFs,
+  hashContent,
+  type Schema,
+  writeGeneratedBundle,
+} from '@contexture/core';
+import {
+  acceptGeneratedTarget,
+  readGeneratedTarget,
+  writeGeneratedTarget,
+} from '@main/ipc/reconcile';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn() },
 }));
+
+const nodeTestFs: GeneratedBundleFs = {
+  readFile: (path) => readFile(path, 'utf8'),
+  async writeFile(path, content) {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, content, 'utf8');
+  },
+  async rename(from, to) {
+    await mkdir(dirname(to), { recursive: true });
+    await rename(from, to);
+  },
+  remove: (path) => rm(path, { force: true }),
+  mkdirp: (path) => mkdir(path, { recursive: true }).then(() => undefined),
+};
 
 describe('reconcile generated-target IPC helpers', () => {
   it('reads and writes known generated targets for the open IR', async () => {
@@ -46,6 +70,57 @@ describe('reconcile generated-target IPC helpers', () => {
     expect(manifest.files[targetPath]).toBe(hashContent('after\n'));
   });
 
+  it('runs one-shot Convex CLI validation for configured Convex targets', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'contexture-reconcile-'));
+    const ctxDir = join(dir, 'packages/contexture');
+    await mkdir(ctxDir, { recursive: true });
+    const irPath = join(ctxDir, 'garden.contexture.json');
+    const targetPath = join(ctxDir, 'convex/schema.ts');
+    const execFile = vi.fn().mockResolvedValue({ stdout: 'validated\n', stderr: '' });
+    await writeFile(irPath, '{"version":"1","types":[]}\n', 'utf8');
+    await writeFile(
+      join(ctxDir, 'package.json'),
+      JSON.stringify({ dependencies: { convex: '^1.0.0' } }),
+      'utf8',
+    );
+
+    const result = await writeGeneratedTarget(
+      { irPath, targetPath, contents: 'export default null;\n' },
+      { execFile, env: { CONVEX_DEPLOYMENT: 'dev:test' } },
+    );
+
+    expect(execFile).toHaveBeenCalledWith(
+      'npx',
+      ['--no-install', 'convex', 'dev', '--once'],
+      expect.objectContaining({ cwd: ctxDir }),
+    );
+    expect(result.convexValidation).toMatchObject({
+      status: 'passed',
+      command: 'npx --no-install convex dev --once',
+    });
+  });
+
+  it('skips Convex CLI validation when the project is not configured for Convex', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'contexture-reconcile-'));
+    const ctxDir = join(dir, 'packages/contexture');
+    await mkdir(ctxDir, { recursive: true });
+    const irPath = join(ctxDir, 'garden.contexture.json');
+    const targetPath = join(ctxDir, 'convex/schema.ts');
+    const execFile = vi.fn().mockResolvedValue({ stdout: 'validated\n', stderr: '' });
+    await writeFile(irPath, '{"version":"1","types":[]}\n', 'utf8');
+
+    const result = await writeGeneratedTarget(
+      { irPath, targetPath, contents: 'export default null;\n' },
+      { execFile, env: {} },
+    );
+
+    expect(execFile).not.toHaveBeenCalled();
+    expect(result.convexValidation).toMatchObject({
+      status: 'skipped',
+      reason: 'No project package.json found.',
+    });
+  });
+
   it('rejects writes outside the generated bundle', async () => {
     const irPath = '/repo/packages/contexture/garden.contexture.json';
     await expect(
@@ -64,5 +139,63 @@ describe('reconcile generated-target IPC helpers', () => {
         targetPath: '/repo/packages/contexture/garden.schema.ts',
       }),
     ).rejects.toThrow(/Invalid reconcile:write-generated-target payload: contents:/);
+  });
+
+  it('accepts a reconciled target by saving the IR and full generated bundle', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'contexture-reconcile-'));
+    const ctxDir = join(dir, 'packages/contexture');
+    await mkdir(ctxDir, { recursive: true });
+    const irPath = join(ctxDir, 'garden.contexture.json');
+    const targetPath = join(ctxDir, 'garden.schema.ts');
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Plot',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    };
+
+    await acceptGeneratedTarget({
+      irPath,
+      targetPath,
+      contents: '// accepted target\n',
+      schema,
+    });
+
+    await expect(readFile(irPath, 'utf8')).resolves.toContain('"title"');
+    await expect(readFile(join(ctxDir, 'convex/schema.ts'), 'utf8')).resolves.toContain('title');
+    await expect(readFile(targetPath, 'utf8')).resolves.toContain('@contexture-generated');
+  });
+
+  it('restores the selected target and manifest if full-bundle save finds other drift', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'contexture-reconcile-'));
+    const ctxDir = join(dir, 'packages/contexture');
+    const irPath = join(ctxDir, 'garden.contexture.json');
+    const targetPath = join(ctxDir, 'garden.schema.ts');
+    const manifestPath = join(ctxDir, '.contexture/emitted.json');
+    const schema: Schema = {
+      version: '1',
+      types: [{ kind: 'object', name: 'Plot', table: true, fields: [] }],
+    };
+    await writeGeneratedBundle({ irPath, schema, fs: nodeTestFs });
+    const previousTarget = await readFile(targetPath, 'utf8');
+    const previousManifest = await readFile(manifestPath, 'utf8');
+    await writeFile(join(ctxDir, 'garden.schema.json'), '{"hand":"edit"}\n', 'utf8');
+
+    await expect(
+      acceptGeneratedTarget({
+        irPath,
+        targetPath,
+        contents: '// accepted target\n',
+        schema,
+      }),
+    ).rejects.toThrow(/Generated files have drifted/);
+
+    await expect(readFile(targetPath, 'utf8')).resolves.toBe(previousTarget);
+    await expect(readFile(manifestPath, 'utf8')).resolves.toBe(previousManifest);
   });
 });

--- a/apps/desktop/tests/main/reconcile-ipc.test.ts
+++ b/apps/desktop/tests/main/reconcile-ipc.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   acceptGeneratedTarget,
   readGeneratedTarget,
+  validateConvexGeneratedTarget,
   writeGeneratedTarget,
 } from '@main/ipc/reconcile';
 import { describe, expect, it, vi } from 'vitest';
@@ -70,7 +71,7 @@ describe('reconcile generated-target IPC helpers', () => {
     expect(manifest.files[targetPath]).toBe(hashContent('after\n'));
   });
 
-  it('runs one-shot Convex CLI validation for configured Convex targets', async () => {
+  it('runs one-shot Convex CLI validation only through the explicit validation IPC helper', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'contexture-reconcile-'));
     const ctxDir = join(dir, 'packages/contexture');
     await mkdir(ctxDir, { recursive: true });
@@ -84,8 +85,11 @@ describe('reconcile generated-target IPC helpers', () => {
       'utf8',
     );
 
-    const result = await writeGeneratedTarget(
-      { irPath, targetPath, contents: 'export default null;\n' },
+    await writeGeneratedTarget({ irPath, targetPath, contents: 'export default null;\n' });
+    expect(execFile).not.toHaveBeenCalled();
+
+    const result = await validateConvexGeneratedTarget(
+      { irPath, targetPath },
       { execFile, env: { CONVEX_DEPLOYMENT: 'dev:test' } },
     );
 
@@ -94,7 +98,7 @@ describe('reconcile generated-target IPC helpers', () => {
       ['--no-install', 'convex', 'dev', '--once'],
       expect.objectContaining({ cwd: ctxDir }),
     );
-    expect(result.convexValidation).toMatchObject({
+    expect(result).toMatchObject({
       status: 'passed',
       command: 'npx --no-install convex dev --once',
     });
@@ -109,13 +113,13 @@ describe('reconcile generated-target IPC helpers', () => {
     const execFile = vi.fn().mockResolvedValue({ stdout: 'validated\n', stderr: '' });
     await writeFile(irPath, '{"version":"1","types":[]}\n', 'utf8');
 
-    const result = await writeGeneratedTarget(
-      { irPath, targetPath, contents: 'export default null;\n' },
+    const result = await validateConvexGeneratedTarget(
+      { irPath, targetPath },
       { execFile, env: {} },
     );
 
     expect(execFile).not.toHaveBeenCalled();
-    expect(result.convexValidation).toMatchObject({
+    expect(result).toMatchObject({
       status: 'skipped',
       reason: 'No project package.json found.',
     });

--- a/apps/desktop/tests/main/reconcile-proposals.test.ts
+++ b/apps/desktop/tests/main/reconcile-proposals.test.ts
@@ -60,6 +60,284 @@ function runtime(provider: ProviderKind, status: ProviderStatus): ProviderRuntim
 }
 
 describe('generateReconcileProposal', () => {
+  it('uses deterministic Convex schema proposals before invoking the provider', async () => {
+    const current: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    const codex = runtime('codex', { provider: 'codex', readiness: 'not_signed_in' });
+
+    await expect(
+      generateReconcileProposal({
+        runtime: codex,
+        schema: current,
+        payload: {
+          irJson: JSON.stringify(current),
+          targetKind: 'convex',
+          onDiskSource: [
+            `import { defineSchema, defineTable } from 'convex/server';`,
+            `import { v } from 'convex/values';`,
+            '',
+            'export default defineSchema({',
+            '  post: defineTable({',
+            '    title: v.string(),',
+            '    published: v.boolean(),',
+            '  }).index("by_published", ["published"]),',
+            '});',
+          ].join('\n'),
+        },
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      ops: [
+        {
+          op: {
+            kind: 'add_field',
+            typeName: 'Post',
+            field: { name: 'published', type: { kind: 'boolean' } },
+          },
+          label: 'Add field "published" to "Post"',
+          lossy: false,
+          provenance: 'deterministic',
+        },
+        {
+          op: {
+            kind: 'add_index',
+            typeName: 'Post',
+            index: { name: 'by_published', fields: ['published'] },
+          },
+          label: 'Add index "by_published" to "Post"',
+          lossy: false,
+          provenance: 'deterministic',
+        },
+      ],
+    });
+    expect(codex.generateText).not.toHaveBeenCalled();
+  });
+
+  it('maps supported Convex validators back to existing IR field semantics', async () => {
+    const current: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'User', table: true, tableName: 'users', fields: [] },
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    const codex = runtime('codex', { provider: 'codex', readiness: 'not_signed_in' });
+
+    await expect(
+      generateReconcileProposal({
+        runtime: codex,
+        schema: current,
+        payload: {
+          irJson: JSON.stringify(current),
+          targetKind: 'convex',
+          onDiskSource: [
+            `import { defineSchema, defineTable } from 'convex/server';`,
+            `import { v } from 'convex/values';`,
+            '',
+            'export default defineSchema({',
+            '  post: defineTable({',
+            '    title: v.string(),',
+            '    author: v.id("users"),',
+            '    tags: v.optional(v.array(v.string())),',
+            '    summary: v.union(v.string(), v.null()),',
+            '  }),',
+            '});',
+          ].join('\n'),
+        },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      ops: [
+        {
+          op: {
+            kind: 'add_field',
+            typeName: 'Post',
+            field: { name: 'author', type: { kind: 'ref', typeName: 'User' } },
+          },
+        },
+        {
+          op: {
+            kind: 'add_field',
+            typeName: 'Post',
+            field: {
+              name: 'tags',
+              type: { kind: 'array', element: { kind: 'string' } },
+              optional: true,
+            },
+          },
+        },
+        {
+          op: {
+            kind: 'add_field',
+            typeName: 'Post',
+            field: { name: 'summary', type: { kind: 'string' }, nullable: true },
+          },
+        },
+      ],
+    });
+    expect(codex.generateText).not.toHaveBeenCalled();
+  });
+
+  it('proposes reviewable lossy ops for removed Convex fields and indexes', async () => {
+    const current: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [
+            { name: 'title', type: { kind: 'string' } },
+            { name: 'archived', type: { kind: 'boolean' } },
+          ],
+          indexes: [{ name: 'by_archived', fields: ['archived'] }],
+        },
+      ],
+    };
+    const codex = runtime('codex', { provider: 'codex', readiness: 'not_signed_in' });
+
+    await expect(
+      generateReconcileProposal({
+        runtime: codex,
+        schema: current,
+        payload: {
+          irJson: JSON.stringify(current),
+          targetKind: 'convex',
+          onDiskSource: [
+            `import { defineSchema, defineTable } from 'convex/server';`,
+            `import { v } from 'convex/values';`,
+            '',
+            'export default defineSchema({',
+            '  post: defineTable({',
+            '    title: v.string(),',
+            '  }),',
+            '});',
+          ].join('\n'),
+        },
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      ops: [
+        {
+          op: { kind: 'remove_field', typeName: 'Post', fieldName: 'archived' },
+          label: 'Remove field "archived" from "Post"',
+          lossy: true,
+          provenance: 'deterministic',
+        },
+        {
+          op: { kind: 'remove_index', typeName: 'Post', name: 'by_archived' },
+          label: 'Remove index "by_archived" from "Post"',
+          lossy: false,
+          provenance: 'deterministic',
+        },
+      ],
+    });
+    expect(codex.generateText).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the provider with a deterministic reason when Convex edits leave the supported subset', async () => {
+    const codex = runtime('codex', { provider: 'codex', readiness: 'authenticated_chatgpt' });
+
+    await expect(
+      generateReconcileProposal({
+        runtime: codex,
+        schema,
+        payload: {
+          irJson: JSON.stringify(schema),
+          targetKind: 'convex',
+          onDiskSource: 'export default makeSchemaSomeOtherWay();',
+        },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      deterministicFallbackReason: 'Could not find `export default defineSchema({ ... })`.',
+      ops: [
+        {
+          label: 'Add Plot',
+          provenance: 'provider',
+        },
+      ],
+    });
+
+    expect(codex.generateText).toHaveBeenCalledOnce();
+  });
+
+  it('does not attach deterministic fallback reasons for non-Convex provider proposals', async () => {
+    const codex = runtime('codex', { provider: 'codex', readiness: 'authenticated_chatgpt' });
+
+    await expect(
+      generateReconcileProposal({
+        runtime: codex,
+        schema,
+        payload,
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      ops: [
+        {
+          op: {
+            kind: 'add_type',
+            type: { kind: 'object', name: 'Plot', fields: [] },
+          },
+          label: 'Add Plot',
+          lossy: false,
+          provenance: 'provider',
+        },
+      ],
+    });
+
+    expect(codex.generateText).toHaveBeenCalledOnce();
+  });
+
+  it('provider provenance overrides model-supplied provenance', async () => {
+    const codex = runtime('codex', { provider: 'codex', readiness: 'authenticated_chatgpt' });
+    vi.mocked(codex.generateText).mockResolvedValueOnce(
+      JSON.stringify([
+        {
+          op: {
+            kind: 'add_type',
+            type: { kind: 'object', name: 'Plot', fields: [] },
+          },
+          label: 'Add Plot',
+          lossy: false,
+          provenance: 'deterministic',
+        },
+      ]),
+    );
+
+    await expect(
+      generateReconcileProposal({
+        runtime: codex,
+        schema,
+        payload,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      ops: [
+        {
+          label: 'Add Plot',
+          provenance: 'provider',
+        },
+      ],
+    });
+
+    expect(codex.generateText).toHaveBeenCalledOnce();
+  });
+
   it('routes Codex proposals through the active provider model settings', async () => {
     const codex = runtime('codex', { provider: 'codex', readiness: 'authenticated_chatgpt' });
 
@@ -70,7 +348,10 @@ describe('generateReconcileProposal', () => {
         modelOptions: { model: 'gpt-5.4', effort: 'high', options: { fastMode: true } },
         payload,
       }),
-    ).resolves.toMatchObject({ ok: true, ops: [expect.objectContaining({ label: 'Add Plot' })] });
+    ).resolves.toMatchObject({
+      ok: true,
+      ops: [expect.objectContaining({ label: 'Add Plot', provenance: 'provider' })],
+    });
 
     expect(codex.generateText).toHaveBeenCalledWith(
       expect.objectContaining<Partial<GenerateTextInput>>({

--- a/apps/desktop/tests/main/reconcile-proposals.test.ts
+++ b/apps/desktop/tests/main/reconcile-proposals.test.ts
@@ -192,7 +192,7 @@ describe('generateReconcileProposal', () => {
     expect(codex.generateText).not.toHaveBeenCalled();
   });
 
-  it('proposes reviewable lossy ops for removed Convex fields and indexes', async () => {
+  it('relies on remove_field pruning when a removed Convex field owned the removed index', async () => {
     const current: Schema = {
       version: '1',
       types: [
@@ -236,12 +236,6 @@ describe('generateReconcileProposal', () => {
           op: { kind: 'remove_field', typeName: 'Post', fieldName: 'archived' },
           label: 'Remove field "archived" from "Post"',
           lossy: true,
-          provenance: 'deterministic',
-        },
-        {
-          op: { kind: 'remove_index', typeName: 'Post', name: 'by_archived' },
-          label: 'Remove index "by_archived" from "Post"',
-          lossy: false,
           provenance: 'deterministic',
         },
       ],

--- a/docs/goals/03-reconcile-as-trust-workflow.md
+++ b/docs/goals/03-reconcile-as-trust-workflow.md
@@ -66,9 +66,18 @@ This is one of the strongest ways to make Contexture feel like a control plane r
 ### Convex-Specific Reconcile
 
 - Prioritize `convex/schema.ts` and `convex/validators.ts`.
+- Use deterministic Convex parsing for supported generated-code edits before asking an LLM to infer changes.
 - Detect table, field, and index changes that can map back to the IR.
 - Distinguish supported generated-code edits from arbitrary app code.
 - Explain when a generated Convex file cannot be reverse-mapped safely.
+
+### Convex CLI Validation
+
+- Treat Convex CLI feedback as downstream validation, not the source of truth.
+- After re-emitting or applying supported IR proposals, optionally run a Convex validation/check path when available.
+- Surface Convex schema, function, or push errors as project validation feedback after Contexture reconcile decisions are made.
+- Do not rely on scraping long-running `convex dev` watcher output as the reconcile authority.
+- Do not use private Convex package internals as a stable reverse-mapping API.
 
 ### Agent-Aware Reconcile
 
@@ -89,6 +98,7 @@ This is one of the strongest ways to make Contexture feel like a control plane r
 - A user can re-emit from IR and return to a clean manifest.
 - A user can keep a generated file dirty intentionally.
 - For supported generated Convex changes, a user can apply proposed IR ops and return to drift clean.
+- When Convex CLI validation is configured, a user can see whether reconciled generated files are accepted by Convex.
 - Reconcile makes agent-generated drift reviewable instead of frightening.
 
 ## Non-Goals
@@ -97,6 +107,7 @@ This is one of the strongest ways to make Contexture feel like a control plane r
 - Do not reverse-engineer every possible generated-code edit.
 - Do not merge source-model sync and generated-target drift into one ambiguous state.
 - Do not auto-apply inferred IR changes without user review.
+- Do not replace Contexture's manifest and IR authority with Convex CLI watcher output.
 
 ## Dependencies
 

--- a/packages/core/src/generated-bundle-writer.ts
+++ b/packages/core/src/generated-bundle-writer.ts
@@ -12,10 +12,24 @@ import {
 } from './pipeline';
 
 export type GeneratedFileStatus = 'clean' | 'drifted' | 'unreadable';
+export type GeneratedDriftClassification =
+  | 'clean'
+  | 'missing'
+  | 'unreadable'
+  | 'modified'
+  | 'stale'
+  | 'externally_regenerated';
 
 export interface GeneratedFileCheck {
   path: string;
   status: GeneratedFileStatus;
+}
+
+export interface GeneratedDriftCheck {
+  path: string;
+  status: GeneratedDriftClassification;
+  matchesManifest: boolean;
+  matchesCurrentIr: boolean;
 }
 
 export interface GeneratedBundleFs {
@@ -105,10 +119,8 @@ export async function checkGeneratedManifestDrift(
   fs: Pick<GeneratedBundleFs, 'readFile'>,
 ): Promise<GeneratedFileCheck[]> {
   const paths = bundlePathsFor(irPath);
-  let manifest: EmittedManifest;
-  try {
-    manifest = JSON.parse(await fs.readFile(paths.emitted)) as EmittedManifest;
-  } catch {
+  const manifest = await readGeneratedManifest(paths.emitted, fs);
+  if (manifest === null) {
     return [];
   }
 
@@ -127,6 +139,77 @@ export async function checkGeneratedManifestDrift(
   }
 
   return checks;
+}
+
+export async function classifyGeneratedBundleDrift(
+  schema: Schema,
+  irPath: string,
+  fs: Pick<GeneratedBundleFs, 'readFile'>,
+  emitDeps?: EmitPipelineDeps,
+): Promise<GeneratedDriftCheck[]> {
+  const bundle = buildGeneratedBundle(schema, irPath, emitDeps);
+  const manifest = await readGeneratedManifest(bundle.paths.emitted, fs);
+  const manifestFiles = manifest?.files ?? {};
+  const emittedByPath = new Map(bundle.emitted.map((entry) => [entry.path, entry.content]));
+  const targetPaths = new Set([...Object.keys(manifestFiles), ...emittedByPath.keys()]);
+  const checks: GeneratedDriftCheck[] = [];
+
+  for (const path of targetPaths) {
+    const expectedContent = emittedByPath.get(path) ?? null;
+    const manifestHash = manifestFiles[path] ?? null;
+    let diskContent: string | null = null;
+    let readable = true;
+
+    try {
+      diskContent = await fs.readFile(path);
+    } catch (err) {
+      readable = false;
+      const code = (err as NodeJS.ErrnoException).code;
+      const status = code === 'ENOENT' ? 'missing' : 'unreadable';
+      checks.push({
+        path,
+        status,
+        matchesManifest: false,
+        matchesCurrentIr: false,
+      });
+    }
+
+    if (!readable || diskContent === null) continue;
+
+    const diskHash = hashContent(diskContent);
+    const matchesManifest = manifestHash !== null && diskHash === manifestHash;
+    const matchesCurrentIr = expectedContent !== null && diskContent === expectedContent;
+
+    let status: GeneratedDriftClassification;
+    if (matchesManifest && matchesCurrentIr) {
+      status = 'clean';
+    } else if (matchesManifest) {
+      status = 'stale';
+    } else if (matchesCurrentIr) {
+      status = 'externally_regenerated';
+    } else {
+      status = 'modified';
+    }
+
+    checks.push({ path, status, matchesManifest, matchesCurrentIr });
+  }
+
+  return checks;
+}
+
+async function readGeneratedManifest(
+  manifestPath: string,
+  fs: Pick<GeneratedBundleFs, 'readFile'>,
+): Promise<EmittedManifest | null> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(manifestPath)) as Partial<EmittedManifest>;
+    return {
+      version: '1',
+      files: parsed.files && typeof parsed.files === 'object' ? parsed.files : {},
+    };
+  } catch {
+    return null;
+  }
 }
 
 export async function writeGeneratedBundle(

--- a/packages/core/tests/generated-bundle-writer.test.ts
+++ b/packages/core/tests/generated-bundle-writer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   checkGeneratedBundle,
+  classifyGeneratedBundleDrift,
   GeneratedBundleDriftError,
   type GeneratedBundleFs,
   type Schema,
@@ -188,5 +189,81 @@ describe('generated bundle writer', () => {
       status: 'drifted',
     });
     expect(checks.find((check) => check.path.endsWith('app.schema.ts'))?.status).toBe('clean');
+  });
+
+  it('classifies files that still match the manifest but not the current IR as stale', async () => {
+    const fs = createFs();
+    await writeGeneratedBundle({ irPath, schema, fs });
+
+    const checks = await classifyGeneratedBundleDrift(
+      {
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'Post',
+            table: true,
+            fields: [{ name: 'title', type: { kind: 'string' } }],
+          },
+        ],
+      },
+      irPath,
+      fs,
+    );
+
+    expect(checks.find((check) => check.path.endsWith('convex/schema.ts'))).toMatchObject({
+      status: 'stale',
+      matchesManifest: true,
+      matchesCurrentIr: false,
+    });
+  });
+
+  it('classifies files that match the current IR but not the manifest as externally regenerated', async () => {
+    const fs = createFs();
+    await writeGeneratedBundle({ irPath, schema, fs });
+    const oldManifest = fs.files.get('/proj/packages/contexture/.contexture/emitted.json');
+    expect(oldManifest).toBeDefined();
+
+    const nextSchema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    };
+    await writeGeneratedBundle({ irPath, schema: nextSchema, fs, driftPreflight: false });
+    await fs.writeFile('/proj/packages/contexture/.contexture/emitted.json', oldManifest ?? '');
+
+    const checks = await classifyGeneratedBundleDrift(nextSchema, irPath, fs);
+
+    expect(checks.find((check) => check.path.endsWith('convex/schema.ts'))).toMatchObject({
+      status: 'externally_regenerated',
+      matchesManifest: false,
+      matchesCurrentIr: true,
+    });
+  });
+
+  it('classifies missing and hand-modified generated files separately', async () => {
+    const fs = createFs();
+    await writeGeneratedBundle({ irPath, schema, fs });
+    await fs.remove('/proj/packages/contexture/convex/validators.ts');
+    await fs.writeFile('/proj/packages/contexture/convex/schema.ts', '// hand edit\n');
+
+    const checks = await classifyGeneratedBundleDrift(schema, irPath, fs);
+
+    expect(checks.find((check) => check.path.endsWith('convex/validators.ts'))).toMatchObject({
+      status: 'missing',
+      matchesManifest: false,
+      matchesCurrentIr: false,
+    });
+    expect(checks.find((check) => check.path.endsWith('convex/schema.ts'))).toMatchObject({
+      status: 'modified',
+      matchesManifest: false,
+      matchesCurrentIr: false,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add deterministic generated drift classification and richer reconcile/HUD status copy
- add deterministic Convex schema reverse-mapping before assistant fallback with provenance labels
- add safe generated-target accept flow plus optional downstream Convex CLI validation via one-shot `npx --no-install convex dev --once`
- update Goal 3 with the Convex CLI validation boundary

## Verification
- `bun run ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782629753&installation_id=136251083&pr_number=328&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F328&signature=41d770fc82cd4351c1084091a5a3f96fdd83c46d03ccc7ce7887dd87d52346f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->