### PR TITLE
Polish graph and properties selection UI

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.22",
+  "version": "0.15.23",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -56,7 +56,7 @@ import { TYPE_EDGE_SELECT_EVENT } from './components/graph/edge-select-event';
 import { GraphBackground } from './components/graph/GraphBackground';
 import { type CanvasPosition, GraphCanvas } from './components/graph/GraphCanvas';
 import { type CreateTypeKind, createFieldOp, createTypeOp } from './components/graph/interactions';
-import { TYPE_NODE_EVENT } from './components/graph/nodes/TypeNode';
+import { TYPE_NODE_EVENT, TYPE_NODE_OBJECT_EVENT } from './components/graph/nodes/TypeNode';
 import { DriftBanner } from './components/hud/DriftBanner';
 import { ModelSyncBanner } from './components/hud/ModelSyncBanner';
 import { SchemaPanel, type SchemaPanelSource } from './components/schema/SchemaPanel';
@@ -142,6 +142,17 @@ export default function App(): React.JSX.Element {
     }
     document.addEventListener(TYPE_NODE_EVENT, onFieldSelect);
     return () => document.removeEventListener(TYPE_NODE_EVENT, onFieldSelect);
+  }, []);
+
+  useEffect(() => {
+    function onTypeSelect(event: Event): void {
+      const detail = (event as CustomEvent<{ typeName?: unknown }>).detail;
+      if (typeof detail?.typeName !== 'string') return;
+      useUIChromeStore.getState().setSidebarVisible(true);
+      useUIChromeStore.getState().setSidebarTab('properties');
+    }
+    document.addEventListener(TYPE_NODE_OBJECT_EVENT, onTypeSelect);
+    return () => document.removeEventListener(TYPE_NODE_OBJECT_EVENT, onTypeSelect);
   }, []);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -31,6 +31,7 @@ import {
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Textarea } from '../ui/textarea';
 import { ModelShapeHints } from './ModelShapeHints';
 import { type ValidationIssueRepair, ValidationIssues } from './ValidationIssues';
@@ -65,6 +66,7 @@ export function FieldDetail({
   const hasSingleFieldIndex =
     tableIndexes?.some((index) => index.fields.length === 1 && index.fields[0] === field.name) ??
     false;
+  const parentKindLabel = tableIndexes ? 'table' : 'object';
   const addIndex = () => {
     if (!tableIndexes || hasSingleFieldIndex) return;
     dispatch({
@@ -75,11 +77,23 @@ export function FieldDetail({
   };
 
   return (
-    <div className="space-y-4 p-3" data-testid="field-detail">
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-semibold">{field.name}</span>
+    <div className="space-y-4 p-3 pt-0" data-testid="field-detail">
+      <header
+        className="-mx-3 flex min-h-20 items-center justify-between border-b bg-muted/20 px-3 py-3"
+        data-testid="field-detail-header"
+      >
+        <div className="min-w-0">
+          <div className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            {parentKindLabel}
+          </div>
+          <div className="truncate text-lg font-semibold leading-tight text-foreground">
+            {typeName}
+          </div>
+          <h2 className="truncate text-sm font-medium leading-snug text-muted-foreground">
+            {field.name}
+          </h2>
+        </div>
         <div className="flex items-center gap-1.5">
-          <span className="text-xs text-muted-foreground">{field.type.kind}</span>
           <Button
             type="button"
             variant="ghost"
@@ -91,7 +105,7 @@ export function FieldDetail({
             <Trash2 aria-hidden="true" />
           </Button>
         </div>
-      </div>
+      </header>
 
       <ValidationIssues errors={validationErrors} repairForIssue={validationRepairForIssue} />
 
@@ -119,31 +133,28 @@ export function FieldDetail({
         />
       </div>
 
-      <div className="flex items-center gap-4 text-xs">
-        <Label htmlFor="field-optional" className="flex items-center gap-1">
-          <Checkbox
-            id="field-optional"
-            checked={field.optional === true}
-            onCheckedChange={(v) => update({ optional: v === true })}
-          />
-          optional
-        </Label>
-        <Label htmlFor="field-nullable" className="flex items-center gap-1">
-          <Checkbox
-            id="field-nullable"
-            checked={field.nullable === true}
-            onCheckedChange={(v) => update({ nullable: v === true })}
-          />
-          nullable
-        </Label>
-        <Label htmlFor="field-server-derived" className="flex items-center gap-1">
-          <Checkbox
-            id="field-server-derived"
-            checked={field.serverDerived === true}
-            onCheckedChange={(v) => update({ serverDerived: v === true ? true : undefined })}
-          />
-          server derived
-        </Label>
+      <div className="grid gap-2 sm:grid-cols-3">
+        <CheckboxOption
+          id="field-optional"
+          label="Optional"
+          description="May be omitted"
+          checked={field.optional === true}
+          onCheckedChange={(v) => update({ optional: v === true })}
+        />
+        <CheckboxOption
+          id="field-nullable"
+          label="Nullable"
+          description="Allows null"
+          checked={field.nullable === true}
+          onCheckedChange={(v) => update({ nullable: v === true })}
+        />
+        <CheckboxOption
+          id="field-server-derived"
+          label="Server derived"
+          description="Computed by backend"
+          checked={field.serverDerived === true}
+          onCheckedChange={(v) => update({ serverDerived: v === true ? true : undefined })}
+        />
       </div>
 
       {tableIndexes && (
@@ -213,42 +224,40 @@ export function FieldTypeBody({
   return (
     <div className="space-y-3">
       {allowListToggle && (
-        <Label className="flex items-center gap-1 text-xs">
-          <Checkbox
-            checked={fieldType.kind === 'array'}
-            onCheckedChange={(checked) => {
-              if (checked === true && fieldType.kind !== 'array') {
-                onChange({ kind: 'array', element: fieldType });
-              } else if (checked !== true && fieldType.kind === 'array') {
-                onChange(fieldType.element);
-              }
-            }}
-          />
-          list
-        </Label>
+        <CheckboxOption
+          label="List"
+          description="Store multiple values"
+          checked={fieldType.kind === 'array'}
+          onCheckedChange={(checked) => {
+            if (checked === true && fieldType.kind !== 'array') {
+              onChange({ kind: 'array', element: fieldType });
+            } else if (checked !== true && fieldType.kind === 'array') {
+              onChange(fieldType.element);
+            }
+          }}
+        />
       )}
       <Row label="type">
-        <select
+        <Select
           value={fieldType.kind}
-          aria-label="Field type"
-          onChange={(ev) => {
-            const next = defaultFieldType(
-              ev.target.value as FieldType['kind'],
-              refTargets,
-              fieldType,
-            );
+          onValueChange={(value) => {
+            const next = defaultFieldType(value as FieldType['kind'], refTargets, fieldType);
             onChange(next);
           }}
-          className="w-full rounded border border-border bg-background p-1"
         >
-          <option value="string">string</option>
-          <option value="number">number</option>
-          <option value="boolean">boolean</option>
-          <option value="date">date</option>
-          <option value="literal">literal</option>
-          <option value="ref">ref</option>
-          <option value="array">array</option>
-        </select>
+          <SelectTrigger aria-label="Field type" className="h-8 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="string">string</SelectItem>
+            <SelectItem value="number">number</SelectItem>
+            <SelectItem value="boolean">boolean</SelectItem>
+            <SelectItem value="date">date</SelectItem>
+            <SelectItem value="literal">literal</SelectItem>
+            <SelectItem value="ref">ref</SelectItem>
+            <SelectItem value="array">array</SelectItem>
+          </SelectContent>
+        </Select>
       </Row>
       {fieldTypeBody(
         fieldType,
@@ -341,12 +350,12 @@ function StringBody({
         />
       </Row>
       <Row label="format">
-        <select
-          defaultValue={value.format ?? ''}
-          onChange={(ev) =>
+        <Select
+          value={value.format ?? 'none'}
+          onValueChange={(nextValue) =>
             onChange({
               ...value,
-              format: (ev.target.value || undefined) as
+              format: (nextValue === 'none' ? undefined : nextValue) as
                 | 'email'
                 | 'url'
                 | 'uuid'
@@ -354,15 +363,22 @@ function StringBody({
                 | undefined,
             })
           }
-          data-testid="string-format-select"
-          className="w-full rounded border border-border bg-background p-1"
         >
-          <option value="">(none)</option>
-          <option value="email">email</option>
-          <option value="url">url</option>
-          <option value="uuid">uuid</option>
-          <option value="datetime">datetime</option>
-        </select>
+          <SelectTrigger
+            aria-label="String format"
+            data-testid="string-format-select"
+            className="h-8 text-xs"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">(none)</SelectItem>
+            <SelectItem value="email">email</SelectItem>
+            <SelectItem value="url">url</SelectItem>
+            <SelectItem value="uuid">uuid</SelectItem>
+            <SelectItem value="datetime">datetime</SelectItem>
+          </SelectContent>
+        </Select>
       </Row>
     </div>
   );
@@ -391,14 +407,13 @@ function NumberBody({
           onBlur={(ev) => onChange({ ...value, max: parseOptNum(ev.target.value) })}
         />
       </Row>
-      <Label htmlFor="field-int" className="flex items-center gap-1">
-        <Checkbox
-          id="field-int"
-          checked={value.int === true}
-          onCheckedChange={(v) => onChange({ ...value, int: v === true ? true : undefined })}
-        />
-        integer
-      </Label>
+      <CheckboxOption
+        id="field-int"
+        label="Integer"
+        description="No decimals"
+        checked={value.int === true}
+        onCheckedChange={(v) => onChange({ ...value, int: v === true ? true : undefined })}
+      />
     </div>
   );
 }
@@ -729,6 +744,33 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
       <span>{label}</span>
       {children}
     </Label>
+  );
+}
+
+function CheckboxOption({
+  id,
+  label,
+  description,
+  checked,
+  onCheckedChange,
+}: {
+  id?: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean | 'indeterminate') => void;
+}) {
+  const checkboxId = id ?? `field-${label.replace(/\s+/gu, '-')}`;
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-border/70 bg-card/50 p-2">
+      <Checkbox id={checkboxId} checked={checked} onCheckedChange={onCheckedChange} />
+      <div className="min-w-0 space-y-0.5">
+        <Label htmlFor={checkboxId} className="block text-xs font-medium leading-none">
+          {label}
+        </Label>
+        <p className="text-[11px] leading-snug text-muted-foreground">{description}</p>
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -761,16 +761,33 @@ function CheckboxOption({
   onCheckedChange: (checked: boolean | 'indeterminate') => void;
 }) {
   const checkboxId = id ?? `field-${label.replace(/\s+/gu, '-')}`;
+  const labelId = `${checkboxId}-label`;
+  const descriptionId = `${checkboxId}-description`;
+
   return (
-    <div className="flex items-start gap-2 rounded-md border border-border/70 bg-card/50 p-2">
-      <Checkbox id={checkboxId} checked={checked} onCheckedChange={onCheckedChange} />
+    <Label
+      htmlFor={checkboxId}
+      className="flex cursor-pointer items-start gap-2 rounded-md border border-border/70 bg-card/50 p-2 transition-colors hover:border-border hover:bg-muted/30 focus-within:border-ring focus-within:bg-muted/30"
+    >
+      <Checkbox
+        id={checkboxId}
+        checked={checked}
+        aria-labelledby={labelId}
+        aria-describedby={descriptionId}
+        onCheckedChange={onCheckedChange}
+      />
       <div className="min-w-0 space-y-0.5">
-        <Label htmlFor={checkboxId} className="block text-xs font-medium leading-none">
+        <span id={labelId} className="block text-xs font-medium leading-none">
           {label}
-        </Label>
-        <p className="text-[11px] leading-snug text-muted-foreground">{description}</p>
+        </span>
+        <p
+          id={descriptionId}
+          className="text-[11px] font-normal leading-snug text-muted-foreground"
+        >
+          {description}
+        </p>
       </div>
-    </div>
+    </Label>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -82,11 +82,24 @@ export function TypeDetail({
   const nameReserved = isTable && isConvexReservedName(type.name);
 
   return (
-    <div className="space-y-4 p-3">
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-semibold">{type.name}</span>
+    <div className="space-y-4 p-3 pt-0">
+      <header
+        className="-mx-3 flex min-h-20 items-center justify-between border-b bg-muted/20 px-3 py-3"
+        data-testid="type-detail-header"
+      >
+        <div className="min-w-0">
+          <div className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            {isTable ? 'table' : type.kind}
+          </div>
+          <h2 className="truncate text-lg font-semibold leading-tight text-foreground">
+            {type.name}
+          </h2>
+          <div
+            aria-hidden="true"
+            className="h-[1.25rem] truncate text-sm font-medium leading-snug text-muted-foreground"
+          />
+        </div>
         <div className="flex items-center gap-1.5">
-          <span className="text-xs text-muted-foreground">{type.kind}</span>
           <Button
             type="button"
             variant="ghost"
@@ -98,7 +111,7 @@ export function TypeDetail({
             <Trash2 aria-hidden="true" />
           </Button>
         </div>
-      </div>
+      </header>
 
       <ValidationIssues
         errors={validationErrors}

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -215,20 +215,6 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         transition: 'opacity 0.15s ease, border-color 0.1s ease',
       }}
     >
-      {fieldsInSelectedType ? (
-        <div
-          aria-hidden="true"
-          data-testid="type-node-selection-rail"
-          style={{
-            position: 'absolute',
-            insetBlock: 0,
-            insetInlineStart: 0,
-            width: 4,
-            background: selectionAccent,
-            zIndex: 1,
-          }}
-        />
-      ) : null}
       {hasValidationIssues ? (
         <div
           aria-hidden="true"
@@ -556,7 +542,7 @@ function FieldRowButton({
         background: selected
           ? `color-mix(in oklch, ${selectionAccent} 22%, var(--graph-node-body-bg))`
           : groupSelected
-            ? `color-mix(in oklch, ${selectionAccent} 14%, var(--graph-node-body-bg))`
+            ? `color-mix(in oklch, ${selectionAccent} 10%, var(--graph-node-body-bg))`
             : highlighted
               ? `color-mix(in oklch, ${selectionAccent} 11%, var(--graph-node-body-bg))`
               : groupHighlighted
@@ -568,13 +554,15 @@ function FieldRowButton({
                     : undefined,
         boxShadow: selected
           ? `inset 4px 0 0 ${selectionAccent}, inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)`
-          : highlighted
-            ? `inset 3px 0 0 color-mix(in oklch, ${selectionAccent} 68%, transparent), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)`
-            : searchFocused
-              ? 'inset 3px 0 0 var(--graph-node-selected), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)'
-              : hasValidationIssues
-                ? 'inset 3px 0 0 var(--destructive), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)'
-                : 'inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)',
+          : groupSelected
+            ? `inset 3px 0 0 color-mix(in oklch, ${selectionAccent} 76%, transparent), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)`
+            : highlighted
+              ? `inset 3px 0 0 color-mix(in oklch, ${selectionAccent} 68%, transparent), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)`
+              : searchFocused
+                ? 'inset 3px 0 0 var(--graph-node-selected), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)'
+                : hasValidationIssues
+                  ? 'inset 3px 0 0 var(--destructive), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)'
+                  : 'inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)',
       }}
     >
       <span

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -29,6 +29,7 @@ import { type FieldRefPreview, TYPE_NODE_REF_PREVIEW_EVENT } from '../ref-previe
 import type { EnumTargetRow, TypeNodeData } from '../schema-to-graph';
 
 export const TYPE_NODE_EVENT = 'contexture:field-select' as const;
+export const TYPE_NODE_OBJECT_EVENT = 'contexture:type-select' as const;
 export const TYPE_NODE_ADD_FIELD_EVENT = 'contexture:type-node-add-field' as const;
 
 type TypeNodeKind = Node<TypeNodeData, 'type'>;
@@ -67,7 +68,10 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
   const { data, id } = props;
   const click = useGraphSelectionStore((s) => s.click);
   const primaryNodeId = useGraphSelectionStore((s) => s.state.primaryNodeId);
+  const selectedField = useGraphSelectionStore((s) => s.state.selectedField);
+  const selectedEdge = useGraphSelectionStore((s) => s.state.selectedEdge);
   const adjacentNodeIds = useGraphSelectionStore((s) => s.state.adjacency.nodeIds);
+  const [headerHighlighted, setHeaderHighlighted] = useState(false);
 
   const isSelected = primaryNodeId === id;
   const isAdjacent = !isSelected && adjacentNodeIds.has(id);
@@ -82,6 +86,8 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
     (data.previewDimmed === true && !isSelected && !isPreviewPrimary && !isPreviewAdjacent);
   const isSyncHighlighted = data.syncHighlighted === true && !isSelected && !isAdjacent;
   const hasValidationIssues = (data.validationIssueCount ?? 0) > 0;
+  const fieldsInSelectedType =
+    isSelected && selectedEdge === null && selectedField?.typeName !== data.typeName;
 
   const onFieldClick = useCallback(
     (field: TypeNodeData['fields'][number], ev: React.MouseEvent<HTMLElement>) => {
@@ -129,6 +135,19 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
     },
     [data.typeName],
   );
+  const onHeaderSelect = useCallback(
+    (ev: React.MouseEvent<HTMLElement>) => {
+      ev.stopPropagation();
+      click(data.typeName, 'replace');
+      ev.currentTarget.dispatchEvent(
+        new CustomEvent(TYPE_NODE_OBJECT_EVENT, {
+          bubbles: true,
+          detail: { typeName: data.typeName },
+        }),
+      );
+    },
+    [click, data.typeName],
+  );
 
   const borderColor = isSelected
     ? 'var(--graph-node-selected)'
@@ -145,6 +164,16 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
     () => (data.table ? 'var(--graph-node-table-header-bg)' : headerColorFor(data.kind)),
     [data.kind, data.table],
   );
+  const selectionAccent = useMemo(
+    () => (data.table ? 'var(--graph-node-table-accent)' : headerColorFor(data.kind)),
+    [data.kind, data.table],
+  );
+  const nodeKindLabel = data.table
+    ? 'table'
+    : data.kind === 'discriminatedUnion'
+      ? 'union'
+      : data.kind;
+  const baseNodeShadow = '0 2px 10px oklch(0 0 0 / 0.18), 0 0 1px oklch(0 0 0 / 0.15)';
   const node = (
     <div
       data-testid="type-node"
@@ -172,8 +201,10 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         WebkitBackdropFilter: 'blur(8px)',
         borderWidth,
         borderStyle,
-        borderColor,
-        boxShadow: '0 2px 10px oklch(0 0 0 / 0.18), 0 0 1px oklch(0 0 0 / 0.15)',
+        borderColor: headerHighlighted ? 'var(--graph-node-selected)' : borderColor,
+        boxShadow: headerHighlighted
+          ? `${baseNodeShadow}, 0 0 0 2px var(--graph-node-selected)`
+          : baseNodeShadow,
         background:
           isSelected || isPreviewPrimary ? 'var(--graph-node-selected-bg)' : 'transparent',
         outline: isSyncHighlighted
@@ -184,16 +215,16 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         transition: 'opacity 0.15s ease, border-color 0.1s ease',
       }}
     >
-      {data.table ? (
+      {fieldsInSelectedType ? (
         <div
           aria-hidden="true"
-          data-testid="type-node-table-rail"
+          data-testid="type-node-selection-rail"
           style={{
             position: 'absolute',
             insetBlock: 0,
             insetInlineStart: 0,
             width: 4,
-            background: 'var(--graph-node-table-accent)',
+            background: selectionAccent,
             zIndex: 1,
           }}
         />
@@ -226,9 +257,20 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         style={{ opacity: 0, top: '50%', left: '50%' }}
       />
 
-      <div
+      <button
+        type="button"
         data-testid="type-node-header"
+        title={`Show ${data.typeName} ${nodeKindLabel} properties`}
+        aria-label={`Show ${data.typeName} ${nodeKindLabel} properties`}
+        onClick={onHeaderSelect}
+        onMouseEnter={() => setHeaderHighlighted(true)}
+        onMouseLeave={() => setHeaderHighlighted(false)}
+        onFocus={() => setHeaderHighlighted(true)}
+        onBlur={() => setHeaderHighlighted(false)}
+        className="focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/70"
         style={{
+          width: '100%',
+          border: 'none',
           padding: '6px 10px',
           fontSize: 12,
           fontWeight: 600,
@@ -239,6 +281,8 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
           alignItems: 'center',
           gap: 6,
           paddingLeft: data.table ? 12 : 10,
+          cursor: 'pointer',
+          textAlign: 'left',
         }}
       >
         {data.table ? (
@@ -295,9 +339,9 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         {data.table ? (
           <NodeKindLabel data-testid="type-node-table-label">table</NodeKindLabel>
         ) : (
-          <NodeKindLabel>{data.kind === 'discriminatedUnion' ? 'union' : data.kind}</NodeKindLabel>
+          <NodeKindLabel>{nodeKindLabel}</NodeKindLabel>
         )}
-      </div>
+      </button>
 
       {data.fields.length > 0 && (
         <div
@@ -311,6 +355,12 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
               key={f.name}
               field={f}
               selectedTarget={primaryNodeId}
+              selected={
+                selectedField?.typeName === data.typeName && selectedField.fieldName === f.name
+              }
+              selectionAccent={selectionAccent}
+              groupSelected={fieldsInSelectedType}
+              groupHighlighted={headerHighlighted}
               searchFocused={data.focusedFieldName === f.name}
               onFieldClick={onFieldClick}
               onRefPreview={onRefPreview}
@@ -431,12 +481,20 @@ function EnumHoverCardContent({ enumTarget }: { enumTarget: EnumTargetRow }) {
 function FieldRowButton({
   field,
   selectedTarget,
+  selected,
+  selectionAccent,
+  groupSelected,
+  groupHighlighted,
   searchFocused,
   onFieldClick,
   onRefPreview,
 }: {
   field: TypeNodeData['fields'][number];
   selectedTarget: string | null;
+  selected: boolean;
+  selectionAccent: string;
+  groupSelected: boolean;
+  groupHighlighted: boolean;
   searchFocused: boolean;
   onFieldClick: (field: TypeNodeData['fields'][number], ev: React.MouseEvent<HTMLElement>) => void;
   onRefPreview: (
@@ -448,6 +506,7 @@ function FieldRowButton({
   const refTargetSelected = field.refTarget !== undefined && field.refTarget === selectedTarget;
   const hasValidationIssues = (field.validationIssueCount ?? 0) > 0;
   const [enumCardOpen, setEnumCardOpen] = useState(false);
+  const [highlighted, setHighlighted] = useState(false);
   const enumSummary = field.enumTarget ? `${field.summary.replace(/^→\s*/, '')} enum` : undefined;
   const isUnionRef = field.refTargetKind === 'discriminatedUnion';
   const button = (
@@ -455,12 +514,25 @@ function FieldRowButton({
       type="button"
       data-testid="type-node-field"
       data-field-name={field.name}
+      data-selected-field={selected ? 'true' : undefined}
       data-validation-issues={hasValidationIssues ? 'true' : undefined}
       onClick={(ev) => onFieldClick(field, ev)}
-      onFocus={field.enumTarget ? () => setEnumCardOpen(true) : undefined}
-      onBlur={field.enumTarget ? () => setEnumCardOpen(false) : undefined}
-      onMouseEnter={(ev) => onRefPreview(field, true, ev)}
-      onMouseLeave={(ev) => onRefPreview(field, false, ev)}
+      onFocus={() => {
+        setHighlighted(true);
+        if (field.enumTarget) setEnumCardOpen(true);
+      }}
+      onBlur={() => {
+        setHighlighted(false);
+        if (field.enumTarget) setEnumCardOpen(false);
+      }}
+      onMouseEnter={(ev) => {
+        setHighlighted(true);
+        onRefPreview(field, true, ev);
+      }}
+      onMouseLeave={(ev) => {
+        setHighlighted(false);
+        onRefPreview(field, false, ev);
+      }}
       onFocusCapture={(ev) => onRefPreview(field, true, ev)}
       onBlurCapture={(ev) => onRefPreview(field, false, ev)}
       aria-label={
@@ -469,7 +541,7 @@ function FieldRowButton({
           : undefined
       }
       data-search-focused={searchFocused ? 'true' : 'false'}
-      className="contexture-type-node-field hover:bg-accent/35 focus-visible:bg-accent/45 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
+      className="contexture-type-node-field focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
       style={{
         display: 'flex',
         justifyContent: 'space-between',
@@ -481,21 +553,41 @@ function FieldRowButton({
         border: 'none',
         cursor: 'pointer',
         textAlign: 'left',
-        background: searchFocused
-          ? 'var(--graph-node-selected-bg)'
-          : hasValidationIssues
-            ? 'color-mix(in oklch, var(--destructive) 10%, transparent)'
-            : undefined,
-        boxShadow: searchFocused
-          ? 'inset 3px 0 0 var(--graph-node-selected), inset 0 0 0 1px color-mix(in oklch, var(--graph-node-selected) 34%, transparent)'
-          : hasValidationIssues
-            ? 'inset 3px 0 0 var(--destructive)'
-            : undefined,
+        background: selected
+          ? `color-mix(in oklch, ${selectionAccent} 22%, var(--graph-node-body-bg))`
+          : groupSelected
+            ? `color-mix(in oklch, ${selectionAccent} 14%, var(--graph-node-body-bg))`
+            : highlighted
+              ? `color-mix(in oklch, ${selectionAccent} 11%, var(--graph-node-body-bg))`
+              : groupHighlighted
+                ? `color-mix(in oklch, ${selectionAccent} 7%, var(--graph-node-body-bg))`
+                : searchFocused
+                  ? 'var(--graph-node-selected-bg)'
+                  : hasValidationIssues
+                    ? 'color-mix(in oklch, var(--destructive) 10%, transparent)'
+                    : undefined,
+        boxShadow: selected
+          ? `inset 4px 0 0 ${selectionAccent}, inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)`
+          : highlighted
+            ? `inset 3px 0 0 color-mix(in oklch, ${selectionAccent} 68%, transparent), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)`
+            : searchFocused
+              ? 'inset 3px 0 0 var(--graph-node-selected), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)'
+              : hasValidationIssues
+                ? 'inset 3px 0 0 var(--destructive), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)'
+                : 'inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)',
       }}
     >
       <span
         style={{
-          color: hasValidationIssues ? 'var(--destructive)' : 'var(--muted-foreground)',
+          color: selected
+            ? `color-mix(in oklch, ${selectionAccent} 58%, var(--foreground))`
+            : groupSelected
+              ? `color-mix(in oklch, ${selectionAccent} 46%, var(--foreground))`
+              : highlighted
+                ? `color-mix(in oklch, ${selectionAccent} 38%, var(--foreground))`
+                : hasValidationIssues
+                  ? 'var(--destructive)'
+                  : 'var(--muted-foreground)',
           fontWeight: 400,
         }}
       >
@@ -514,11 +606,17 @@ function FieldRowButton({
         style={{
           color: refTargetSelected
             ? 'var(--graph-node-selected)'
-            : field.enumTarget
-              ? 'var(--muted-foreground)'
-              : field.refTarget
-                ? 'var(--graph-edge-property)'
-                : 'var(--muted-foreground)',
+            : selected
+              ? `color-mix(in oklch, ${selectionAccent} 62%, var(--foreground))`
+              : groupSelected
+                ? `color-mix(in oklch, ${selectionAccent} 48%, var(--foreground))`
+                : highlighted
+                  ? `color-mix(in oklch, ${selectionAccent} 42%, var(--foreground))`
+                  : field.enumTarget
+                    ? 'var(--muted-foreground)'
+                    : field.refTarget
+                      ? 'var(--graph-edge-property)'
+                      : 'var(--muted-foreground)',
           fontFamily: field.enumTarget
             ? 'var(--font-mono)'
             : field.refTarget

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -64,9 +64,9 @@
   --graph-node-body-bg: oklch(0.95 0.01 270 / 0.85);
   --graph-node-border: oklch(0.45 0.15 270 / 0.25);
   --graph-node-table-accent: oklch(0.66 0.13 195);
-  --graph-node-selected: oklch(0.75 0.15 195);
-  --graph-node-selected-bg: oklch(0.75 0.15 195 / 0.1);
-  --graph-node-adjacent: oklch(0.75 0.15 195 / 0.45);
+  --graph-node-selected: color-mix(in oklch, var(--muted-foreground) 74%, transparent);
+  --graph-node-selected-bg: color-mix(in oklch, var(--muted-foreground) 7%, transparent);
+  --graph-node-adjacent: color-mix(in oklch, var(--muted-foreground) 28%, transparent);
   --graph-edge-property: oklch(0.65 0.12 280);
   --graph-edge-disjoint: oklch(0.60 0.12 15);
   --graph-edge-subclass: oklch(0.50 0.02 270);
@@ -127,9 +127,9 @@
   --graph-node-body-bg: oklch(0.18 0.02 270 / 0.92);
   --graph-node-border: oklch(0.25 0.02 270);
   --graph-node-table-accent: oklch(0.68 0.11 195);
-  --graph-node-selected: oklch(0.75 0.15 195);
-  --graph-node-selected-bg: oklch(0.75 0.15 195 / 0.1);
-  --graph-node-adjacent: oklch(0.75 0.15 195 / 0.45);
+  --graph-node-selected: color-mix(in oklch, var(--muted-foreground) 76%, transparent);
+  --graph-node-selected-bg: color-mix(in oklch, var(--muted-foreground) 8%, transparent);
+  --graph-node-adjacent: color-mix(in oklch, var(--muted-foreground) 30%, transparent);
   --graph-edge-property: oklch(0.65 0.08 280);
   --graph-edge-disjoint: oklch(0.65 0.12 15);
   --graph-edge-subclass: oklch(0.65 0.015 270);

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -64,9 +64,9 @@
   --graph-node-body-bg: oklch(0.95 0.01 270 / 0.85);
   --graph-node-border: oklch(0.45 0.15 270 / 0.25);
   --graph-node-table-accent: oklch(0.66 0.13 195);
-  --graph-node-selected: color-mix(in oklch, var(--muted-foreground) 74%, transparent);
-  --graph-node-selected-bg: color-mix(in oklch, var(--muted-foreground) 7%, transparent);
-  --graph-node-adjacent: color-mix(in oklch, var(--muted-foreground) 28%, transparent);
+  --graph-node-selected: oklch(0.75 0.15 195 / 0.72);
+  --graph-node-selected-bg: oklch(0.75 0.15 195 / 0.08);
+  --graph-node-adjacent: oklch(0.75 0.15 195 / 0.32);
   --graph-edge-property: oklch(0.65 0.12 280);
   --graph-edge-disjoint: oklch(0.60 0.12 15);
   --graph-edge-subclass: oklch(0.50 0.02 270);
@@ -127,9 +127,9 @@
   --graph-node-body-bg: oklch(0.18 0.02 270 / 0.92);
   --graph-node-border: oklch(0.25 0.02 270);
   --graph-node-table-accent: oklch(0.68 0.11 195);
-  --graph-node-selected: color-mix(in oklch, var(--muted-foreground) 76%, transparent);
-  --graph-node-selected-bg: color-mix(in oklch, var(--muted-foreground) 8%, transparent);
-  --graph-node-adjacent: color-mix(in oklch, var(--muted-foreground) 30%, transparent);
+  --graph-node-selected: oklch(0.75 0.15 195 / 0.76);
+  --graph-node-selected-bg: oklch(0.75 0.15 195 / 0.08);
+  --graph-node-adjacent: oklch(0.75 0.15 195 / 0.34);
   --graph-edge-property: oklch(0.65 0.08 280);
   --graph-edge-disjoint: oklch(0.65 0.12 15);
   --graph-edge-subclass: oklch(0.65 0.015 270);

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -88,8 +88,9 @@ describe('DetailPanel', () => {
   it('renders TypeDetail when a type is selected', () => {
     seed(plotSchema);
     render(<DetailPanel selection={{ typeName: 'Plot' }} />);
-    expect(screen.getByText('Plot')).toBeInTheDocument();
-    expect(screen.getByText('object')).toBeInTheDocument();
+    const header = screen.getByTestId('type-detail-header');
+    expect(header).toContainElement(screen.getByRole('heading', { name: 'Plot' }));
+    expect(header).toHaveTextContent('object');
   });
 
   it('renders FieldDetail when a type + field are selected', () => {

--- a/apps/desktop/tests/components/detail/FieldDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/FieldDetail.test.tsx
@@ -444,8 +444,8 @@ describe('FieldDetail', () => {
 
   it('optional / nullable checkboxes dispatch update_field', () => {
     const { dispatch } = setup({ name: 'n', type: { kind: 'string' } });
-    // First checkbox is "optional".
-    const optional = screen.getAllByRole('checkbox')[0];
+    const optional = screen.getByRole('checkbox', { name: 'Optional' });
+    expect(optional).toHaveAccessibleDescription('May be omitted');
     fireEvent.click(optional);
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
@@ -457,7 +457,9 @@ describe('FieldDetail', () => {
 
   it('server-derived checkbox dispatches update_field', () => {
     const { dispatch } = setup({ name: 'createdAt', type: { kind: 'date' } });
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Server derived' }));
+    const serverDerived = screen.getByRole('checkbox', { name: 'Server derived' });
+    expect(serverDerived).toHaveAccessibleDescription('Computed by backend');
+    fireEvent.click(serverDerived);
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',

--- a/apps/desktop/tests/components/detail/FieldDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/FieldDetail.test.tsx
@@ -9,6 +9,7 @@ import { FieldDetail } from '@renderer/components/detail/FieldDetail';
 import { TYPE_NODE_REF_PREVIEW_EVENT } from '@renderer/components/graph/ref-preview-event';
 import type { Op } from '@renderer/store/ops';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 function setup(
@@ -33,8 +34,27 @@ function setup(
   return { dispatch };
 }
 
+async function chooseSelectOption(label: string, option: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('combobox', { name: label }));
+  await user.click(screen.getByRole('option', { name: option }));
+}
+
 describe('FieldDetail', () => {
   afterEach(cleanup);
+
+  it('renders the selected field title as a panel header', () => {
+    setup({ name: 'showPrice', type: { kind: 'boolean' } });
+
+    const header = screen.getByTestId('field-detail-header');
+    expect(header).toContainElement(screen.getByRole('heading', { name: 'showPrice' }));
+    expect(header).toHaveTextContent('Plot');
+    expect(header).toHaveTextContent('object');
+    expect(screen.getByText('Plot')).toHaveClass('text-lg');
+    expect(screen.getByRole('heading', { name: 'showPrice' })).toHaveClass('text-sm');
+    expect(header).toHaveClass('border-b');
+    expect(header).toHaveClass('bg-muted/20');
+  });
 
   it('string: min/max/regex/format controls; blur dispatches update_field', () => {
     const { dispatch } = setup({ name: 'name', type: { kind: 'string' } });
@@ -49,10 +69,13 @@ describe('FieldDetail', () => {
     });
   });
 
-  it('string: format select dispatches with correct format', () => {
+  it('string: format select dispatches with correct format', async () => {
     const { dispatch } = setup({ name: 'email', type: { kind: 'string' } });
-    const select = screen.getByTestId('string-format-select');
-    fireEvent.change(select, { target: { value: 'email' } });
+    expect(screen.getByTestId('string-format-select')).toHaveAttribute(
+      'aria-label',
+      'String format',
+    );
+    await chooseSelectOption('String format', 'email');
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',
@@ -61,9 +84,9 @@ describe('FieldDetail', () => {
     });
   });
 
-  it('type picker changes a field from string to number', () => {
+  it('type picker changes a field from string to number', async () => {
     const { dispatch } = setup({ name: 'name', type: { kind: 'string' } });
-    fireEvent.change(screen.getByLabelText('Field type'), { target: { value: 'number' } });
+    await chooseSelectOption('Field type', 'number');
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',
@@ -201,13 +224,13 @@ describe('FieldDetail', () => {
     expect(screen.queryByRole('button', { name: 'Add index' })).not.toBeInTheDocument();
   });
 
-  it('type picker creates a ref to the first available type', () => {
+  it('type picker creates a ref to the first available type', async () => {
     const { dispatch } = setup(
       { name: 'harvest', type: { kind: 'string' } },
       [],
       ['Harvest', 'Season'],
     );
-    fireEvent.change(screen.getByLabelText('Field type'), { target: { value: 'ref' } });
+    await chooseSelectOption('Field type', 'ref');
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',
@@ -216,9 +239,9 @@ describe('FieldDetail', () => {
     });
   });
 
-  it('type picker creates a stdlib ref when no local type is available', () => {
+  it('type picker creates a stdlib ref when no local type is available', async () => {
     const { dispatch } = setup({ name: 'email', type: { kind: 'string' } });
-    fireEvent.change(screen.getByLabelText('Field type'), { target: { value: 'ref' } });
+    await chooseSelectOption('Field type', 'ref');
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',
@@ -365,9 +388,9 @@ describe('FieldDetail', () => {
     });
   });
 
-  it('type picker wraps the current field as a string array', () => {
+  it('type picker wraps the current field as a string array', async () => {
     const { dispatch } = setup({ name: 'tags', type: { kind: 'string' } });
-    fireEvent.change(screen.getByLabelText('Field type'), { target: { value: 'array' } });
+    await chooseSelectOption('Field type', 'array');
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',
@@ -378,7 +401,7 @@ describe('FieldDetail', () => {
 
   it('list toggle wraps the current type without resetting constraints', () => {
     const { dispatch } = setup({ name: 'tags', type: { kind: 'string', min: 2 } });
-    fireEvent.click(screen.getByRole('checkbox', { name: 'list' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'List' }));
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',
@@ -392,7 +415,7 @@ describe('FieldDetail', () => {
       name: 'scores',
       type: { kind: 'array', element: { kind: 'number', int: true } },
     });
-    fireEvent.click(screen.getByRole('checkbox', { name: 'list' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'List' }));
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',
@@ -434,7 +457,7 @@ describe('FieldDetail', () => {
 
   it('server-derived checkbox dispatches update_field', () => {
     const { dispatch } = setup({ name: 'createdAt', type: { kind: 'date' } });
-    fireEvent.click(screen.getByRole('checkbox', { name: 'server derived' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Server derived' }));
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',
@@ -449,7 +472,7 @@ describe('FieldDetail', () => {
       type: { kind: 'date' },
       serverDerived: true,
     });
-    fireEvent.click(screen.getByRole('checkbox', { name: 'server derived' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Server derived' }));
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -51,8 +51,12 @@ describe('TypeDetail', () => {
 
     it('renders name, kind, and each field summary', () => {
       setup(type);
-      expect(screen.getByText('Plot')).toBeInTheDocument();
-      expect(screen.getByText('object')).toBeInTheDocument();
+      const header = screen.getByTestId('type-detail-header');
+      expect(header).toContainElement(screen.getByRole('heading', { name: 'Plot' }));
+      expect(header).toHaveTextContent('object');
+      expect(header).toHaveClass('border-b');
+      expect(header).toHaveClass('min-h-20');
+      expect(header.querySelector('[aria-hidden="true"]')).toHaveClass('h-[1.25rem]');
       const rows = screen.getAllByTestId('object-field-summary');
       expect(rows).toHaveLength(2);
       expect(screen.getByDisplayValue('area')).toBeInTheDocument();

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -11,6 +11,7 @@
 import {
   TYPE_NODE_ADD_FIELD_EVENT,
   TYPE_NODE_EVENT,
+  TYPE_NODE_OBJECT_EVENT,
   TypeNode,
 } from '@renderer/components/graph/nodes/TypeNode';
 import { TYPE_NODE_REF_PREVIEW_EVENT } from '@renderer/components/graph/ref-preview-event';
@@ -116,7 +117,10 @@ describe('TypeNode', () => {
     );
     expect(screen.getByTestId('type-node-validation-rail')).toBeInTheDocument();
     expect(field.dataset.validationIssues).toBe('true');
-    expect(field).toHaveStyle({ boxShadow: 'inset 3px 0 0 var(--destructive)' });
+    expect(field.getAttribute('style')).toContain('inset 3px 0 0 var(--destructive)');
+    expect(field.getAttribute('style')).toContain(
+      'inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)',
+    );
   });
 
   it('raises a contexture:field-select event with typeName + fieldName when a field is clicked', () => {
@@ -124,7 +128,10 @@ describe('TypeNode', () => {
       typeName: 'Plot',
       kind: 'object',
       imported: false,
-      fields: [{ name: 'name', summary: 'string', optional: false, nullable: false }],
+      fields: [
+        { name: 'name', summary: 'string', optional: false, nullable: false },
+        { name: 'area', summary: 'number', optional: false, nullable: false },
+      ],
     };
     const handler = vi.fn();
     const { container } = render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
@@ -136,6 +143,164 @@ describe('TypeNode', () => {
     expect(handler).toHaveBeenCalledTimes(1);
     const event = handler.mock.calls[0][0] as CustomEvent<{ typeName: string; fieldName: string }>;
     expect(event.detail).toEqual({ typeName: 'Plot', fieldName: 'name' });
+  });
+
+  it('visually marks the selected field row', () => {
+    const data: TypeNodeData = {
+      typeName: 'Plot',
+      kind: 'object',
+      imported: false,
+      fields: [
+        { name: 'name', summary: 'string', optional: false, nullable: false },
+        { name: 'area', summary: 'number', optional: true, nullable: false },
+      ],
+    };
+    useGraphSelectionStore.getState().selectField({ typeName: 'Plot', fieldName: 'area' });
+
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    const fields = screen.getAllByTestId('type-node-field');
+    expect(fields[0].dataset.selectedField).toBeUndefined();
+    expect(fields[1].dataset.selectedField).toBe('true');
+    expect(fields[1]).toHaveStyle({
+      background: 'color-mix(in oklch, var(--graph-node-header-bg) 22%, var(--graph-node-body-bg))',
+    });
+    expect(fields[1].getAttribute('style')).toContain('inset 4px 0 0 var(--graph-node-header-bg)');
+    expect(fields[1].getAttribute('style')).toContain(
+      'inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)',
+    );
+    expect(screen.getByText('area?')).toHaveStyle({
+      color: 'color-mix(in oklch, var(--graph-node-header-bg) 58%, var(--foreground))',
+      fontWeight: '400',
+    });
+  });
+
+  it('uses the table accent for selected table field rows', () => {
+    const data: TypeNodeData = {
+      typeName: 'Posts',
+      kind: 'object',
+      imported: false,
+      table: true,
+      fields: [{ name: 'title', summary: 'string', optional: false, nullable: false }],
+    };
+    useGraphSelectionStore.getState().selectField({ typeName: 'Posts', fieldName: 'title' });
+
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId('type-node-field')).toHaveStyle({
+      background:
+        'color-mix(in oklch, var(--graph-node-table-accent) 22%, var(--graph-node-body-bg))',
+    });
+  });
+
+  it('tints every field row when the parent object is selected', () => {
+    const data: TypeNodeData = {
+      typeName: 'Plot',
+      kind: 'object',
+      imported: false,
+      fields: [
+        { name: 'name', summary: 'string', optional: false, nullable: false },
+        { name: 'area', summary: 'number', optional: false, nullable: false },
+      ],
+    };
+    useGraphSelectionStore.getState().click('Plot', 'replace');
+
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    const fields = screen.getAllByTestId('type-node-field');
+    expect(fields[0]).toHaveStyle({
+      background: 'color-mix(in oklch, var(--graph-node-header-bg) 14%, var(--graph-node-body-bg))',
+    });
+    expect(fields[1]).toHaveStyle({
+      background: 'color-mix(in oklch, var(--graph-node-header-bg) 14%, var(--graph-node-body-bg))',
+    });
+    expect(screen.getByText('name')).toHaveStyle({
+      color: 'color-mix(in oklch, var(--graph-node-header-bg) 46%, var(--foreground))',
+      fontWeight: '400',
+    });
+    expect(screen.getByTestId('type-node-selection-rail')).toHaveStyle({
+      width: '4px',
+      background: 'var(--graph-node-header-bg)',
+    });
+  });
+
+  it('uses a table rail only when the parent table is selected', () => {
+    const data: TypeNodeData = {
+      typeName: 'Posts',
+      kind: 'object',
+      imported: false,
+      table: true,
+      fields: [{ name: 'title', summary: 'string', optional: false, nullable: false }],
+    };
+    useGraphSelectionStore.getState().click('Posts', 'replace');
+
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId('type-node-selection-rail')).toHaveStyle({
+      width: '4px',
+      background: 'var(--graph-node-table-accent)',
+    });
+  });
+
+  it('uses a lighter selected-color treatment for field hover', () => {
+    const data: TypeNodeData = {
+      typeName: 'Plot',
+      kind: 'object',
+      imported: false,
+      fields: [
+        { name: 'name', summary: 'string', optional: false, nullable: false },
+        { name: 'area', summary: 'number', optional: false, nullable: false },
+      ],
+    };
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    const field = screen.getAllByTestId('type-node-field')[0];
+    fireEvent.mouseEnter(field);
+
+    expect(field).toHaveStyle({
+      background: 'color-mix(in oklch, var(--graph-node-header-bg) 11%, var(--graph-node-body-bg))',
+    });
+    expect(screen.getByText('name')).toHaveStyle({
+      color: 'color-mix(in oklch, var(--graph-node-header-bg) 38%, var(--foreground))',
+      fontWeight: '400',
+    });
+  });
+
+  it('uses the node header as an explicit route back to object properties', () => {
+    const data: TypeNodeData = {
+      typeName: 'Plot',
+      kind: 'object',
+      imported: false,
+      fields: [
+        { name: 'name', summary: 'string', optional: false, nullable: false },
+        { name: 'area', summary: 'number', optional: false, nullable: false },
+      ],
+    };
+    useGraphSelectionStore.getState().selectField({ typeName: 'Plot', fieldName: 'name' });
+    const handler = vi.fn();
+
+    const { container } = render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+    container.addEventListener(TYPE_NODE_OBJECT_EVENT, handler as EventListener);
+
+    const header = screen.getByTestId('type-node-header');
+    expect(header).toHaveAccessibleName('Show Plot object properties');
+    expect(header).toHaveAttribute('title', 'Show Plot object properties');
+    act(() => fireEvent.mouseOver(header));
+    expect(header).toHaveStyle({ background: 'var(--graph-node-header-bg)' });
+    expect(container.querySelector('[data-testid="type-node"]')?.getAttribute('style')).toContain(
+      '0 0 0 2px var(--graph-node-selected)',
+    );
+    expect(header.getAttribute('style')).not.toContain('inset 0 -2px');
+    expect(screen.getAllByTestId('type-node-field')[1]).toHaveStyle({
+      background: 'color-mix(in oklch, var(--graph-node-header-bg) 7%, var(--graph-node-body-bg))',
+    });
+
+    fireEvent.click(header);
+
+    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('Plot');
+    expect(useGraphSelectionStore.getState().state.selectedField).toBeNull();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect((handler.mock.calls[0][0] as CustomEvent).detail).toEqual({ typeName: 'Plot' });
   });
 
   it('selects referenced object targets when a ref field is clicked', () => {
@@ -177,10 +342,7 @@ describe('TypeNode', () => {
     expect(screen.getByTestId('type-node-header')).toHaveStyle({
       background: 'var(--graph-node-table-header-bg)',
     });
-    expect(screen.getByTestId('type-node-table-rail')).toHaveStyle({
-      width: '4px',
-      background: 'var(--graph-node-table-accent)',
-    });
+    expect(screen.queryByTestId('type-node-selection-rail')).not.toBeInTheDocument();
     expect(screen.getByTestId('type-node-table-icon')).toBeInTheDocument();
     expect(screen.getByTestId('type-node-table-label')).toHaveTextContent('table');
     expect(screen.getByTestId('type-node-table-label')).toHaveStyle({

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -209,22 +209,24 @@ describe('TypeNode', () => {
 
     const fields = screen.getAllByTestId('type-node-field');
     expect(fields[0]).toHaveStyle({
-      background: 'color-mix(in oklch, var(--graph-node-header-bg) 14%, var(--graph-node-body-bg))',
+      background: 'color-mix(in oklch, var(--graph-node-header-bg) 10%, var(--graph-node-body-bg))',
     });
     expect(fields[1]).toHaveStyle({
-      background: 'color-mix(in oklch, var(--graph-node-header-bg) 14%, var(--graph-node-body-bg))',
+      background: 'color-mix(in oklch, var(--graph-node-header-bg) 10%, var(--graph-node-body-bg))',
     });
     expect(screen.getByText('name')).toHaveStyle({
       color: 'color-mix(in oklch, var(--graph-node-header-bg) 46%, var(--foreground))',
       fontWeight: '400',
     });
-    expect(screen.getByTestId('type-node-selection-rail')).toHaveStyle({
-      width: '4px',
-      background: 'var(--graph-node-header-bg)',
-    });
+    expect(fields[0].getAttribute('style')).toContain(
+      'inset 3px 0 0 color-mix(in oklch, var(--graph-node-header-bg) 76%, transparent)',
+    );
+    expect(fields[1].getAttribute('style')).toContain(
+      'inset 3px 0 0 color-mix(in oklch, var(--graph-node-header-bg) 76%, transparent)',
+    );
   });
 
-  it('uses a table rail only when the parent table is selected', () => {
+  it('uses table-accent field rails when the parent table is selected', () => {
     const data: TypeNodeData = {
       typeName: 'Posts',
       kind: 'object',
@@ -236,10 +238,9 @@ describe('TypeNode', () => {
 
     render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
 
-    expect(screen.getByTestId('type-node-selection-rail')).toHaveStyle({
-      width: '4px',
-      background: 'var(--graph-node-table-accent)',
-    });
+    expect(screen.getByTestId('type-node-field').getAttribute('style')).toContain(
+      'inset 3px 0 0 color-mix(in oklch, var(--graph-node-table-accent) 76%, transparent)',
+    );
   });
 
   it('uses a lighter selected-color treatment for field hover', () => {


### PR DESCRIPTION
## Summary
- Improve graph field/object/table selection and hover states, including parent-selected field tinting and quieter selected tokens
- Rework properties panel headers into stable tiered breadcrumbs and shadcn-style checkbox/select controls
- Bump desktop app version to 0.15.23

## Tests
- bunx biome check apps/desktop/package.json apps/desktop/src/renderer/src/App.tsx apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx apps/desktop/src/renderer/src/globals.css apps/desktop/tests/components/detail/DetailPanel.test.tsx apps/desktop/tests/components/detail/FieldDetail.test.tsx apps/desktop/tests/components/detail/TypeDetail.test.tsx apps/desktop/tests/components/graph/TypeNode.test.tsx
- bun run test -- tests/components/detail/FieldDetail.test.tsx tests/components/detail/TypeDetail.test.tsx tests/components/detail/DetailPanel.test.tsx tests/components/graph/TypeNode.test.tsx
- pre-commit: turbo typecheck
- pre-commit: turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782676784&installation_id=136251083&pr_number=335&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F335&signature=d557296e5d65bc1604bff0d0bac87961d464ebc951f91cb21b8b6399e8ddcf0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->