### PR TITLE
Polish agent change indicators

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.21",
+  "version": "0.15.22",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -52,6 +52,7 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Streamdown } from 'streamdown';
+import { BorderBeam } from '@/components/ui/border-beam';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -144,6 +145,8 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   } = history;
 
   const [input, setInput] = useState('');
+  const [responsePending, setResponsePending] = useState(false);
+  const isWaitingForFinalResponse = responsePending || isStreaming;
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // Snapshot the last-persisted messages so we don't re-write the
@@ -221,6 +224,10 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     if (!desynced || !activeThreadId) return;
     markThreadDesynced(activeThreadId);
   }, [desynced, activeThreadId, markThreadDesynced]);
+
+  useEffect(() => {
+    if (!isStreaming) setResponsePending(false);
+  }, [isStreaming]);
 
   const messageCount = messages.length;
   useEffect(() => {
@@ -315,7 +322,12 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       const text = input.trim();
       if (!text || !canCompose) return;
       setInput('');
-      await send(text);
+      setResponsePending(true);
+      try {
+        await send(text);
+      } finally {
+        setResponsePending(false);
+      }
     },
     [canCompose, input, send],
   );
@@ -431,7 +443,12 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
               </button>
             </div>
           )}
-          {recentAgentTurn && <AgentTurnSummaryCard turn={recentAgentTurn} />}
+          {recentAgentTurn && (
+            <AgentTurnSummaryCard
+              turn={recentAgentTurn}
+              isWaitingForFinalResponse={isWaitingForFinalResponse}
+            />
+          )}
           <div ref={messagesEndRef} />
         </div>
       )}
@@ -574,7 +591,13 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   );
 }
 
-function AgentTurnSummaryCard({ turn }: { turn: AgentTurnRecord }): React.JSX.Element {
+function AgentTurnSummaryCard({
+  turn,
+  isWaitingForFinalResponse,
+}: {
+  turn: AgentTurnRecord;
+  isWaitingForFinalResponse: boolean;
+}): React.JSX.Element {
   const applied = turn.ops.filter((op) => op.status === 'applied').length;
   const rejected = turn.ops.filter((op) => op.status === 'rejected').length;
   const pending =
@@ -601,9 +624,13 @@ function AgentTurnSummaryCard({ turn }: { turn: AgentTurnRecord }): React.JSX.El
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="w-full rounded-md border border-border/70 bg-card/70 px-2.5 py-2 text-left text-xs text-muted-foreground shadow-sm transition-colors hover:border-primary/30 hover:bg-accent/50 focus:outline-none focus:ring-1 focus:ring-ring"
+          className={cn(
+            'relative w-full overflow-hidden rounded-md border border-border/70 bg-card/70 px-2.5 py-2 text-left text-xs text-muted-foreground shadow-sm transition-colors',
+            'hover:border-primary/30 hover:bg-accent/50 focus:outline-none focus:ring-1 focus:ring-ring',
+          )}
           data-testid="agent-turn-summary"
         >
+          {isWaitingForFinalResponse && <BorderBeam duration={6} size={100} />}
           <div className="flex items-center justify-between gap-2">
             <div className="min-w-0">
               <div className="truncate font-medium text-foreground">{turn.summary}</div>

--- a/apps/desktop/src/renderer/src/components/toolbar/GraphSearchBar.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphSearchBar.tsx
@@ -15,25 +15,18 @@ import { useGraphLayoutStore } from '@renderer/store/layout-config';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { useUndoStore } from '@renderer/store/undo';
 import { Search, X } from 'lucide-react';
-import type { CSSProperties } from 'react';
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { TypeKindBadge, type TypeKindLabel } from './type-kind-badge';
+import { TypeKindIcon } from './type-kind-icon';
 
 interface Result {
   name: string;
   focusName: string;
   matchType: 'name' | 'description' | 'enum';
-  kindLabel: 'object' | 'table' | 'enum' | 'union' | 'raw';
+  kindLabel: TypeKindLabel;
   focusFieldName?: string;
   detail?: string;
 }
-
-const KIND_BADGE_STYLES: Record<Result['kindLabel'], CSSProperties> = {
-  object: badgeStyle('var(--graph-node-header-bg)'),
-  table: badgeStyle('var(--graph-node-table-accent)'),
-  enum: badgeStyle('var(--chart-3)'),
-  union: badgeStyle('var(--graph-edge-union)'),
-  raw: badgeStyle('var(--muted-foreground)'),
-};
 
 export function GraphSearchBar(): React.JSX.Element {
   const [query, setQuery] = useState('');
@@ -187,25 +180,15 @@ export function GraphSearchBar(): React.JSX.Element {
               key={`${r.name}-${r.focusName}-${r.detail ?? r.matchType}`}
               onMouseDown={(e) => e.preventDefault()}
               onClick={() => pick(r)}
-              className={`flex w-full min-w-0 items-baseline gap-1.5 px-3 py-1.5 text-left text-xs transition-colors ${
+              className={`flex w-full min-w-0 items-center gap-1.5 px-3 py-1.5 text-left text-xs transition-colors ${
                 i === activeIndex
                   ? 'bg-secondary text-foreground'
                   : 'text-foreground hover:bg-secondary/60'
               }`}
             >
+              <TypeKindIcon kind={r.kindLabel} />
               <span className="min-w-0 flex-1 truncate">{r.name}</span>
-              <span
-                className="shrink-0 rounded border px-1.5 py-0 text-[9px] font-medium uppercase tracking-wide"
-                style={KIND_BADGE_STYLES[r.kindLabel]}
-                title={r.detail}
-              >
-                {r.kindLabel}
-              </span>
-              {r.matchType === 'description' && (
-                <span className="shrink min-w-0 truncate text-muted-foreground/60">
-                  (in description)
-                </span>
-              )}
+              <TypeKindBadge kind={r.kindLabel} title={r.detail} />
             </button>
           ))}
         </div>
@@ -223,16 +206,8 @@ function unwrapRefTarget(t: FieldType): string | undefined {
 function kindLabel(type: {
   kind: 'object' | 'enum' | 'discriminatedUnion' | 'raw';
   table?: boolean;
-}): Result['kindLabel'] {
+}): TypeKindLabel {
   if (type.kind === 'object') return type.table ? 'table' : 'object';
   if (type.kind === 'discriminatedUnion') return 'union';
   return type.kind;
-}
-
-function badgeStyle(color: string): CSSProperties {
-  return {
-    background: `color-mix(in oklch, ${color} 12%, transparent)`,
-    borderColor: `color-mix(in oklch, ${color} 42%, var(--border))`,
-    color: `color-mix(in oklch, ${color} 70%, var(--foreground))`,
-  };
 }

--- a/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
@@ -11,18 +11,7 @@ import {
   useSchemaAgentSettingsStore,
 } from '@renderer/store/schema-agent-settings';
 import { useUIChromeStore } from '@renderer/store/ui-chrome';
-import {
-  Bot,
-  Box,
-  ChevronDown,
-  GitBranch,
-  ListChecks,
-  Moon,
-  PanelRight,
-  Plus,
-  Sun,
-  Table2,
-} from 'lucide-react';
+import { Bot, ChevronDown, Moon, PanelRight, Plus, Sun } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -31,6 +20,8 @@ import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 import type { CreateTypeKind } from '../graph/interactions';
 import { GraphSearchBar } from './GraphSearchBar';
+import { TypeKindBadge, type TypeKindLabel } from './type-kind-badge';
+import { TypeKindIcon } from './type-kind-icon';
 
 interface ToolbarProps {
   onCreateType?: (kind: CreateTypeKind) => void;
@@ -151,26 +142,10 @@ export function Toolbar({ onCreateType }: ToolbarProps): React.JSX.Element {
             </Button>
           </PopoverTrigger>
           <PopoverContent className="w-48 p-1" align="end">
-            <CreateTypeButton
-              icon={<Table2 className="size-4" />}
-              label="Table"
-              onClick={() => onCreateType('table')}
-            />
-            <CreateTypeButton
-              icon={<Box className="size-4" />}
-              label="Object"
-              onClick={() => onCreateType('object')}
-            />
-            <CreateTypeButton
-              icon={<ListChecks className="size-4" />}
-              label="Enum"
-              onClick={() => onCreateType('enum')}
-            />
-            <CreateTypeButton
-              icon={<GitBranch className="size-4" />}
-              label="Union"
-              onClick={() => onCreateType('union')}
-            />
+            <CreateTypeButton kind="table" label="Table" onClick={() => onCreateType('table')} />
+            <CreateTypeButton kind="object" label="Object" onClick={() => onCreateType('object')} />
+            <CreateTypeButton kind="enum" label="Enum" onClick={() => onCreateType('enum')} />
+            <CreateTypeButton kind="union" label="Union" onClick={() => onCreateType('union')} />
           </PopoverContent>
         </Popover>
       )}
@@ -296,11 +271,11 @@ export function Toolbar({ onCreateType }: ToolbarProps): React.JSX.Element {
 }
 
 function CreateTypeButton({
-  icon,
+  kind,
   label,
   onClick,
 }: {
-  icon: React.ReactNode;
+  kind: TypeKindLabel;
   label: string;
   onClick: () => void;
 }): React.JSX.Element {
@@ -308,11 +283,12 @@ function CreateTypeButton({
     <Button
       type="button"
       variant="ghost"
+      aria-label={label}
       className="h-8 w-full justify-start gap-2 px-2 text-xs"
       onClick={onClick}
     >
-      {icon}
-      {label}
+      <TypeKindIcon kind={kind} />
+      <TypeKindBadge kind={kind} title={label} />
     </Button>
   );
 }

--- a/apps/desktop/src/renderer/src/components/toolbar/type-kind-badge.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/type-kind-badge.tsx
@@ -1,0 +1,37 @@
+import type { CSSProperties } from 'react';
+
+export type TypeKindLabel = 'object' | 'table' | 'enum' | 'union' | 'raw';
+
+const KIND_BADGE_STYLES: Record<TypeKindLabel, CSSProperties> = {
+  object: badgeStyle('var(--graph-node-header-bg)'),
+  table: badgeStyle('var(--graph-node-table-accent)'),
+  enum: badgeStyle('var(--chart-3)'),
+  union: badgeStyle('var(--graph-edge-union)'),
+  raw: badgeStyle('var(--muted-foreground)'),
+};
+
+export function TypeKindBadge({
+  kind,
+  title,
+}: {
+  kind: TypeKindLabel;
+  title?: string;
+}): React.JSX.Element {
+  return (
+    <span
+      className="shrink-0 rounded border px-1.5 py-0 text-[9px] font-medium uppercase tracking-wide"
+      style={KIND_BADGE_STYLES[kind]}
+      title={title}
+    >
+      {kind}
+    </span>
+  );
+}
+
+function badgeStyle(color: string): CSSProperties {
+  return {
+    background: `color-mix(in oklch, ${color} 12%, transparent)`,
+    borderColor: `color-mix(in oklch, ${color} 42%, var(--border))`,
+    color: `color-mix(in oklch, ${color} 70%, var(--foreground))`,
+  };
+}

--- a/apps/desktop/src/renderer/src/components/toolbar/type-kind-icon.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/type-kind-icon.tsx
@@ -1,0 +1,12 @@
+import { Box, GitBranch, ListChecks, Table2 } from 'lucide-react';
+import type { TypeKindLabel } from './type-kind-badge';
+
+export function TypeKindIcon({ kind }: { kind: TypeKindLabel }): React.JSX.Element | null {
+  const className = 'size-4 shrink-0 text-muted-foreground';
+
+  if (kind === 'table') return <Table2 className={className} aria-hidden="true" />;
+  if (kind === 'object') return <Box className={className} aria-hidden="true" />;
+  if (kind === 'enum') return <ListChecks className={className} aria-hidden="true" />;
+  if (kind === 'union') return <GitBranch className={className} aria-hidden="true" />;
+  return null;
+}

--- a/apps/desktop/src/renderer/src/components/ui/border-beam.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/border-beam.tsx
@@ -1,0 +1,73 @@
+import { type MotionStyle, motion, type Transition } from 'motion/react';
+import type { CSSProperties } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface BorderBeamProps {
+  size?: number;
+  duration?: number;
+  delay?: number;
+  colorFrom?: string;
+  colorTo?: string;
+  transition?: Transition;
+  className?: string;
+  style?: CSSProperties;
+  reverse?: boolean;
+  initialOffset?: number;
+  borderWidth?: number;
+}
+
+export function BorderBeam({
+  className,
+  size = 50,
+  delay = 0,
+  duration = 6,
+  colorFrom = '#ffaa40',
+  colorTo = '#9c40ff',
+  transition,
+  style,
+  reverse = false,
+  initialOffset = 0,
+  borderWidth = 1,
+}: BorderBeamProps): React.JSX.Element {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 rounded-[inherit] border-(length:--border-beam-width) border-transparent mask-[linear-gradient(transparent,transparent),linear-gradient(#000,#000)] mask-intersect [mask-clip:padding-box,border-box]"
+      style={
+        {
+          '--border-beam-width': `${borderWidth}px`,
+        } as CSSProperties
+      }
+    >
+      <motion.div
+        className={cn(
+          'absolute aspect-square',
+          'bg-linear-to-l from-(--color-from) via-(--color-to) to-transparent',
+          className,
+        )}
+        style={
+          {
+            width: size,
+            offsetPath: `rect(0 auto auto 0 round ${size}px)`,
+            '--color-from': colorFrom,
+            '--color-to': colorTo,
+            ...style,
+          } as MotionStyle
+        }
+        initial={{ offsetDistance: `${initialOffset}%` }}
+        animate={{
+          offsetDistance: reverse
+            ? [`${100 - initialOffset}%`, `${-initialOffset}%`]
+            : [`${initialOffset}%`, `${100 + initialOffset}%`],
+        }}
+        transition={{
+          repeat: Infinity,
+          ease: 'linear',
+          duration,
+          delay: -delay,
+          ...transition,
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/tests/components/chat/ChatPanel.test.tsx
+++ b/apps/desktop/tests/components/chat/ChatPanel.test.tsx
@@ -181,6 +181,62 @@ describe('ChatPanel', () => {
     expect(screen.queryByText('Undo turn')).not.toBeInTheDocument();
   });
 
+  it('highlights an applied agent turn while the final response is pending', () => {
+    useAgentTurnsStore.getState().begin({
+      before: { version: '1', types: [] },
+      userMessage: 'add a Plot type',
+      provider: 'codex',
+      model: 'gpt-5.4',
+    });
+    useAgentTurnsStore.getState().recordToolResult({
+      id: '1',
+      op: { kind: 'add_type', type: { kind: 'object', name: 'Plot', fields: [] } },
+      result: { schema: { version: '1', types: [{ kind: 'object', name: 'Plot', fields: [] }] } },
+    });
+
+    render(<ChatPanel chat={makeChat({ isStreaming: true })} />);
+
+    expect(screen.getByTestId('agent-turn-summary').querySelector('[aria-hidden="true"]')).not.toBe(
+      null,
+    );
+  });
+
+  it('highlights the agent turn from Enter submit until send completes', async () => {
+    let resolveSend: () => void = () => undefined;
+    const send = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = resolve;
+        }),
+    );
+    useAgentTurnsStore.getState().begin({
+      before: { version: '1', types: [] },
+      userMessage: 'add a Plot type',
+      provider: 'codex',
+      model: 'gpt-5.4',
+    });
+
+    render(<ChatPanel chat={makeChat({ send })} />);
+
+    const textarea = screen.getByTestId('chat-input');
+    fireEvent.change(textarea, { target: { value: 'add a Plot type' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('agent-turn-summary').querySelector('[aria-hidden="true"]'),
+      ).not.toBe(null),
+    );
+
+    resolveSend();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('agent-turn-summary').querySelector('[aria-hidden="true"]')).toBe(
+        null,
+      ),
+    );
+  });
+
   it('does not offer agent turn undo after an intervening schema edit', async () => {
     useUndoStore.getState().apply({
       kind: 'add_type',

--- a/apps/desktop/tests/components/toolbar/GraphSearchBar.test.tsx
+++ b/apps/desktop/tests/components/toolbar/GraphSearchBar.test.tsx
@@ -12,6 +12,7 @@ const schema: Schema = {
     {
       kind: 'object',
       name: 'Recipe',
+      description: 'Weeknight cooking plan',
       fields: [{ name: 'season', type: { kind: 'ref', typeName: 'Season' } }],
     },
     {
@@ -93,5 +94,16 @@ describe('GraphSearchBar', () => {
     expect(
       screen.getByRole('button', { name: /ArtworkSourceReference.*union/ }),
     ).toBeInTheDocument();
+  });
+
+  it('does not label description matches in the result row', () => {
+    render(<GraphSearchBar />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search types and enums' }), {
+      target: { value: 'weeknight' },
+    });
+
+    expect(screen.getByRole('button', { name: /Recipe.*object/ })).toBeInTheDocument();
+    expect(screen.queryByText('(in description)')).not.toBeInTheDocument();
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.17",
+      "version": "0.15.22",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",


### PR DESCRIPTION
## Summary
- remove the search result description marker and share kind badges/icons across search and create menus
- add a Magic UI-style BorderBeam to the agent turn summary while a response is pending
- bump the desktop app version to 0.15.22

## Validation
- turbo typecheck
- turbo test
- focused chat and toolbar tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782652757&installation_id=136251083&pr_number=332&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F332&signature=a79db76505693c748ae187ad917fb52d7437138a1a7023b4d9bae0965773357d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->