### PR TITLE
fix(web): summarise changelog release links

### DIFF
--- a/apps/web/src/app/changelog/page.tsx
+++ b/apps/web/src/app/changelog/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { AnimatedThemeToggler } from '@/components/ui/animated-theme-toggler';
 import { fetchReleases } from '@/lib/changelog';
+import { getReleaseLinkLabel } from '@/lib/release-links';
 
 export const metadata: Metadata = {
   title: 'Changelog — Contexture',
@@ -52,6 +54,18 @@ function formatDate(iso: string): string {
     month: 'long',
     day: 'numeric',
   });
+}
+
+function getTextContent(children: ReactNode): string {
+  if (typeof children === 'string' || typeof children === 'number') {
+    return String(children);
+  }
+
+  if (Array.isArray(children)) {
+    return children.map(getTextContent).join('');
+  }
+
+  return '';
 }
 
 export default async function ChangelogPage() {
@@ -141,16 +155,22 @@ export default async function ChangelogPage() {
                           <ol className="list-decimal pl-6 mb-3 space-y-1">{children}</ol>
                         ),
                         li: ({ children }) => <li>{children}</li>,
-                        a: ({ href, children }) => (
-                          <a
-                            href={href}
-                            className="text-accent hover:underline"
-                            target={href?.startsWith('http') ? '_blank' : undefined}
-                            rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
-                          >
-                            {children}
-                          </a>
-                        ),
+                        a: ({ href, children }) => {
+                          const visibleText = getTextContent(children);
+                          const label = getReleaseLinkLabel(href, visibleText);
+
+                          return (
+                            <a
+                              href={href}
+                              className="text-accent break-words [overflow-wrap:anywhere] hover:underline"
+                              target={href?.startsWith('http') ? '_blank' : undefined}
+                              rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
+                              title={href}
+                            >
+                              {label === visibleText ? children : label}
+                            </a>
+                          );
+                        },
                         code: ({ children }) => (
                           <code className="px-1.5 py-0.5 rounded bg-muted text-foreground font-mono text-xs">
                             {children}

--- a/apps/web/src/lib/release-links.ts
+++ b/apps/web/src/lib/release-links.ts
@@ -1,0 +1,47 @@
+const BARE_URL_PATTERN = /^https?:\/\/\S+$/;
+
+export function getReleaseLinkLabel(href: string | undefined, visibleText: string): string {
+  const trimmedText = visibleText.trim();
+  if (!href || trimmedText !== href || !BARE_URL_PATTERN.test(trimmedText)) {
+    return visibleText;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return visibleText;
+  }
+
+  if (url.hostname === 'github.com') {
+    const pathParts = url.pathname.split('/').filter(Boolean).map(decodeURIComponent);
+    const [owner, repo, section, id, tag] = pathParts;
+    const isContextureRepo = owner === 'applification' && repo === 'contexture';
+
+    if (isContextureRepo && section === 'pull' && id) {
+      return `Pull request #${id}`;
+    }
+
+    if (isContextureRepo && section === 'issues' && id) {
+      return `Issue #${id}`;
+    }
+
+    if (isContextureRepo && section === 'compare') {
+      return 'Compare changes';
+    }
+
+    if (isContextureRepo && section === 'releases' && id === 'tag' && tag) {
+      return `Release ${tag}`;
+    }
+
+    if (isContextureRepo && section === 'commit' && id) {
+      return `Commit ${id.slice(0, 7)}`;
+    }
+
+    if (isContextureRepo && !section) {
+      return 'Contexture on GitHub';
+    }
+  }
+
+  return url.hostname.replace(/^www\./, '');
+}

--- a/apps/web/tests/lib/release-links.test.ts
+++ b/apps/web/tests/lib/release-links.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { getReleaseLinkLabel } from '@/lib/release-links';
+
+describe('getReleaseLinkLabel', () => {
+  it('summarises bare Contexture pull request links', () => {
+    const href = 'https://github.com/applification/contexture/pull/320';
+
+    expect(getReleaseLinkLabel(href, href)).toBe('Pull request #320');
+  });
+
+  it('summarises bare Contexture compare links', () => {
+    const href = 'https://github.com/applification/contexture/compare/v0.1.0...v0.2.0';
+
+    expect(getReleaseLinkLabel(href, href)).toBe('Compare changes');
+  });
+
+  it('keeps authored markdown link text unchanged', () => {
+    const href = 'https://github.com/applification/contexture/compare/v0.1.0...v0.2.0';
+
+    expect(getReleaseLinkLabel(href, 'Full changelog')).toBe('Full changelog');
+  });
+
+  it('falls back to the hostname for other bare links', () => {
+    const href = 'https://example.com/really/long/path';
+
+    expect(getReleaseLinkLabel(href, href)).toBe('example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- Render bare Contexture GitHub changelog URLs as short labels such as `Pull request #320` and `Compare changes`
- Preserve authored markdown link text and keep the original href/title for context
- Add tests for release link labelling behavior

## Verification
- `bun run test -- tests/lib/release-links.test.ts tests/lib/changelog.test.ts`
- Pre-commit hook ran `turbo typecheck` and `turbo test` successfully

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782677899&installation_id=136251083&pr_number=336&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F336&signature=695f487cba284164c137e179e182d85c19970da0ab81c8ba5e8bcf0cb174010e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->