### PR TITLE
fix: remove optional marker from properties fields

### DIFF
--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -294,9 +294,6 @@ function ObjectBody({
                       }
                     }}
                   />
-                  <span aria-hidden="true" className="inline-block w-[1ch] text-muted-foreground">
-                    {f.optional ? '?' : ''}
-                  </span>
                 </TableCell>
                 <TableCell className="px-2 py-1.5 text-center">
                   <Checkbox

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -60,7 +60,7 @@ describe('TypeDetail', () => {
       const rows = screen.getAllByTestId('object-field-summary');
       expect(rows).toHaveLength(2);
       expect(screen.getByDisplayValue('area')).toBeInTheDocument();
-      expect(rows[1]).toHaveTextContent('?');
+      expect(rows[1]).not.toHaveTextContent('?');
     });
 
     it('renders field optionality as editable checkboxes', () => {


### PR DESCRIPTION
## Summary
- remove the redundant optional `?` marker from properties panel field rows
- keep optionality represented by the existing checkbox column
- update TypeDetail coverage so the stray marker does not return

## Tests
- `bun run test -- tests/components/detail/TypeDetail.test.tsx`
- pre-commit hook: `turbo typecheck`
- pre-commit hook: `turbo test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782678085&installation_id=136251083&pr_number=337&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F337&signature=0ca5ef469e239ac314ce931888eaf0677525b7ea2c5e6a5a1256f468aa50e315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->