### PR TITLE
fix: prevent mobile homepage overflow

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -430,7 +430,7 @@ const highlightedConvexLineIds = new Set([
 
 function ConvexGeneratedPreview() {
   return (
-    <div className="overflow-hidden rounded-xl border border-border/60 bg-card/70 text-left screenshot-glow">
+    <div className="w-full min-w-0 overflow-hidden rounded-xl border border-border/60 bg-card/70 text-left screenshot-glow">
       <div className="flex items-center justify-between border-b border-border/60 bg-background/70 px-4 py-3">
         <div>
           <div className="font-mono text-xs text-primary dark:text-accent">convex/schema.ts</div>
@@ -443,7 +443,7 @@ function ConvexGeneratedPreview() {
           Drift clean
         </MotionStatusBadge>
       </div>
-      <pre className="overflow-x-auto p-4 text-[11px] leading-relaxed text-muted-foreground sm:text-xs">
+      <pre className="max-w-full overflow-x-auto p-4 text-[11px] leading-relaxed text-muted-foreground sm:text-xs">
         <code>
           {convexPreviewLines.map((line, index) => (
             <span
@@ -468,7 +468,7 @@ function ConvexGeneratedPreview() {
       </pre>
       <div className="border-t border-border/60 bg-background/50 px-4 py-3">
         <div className="font-mono text-xs text-primary dark:text-accent">convex/validators.ts</div>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-xs text-muted-foreground break-words">
           Reusable validators emit beside the schema for functions, forms, and app boundaries.
         </p>
       </div>
@@ -900,11 +900,11 @@ export default function Home() {
           </div>
 
           {/* Two-column: generated surface preview + description */}
-          <div className="grid sm:grid-cols-5 gap-8 sm:gap-12 items-center">
-            <div className="sm:col-span-2">
+          <div className="grid min-w-0 sm:grid-cols-5 gap-8 sm:gap-12 items-center">
+            <div className="min-w-0 sm:col-span-2">
               <ConvexGeneratedPreview />
             </div>
-            <div className="sm:col-span-3 space-y-6">
+            <div className="min-w-0 sm:col-span-3 space-y-6">
               <h3 className="text-2xl font-bold tracking-tight">
                 See generated Convex files before they land in git
               </h3>
@@ -918,7 +918,7 @@ export default function Home() {
                   <div className="size-8 rounded-lg bg-accent/10 flex items-center justify-center shrink-0">
                     <Zap className="size-4 text-accent" />
                   </div>
-                  <span className="text-muted-foreground">
+                  <span className="min-w-0 text-muted-foreground">
                     Convex schema, validators, Zod, JSON Schema, structured output, MCP, and forms
                   </span>
                 </div>
@@ -926,7 +926,7 @@ export default function Home() {
                   <div className="size-8 rounded-lg bg-accent/10 flex items-center justify-center shrink-0">
                     <Shield className="size-4 text-accent" />
                   </div>
-                  <span className="text-muted-foreground">
+                  <span className="min-w-0 text-muted-foreground">
                     Manifest-backed drift checks for every emitted target
                   </span>
                 </div>
@@ -934,7 +934,7 @@ export default function Home() {
                   <div className="size-8 rounded-lg bg-accent/10 flex items-center justify-center shrink-0">
                     <Brain className="size-4 text-accent" />
                   </div>
-                  <span className="text-muted-foreground">
+                  <span className="min-w-0 text-muted-foreground">
                     MCP tools for agents that need to inspect, mutate, emit, and validate
                   </span>
                 </div>
@@ -946,8 +946,8 @@ export default function Home() {
 
       {/* Reconcile */}
       <section className="relative py-16 sm:py-32 px-4 sm:px-8 border-t border-border/30">
-        <div className="relative max-w-5xl mx-auto grid gap-8 sm:grid-cols-5 sm:gap-12 items-center">
-          <div className="sm:col-span-3 space-y-6">
+        <div className="relative max-w-5xl mx-auto grid min-w-0 gap-8 sm:grid-cols-5 sm:gap-12 items-center">
+          <div className="min-w-0 sm:col-span-3 space-y-6">
             <div className="inline-flex items-center gap-2 text-sm text-primary dark:text-accent font-medium px-4 py-1.5 rounded-full border border-accent/20 bg-accent/5">
               <GitPullRequestArrow className="size-4" />
               Reconcile as review
@@ -978,7 +978,7 @@ export default function Home() {
               </div>
             </div>
           </div>
-          <div className="sm:col-span-2">
+          <div className="min-w-0 sm:col-span-2">
             <ReconcileDemo />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Allow the Convex generated preview and mobile grid columns to shrink within the viewport
- Keep long generated code constrained to the preview's internal horizontal scroll
- Prevent mobile list/body copy from forcing page-level overflow

## Verification
- bun run typecheck
- bun run test
- Playwright mobile viewport check: 390px viewport, document scroll width remained 390px

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782661850&installation_id=136251083&pr_number=334&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F334&signature=1329aaf1434ca5daa13618af1f9eac8df8fbce4eca0b2c86f2849e25d9d0b577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->