### PR TITLE
feat(desktop): add reviewable agent turn ledger

### DIFF
--- a/apps/desktop/src/renderer/src/chat/useChatThreads.ts
+++ b/apps/desktop/src/renderer/src/chat/useChatThreads.ts
@@ -16,7 +16,7 @@
  * schema authoring.
  */
 
-import type { ChatMessage } from '@contexture/core';
+import type { AgentTurnRecord, ChatMessage } from '@contexture/core';
 import { create } from 'zustand';
 
 export type ProviderKind = 'codex' | 'claude';
@@ -31,6 +31,7 @@ export interface ChatThread {
   modelOptions?: Record<string, string | boolean>;
   filePath: string | null;
   providerThreadRef?: unknown;
+  agentTurns?: AgentTurnRecord[];
   desynced?: boolean;
   createdAt: number;
   updatedAt: number;
@@ -53,6 +54,7 @@ function loadThreads(): ChatThread[] {
       if (t.provider === undefined) t.provider = 'claude';
       if (t.filePath === undefined) t.filePath = null;
       if (!Array.isArray(t.messages)) t.messages = [];
+      if (t.agentTurns !== undefined && !Array.isArray(t.agentTurns)) t.agentTurns = [];
     }
     return threads;
   } catch {
@@ -95,6 +97,7 @@ export interface UseChatThreadsReturn {
     model?: string;
     effort?: string;
     modelOptions?: Record<string, string | boolean>;
+    agentTurns?: AgentTurnRecord[];
     filePath: string;
     messages?: ChatMessage[];
   }) => ChatThread;
@@ -105,6 +108,7 @@ export interface UseChatThreadsReturn {
     model?: string;
     effort?: string;
     modelOptions?: Record<string, string | boolean>;
+    agentTurns?: AgentTurnRecord[];
     filePath: string | null;
   }) => ChatThread | null;
   /** All threads for a given file, newest-first. */
@@ -145,6 +149,7 @@ export const useChatThreadStore = create<UseChatThreadsReturn>((set, get) => {
     model?: string;
     effort?: string;
     modelOptions?: Record<string, string | boolean>;
+    agentTurns?: AgentTurnRecord[];
     filePath: string | null;
     messages?: ChatMessage[];
   }): ChatThread {
@@ -159,6 +164,7 @@ export const useChatThreadStore = create<UseChatThreadsReturn>((set, get) => {
       model: input.model,
       effort: input.effort,
       modelOptions: input.modelOptions,
+      agentTurns: input.agentTurns,
       filePath: input.filePath,
       createdAt: now,
       updatedAt: now,
@@ -220,6 +226,7 @@ export const useChatThreadStore = create<UseChatThreadsReturn>((set, get) => {
               model: input.model,
               effort: input.effort,
               modelOptions: input.modelOptions,
+              agentTurns: input.agentTurns,
               filePath: input.filePath,
             });
 
@@ -230,6 +237,11 @@ export const useChatThreadStore = create<UseChatThreadsReturn>((set, get) => {
         effort: input.effort,
         modelOptions: input.modelOptions,
       });
+      replaceThread(thread.id, (current) =>
+        current.agentTurns === input.agentTurns
+          ? current
+          : { ...current, agentTurns: input.agentTurns, updatedAt: Date.now() },
+      );
       return get().threads.find((candidate) => candidate.id === thread.id) ?? thread;
     },
 

--- a/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
+++ b/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
@@ -15,7 +15,7 @@ import {
   type SchemaAgentProvider,
   useSchemaAgentSettingsStore,
 } from '../store/schema-agent-settings';
-import { subscribeUndoMutations, useUndoStore } from '../store/undo';
+import { subscribeUndoHistory, subscribeUndoMutations, useUndoStore } from '../store/undo';
 import {
   type SchemaAgentModelInfo,
   type SchemaAgentModelOptionDescriptor,
@@ -75,6 +75,14 @@ function mkId(): string {
 
 function mkMessage(role: ChatRole, content: string): ChatMessage {
   return { id: mkId(), role, content, createdAt: Date.now() };
+}
+
+function readToolError(result: unknown): string {
+  if (result && typeof result === 'object') {
+    const error = (result as { error?: unknown }).error;
+    if (typeof error === 'string') return error;
+  }
+  return 'Tool call failed';
 }
 
 export function useSchemaAgentChat({
@@ -207,12 +215,20 @@ export function useSchemaAgentChat({
   }, [provider, providerThreadRef, schema, selectedModel]);
 
   useEffect(() => {
-    return subscribeUndoMutations((event) => {
-      if (event.meta.source === 'schema_agent') return;
-      const thread = latestTurnContextRef.current.providerThreadRef;
+    const markDesynced = () => {
+      const thread = useSchemaAgentSessionStore.getState().providerThreadRef;
       if (!thread) return;
       setProviderThread(thread, true);
+    };
+    const unsubscribeMutations = subscribeUndoMutations((event) => {
+      if (event.meta.source === 'schema_agent') return;
+      markDesynced();
     });
+    const unsubscribeHistory = subscribeUndoHistory(markDesynced);
+    return () => {
+      unsubscribeMutations();
+      unsubscribeHistory();
+    };
   }, [setProviderThread]);
 
   useEffect(() => {
@@ -361,6 +377,16 @@ export function useSchemaAgentChat({
       appendMessage(mkMessage('assistant', `\`${name}\``));
     });
   }, [api, appendMessage]);
+
+  useEffect(() => {
+    return api.onToolCallFinished(({ id, name, ok, result }) => {
+      useAgentTurnsStore.getState().recordToolResult({
+        id,
+        name,
+        result: ok ? result : { error: readToolError(result) },
+      });
+    });
+  }, [api]);
 
   useEffect(() => {
     return api.onAssistantFinal(({ text }) => {

--- a/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
+++ b/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
@@ -1,6 +1,7 @@
 import type { ChatHistory, ChatMessage, ChatRole } from '@contexture/core';
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import type { ContextureSchemaAgentAPI } from '../../../preload/index.d';
+import { useAgentTurnsStore } from '../store/agent-turns';
 import { useChatComposerStore } from '../store/chat-composer';
 import type { ApplyResult, Op } from '../store/ops';
 import {
@@ -14,7 +15,7 @@ import {
   type SchemaAgentProvider,
   useSchemaAgentSettingsStore,
 } from '../store/schema-agent-settings';
-import { useUndoStore } from '../store/undo';
+import { subscribeUndoMutations, useUndoStore } from '../store/undo';
 import {
   type SchemaAgentModelInfo,
   type SchemaAgentModelOptionDescriptor,
@@ -123,6 +124,7 @@ export function useSchemaAgentChat({
   const persistenceEnabled = useChatComposerStore((s) => s.chatHistoryPersistence);
   const assistantBufferRef = useRef('');
   const rafHandleRef = useRef<number | null>(null);
+  const pendingUserMessageRef = useRef<string | undefined>(undefined);
 
   const flushLiveAssistant = useCallback(() => {
     rafHandleRef.current = null;
@@ -182,12 +184,36 @@ export function useSchemaAgentChat({
     () => readEffortFromOptions(provider, selectedModelOptions, selectedModelInfo, effort),
     [provider, selectedModelOptions, selectedModelInfo, effort],
   );
+  const latestTurnContextRef = useRef({
+    schema,
+    provider,
+    model: selectedModel,
+    providerThreadRef,
+  });
   const modelsLoading = modelListState === 'loading' || modelListState === 'idle';
   const modelsUnavailable = modelListState === 'loaded' && visibleModels.length === 0;
 
   useEffect(() => {
     providerRef.current = provider;
   }, [provider]);
+
+  useEffect(() => {
+    latestTurnContextRef.current = {
+      schema,
+      provider,
+      model: selectedModel,
+      providerThreadRef,
+    };
+  }, [provider, providerThreadRef, schema, selectedModel]);
+
+  useEffect(() => {
+    return subscribeUndoMutations((event) => {
+      if (event.meta.source === 'schema_agent') return;
+      const thread = latestTurnContextRef.current.providerThreadRef;
+      if (!thread) return;
+      setProviderThread(thread, true);
+    });
+  }, [setProviderThread]);
 
   useEffect(() => {
     let cancelled = false;
@@ -305,6 +331,7 @@ export function useSchemaAgentChat({
       const result: ApplyResult = useUndoStore
         .getState()
         .apply(op as Op, { source: 'schema_agent' });
+      useAgentTurnsStore.getState().recordToolResult({ id, op: op as Op, result });
       api.replyTool(id, result);
     });
   }, [api]);
@@ -329,7 +356,8 @@ export function useSchemaAgentChat({
   }, [api, scheduleLiveFlush]);
 
   useEffect(() => {
-    return api.onToolCallStarted(({ name }) => {
+    return api.onToolCallStarted(({ id, name, input }) => {
+      useAgentTurnsStore.getState().recordToolCallStarted({ id, name, input });
       appendMessage(mkMessage('assistant', `\`${name}\``));
     });
   }, [api, appendMessage]);
@@ -340,6 +368,7 @@ export function useSchemaAgentChat({
       assistantBufferRef.current = '';
       const trimmed = text.trim();
       const message = trimmed ? mkMessage('assistant', trimmed) : null;
+      if (trimmed) useAgentTurnsStore.getState().setAssistantText(trimmed);
       finishAssistant(message);
       if (message && persistenceEnabled) onMessagePersisted?.(message);
     });
@@ -365,6 +394,38 @@ export function useSchemaAgentChat({
       },
     };
     return bindTurnToUndo(subscriber, useUndoStore.getState());
+  }, [api]);
+
+  useEffect(() => {
+    const unsubBegin = api.onTurnBegin(() => {
+      const context = latestTurnContextRef.current;
+      useAgentTurnsStore.getState().begin({
+        userMessage: pendingUserMessageRef.current,
+        provider: context.provider,
+        model: context.model,
+        providerThreadRef: context.providerThreadRef,
+        before: context.schema,
+      });
+    });
+    const unsubCommit = api.onTurnCommit(() => {
+      useAgentTurnsStore.getState().finish({
+        status: 'committed',
+        after: useUndoStore.getState().schema,
+      });
+      pendingUserMessageRef.current = undefined;
+    });
+    const unsubRollback = api.onTurnRollback(() => {
+      useAgentTurnsStore.getState().finish({
+        status: 'rolled_back',
+        after: useUndoStore.getState().schema,
+      });
+      pendingUserMessageRef.current = undefined;
+    });
+    return () => {
+      unsubBegin();
+      unsubCommit();
+      unsubRollback();
+    };
   }, [api]);
 
   const send = useCallback(
@@ -393,6 +454,7 @@ export function useSchemaAgentChat({
       }
       const userMessage = mkMessage('user', trimmed);
       beginTurn(userMessage);
+      pendingUserMessageRef.current = trimmed;
       if (persistenceEnabled) onMessagePersisted?.(userMessage);
       assistantBufferRef.current = '';
       api.setIR(schema);
@@ -513,7 +575,10 @@ export function useSchemaAgentChat({
   );
 
   const hydrate = useCallback(
-    (next: ChatMessage[]) => hydrateHistoryState({ version: '1', messages: next }),
+    (next: ChatMessage[]) => {
+      hydrateHistoryState({ version: '1', messages: next });
+      useAgentTurnsStore.getState().reset();
+    },
     [hydrateHistoryState],
   );
   const hydrateHistory = useCallback(
@@ -526,6 +591,7 @@ export function useSchemaAgentChat({
           modelOptions: history.modelOptions,
         });
       }
+      useAgentTurnsStore.getState().hydrate(history.agentTurns ?? []);
       hydrateHistoryState(history);
       if (history.providerThreadRef) {
         api.threadSet(history.providerThreadRef).catch(() => undefined);
@@ -546,11 +612,15 @@ export function useSchemaAgentChat({
         ? { modelOptions: selectedModelOptions }
         : {}),
       ...(providerThreadRef ? { providerThreadRef } : {}),
+      ...(useAgentTurnsStore.getState().turns.length > 0
+        ? { agentTurns: useAgentTurnsStore.getState().turns }
+        : {}),
     };
     return history;
   }, [messages, provider, providerThreadRef, selectedEffort, selectedModel, selectedModelOptions]);
   const clear = useCallback(() => {
     clearTranscript();
+    useAgentTurnsStore.getState().reset();
     cancelLiveFlush();
     assistantBufferRef.current = '';
   }, [cancelLiveFlush, clearTranscript]);

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -22,14 +22,33 @@
  */
 
 import type { ChatMessage } from '@contexture/core';
+import {
+  type AgentTurnOpResult,
+  type AgentTurnRecord,
+  describeAgentTurnOp,
+  diffAgentTurnSchema,
+  summarizeAgentTurnSchemaDiff,
+} from '@contexture/core/agent-turn-ledger';
 import { type ChatThread, useChatThreads } from '@renderer/chat/useChatThreads';
 import type {
   SchemaAgentChatState,
   SchemaAgentModelOptionDescriptor,
 } from '@renderer/chat/useSchemaAgentChat';
+import { useAgentTurnsStore } from '@renderer/store/agent-turns';
 import { useDocumentStore } from '@renderer/store/document';
+import { useUndoStore } from '@renderer/store/undo';
 import { code } from '@streamdown/code';
-import { ArrowUp, BotMessageSquare, List, Square, SquarePen } from 'lucide-react';
+import {
+  ArrowUp,
+  BotMessageSquare,
+  CheckCircle2,
+  Clock3,
+  List,
+  RotateCcw,
+  Square,
+  SquarePen,
+  XCircle,
+} from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Streamdown } from 'streamdown';
 import { Button } from '@/components/ui/button';
@@ -41,6 +60,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '@/components/ui/empty';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Select,
   SelectContent,
@@ -66,6 +86,7 @@ function historyFromThread(thread: ChatThread) {
     ...(thread.effort ? { effort: thread.effort } : {}),
     ...(thread.modelOptions ? { modelOptions: thread.modelOptions } : {}),
     ...(thread.providerThreadRef ? { providerThreadRef: thread.providerThreadRef } : {}),
+    ...(thread.agentTurns ? { agentTurns: thread.agentTurns } : {}),
   };
 }
 
@@ -97,6 +118,8 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   const unavailableMessage = chat.unavailableMessage;
   const providerThreadRef = chat.providerThreadRef;
   const desynced = chat.desynced;
+  const recentAgentTurn = useAgentTurnsStore((s) => s.turns[0] ?? null);
+  const agentTurns = useAgentTurnsStore((s) => s.turns);
   const hasUsableModel = providerModels.some((option) => option.id === modelSelectValue);
   const canCompose =
     isReady && !isStreaming && hasUsableModel && !modelsLoading && !modelsUnavailable;
@@ -126,6 +149,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   // active thread for no reason (hydrate from a switch would otherwise
   // trigger a spurious update).
   const prevMessagesRef = useRef<ChatMessage[] | null>(null);
+  const prevAgentTurnsRef = useRef<AgentTurnRecord[] | null>(null);
 
   // Enter the current document's chat scope. The store owns the
   // lifecycle policy: untitled documents stay ephemeral, while
@@ -135,16 +159,18 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     if (!thread) {
       hydrateHistory({ version: '1', messages: [] });
       prevMessagesRef.current = [];
+      prevAgentTurnsRef.current = [];
       return;
     }
     hydrateHistory(historyFromThread(thread));
     prevMessagesRef.current = thread.messages;
+    prevAgentTurnsRef.current = thread.agentTurns ?? [];
   }, [filePath, enterDocumentScope, hydrateHistory]);
 
   // Persist messages into the active file-backed thread whenever they
   // change. Untitled transcripts remain in-memory.
   useEffect(() => {
-    if (messages === prevMessagesRef.current) return;
+    if (messages === prevMessagesRef.current && agentTurns === prevAgentTurnsRef.current) return;
     if (messages.length === 0) return;
     persistActiveTranscript({
       messages,
@@ -152,9 +178,11 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       model,
       effort: thinkingBudget,
       modelOptions: currentModelOptions,
+      agentTurns,
       filePath,
     });
     prevMessagesRef.current = messages;
+    prevAgentTurnsRef.current = agentTurns;
   }, [
     messages,
     persistActiveTranscript,
@@ -162,6 +190,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     model,
     thinkingBudget,
     currentModelOptions,
+    agentTurns,
     filePath,
   ]);
 
@@ -213,6 +242,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       hydrateHistory({ version: '1', messages: [] });
       setInput('');
       prevMessagesRef.current = [];
+      prevAgentTurnsRef.current = [];
       setShowThreadList(false);
       return;
     }
@@ -231,6 +261,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     hydrateHistory({ version: '1', messages: [] });
     setInput('');
     prevMessagesRef.current = [];
+    prevAgentTurnsRef.current = [];
     setShowThreadList(false);
   }, [
     activeThreadId,
@@ -254,6 +285,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       switchThread(id);
       hydrateHistory(historyFromThread(thread));
       prevMessagesRef.current = thread.messages;
+      prevAgentTurnsRef.current = thread.agentTurns ?? [];
     },
     [threads, switchThread, hydrateHistory],
   );
@@ -266,9 +298,11 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       if (next) {
         hydrateHistory(historyFromThread(next));
         prevMessagesRef.current = next.messages;
+        prevAgentTurnsRef.current = next.agentTurns ?? [];
       } else {
         hydrateHistory({ version: '1', messages: [] });
         prevMessagesRef.current = [];
+        prevAgentTurnsRef.current = [];
       }
     },
     [activeThreadId, deleteThread, filePath, hydrateHistory],
@@ -396,6 +430,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
               </button>
             </div>
           )}
+          {recentAgentTurn && <AgentTurnSummaryCard turn={recentAgentTurn} />}
           <div ref={messagesEndRef} />
         </div>
       )}
@@ -536,6 +571,228 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       </form>
     </div>
   );
+}
+
+function AgentTurnSummaryCard({ turn }: { turn: AgentTurnRecord }): React.JSX.Element {
+  const applied = turn.ops.filter((op) => op.status === 'applied').length;
+  const rejected = turn.ops.filter((op) => op.status === 'rejected').length;
+  const pending =
+    turn.status === 'running' ? turn.ops.filter((op) => op.status === 'pending').length : 0;
+  const diffRows = summarizeAgentTurnSchemaDiff(diffAgentTurnSchema(turn.before, turn.after));
+  const canUndo = useUndoStore((s) => s.canUndo);
+  const undo = useUndoStore((s) => s.undo);
+  const markRolledBack = useAgentTurnsStore((s) => s.markRolledBack);
+  const handleUndo = useCallback(() => {
+    undo();
+    markRolledBack(turn.id);
+  }, [markRolledBack, turn.id, undo]);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="w-full rounded-md border border-border/70 bg-card/70 px-2.5 py-2 text-left text-xs text-muted-foreground shadow-sm transition-colors hover:border-primary/30 hover:bg-accent/50 focus:outline-none focus:ring-1 focus:ring-ring"
+          data-testid="agent-turn-summary"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="truncate font-medium text-foreground">{turn.summary}</div>
+              <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
+                <AgentTurnMetaPill>{turnStatusLabel(turn.status)}</AgentTurnMetaPill>
+                <span>{applied} applied</span>
+                {rejected > 0 && <span className="text-destructive">{rejected} rejected</span>}
+                {pending > 0 && <span>{pending} pending</span>}
+              </div>
+              {diffRows.length > 0 && (
+                <div className="mt-1 truncate text-[11px] text-muted-foreground">
+                  {diffRows.slice(0, 2).join(', ')}
+                </div>
+              )}
+            </div>
+            {turn.status === 'committed' && applied > 0 && (
+              <CheckCircle2 className="size-3.5 shrink-0 text-success" aria-hidden="true" />
+            )}
+            {turn.status === 'rolled_back' && (
+              <RotateCcw className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+            )}
+          </div>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        side="top"
+        sideOffset={8}
+        className="w-[min(24rem,calc(100vw-2rem))] p-0"
+      >
+        <AgentTurnDetail
+          turn={turn}
+          canUndo={turn.status === 'committed' && applied > 0 && canUndo}
+          onUndo={handleUndo}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function AgentTurnDetail({
+  turn,
+  canUndo,
+  onUndo,
+}: {
+  turn: AgentTurnRecord;
+  canUndo: boolean;
+  onUndo: () => void;
+}): React.JSX.Element {
+  const diffRows = summarizeAgentTurnSchemaDiff(diffAgentTurnSchema(turn.before, turn.after));
+  const visibleOps = turn.ops.filter((op) => op.status !== 'pending' || turn.status === 'running');
+  const hiddenPending = turn.ops.length - visibleOps.length;
+  return (
+    <div className="max-h-96 overflow-y-auto text-xs">
+      <div className="border-b border-border/70 px-3 py-2.5">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="truncate font-semibold text-foreground">{turn.summary}</div>
+            <div className="mt-1 text-[11px] text-muted-foreground">
+              {turn.provider ?? 'Agent'}
+              {turn.model ? ` · ${turn.model}` : ''} · {turnStatusLabel(turn.status)}
+            </div>
+          </div>
+          {canUndo && (
+            <button
+              type="button"
+              className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-border/70 px-2 text-[11px] font-medium text-foreground transition-colors hover:bg-accent"
+              onClick={onUndo}
+            >
+              <RotateCcw className="size-3" aria-hidden="true" />
+              Undo turn
+            </button>
+          )}
+        </div>
+      </div>
+      <div className="space-y-2 px-3 py-2.5">
+        {diffRows.length > 0 && (
+          <div className="rounded-md border border-primary/15 bg-primary/5 px-2 py-1.5">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Schema diff
+            </div>
+            <ul className="space-y-0.5">
+              {diffRows.map((row) => (
+                <li key={row} className="text-[11px] leading-5 text-foreground">
+                  {row}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {visibleOps.length === 0 ? (
+          <div className="text-muted-foreground">No model operations recorded yet.</div>
+        ) : (
+          <details>
+            <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Tool log
+            </summary>
+            <div className="mt-1 overflow-hidden rounded-md border border-border/70">
+              {visibleOps.map((op) => (
+                <AgentTurnOpRow key={op.id} op={op} />
+              ))}
+            </div>
+          </details>
+        )}
+        {hiddenPending > 0 && (
+          <div className="text-[11px] text-muted-foreground">
+            {hiddenPending} provisional tool {hiddenPending === 1 ? 'call was' : 'calls were'}{' '}
+            resolved by the applied operations above.
+          </div>
+        )}
+      </div>
+      <details className="border-t border-border/70 px-3 py-2">
+        <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Raw turn record
+        </summary>
+        <pre className="mt-2 max-h-40 overflow-auto rounded border border-border bg-muted/40 p-2 text-[10px]">
+          {JSON.stringify(turn, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
+function AgentTurnOpRow({ op }: { op: AgentTurnOpResult }): React.JSX.Element {
+  return (
+    <div className="border-b border-border/60 bg-background px-2.5 py-1.5 last:border-b-0">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate text-[12px] font-medium leading-5 text-foreground">
+            {describeAgentTurnOp(op)}
+          </div>
+          <div className="font-mono text-[10px] leading-4 text-muted-foreground">{op.name}</div>
+        </div>
+        <AgentTurnStatusPill status={op.status} />
+      </div>
+      {op.error && (
+        <div className="mt-1 whitespace-pre-wrap text-[11px] text-destructive">{op.error}</div>
+      )}
+    </div>
+  );
+}
+
+function AgentTurnMetaPill({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <span className="rounded-full border border-border/70 bg-background/70 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+function AgentTurnStatusPill({
+  status,
+}: {
+  status: AgentTurnOpResult['status'];
+}): React.JSX.Element {
+  const iconClass = 'size-3';
+  const content =
+    status === 'applied'
+      ? {
+          label: 'Applied',
+          icon: CheckCircle2,
+          className: 'border-success/30 bg-success/10 text-success',
+        }
+      : status === 'rejected'
+        ? {
+            label: 'Rejected',
+            icon: XCircle,
+            className: 'border-destructive/30 bg-destructive/10 text-destructive',
+          }
+        : status === 'pending'
+          ? {
+              label: 'Pending',
+              icon: Clock3,
+              className: 'border-border/70 bg-muted/60 text-muted-foreground',
+            }
+          : {
+              label: 'Tool',
+              icon: Clock3,
+              className: 'border-border/70 bg-muted/60 text-muted-foreground',
+            };
+  const Icon = content.icon;
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium',
+        content.className,
+      )}
+    >
+      <Icon className={iconClass} aria-hidden="true" />
+      {content.label}
+    </span>
+  );
+}
+
+function turnStatusLabel(status: AgentTurnRecord['status']): string {
+  if (status === 'running') return 'running';
+  if (status === 'rolled_back') return 'rolled back';
+  return 'reviewable';
 }
 
 function MessageBubble({ message }: { message: ChatMessage }): React.JSX.Element {

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -27,6 +27,7 @@ import {
   type AgentTurnRecord,
   describeAgentTurnOp,
   diffAgentTurnSchema,
+  hashAgentTurnSchema,
   summarizeAgentTurnSchemaDiff,
 } from '@contexture/core/agent-turn-ledger';
 import { type ChatThread, useChatThreads } from '@renderer/chat/useChatThreads';
@@ -581,11 +582,19 @@ function AgentTurnSummaryCard({ turn }: { turn: AgentTurnRecord }): React.JSX.El
   const diffRows = summarizeAgentTurnSchemaDiff(diffAgentTurnSchema(turn.before, turn.after));
   const canUndo = useUndoStore((s) => s.canUndo);
   const undo = useUndoStore((s) => s.undo);
+  const schema = useUndoStore((s) => s.schema);
   const markRolledBack = useAgentTurnsStore((s) => s.markRolledBack);
+  const canUndoTurn =
+    turn.status === 'committed' &&
+    applied > 0 &&
+    canUndo &&
+    !!turn.afterHash &&
+    hashAgentTurnSchema(schema) === turn.afterHash;
   const handleUndo = useCallback(() => {
+    if (!canUndoTurn) return;
     undo();
     markRolledBack(turn.id);
-  }, [markRolledBack, turn.id, undo]);
+  }, [canUndoTurn, markRolledBack, turn.id, undo]);
 
   return (
     <Popover>
@@ -625,11 +634,7 @@ function AgentTurnSummaryCard({ turn }: { turn: AgentTurnRecord }): React.JSX.El
         sideOffset={8}
         className="w-[min(24rem,calc(100vw-2rem))] p-0"
       >
-        <AgentTurnDetail
-          turn={turn}
-          canUndo={turn.status === 'committed' && applied > 0 && canUndo}
-          onUndo={handleUndo}
-        />
+        <AgentTurnDetail turn={turn} canUndo={canUndoTurn} onUndo={handleUndo} />
       </PopoverContent>
     </Popover>
   );

--- a/apps/desktop/src/renderer/src/store/agent-turns.ts
+++ b/apps/desktop/src/renderer/src/store/agent-turns.ts
@@ -103,7 +103,7 @@ export const useAgentTurnsStore = create<AgentTurnsState>((set, get) => ({
       const turns = state.turns.map((turn) => {
         if (turn.id !== activeTurnId) return turn;
         const existing = turn.ops.find((op) => op.id === input.id);
-        const status = isApplyError(input.result) ? 'rejected' : input.op ? 'applied' : 'non_op';
+        const status = input.op ? (isApplyError(input.result) ? 'rejected' : 'applied') : 'non_op';
         const nextOp: AgentTurnOpResult = {
           id: input.id,
           name: input.name ?? existing?.name ?? opKind(input.op),

--- a/apps/desktop/src/renderer/src/store/agent-turns.ts
+++ b/apps/desktop/src/renderer/src/store/agent-turns.ts
@@ -1,0 +1,212 @@
+import {
+  type AgentTurnOpResult,
+  type AgentTurnRecord,
+  buildAgentTurnSummary,
+  hashAgentTurnSchema,
+} from '@contexture/core/agent-turn-ledger';
+import type { Schema } from '@contexture/core/ir';
+import type { Op } from '@contexture/core/ops';
+import { create } from 'zustand';
+
+interface BeginAgentTurnInput {
+  userMessage?: string;
+  provider?: string;
+  model?: string;
+  providerThreadRef?: unknown;
+  before: Schema;
+}
+
+interface FinishAgentTurnInput {
+  status: AgentTurnRecord['status'];
+  after?: Schema;
+}
+
+interface AgentTurnsState {
+  turns: AgentTurnRecord[];
+  activeTurnId: string | null;
+  begin: (input: BeginAgentTurnInput) => void;
+  finish: (input: FinishAgentTurnInput) => void;
+  setAssistantText: (assistantText: string) => void;
+  recordToolCallStarted: (input: { id: string; name: string; input?: unknown }) => void;
+  recordToolResult: (input: { id: string; name?: string; op?: Op; result: unknown }) => void;
+  markRolledBack: (id: string) => void;
+  hydrate: (turns: AgentTurnRecord[]) => void;
+  reset: () => void;
+}
+
+export const useAgentTurnsStore = create<AgentTurnsState>((set, get) => ({
+  turns: [],
+  activeTurnId: null,
+
+  begin: (input) => {
+    const id = makeId();
+    const startedAt = new Date().toISOString();
+    const turn: AgentTurnRecord = {
+      id,
+      status: 'running',
+      startedAt,
+      userMessage: input.userMessage,
+      provider: input.provider,
+      model: input.model,
+      providerThreadRef: input.providerThreadRef,
+      beforeHash: hashAgentTurnSchema(input.before),
+      before: input.before,
+      ops: [],
+      summary: buildAgentTurnSummary({ status: 'running', ops: [] }),
+    };
+    set((state) => ({ activeTurnId: id, turns: [turn, ...state.turns] }));
+  },
+
+  finish: (input) => {
+    const activeTurnId = get().activeTurnId;
+    if (!activeTurnId) return;
+    set((state) => ({
+      activeTurnId: null,
+      turns: state.turns.map((turn) => (turn.id === activeTurnId ? finishTurn(turn, input) : turn)),
+    }));
+  },
+
+  setAssistantText: (assistantText) => {
+    const activeTurnId = get().activeTurnId;
+    if (!activeTurnId) return;
+    set((state) => ({
+      turns: state.turns.map((turn) =>
+        turn.id === activeTurnId ? { ...turn, assistantText } : turn,
+      ),
+    }));
+  },
+
+  recordToolCallStarted: (input) => {
+    const activeTurnId = get().activeTurnId;
+    if (!activeTurnId) return;
+    set((state) => ({
+      turns: state.turns.map((turn) =>
+        turn.id === activeTurnId
+          ? {
+              ...turn,
+              ops: upsertOpResult(turn.ops, {
+                id: input.id,
+                name: input.name,
+                input: input.input,
+                status: 'pending',
+              }),
+            }
+          : turn,
+      ),
+    }));
+  },
+
+  recordToolResult: (input) => {
+    const activeTurnId = get().activeTurnId;
+    if (!activeTurnId) return;
+    set((state) => {
+      const turns = state.turns.map((turn) => {
+        if (turn.id !== activeTurnId) return turn;
+        const existing = turn.ops.find((op) => op.id === input.id);
+        const status = isApplyError(input.result) ? 'rejected' : input.op ? 'applied' : 'non_op';
+        const nextOp: AgentTurnOpResult = {
+          id: input.id,
+          name: input.name ?? existing?.name ?? opKind(input.op),
+          input: existing?.input,
+          op: input.op,
+          status,
+          result: input.result,
+          ...(isApplyError(input.result) ? { error: input.result.error } : {}),
+        };
+        const ops = upsertOpResult(turn.ops, nextOp);
+        return {
+          ...turn,
+          ops,
+          summary: buildAgentTurnSummary({ status: turn.status, ops }),
+        };
+      });
+      return { turns };
+    });
+  },
+
+  markRolledBack: (id) => {
+    set((state) => ({
+      activeTurnId: state.activeTurnId === id ? null : state.activeTurnId,
+      turns: state.turns.map((turn) =>
+        turn.id === id
+          ? {
+              ...turn,
+              status: 'rolled_back',
+              finishedAt: new Date().toISOString(),
+              summary: buildAgentTurnSummary({ status: 'rolled_back', ops: turn.ops }),
+            }
+          : turn,
+      ),
+    }));
+  },
+
+  hydrate: (turns) => set({ turns, activeTurnId: null }),
+
+  reset: () => set({ turns: [], activeTurnId: null }),
+}));
+
+function finishTurn(turn: AgentTurnRecord, input: FinishAgentTurnInput): AgentTurnRecord {
+  const ops =
+    input.status === 'running' ? turn.ops : turn.ops.filter((op) => op.status !== 'pending');
+  return {
+    ...turn,
+    status: input.status,
+    finishedAt: new Date().toISOString(),
+    afterHash: hashAgentTurnSchema(input.after),
+    after: input.after,
+    ops,
+    summary: buildAgentTurnSummary({ status: input.status, ops }),
+  };
+}
+
+function upsertOpResult(ops: AgentTurnOpResult[], next: AgentTurnOpResult): AgentTurnOpResult[] {
+  const index = ops.findIndex((op) => op.id === next.id);
+  if (index === -1) {
+    const pendingIndex =
+      next.status === 'applied' || next.status === 'rejected'
+        ? ops.findIndex(
+            (op) => op.status === 'pending' && op.name === next.name && op.op === undefined,
+          )
+        : -1;
+    if (pendingIndex === -1) return [...ops, next];
+    return ops.map((op, i) =>
+      i === pendingIndex
+        ? {
+            ...next,
+            id: next.id,
+            input: op.input ?? next.input,
+          }
+        : op,
+    );
+  }
+  return ops.map((op, i) => (i === index ? { ...op, ...next } : op));
+}
+
+function isApplyError(value: unknown): value is { error: string } {
+  return (
+    !!value && typeof value === 'object' && typeof (value as { error?: unknown }).error === 'string'
+  );
+}
+
+function opKind(op: Op | undefined): string {
+  return op?.kind ?? 'tool';
+}
+
+function makeId(): string {
+  const c = globalThis.crypto;
+  return c?.randomUUID ? c.randomUUID() : `turn-${Date.now()}-${Math.random().toString(36)}`;
+}
+
+function shouldExposeTestHooks(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (import.meta.env.DEV || import.meta.env.MODE === 'test') return true;
+  return new URLSearchParams(window.location.search).get('e2e') === '1';
+}
+
+if (shouldExposeTestHooks()) {
+  (
+    window as unknown as {
+      __contextureAgentTurns?: typeof useAgentTurnsStore;
+    }
+  ).__contextureAgentTurns = useAgentTurnsStore;
+}

--- a/apps/desktop/src/renderer/src/store/undo.ts
+++ b/apps/desktop/src/renderer/src/store/undo.ts
@@ -43,8 +43,16 @@ export interface UndoMutationEvent {
 }
 
 export type UndoMutationListener = (event: UndoMutationEvent) => void;
+export interface UndoHistoryEvent {
+  action: 'undo' | 'redo';
+  before: Schema;
+  after: Schema;
+}
+
+export type UndoHistoryListener = (event: UndoHistoryEvent) => void;
 
 const mutationListeners = new Set<UndoMutationListener>();
+const historyListeners = new Set<UndoHistoryListener>();
 
 export interface UndoableState {
   schema: Schema;
@@ -113,6 +121,7 @@ export function createUndoableContextureStore(initial: Schema) {
         const prev = state.past[state.past.length - 1];
         const future = [state.schema, ...state.future];
         set({ schema: prev, past, future, ...recompute(past, future) });
+        notifyHistory(historyListeners, { action: 'undo', before: state.schema, after: prev });
       },
 
       redo: () => {
@@ -121,6 +130,7 @@ export function createUndoableContextureStore(initial: Schema) {
         const [next, ...future] = state.future;
         const past = [...state.past, state.schema];
         set({ schema: next, past, future, ...recompute(past, future) });
+        notifyHistory(historyListeners, { action: 'redo', before: state.schema, after: next });
       },
 
       begin: () => {
@@ -175,7 +185,18 @@ export function subscribeUndoMutations(listener: UndoMutationListener): () => vo
   };
 }
 
+export function subscribeUndoHistory(listener: UndoHistoryListener): () => void {
+  historyListeners.add(listener);
+  return () => {
+    historyListeners.delete(listener);
+  };
+}
+
 function notifyMutation(listeners: Set<UndoMutationListener>, event: UndoMutationEvent): void {
+  for (const listener of listeners) listener(event);
+}
+
+function notifyHistory(listeners: Set<UndoHistoryListener>, event: UndoHistoryEvent): void {
   for (const listener of listeners) listener(event);
 }
 

--- a/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
+++ b/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
@@ -14,6 +14,9 @@ function makeApi(status: unknown = { provider: 'codex', readiness: 'authenticate
     assistantDelta: new Set<Listener<{ text: string }>>(),
     assistantFinal: new Set<Listener<{ text: string }>>(),
     toolCallStarted: new Set<Listener<{ id: string; name: string; input?: unknown }>>(),
+    toolCallFinished: new Set<
+      Listener<{ id: string; name: string; ok: boolean; result?: unknown }>
+    >(),
     error: new Set<Listener<{ message: string }>>(),
     statusChanged: new Set<Listener<unknown>>(),
     turnBegin: new Set<() => void>(),
@@ -70,7 +73,10 @@ function makeApi(status: unknown = { provider: 'codex', readiness: 'authenticate
       listeners.toolCallStarted.add(l);
       return () => listeners.toolCallStarted.delete(l);
     },
-    onToolCallFinished: () => () => undefined,
+    onToolCallFinished: (l) => {
+      listeners.toolCallFinished.add(l);
+      return () => listeners.toolCallFinished.delete(l);
+    },
     onError: (l) => {
       listeners.error.add(l);
       return () => listeners.error.delete(l);
@@ -118,6 +124,11 @@ function makeApi(status: unknown = { provider: 'codex', readiness: 'authenticate
     },
     toolCallStarted: (p: { id: string; name: string; input?: unknown }) => {
       listeners.toolCallStarted.forEach((l) => {
+        l(p);
+      });
+    },
+    toolCallFinished: (p: { id: string; name: string; ok: boolean; result?: unknown }) => {
+      listeners.toolCallFinished.forEach((l) => {
         l(p);
       });
     },
@@ -306,6 +317,66 @@ describe('useSchemaAgentChat', () => {
         ],
       }),
     ]);
+  });
+
+  it('records completed non-op tools in the agent turn ledger', async () => {
+    const { api, emit } = makeApi();
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await waitFor(() => {
+      expect(result.current.model).toBe('gpt-5.4');
+    });
+    await act(async () => {
+      await result.current.send('emit and check drift');
+    });
+    act(() => {
+      emit.turnBegin();
+      emit.toolCallStarted({ id: 'emit-1', name: 'emit_contexture', input: {} });
+      emit.toolCallFinished({
+        id: 'emit-1',
+        name: 'emit_contexture',
+        ok: true,
+        result: { emitted: ['convex/schema.ts'] },
+      });
+      emit.toolCallStarted({ id: 'drift-1', name: 'check_contexture_drift', input: {} });
+      emit.toolCallFinished({
+        id: 'drift-1',
+        name: 'check_contexture_drift',
+        ok: true,
+        result: { clean: true },
+      });
+      emit.turnCommit();
+    });
+
+    expect(useAgentTurnsStore.getState().turns[0]).toEqual(
+      expect.objectContaining({
+        summary: 'Agent emitted generated files and checked drift: clean',
+        ops: [
+          expect.objectContaining({ id: 'emit-1', name: 'emit_contexture', status: 'non_op' }),
+          expect.objectContaining({
+            id: 'drift-1',
+            name: 'check_contexture_drift',
+            status: 'non_op',
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('marks provider threads stale after undo and redo', async () => {
+    const { api, emit } = makeApi();
+    renderHook(() => useSchemaAgentChat({ api }));
+
+    act(() => {
+      emit.threadUpdated({ thread: { provider: 'codex', threadId: 'thread-1' } });
+      useUndoStore.getState().apply({
+        kind: 'add_type',
+        type: { kind: 'object', name: 'Plot', fields: [] },
+      });
+      useUndoStore.getState().undo();
+    });
+
+    expect(useSchemaAgentSessionStore.getState().desynced).toBe(true);
   });
 
   it('surfaces non-ready Codex status', async () => {

--- a/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
+++ b/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
@@ -1,6 +1,7 @@
 import { useSchemaAgentModelsStore } from '@renderer/chat/schemaAgentModelsStore';
 import { useSchemaAgentSessionStore } from '@renderer/chat/schemaAgentSessionStore';
 import { useSchemaAgentChat } from '@renderer/chat/useSchemaAgentChat';
+import { useAgentTurnsStore } from '@renderer/store/agent-turns';
 import { useUndoStore } from '@renderer/store/undo';
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -165,6 +166,7 @@ describe('useSchemaAgentChat', () => {
     localStorage.clear();
     useSchemaAgentModelsStore.getState().reset();
     useSchemaAgentSessionStore.getState().reset();
+    useAgentTurnsStore.getState().reset();
     useUndoStore.getState().apply({ kind: 'replace_schema', schema: { version: '1', types: [] } });
   });
   afterEach(cleanup);
@@ -262,6 +264,48 @@ describe('useSchemaAgentChat', () => {
     expect(useUndoStore.getState().schema.types.map((t) => t.name)).toEqual(['A', 'B']);
     act(() => useUndoStore.getState().undo());
     expect(useUndoStore.getState().schema.types).toEqual([]);
+  });
+
+  it('records applied and rejected schema-agent ops as one reviewable turn', async () => {
+    const { api, emit } = makeApi();
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await waitFor(() => {
+      expect(result.current.model).toBe('gpt-5.4');
+    });
+    await act(async () => {
+      await result.current.send('add a plot');
+    });
+    act(() => {
+      emit.turnBegin();
+      emit.toolCallStarted({ id: 'pending-1', name: 'add_type', input: { name: 'Plot' } });
+      emit.toolRequest({
+        id: '1',
+        op: { kind: 'add_type', type: { kind: 'object', name: 'Plot', fields: [] } },
+      });
+      emit.toolCallStarted({ id: 'pending-2', name: 'add_type', input: { name: 'Plot' } });
+      emit.toolRequest({
+        id: '2',
+        op: { kind: 'add_type', type: { kind: 'object', name: 'Plot', fields: [] } },
+      });
+      emit.assistantFinal({ text: 'Added Plot.' });
+      emit.turnCommit();
+    });
+
+    expect(useAgentTurnsStore.getState().turns).toEqual([
+      expect.objectContaining({
+        status: 'committed',
+        userMessage: 'add a plot',
+        assistantText: 'Added Plot.',
+        provider: 'codex',
+        model: 'gpt-5.4',
+        summary: 'Agent proposed 2 model changes: 1 applied, 1 rejected',
+        ops: [
+          expect.objectContaining({ id: '1', name: 'add_type', status: 'applied' }),
+          expect.objectContaining({ id: '2', name: 'add_type', status: 'rejected' }),
+        ],
+      }),
+    ]);
   });
 
   it('surfaces non-ready Codex status', async () => {
@@ -639,6 +683,27 @@ describe('useSchemaAgentChat', () => {
 
     act(() => {
       emit.threadDesynced({ thread, reason: 'rollback failed' });
+    });
+
+    expect(result.current.providerThreadRef).toEqual(thread);
+    expect(result.current.desynced).toBe(true);
+  });
+
+  it('marks the provider thread stale when the model changes outside the agent', () => {
+    const { api, emit } = makeApi();
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+    const thread = { provider: 'codex', threadId: 'thread-1' };
+
+    act(() => {
+      emit.threadUpdated({ thread });
+    });
+    expect(result.current.desynced).toBe(false);
+
+    act(() => {
+      useUndoStore.getState().apply({
+        kind: 'add_type',
+        type: { kind: 'object', name: 'ExternalEdit', fields: [] },
+      });
     });
 
     expect(result.current.providerThreadRef).toEqual(thread);

--- a/apps/desktop/tests/components/chat/ChatPanel.test.tsx
+++ b/apps/desktop/tests/components/chat/ChatPanel.test.tsx
@@ -181,6 +181,38 @@ describe('ChatPanel', () => {
     expect(screen.queryByText('Undo turn')).not.toBeInTheDocument();
   });
 
+  it('does not offer agent turn undo after an intervening schema edit', async () => {
+    useUndoStore.getState().apply({
+      kind: 'add_type',
+      type: { kind: 'object', name: 'Plot', fields: [] },
+    });
+    useAgentTurnsStore.getState().begin({
+      before: { version: '1', types: [] },
+      userMessage: 'add a Plot type',
+      provider: 'codex',
+      model: 'gpt-5.4',
+    });
+    useAgentTurnsStore.getState().recordToolResult({
+      id: '1',
+      op: { kind: 'add_type', type: { kind: 'object', name: 'Plot', fields: [] } },
+      result: { schema: { version: '1', types: [{ kind: 'object', name: 'Plot', fields: [] }] } },
+    });
+    useAgentTurnsStore.getState().finish({
+      status: 'committed',
+      after: { version: '1', types: [{ kind: 'object', name: 'Plot', fields: [] }] },
+    });
+    useUndoStore.getState().apply({
+      kind: 'add_type',
+      type: { kind: 'object', name: 'ManualEdit', fields: [] },
+    });
+
+    render(<ChatPanel chat={makeChat()} />);
+
+    fireEvent.click(screen.getByTestId('agent-turn-summary'));
+    await waitFor(() => expect(screen.getByText('Schema diff')).toBeInTheDocument());
+    expect(screen.queryByText('Undo turn')).not.toBeInTheDocument();
+  });
+
   it('Enter in the textarea calls chat.send with the trimmed draft', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
     render(<ChatPanel chat={makeChat({ send })} />);

--- a/apps/desktop/tests/components/chat/ChatPanel.test.tsx
+++ b/apps/desktop/tests/components/chat/ChatPanel.test.tsx
@@ -6,7 +6,9 @@
 import { useChatThreadStore } from '@renderer/chat/useChatThreads';
 import type { SchemaAgentChatState } from '@renderer/chat/useSchemaAgentChat';
 import { ChatPanel } from '@renderer/components/chat/ChatPanel';
+import { useAgentTurnsStore } from '@renderer/store/agent-turns';
 import { useDocumentStore } from '@renderer/store/document';
+import { useUndoStore } from '@renderer/store/undo';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -74,6 +76,16 @@ function mockBridge(): void {
 
 beforeEach(() => {
   localStorage.clear();
+  useAgentTurnsStore.getState().reset();
+  useUndoStore.setState({
+    schema: { version: '1', types: [] },
+    past: [],
+    future: [],
+    txDepth: 0,
+    txStart: null,
+    canUndo: false,
+    canRedo: false,
+  });
   useChatThreadStore.getState().reloadFromStorage();
   useDocumentStore.setState({
     filePath: null,
@@ -118,6 +130,55 @@ describe('ChatPanel', () => {
   it('shows the streaming indicator while isStreaming is true', () => {
     render(<ChatPanel chat={makeChat({ isStreaming: true })} />);
     expect(screen.getByText(/Codex is thinking/i)).toBeInTheDocument();
+  });
+
+  it('renders the latest agent turn summary for manual oversight', async () => {
+    useUndoStore.getState().apply({
+      kind: 'add_type',
+      type: { kind: 'object', name: 'Plot', fields: [] },
+    });
+    useAgentTurnsStore.getState().begin({
+      before: { version: '1', types: [] },
+      userMessage: 'add a Plot type',
+      provider: 'codex',
+      model: 'gpt-5.4',
+    });
+    useAgentTurnsStore.getState().recordToolResult({
+      id: '1',
+      op: { kind: 'add_type', type: { kind: 'object', name: 'Plot', fields: [] } },
+      result: { schema: { version: '1', types: [{ kind: 'object', name: 'Plot', fields: [] }] } },
+    });
+    useAgentTurnsStore.getState().recordToolResult({
+      id: '2',
+      op: { kind: 'add_type', type: { kind: 'object', name: 'Plot', fields: [] } },
+      result: { error: 'add_type: type "Plot" already exists' },
+    });
+    useAgentTurnsStore.getState().finish({
+      status: 'committed',
+      after: { version: '1', types: [{ kind: 'object', name: 'Plot', fields: [] }] },
+    });
+
+    render(<ChatPanel chat={makeChat()} />);
+
+    expect(screen.getByTestId('agent-turn-summary')).toHaveTextContent(
+      'Agent proposed 2 model changes: 1 applied, 1 rejected',
+    );
+    expect(screen.getByTestId('agent-turn-summary')).toHaveTextContent('1 applied');
+    expect(screen.getByTestId('agent-turn-summary')).toHaveTextContent('1 rejected');
+    fireEvent.click(screen.getByTestId('agent-turn-summary'));
+    await waitFor(() => expect(screen.getAllByText('Added Plot')).toHaveLength(2));
+    expect(screen.getByText('Schema diff')).toBeInTheDocument();
+    expect(screen.getByText('add_type: type "Plot" already exists')).toBeInTheDocument();
+    expect(screen.getByText('Raw turn record')).toBeInTheDocument();
+    expect(screen.getByText('Undo turn')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Undo turn'));
+    expect(useUndoStore.getState().schema.types).toEqual([]);
+    await waitFor(() =>
+      expect(screen.getByTestId('agent-turn-summary')).toHaveTextContent(
+        'Agent turn undone: 1 model change rolled back',
+      ),
+    );
+    expect(screen.queryByText('Undo turn')).not.toBeInTheDocument();
   });
 
   it('Enter in the textarea calls chat.send with the trimmed draft', async () => {

--- a/apps/desktop/tests/model/chat-history.test.ts
+++ b/apps/desktop/tests/model/chat-history.test.ts
@@ -87,6 +87,38 @@ describe('chat history sidecar', () => {
     expect(warnings).toEqual([]);
   });
 
+  it('drops malformed agent turn snapshots and ops without discarding chat history', () => {
+    const raw = JSON.stringify({
+      version: '1',
+      messages: [{ id: 'm1', role: 'user', content: 'hi', createdAt: 1 }],
+      agentTurns: [
+        {
+          id: 'turn-1',
+          status: 'committed',
+          startedAt: '2026-05-29T09:00:00.000Z',
+          before: {},
+          after: { version: '1', types: [] },
+          ops: [
+            { id: 'op-1', name: 'add_type', status: 'applied', op: { kind: 'not_real' } },
+            { id: 'op-2', name: 'emit_contexture', status: 'non_op', result: { emitted: [] } },
+          ],
+          summary: 'Agent applied 1 model change',
+        },
+      ],
+    });
+    const { history, warnings } = loadChatHistory(raw);
+
+    expect(history.messages).toHaveLength(1);
+    expect(history.agentTurns?.[0]?.before).toBeUndefined();
+    expect(history.agentTurns?.[0]?.after).toEqual({ version: '1', types: [] });
+    expect(history.agentTurns?.[0]?.ops).toEqual([
+      expect.objectContaining({ id: 'op-1', name: 'add_type', status: 'applied' }),
+      expect.objectContaining({ id: 'op-2', name: 'emit_contexture', status: 'non_op' }),
+    ]);
+    expect(history.agentTurns?.[0]?.ops[0]?.op).toBeUndefined();
+    expect(warnings).toEqual([]);
+  });
+
   it('ignores unknown sidecar fields', () => {
     const raw = JSON.stringify({
       version: '1',

--- a/apps/desktop/tests/model/chat-history.test.ts
+++ b/apps/desktop/tests/model/chat-history.test.ts
@@ -55,6 +55,38 @@ describe('chat history sidecar', () => {
     expect(warnings).toEqual([]);
   });
 
+  it('round-trips agent turn records', () => {
+    const history = {
+      version: '1' as const,
+      messages: [{ id: 'm1', role: 'user' as const, content: 'add Plot', createdAt: 1 }],
+      agentTurns: [
+        {
+          id: 'turn-1',
+          status: 'committed' as const,
+          startedAt: '2026-05-29T09:00:00.000Z',
+          finishedAt: '2026-05-29T09:00:01.000Z',
+          ops: [
+            {
+              id: 'op-1',
+              name: 'add_type',
+              status: 'applied' as const,
+              op: {
+                kind: 'add_type' as const,
+                type: { kind: 'object' as const, name: 'Plot', fields: [] },
+              },
+            },
+          ],
+          summary: 'Agent applied 1 model change',
+        },
+      ],
+    };
+    const raw = saveChatHistory(history);
+    const { history: round, warnings } = loadChatHistory(raw);
+
+    expect(round).toEqual(history);
+    expect(warnings).toEqual([]);
+  });
+
   it('ignores unknown sidecar fields', () => {
     const raw = JSON.stringify({
       version: '1',

--- a/docs/goals/04-agent-collaborator-with-oversight.md
+++ b/docs/goals/04-agent-collaborator-with-oversight.md
@@ -32,11 +32,40 @@ This is the difference between AI-assisted modeling and a chatbot that edits fil
 - Surface successful, rejected, and pending changes clearly.
 - Integrate agent changes with undo, reconcile, sync, and drift.
 
+## Current Baseline
+
+Contexture already has the foundations this goal depends on:
+
+- a closed-world op vocabulary shared by the UI, chat, CLI, and MCP paths
+- structural and semantic validation inside the shared op applier
+- provider-neutral schema-agent runtime adapters for Codex and Claude
+- whole-turn undo transactions for schema-agent tool calls
+- change-log storage and a Changes panel with raw-entry inspection
+- provider thread desync signaling
+- MCP tools for inspecting, validating, applying ops, emitting, and checking drift
+- reconcile and generated-drift flows that already preserve the IR as source of truth
+
+Goal 4 should therefore not create a second mutation or review system. It should
+promote these primitives into a durable, user-facing agent-turn oversight
+workflow.
+
 ## Key Work
+
+### Agent Turn Ledger
+
+- Add a durable agent-turn record that groups attempted ops, applied ops,
+  rejected ops, assistant output, provider/thread metadata, and final turn state.
+- Link each turn record to the undo transaction that landed its successful ops.
+- Store enough before/after hash context to prove which model snapshot the turn
+  started from and where it ended.
+- Preserve raw tool inputs/results for debugging while also producing readable
+  summaries for normal review.
+- Treat turns with no model changes as valid review units when they explain,
+  inspect, emit, or check drift.
 
 ### Operation-Centered Turns
 
-- Record every agent-applied op in a readable change log.
+- Record every agent-applied or rejected op in a readable turn ledger.
 - Group multiple ops into one agent turn.
 - Show user-facing summaries such as:
   - added `Release`
@@ -47,7 +76,8 @@ This is the difference between AI-assisted modeling and a chatbot that edits fil
 
 ### Review And Undo
 
-- Let users undo a whole agent turn.
+- Build on the existing whole-turn undo transaction so users can undo a whole
+  agent turn.
 - Consider before/after review for larger multi-op turns.
 - Show which ops succeeded and which were rejected.
 - Explain validation failures in terms both the user and agent can act on.
@@ -106,10 +136,35 @@ This is the difference between AI-assisted modeling and a chatbot that edits fil
 
 - Existing schema-agent provider runtime.
 - Existing op applier and semantic gate.
+- Existing whole-turn undo transaction boundary.
+- Existing change log and Changes panel.
 - Existing chat history and provider thread concepts.
 - Model authoring improvements that make ops map cleanly to visible model concepts.
 - Reconcile and drift flows for generated output review.
 
 ## Priority
 
-High. This becomes most valuable once Convex-first authoring and reconcile workflows are strong.
+High. The first implementation priority is a durable agent-turn ledger that
+captures attempted ops, applied ops, rejected ops, generated artifact actions,
+drift checks, assistant text, provider/thread metadata, and undo linkage as one
+reviewable unit.
+
+## Implementation Status
+
+Implemented in the desktop schema-agent workflow:
+
+- Durable agent-turn records are captured, persisted with chat history, and
+  restored when switching file-backed threads.
+- Each turn records provider/model metadata, assistant text, attempted tool
+  calls, applied/rejected op results, before/after schema snapshots, and
+  deterministic snapshot hashes.
+- The chat transcript shows the latest turn as a reviewable unit with applied,
+  rejected, and pending counts.
+- Hover/focus review shows readable operation rows, validation failures, a
+  schema diff summary, and the raw turn record for debugging.
+- Committed turns with applied ops expose whole-turn undo through the existing
+  schema-agent undo transaction.
+- Provider threads are marked desynced when non-agent model edits happen under
+  an active provider thread.
+- Generated emit and drift-check tool results are treated as no-model-change
+  turn actions when they appear in the provider tool stream.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./agent-turn-ledger": "./src/agent-turn-ledger.ts",
     "./change-log": "./src/change-log.ts",
     "./emit-ai-tool-schemas": "./src/emit-ai-tool-schemas.ts",
     "./emit-convex": "./src/emit-convex.ts",

--- a/packages/core/src/agent-turn-ledger.ts
+++ b/packages/core/src/agent-turn-ledger.ts
@@ -1,0 +1,307 @@
+import type { IndexDef, Schema, TypeDef } from './ir';
+import type { Op } from './ops';
+
+export type AgentTurnStatus = 'running' | 'committed' | 'rolled_back';
+
+export interface AgentTurnOpResult {
+  id: string;
+  name: string;
+  op?: Op;
+  input?: unknown;
+  status: 'pending' | 'applied' | 'rejected' | 'non_op';
+  error?: string;
+  result?: unknown;
+}
+
+export interface AgentTurnRecord {
+  id: string;
+  status: AgentTurnStatus;
+  startedAt: string;
+  finishedAt?: string;
+  userMessage?: string;
+  assistantText?: string;
+  provider?: string;
+  model?: string;
+  providerThreadRef?: unknown;
+  beforeHash?: string;
+  afterHash?: string;
+  before?: Schema;
+  after?: Schema;
+  ops: AgentTurnOpResult[];
+  summary: string;
+}
+
+export interface BuildAgentTurnSummaryInput {
+  status: AgentTurnStatus;
+  ops: Array<{ status: AgentTurnOpResult['status']; name?: string; result?: unknown }>;
+}
+
+export interface AgentTurnSchemaDiff {
+  addedTypes: string[];
+  removedTypes: string[];
+  changedTypes: string[];
+  addedFields: string[];
+  removedFields: string[];
+  changedFields: string[];
+  addedIndexes: string[];
+  removedIndexes: string[];
+  changedIndexes: string[];
+  importChanged: boolean;
+  outputChanged: boolean;
+}
+
+export function describeAgentTurnOp(op: Pick<AgentTurnOpResult, 'name' | 'op'>): string {
+  if (!op.op) return op.name;
+  switch (op.op.kind) {
+    case 'add_type':
+      return `Added ${op.op.type.name}`;
+    case 'update_type':
+      return `Updated ${op.op.name}`;
+    case 'rename_type':
+      return `Renamed ${op.op.from} to ${op.op.to}`;
+    case 'delete_type':
+      return `Deleted ${op.op.name}`;
+    case 'add_field':
+      return `Added field ${op.op.typeName}.${op.op.field.name}`;
+    case 'update_field':
+      return `Updated field ${op.op.typeName}.${op.op.fieldName}`;
+    case 'remove_field':
+      return `Removed field ${op.op.typeName}.${op.op.fieldName}`;
+    case 'add_value':
+      return `Added value ${op.op.typeName}.${op.op.value}`;
+    case 'update_value':
+      return `Updated value ${op.op.typeName}.${op.op.value}`;
+    case 'remove_value':
+      return `Removed value ${op.op.typeName}.${op.op.value}`;
+    case 'reorder_fields':
+      return `Reordered fields on ${op.op.typeName}`;
+    case 'add_variant':
+      return `Added variant ${op.op.typeName}.${op.op.variant}`;
+    case 'remove_variant':
+      return `Removed variant ${op.op.typeName}.${op.op.variant}`;
+    case 'set_discriminator':
+      return `Set discriminator on ${op.op.typeName}`;
+    case 'add_import':
+      return `Added import ${op.op.import.alias}`;
+    case 'remove_import':
+      return `Removed import ${op.op.alias}`;
+    case 'remove_import_at':
+      return `Removed import at ${op.op.index}`;
+    case 'set_table_flag':
+      return op.op.table
+        ? `Marked ${op.op.typeName} as table`
+        : `Unmarked ${op.op.typeName} as table`;
+    case 'add_index':
+      return `Added index ${op.op.typeName}.${op.op.index.name}`;
+    case 'remove_index':
+      return `Removed index ${op.op.typeName}.${op.op.name}`;
+    case 'update_index':
+      return `Updated index ${op.op.typeName}.${op.op.name}`;
+    case 'replace_schema':
+      return 'Replaced schema';
+  }
+}
+
+export function buildAgentTurnSummary(input: BuildAgentTurnSummaryInput): string {
+  const attempted = input.ops.filter((op) => op.status !== 'non_op').length;
+  const applied = input.ops.filter((op) => op.status === 'applied').length;
+  const rejected = input.ops.filter((op) => op.status === 'rejected').length;
+  const pending = input.ops.filter((op) => op.status === 'pending').length;
+  const nonOpSummaries = summarizeNonOpTools(input.ops);
+
+  if (attempted === 0) {
+    if (input.status === 'running') return 'Agent is working on your request';
+    if (input.status === 'rolled_back') return 'Agent turn rolled back with no model changes';
+    if (nonOpSummaries.length > 0) return `Agent ${joinSummaryList(nonOpSummaries)}`;
+    return 'Agent turn completed with no model changes';
+  }
+
+  const proposed = attempted === 1 ? '1 model change' : `${attempted} model changes`;
+  if (input.status === 'running') {
+    return `Agent is working on ${proposed}: ${applied} applied, ${rejected} rejected, ${pending} pending`;
+  }
+  if (input.status === 'rolled_back') {
+    return applied === 1
+      ? 'Agent turn undone: 1 model change rolled back'
+      : `Agent turn undone: ${applied} model changes rolled back`;
+  }
+  if (rejected === 0) {
+    return applied === 1
+      ? 'Agent applied 1 model change'
+      : `Agent applied ${applied} model changes`;
+  }
+  return `Agent proposed ${proposed}: ${applied} applied, ${rejected} rejected`;
+}
+
+export function diffAgentTurnSchema(before?: Schema, after?: Schema): AgentTurnSchemaDiff {
+  const diff: AgentTurnSchemaDiff = {
+    addedTypes: [],
+    removedTypes: [],
+    changedTypes: [],
+    addedFields: [],
+    removedFields: [],
+    changedFields: [],
+    addedIndexes: [],
+    removedIndexes: [],
+    changedIndexes: [],
+    importChanged: false,
+    outputChanged: false,
+  };
+  if (!before || !after) return diff;
+
+  const beforeTypes = byName(before.types);
+  const afterTypes = byName(after.types);
+  for (const name of afterTypes.keys()) {
+    if (!beforeTypes.has(name)) diff.addedTypes.push(name);
+  }
+  for (const name of beforeTypes.keys()) {
+    if (!afterTypes.has(name)) diff.removedTypes.push(name);
+  }
+  for (const [name, beforeType] of beforeTypes) {
+    const afterType = afterTypes.get(name);
+    if (!afterType) continue;
+    diffType(name, beforeType, afterType, diff);
+  }
+
+  diff.importChanged = stableJson(before.imports ?? []) !== stableJson(after.imports ?? []);
+  diff.outputChanged = stableJson(before.outputs ?? {}) !== stableJson(after.outputs ?? {});
+  return sortDiff(diff);
+}
+
+export function summarizeAgentTurnSchemaDiff(diff: AgentTurnSchemaDiff): string[] {
+  const rows: string[] = [];
+  rows.push(...diff.addedTypes.map((name) => `Added type ${name}`));
+  rows.push(...diff.removedTypes.map((name) => `Removed type ${name}`));
+  rows.push(...diff.changedTypes.map((name) => `Changed type ${name}`));
+  rows.push(...diff.addedFields.map((name) => `Added field ${name}`));
+  rows.push(...diff.removedFields.map((name) => `Removed field ${name}`));
+  rows.push(...diff.changedFields.map((name) => `Changed field ${name}`));
+  rows.push(...diff.addedIndexes.map((name) => `Added index ${name}`));
+  rows.push(...diff.removedIndexes.map((name) => `Removed index ${name}`));
+  rows.push(...diff.changedIndexes.map((name) => `Changed index ${name}`));
+  if (diff.importChanged) rows.push('Changed imports');
+  if (diff.outputChanged) rows.push('Changed outputs');
+  return rows;
+}
+
+export function hashAgentTurnSchema(schema: Schema | undefined): string | undefined {
+  if (!schema) return undefined;
+  let hash = 0x811c9dc5;
+  const text = stableJson(schema);
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `fnv1a32:${(hash >>> 0).toString(16).padStart(8, '0')}`;
+}
+
+function diffType(
+  name: string,
+  beforeType: TypeDef,
+  afterType: TypeDef,
+  diff: AgentTurnSchemaDiff,
+): void {
+  if (beforeType.kind !== afterType.kind) {
+    diff.changedTypes.push(name);
+    return;
+  }
+  const beforeRest = stripTypeChildren(beforeType);
+  const afterRest = stripTypeChildren(afterType);
+  if (stableJson(beforeRest) !== stableJson(afterRest)) diff.changedTypes.push(name);
+
+  if (beforeType.kind === 'object' && afterType.kind === 'object') {
+    diffNamedChildren(
+      name,
+      beforeType.fields,
+      afterType.fields,
+      diff.addedFields,
+      diff.removedFields,
+      diff.changedFields,
+    );
+    diffNamedChildren(
+      name,
+      beforeType.indexes ?? [],
+      afterType.indexes ?? [],
+      diff.addedIndexes,
+      diff.removedIndexes,
+      diff.changedIndexes,
+    );
+    return;
+  }
+
+  if (stableJson(beforeType) !== stableJson(afterType) && !diff.changedTypes.includes(name)) {
+    diff.changedTypes.push(name);
+  }
+}
+
+function diffNamedChildren<T extends { name: string }>(
+  typeName: string,
+  beforeItems: T[],
+  afterItems: T[],
+  added: string[],
+  removed: string[],
+  changed: string[],
+): void {
+  const beforeByName = byName(beforeItems);
+  const afterByName = byName(afterItems);
+  for (const name of afterByName.keys()) {
+    if (!beforeByName.has(name)) added.push(`${typeName}.${name}`);
+  }
+  for (const name of beforeByName.keys()) {
+    if (!afterByName.has(name)) removed.push(`${typeName}.${name}`);
+  }
+  for (const [name, beforeItem] of beforeByName) {
+    const afterItem = afterByName.get(name);
+    if (afterItem && stableJson(beforeItem) !== stableJson(afterItem)) {
+      changed.push(`${typeName}.${name}`);
+    }
+  }
+}
+
+function stripTypeChildren(type: TypeDef): Omit<TypeDef, 'fields' | 'indexes'> {
+  if (type.kind === 'object') {
+    const { fields: _fields, indexes: _indexes, ...rest } = type;
+    return rest;
+  }
+  return type;
+}
+
+function byName<T extends { name: string } | IndexDef>(items: T[]): Map<string, T> {
+  return new Map(items.map((item) => [item.name, item]));
+}
+
+function sortDiff(diff: AgentTurnSchemaDiff): AgentTurnSchemaDiff {
+  return Object.fromEntries(
+    Object.entries(diff).map(([key, value]) => [key, Array.isArray(value) ? value.sort() : value]),
+  ) as unknown as AgentTurnSchemaDiff;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function summarizeNonOpTools(ops: BuildAgentTurnSummaryInput['ops']): string[] {
+  const completed = ops.filter((op) => op.status === 'non_op');
+  const summaries = new Set<string>();
+  for (const op of completed) {
+    if (op.name === 'emit_contexture') {
+      summaries.add('emitted generated files');
+    } else if (op.name === 'check_contexture_drift') {
+      summaries.add(readDriftClean(op.result) ? 'checked drift: clean' : 'checked drift');
+    }
+  }
+  return [...summaries];
+}
+
+function readDriftClean(result: unknown): boolean {
+  if (!result || typeof result !== 'object') return false;
+  const clean = (result as { clean?: unknown }).clean;
+  return clean === true;
+}
+
+function joinSummaryList(items: string[]): string {
+  const last = items.at(-1);
+  if (!last) return '';
+  if (items.length === 1) return last;
+  return `${items.slice(0, -1).join(', ')} and ${last}`;
+}

--- a/packages/core/src/chat-history.ts
+++ b/packages/core/src/chat-history.ts
@@ -5,7 +5,9 @@
  * discarded with a warning rather than blocking the Contexture IR.
  */
 
-import type { AgentTurnRecord } from './agent-turn-ledger';
+import type { AgentTurnOpResult, AgentTurnRecord } from './agent-turn-ledger';
+import { IRSchema } from './ir';
+import { OpSchema } from './ops';
 
 export type ChatRole = 'user' | 'assistant' | 'system';
 
@@ -144,11 +146,66 @@ function sanitiseAgentTurns(input: unknown): AgentTurnRecord[] {
     ) {
       continue;
     }
-    turns.push(record as unknown as AgentTurnRecord);
+    turns.push({
+      id: record.id,
+      status: record.status,
+      startedAt: record.startedAt,
+      ...(typeof record.finishedAt === 'string' ? { finishedAt: record.finishedAt } : {}),
+      ...(typeof record.userMessage === 'string' ? { userMessage: record.userMessage } : {}),
+      ...(typeof record.assistantText === 'string' ? { assistantText: record.assistantText } : {}),
+      ...(typeof record.provider === 'string' ? { provider: record.provider } : {}),
+      ...(typeof record.model === 'string' ? { model: record.model } : {}),
+      ...(record.providerThreadRef ? { providerThreadRef: record.providerThreadRef } : {}),
+      ...(typeof record.beforeHash === 'string' ? { beforeHash: record.beforeHash } : {}),
+      ...(typeof record.afterHash === 'string' ? { afterHash: record.afterHash } : {}),
+      ...readSchemaField('before', record.before),
+      ...readSchemaField('after', record.after),
+      ops: sanitiseAgentTurnOps(record.ops),
+      summary: record.summary,
+    });
   }
   return turns;
 }
 
-function isAgentTurnStatus(value: unknown): boolean {
+function sanitiseAgentTurnOps(input: unknown): AgentTurnOpResult[] {
+  if (!Array.isArray(input)) return [];
+  const ops: AgentTurnOpResult[] = [];
+  for (const value of input) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const record = value as Record<string, unknown>;
+    if (
+      typeof record.id !== 'string' ||
+      typeof record.name !== 'string' ||
+      !isAgentTurnOpStatus(record.status)
+    ) {
+      continue;
+    }
+    const parsedOp = OpSchema.safeParse(record.op);
+    ops.push({
+      id: record.id,
+      name: record.name,
+      status: record.status,
+      ...(record.input !== undefined ? { input: record.input } : {}),
+      ...(parsedOp.success ? { op: parsedOp.data } : {}),
+      ...(typeof record.error === 'string' ? { error: record.error } : {}),
+      ...(record.result !== undefined ? { result: record.result } : {}),
+    });
+  }
+  return ops;
+}
+
+function readSchemaField(
+  key: 'before' | 'after',
+  value: unknown,
+): Partial<Pick<AgentTurnRecord, 'before' | 'after'>> {
+  const parsed = IRSchema.safeParse(value);
+  return parsed.success ? { [key]: parsed.data } : {};
+}
+
+function isAgentTurnStatus(value: unknown): value is AgentTurnRecord['status'] {
   return value === 'running' || value === 'committed' || value === 'rolled_back';
+}
+
+function isAgentTurnOpStatus(value: unknown): value is AgentTurnOpResult['status'] {
+  return value === 'pending' || value === 'applied' || value === 'rejected' || value === 'non_op';
 }

--- a/packages/core/src/chat-history.ts
+++ b/packages/core/src/chat-history.ts
@@ -5,6 +5,8 @@
  * discarded with a warning rather than blocking the Contexture IR.
  */
 
+import type { AgentTurnRecord } from './agent-turn-ledger';
+
 export type ChatRole = 'user' | 'assistant' | 'system';
 
 export interface ChatMessage {
@@ -22,6 +24,7 @@ export interface ChatHistory {
   model?: string;
   effort?: string;
   modelOptions?: Record<string, string | boolean>;
+  agentTurns?: AgentTurnRecord[];
 }
 
 export interface LoadChatHistoryResult {
@@ -75,6 +78,7 @@ export function loadChatHistory(raw: string): LoadChatHistoryResult {
   const model = typeof obj.model === 'string' ? obj.model : undefined;
   const effort = typeof obj.effort === 'string' ? obj.effort : undefined;
   const modelOptions = sanitiseModelOptions(obj.modelOptions);
+  const agentTurns = sanitiseAgentTurns(obj.agentTurns);
   return {
     history: {
       version: CHAT_HISTORY_VERSION,
@@ -84,6 +88,7 @@ export function loadChatHistory(raw: string): LoadChatHistoryResult {
       ...(model ? { model } : {}),
       ...(effort ? { effort } : {}),
       ...(modelOptions ? { modelOptions } : {}),
+      ...(agentTurns.length > 0 ? { agentTurns } : {}),
     },
     warnings: [],
   };
@@ -122,4 +127,28 @@ function sanitiseModelOptions(input: unknown): Record<string, string | boolean> 
       typeof entry[1] === 'string' || typeof entry[1] === 'boolean',
   );
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function sanitiseAgentTurns(input: unknown): AgentTurnRecord[] {
+  if (!Array.isArray(input)) return [];
+  const turns: AgentTurnRecord[] = [];
+  for (const value of input) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const record = value as Record<string, unknown>;
+    if (
+      typeof record.id !== 'string' ||
+      !isAgentTurnStatus(record.status) ||
+      typeof record.startedAt !== 'string' ||
+      !Array.isArray(record.ops) ||
+      typeof record.summary !== 'string'
+    ) {
+      continue;
+    }
+    turns.push(record as unknown as AgentTurnRecord);
+  }
+  return turns;
+}
+
+function isAgentTurnStatus(value: unknown): boolean {
+  return value === 'running' || value === 'committed' || value === 'rolled_back';
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './agent-turn-ledger';
 export * from './change-log';
 export * from './chat-history';
 export * from './document-bundle';

--- a/packages/core/tests/agent-turn-ledger.test.ts
+++ b/packages/core/tests/agent-turn-ledger.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'vitest';
+import {
+  buildAgentTurnSummary,
+  describeAgentTurnOp,
+  diffAgentTurnSchema,
+  hashAgentTurnSchema,
+  summarizeAgentTurnSchemaDiff,
+} from '../src/agent-turn-ledger';
+
+describe('buildAgentTurnSummary', () => {
+  test('describes a running turn with no ops as in progress', () => {
+    expect(buildAgentTurnSummary({ status: 'running', ops: [] })).toBe(
+      'Agent is working on your request',
+    );
+  });
+
+  test('describes pending ops without implying completion', () => {
+    expect(
+      buildAgentTurnSummary({
+        status: 'running',
+        ops: [{ status: 'pending' }],
+      }),
+    ).toBe('Agent is working on 1 model change: 0 applied, 0 rejected, 1 pending');
+  });
+
+  test('keeps completed no-op turns distinct from running turns', () => {
+    expect(buildAgentTurnSummary({ status: 'committed', ops: [] })).toBe(
+      'Agent turn completed with no model changes',
+    );
+  });
+
+  test('describes undone turns as rolled back', () => {
+    expect(
+      buildAgentTurnSummary({
+        status: 'rolled_back',
+        ops: [{ status: 'applied' }],
+      }),
+    ).toBe('Agent turn undone: 1 model change rolled back');
+  });
+
+  test('describes common ops in user-facing language', () => {
+    expect(
+      describeAgentTurnOp({
+        name: 'add_field',
+        op: {
+          kind: 'add_field',
+          typeName: 'Release',
+          field: { name: 'discogsReleaseId', type: { kind: 'string' } },
+        },
+      }),
+    ).toBe('Added field Release.discogsReleaseId');
+  });
+
+  test('describes completed generated/drift tool turns', () => {
+    expect(
+      buildAgentTurnSummary({
+        status: 'committed',
+        ops: [
+          { name: 'emit_contexture', status: 'non_op', result: { emitted: ['convex/schema.ts'] } },
+          { name: 'check_contexture_drift', status: 'non_op', result: { clean: true } },
+        ],
+      }),
+    ).toBe('Agent emitted generated files and checked drift: clean');
+  });
+});
+
+describe('diffAgentTurnSchema', () => {
+  test('summarizes type, field, and index changes from turn snapshots', () => {
+    const rows = summarizeAgentTurnSchemaDiff(
+      diffAgentTurnSchema(
+        {
+          version: '1',
+          types: [
+            {
+              kind: 'object',
+              name: 'Release',
+              fields: [{ name: 'title', type: { kind: 'string' } }],
+              table: true,
+            },
+          ],
+        },
+        {
+          version: '1',
+          types: [
+            {
+              kind: 'object',
+              name: 'Release',
+              fields: [
+                { name: 'title', type: { kind: 'string' } },
+                { name: 'discogsReleaseId', type: { kind: 'string' } },
+              ],
+              table: true,
+              indexes: [{ name: 'byDiscogsId', fields: ['discogsReleaseId'] }],
+            },
+            { kind: 'enum', name: 'Format', values: [{ value: 'LP' }] },
+          ],
+        },
+      ),
+    );
+
+    expect(rows).toEqual([
+      'Added type Format',
+      'Added field Release.discogsReleaseId',
+      'Added index Release.byDiscogsId',
+    ]);
+  });
+});
+
+describe('hashAgentTurnSchema', () => {
+  test('returns a stable browser-safe snapshot hash', () => {
+    expect(hashAgentTurnSchema({ version: '1', types: [] })).toBe(
+      hashAgentTurnSchema({ version: '1', types: [] }),
+    );
+    expect(hashAgentTurnSchema(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a durable agent turn ledger for schema-agent turns with applied, rejected, pending, and non-op tool actions
- surface reviewable chat receipts with schema diffs, raw turn inspection, and whole-turn undo state
- persist agent turns with chat history and mark provider threads stale after non-agent model edits

## Verification
- pre-commit hook ran `turbo typecheck` successfully
- pre-commit hook ran `turbo test` successfully
- previously verified desktop build and launch e2e during implementation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782635751&installation_id=136251083&pr_number=329&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F329&signature=a79d3d4bdd45b7bb6069bc5494703c7d1e281ac446046c220c22d8ec48e99f82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->