### PR TITLE
fix(web): restore hero animated nodes

### DIFF
--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -9,6 +9,12 @@ test.describe('Home page', () => {
     await expect(page.locator('nav')).toBeVisible();
   });
 
+  test('hero keeps animated nodes and side graph treatment', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('hero-animated-graph').locator('canvas')).toBeVisible();
+    await expect(page.getByTestId('hero-side-graph')).toBeVisible();
+  });
+
   test('navigation links are present', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('nav a[href="#features"]')).toBeVisible();

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -25,6 +25,7 @@ import {
   MotionStatusBadge,
 } from '@/components/homepage-motion';
 import { TrackedLink } from '@/components/tracked-link';
+import { AnimatedGraph } from '@/components/ui/animated-graph';
 import { AnimatedThemeToggler } from '@/components/ui/animated-theme-toggler';
 import { MobileNav } from '@/components/ui/mobile-nav';
 import { ThemeImage } from '@/components/ui/theme-image';
@@ -109,6 +110,7 @@ function HeroSideGraph() {
   return (
     <svg
       aria-hidden="true"
+      data-testid="hero-side-graph"
       className="pointer-events-none absolute left-1/2 top-8 z-0 hidden h-[64%] w-screen -translate-x-1/2 lg:block"
       viewBox="0 0 1440 520"
       preserveAspectRatio="none"
@@ -815,7 +817,14 @@ export default function Home() {
 
       {/* Hero */}
       <section className="relative px-4 sm:px-8">
-        <div className="relative max-w-3xl mx-auto text-center pt-28 sm:pt-44 pb-12 sm:pb-16">
+        <div
+          data-testid="hero-animated-graph"
+          className="pointer-events-none absolute inset-0 z-0 hidden sm:block"
+        >
+          <AnimatedGraph />
+        </div>
+
+        <div className="relative z-10 max-w-3xl mx-auto text-center pt-28 sm:pt-44 pb-12 sm:pb-16">
           <p className="animate-fade-in-up text-sm text-primary dark:text-accent font-medium mb-6 tracking-widest uppercase">
             Convex model editor + MCP server
           </p>
@@ -863,7 +872,7 @@ export default function Home() {
         </div>
 
         {/* Hero screenshot — perspective tilt for depth */}
-        <div className="relative max-w-5xl mx-auto pb-16 sm:pb-32">
+        <div className="relative z-10 max-w-5xl mx-auto pb-16 sm:pb-32">
           <HeroSideGraph />
           <HeroScreenshotMotion
             className="animate-fade-in-up-delay-3 relative z-10 rounded-xl overflow-hidden border border-border/60 screenshot-glow transition-shadow duration-500"

--- a/apps/web/src/components/ui/animated-graph.tsx
+++ b/apps/web/src/components/ui/animated-graph.tsx
@@ -22,8 +22,6 @@ export function AnimatedGraph() {
   const animRef = useRef<number>(0);
 
   useEffect(() => {
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-
     const cvs = canvasRef.current;
     if (!cvs) return;
 
@@ -32,31 +30,35 @@ export function AnimatedGraph() {
 
     const canvas = cvs;
     const ctx = context;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const w = () => canvas.offsetWidth;
+    const h = () => canvas.offsetHeight;
+
+    function seedNodes() {
+      nodesRef.current = Array.from({ length: NODE_COUNT }, (_, i) => ({
+        x: Math.random() * w(),
+        y: Math.random() * h(),
+        vx: (Math.random() - 0.5) * NODE_SPEED,
+        vy: (Math.random() - 0.5) * NODE_SPEED,
+        isAccent: i % 3 === 0,
+        outerR: 6 + Math.random() * 4,
+        innerR: 3 + Math.random() * 2,
+      }));
+    }
 
     function resize() {
       const dpr = window.devicePixelRatio || 1;
       canvas.width = canvas.offsetWidth * dpr;
       canvas.height = canvas.offsetHeight * dpr;
-      ctx.scale(dpr, dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     }
     resize();
-
-    const w = () => canvas.offsetWidth;
-    const h = () => canvas.offsetHeight;
-
-    nodesRef.current = Array.from({ length: NODE_COUNT }, (_, i) => ({
-      x: Math.random() * w(),
-      y: Math.random() * h(),
-      vx: (Math.random() - 0.5) * NODE_SPEED,
-      vy: (Math.random() - 0.5) * NODE_SPEED,
-      isAccent: i % 3 === 0,
-      outerR: 6 + Math.random() * 4,
-      innerR: 3 + Math.random() * 2,
-    }));
+    seedNodes();
 
     const style = getComputedStyle(document.documentElement);
 
-    function draw() {
+    function draw(advance: boolean) {
       const width = w();
       const height = h();
       ctx.clearRect(0, 0, width, height);
@@ -65,13 +67,15 @@ export function AnimatedGraph() {
       const primary = style.getPropertyValue('--primary').trim();
       const accent = style.getPropertyValue('--accent').trim();
 
-      for (const node of nodes) {
-        node.x += node.vx;
-        node.y += node.vy;
-        if (node.x < 0 || node.x > width) node.vx *= -1;
-        if (node.y < 0 || node.y > height) node.vy *= -1;
-        node.x = Math.max(0, Math.min(width, node.x));
-        node.y = Math.max(0, Math.min(height, node.y));
+      if (advance) {
+        for (const node of nodes) {
+          node.x += node.vx;
+          node.y += node.vy;
+          if (node.x < 0 || node.x > width) node.vx *= -1;
+          if (node.y < 0 || node.y > height) node.vy *= -1;
+          node.x = Math.max(0, Math.min(width, node.x));
+          node.y = Math.max(0, Math.min(height, node.y));
+        }
       }
 
       for (let i = 0; i < nodes.length; i++) {
@@ -109,12 +113,23 @@ export function AnimatedGraph() {
       }
 
       ctx.globalAlpha = 1;
-      animRef.current = requestAnimationFrame(draw);
     }
 
-    draw();
+    function animate() {
+      draw(true);
+      animRef.current = requestAnimationFrame(animate);
+    }
 
-    const ro = new ResizeObserver(resize);
+    if (reduceMotion) {
+      draw(false);
+    } else {
+      animate();
+    }
+
+    const ro = new ResizeObserver(() => {
+      resize();
+      if (reduceMotion) draw(false);
+    });
     ro.observe(canvas);
 
     return () => {


### PR DESCRIPTION
## Summary
- restore the animated node canvas behind the marketing hero while keeping the side graph treatment
- draw a static graph for reduced-motion users instead of leaving the canvas blank
- add a homepage e2e guard for both hero graph layers

## Verification
- bun run typecheck
- bunx biome check apps/web/src/components/ui/animated-graph.tsx apps/web/src/app/page.tsx apps/web/e2e/home.spec.ts
- bun run build
- commit hook ran turbo typecheck and turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782681698&installation_id=136251083&pr_number=339&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F339&signature=7d09ff71be65e508451ec82210bd0a5e7d640c28330ba8cef561243fdd4a0d08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->