### PR TITLE
feat: expand Contexture MCP agent capabilities

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.23",
+  "version": "0.15.24",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.22",
+      "version": "0.15.24",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -145,6 +145,7 @@
       },
       "dependencies": {
         "@contexture/core": "workspace:*",
+        "@contexture/stdlib": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.3.6",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@contexture/core": "workspace:*",
+    "@contexture/stdlib": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.3.6"
   },

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -1,1 +1,27 @@
-export { createContextureMcpServer } from '@contexture/core/mcp-server';
+import {
+  type ContextureMcpServerOptions,
+  createContextureMcpServer as createCoreContextureMcpServer,
+} from '@contexture/core/mcp-server';
+import { IR_BY_NAMESPACE, NAMESPACES } from '@contexture/stdlib/registry';
+
+const typeNamesByNamespace: Record<string, ReadonlySet<string>> = Object.fromEntries(
+  NAMESPACES.map((namespace) => [
+    namespace,
+    new Set(IR_BY_NAMESPACE[namespace].types.map((type) => type.name)),
+  ]),
+);
+
+const STDLIB_REGISTRY = {
+  namespaces: NAMESPACES,
+  hasType: (namespace: string, typeName: string) =>
+    typeNamesByNamespace[namespace]?.has(typeName) ?? false,
+};
+
+export function createContextureMcpServer(options: ContextureMcpServerOptions = {}) {
+  return createCoreContextureMcpServer({
+    ...options,
+    stdlib: options.stdlib ?? STDLIB_REGISTRY,
+  });
+}
+
+export type { ContextureMcpServerOptions };

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -35,7 +35,7 @@ async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
 }
 
 describe('Contexture MCP server', () => {
-  it('lists inspect, validate, mutation, emit, and drift tools', async () => {
+  it('lists inspect, validate, typed mutation, emit, drift, and guidance tools', async () => {
     await withClient(async (client) => {
       const { tools } = await client.listTools();
       expect(tools).toEqual(
@@ -70,6 +70,34 @@ describe('Contexture MCP server', () => {
           }),
           expect.objectContaining({
             name: 'check_contexture_drift',
+            annotations: expect.objectContaining({
+              readOnlyHint: true,
+              destructiveHint: false,
+            }),
+          }),
+          expect.objectContaining({
+            name: 'add_field',
+            annotations: expect.objectContaining({
+              readOnlyHint: false,
+              destructiveHint: true,
+            }),
+          }),
+          expect.objectContaining({
+            name: 'rename_type',
+            annotations: expect.objectContaining({
+              readOnlyHint: false,
+              destructiveHint: true,
+            }),
+          }),
+          expect.objectContaining({
+            name: 'add_index',
+            annotations: expect.objectContaining({
+              readOnlyHint: false,
+              destructiveHint: true,
+            }),
+          }),
+          expect.objectContaining({
+            name: 'get_contexture_integration_guidance',
             annotations: expect.objectContaining({
               readOnlyHint: true,
               destructiveHint: false,
@@ -110,9 +138,88 @@ describe('Contexture MCP server', () => {
             name: 'Plot',
             kind: 'object',
             table: true,
+            tableName: 'plot',
             fields: [{ name: 'name', type: 'string' }],
           },
         ],
+        generatedTargets: expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'convex',
+            path: expect.stringContaining('convex/schema.ts'),
+            enabled: true,
+          }),
+          expect.objectContaining({
+            kind: 'convex-validators',
+            path: expect.stringContaining('convex/validators.ts'),
+            enabled: true,
+          }),
+        ]),
+        agent: expect.objectContaining({
+          preferredMutationTools: expect.arrayContaining(['add_field', 'rename_type', 'add_index']),
+        }),
+      });
+    });
+  });
+
+  it('includes indexes, descriptions, output config, and generated paths in inspect output', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      metadata: { name: 'Garden' },
+      outputs: {
+        aiPipeline: {
+          mcpDefinitions: { enabled: true },
+        },
+      },
+      types: [
+        {
+          kind: 'object',
+          name: 'Plot',
+          description: 'A rentable garden plot.',
+          table: true,
+          tableName: 'plots',
+          fields: [
+            { name: 'name', description: 'Public plot name.', type: { kind: 'string' } },
+            { name: 'growerId', type: { kind: 'string' } },
+          ],
+          indexes: [{ name: 'by_grower', fields: ['growerId'] }],
+        },
+      ],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'inspect_contexture',
+        arguments: { irPath },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        outputConfig: expect.objectContaining({
+          aiPipeline: expect.objectContaining({
+            mcpDefinitions: { enabled: true },
+          }),
+        }),
+        types: [
+          expect.objectContaining({
+            name: 'Plot',
+            description: 'A rentable garden plot.',
+            tableName: 'plots',
+            indexes: [{ name: 'by_grower', fields: ['growerId'] }],
+            fields: [
+              expect.objectContaining({
+                name: 'name',
+                description: 'Public plot name.',
+              }),
+              expect.objectContaining({ name: 'growerId' }),
+            ],
+          }),
+        ],
+        generatedTargets: expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'mcp-definitions',
+            enabled: true,
+            path: expect.stringContaining('.contexture/mcp-definitions.json'),
+          }),
+        ]),
       });
     });
   });
@@ -216,6 +323,125 @@ describe('Contexture MCP server', () => {
             message: expect.any(String),
           }),
         ],
+      });
+    });
+  });
+
+  it('validates bundled stdlib-qualified refs through the CLI MCP server', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Grower',
+          fields: [{ name: 'email', type: { kind: 'ref', typeName: 'common.Email' } }],
+        },
+      ],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'validate_contexture',
+        arguments: { irPath },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        valid: true,
+        errors: [],
+      });
+    });
+  });
+
+  it('applies typed per-op MCP tools without requiring generic op JSON', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      metadata: { name: 'Garden' },
+      types: [
+        {
+          kind: 'object',
+          name: 'Plot',
+          table: true,
+          fields: [{ name: 'name', type: { kind: 'string' } }],
+        },
+      ],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'add_field',
+        arguments: {
+          irPath,
+          typeName: 'Plot',
+          field: { name: 'size', type: { kind: 'number', int: true } },
+        },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        applied: true,
+        opKind: 'add_field',
+        typeCount: 1,
+      });
+
+      const updatedIr = JSON.parse(await readFile(irPath, 'utf8')) as {
+        types: Array<{ name: string; fields?: Array<{ name: string }> }>;
+      };
+      expect(updatedIr.types[0]?.fields?.map((field) => field.name)).toEqual(['name', 'size']);
+    });
+  });
+
+  it('returns structured failures from typed per-op MCP tools', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      types: [{ kind: 'object', name: 'Plot', fields: [] }],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'add_field',
+        arguments: {
+          irPath,
+          typeName: 'Missing',
+          field: { name: 'size', type: { kind: 'number' } },
+        },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        applied: false,
+        opKind: 'add_field',
+        error: expect.stringContaining('Missing'),
+      });
+    });
+  });
+
+  it('provides repo integration guidance for MCP-capable agents', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      types: [{ kind: 'object', name: 'Plot', table: true, fields: [] }],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'get_contexture_integration_guidance',
+        arguments: { irPath },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        sourceOfTruth: '.contexture.json',
+        safeLoop: [
+          'inspect_contexture',
+          'validate_contexture',
+          'emit_contexture',
+          'check_contexture_drift',
+        ],
+        prompt: expect.stringContaining('Use the Contexture MCP server'),
+        rules: expect.arrayContaining([
+          expect.stringContaining('Do not hand-edit generated files'),
+          expect.stringContaining('Prefer typed op tools'),
+        ]),
       });
     });
   });

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -3,10 +3,12 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ZodError, z } from 'zod';
 import { createFileBackedForward, nodeFileBackedFs } from './file-forward';
 import { checkGeneratedBundle, writeGeneratedBundle } from './generated-bundle-writer';
+import { GENERATED_TARGETS } from './generated-targets';
 import type { FieldType, Schema, TypeDef } from './ir';
 import { load } from './load';
+import { createOpTools } from './op-tools';
 import { OpSchema } from './ops';
-import { assertContextureIrPath } from './paths';
+import { assertContextureIrPath, bundlePathsFor } from './paths';
 import { checkSemantic, type StdlibCatalog } from './semantic-validation';
 
 const VERSION = '0.0.0';
@@ -22,21 +24,40 @@ const IrPathInput = {
 const InspectTypeSchema = z.object({
   name: z.string(),
   kind: z.enum(['object', 'enum', 'discriminatedUnion', 'raw']),
+  description: z.string().optional(),
   table: z.boolean().optional(),
+  tableName: z.string().optional(),
   fieldCount: z.number().optional(),
   fields: z
     .array(
       z.object({
         name: z.string(),
+        description: z.string().optional(),
         type: z.string(),
         optional: z.boolean().optional(),
         nullable: z.boolean().optional(),
       }),
     )
     .optional(),
+  indexes: z
+    .array(
+      z.object({
+        name: z.string(),
+        fields: z.array(z.string()),
+      }),
+    )
+    .optional(),
   values: z.array(z.string()).optional(),
   variants: z.array(z.string()).optional(),
   discriminator: z.string().optional(),
+});
+
+const GeneratedTargetInspectSchema = z.object({
+  kind: z.string(),
+  group: z.enum(['convex', 'supporting', 'agent']),
+  label: z.string(),
+  path: z.string(),
+  enabled: z.boolean(),
 });
 
 const InspectOutput = {
@@ -52,6 +73,12 @@ const InspectOutput = {
       path: z.string(),
     }),
   ),
+  outputConfig: z.unknown().optional(),
+  generatedTargets: z.array(GeneratedTargetInspectSchema),
+  agent: z.object({
+    preferredMutationTools: z.array(z.string()),
+    safeLoop: z.array(z.string()),
+  }),
 };
 
 const ValidationIssueSchema = z.object({
@@ -108,6 +135,15 @@ const CheckContextureDriftOutput = {
       status: GeneratedFileStatusSchema,
     }),
   ),
+};
+
+const IntegrationGuidanceOutput = {
+  path: z.string(),
+  sourceOfTruth: z.literal('.contexture.json'),
+  safeLoop: z.array(z.string()),
+  preferredMutationTools: z.array(z.string()),
+  rules: z.array(z.string()),
+  prompt: z.string(),
 };
 
 export function createContextureMcpServer(options: ContextureMcpServerOptions = {}): McpServer {
@@ -212,6 +248,48 @@ export function createContextureMcpServer(options: ContextureMcpServerOptions = 
       return jsonToolResult(structuredContent);
     },
   );
+
+  server.registerTool(
+    'get_contexture_integration_guidance',
+    {
+      title: 'Get Contexture Integration Guidance',
+      description:
+        'Return concise repo-integration guidance for agents using Contexture as the source of truth.',
+      inputSchema: IrPathInput,
+      outputSchema: IntegrationGuidanceOutput,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async ({ irPath }) => {
+      const path = assertContextureIrPath(irPath);
+      const structuredContent = buildIntegrationGuidance(path);
+      return jsonToolResult(structuredContent);
+    },
+  );
+
+  for (const tool of createOpTools(async () => ({ error: 'unbound MCP op tool' }))) {
+    server.registerTool(
+      tool.name,
+      {
+        title: `Contexture ${tool.name}`,
+        description: `${tool.description} Mutates the .contexture.json file through the shared Contexture op applier and rewrites generated artifacts.`,
+        inputSchema: { ...IrPathInput, ...tool.inputSchema },
+        outputSchema: ApplyContextureOpOutput,
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+        },
+      },
+      async (args) => {
+        const structuredContent = await applyTypedContextureOp(tool.name, args, options.stdlib);
+        return jsonToolResult(structuredContent);
+      },
+    );
+  }
 
   return server;
 }
@@ -351,6 +429,10 @@ function buildInspectSummary(
   schema: Schema,
   irPath: string,
 ): z.infer<z.ZodObject<typeof InspectOutput>> {
+  const paths = bundlePathsFor(irPath);
+  const preferredMutationTools = createOpTools(async () => ({ error: 'inspect only' })).map(
+    (tool) => tool.name,
+  );
   return {
     path: irPath,
     version: schema.version,
@@ -362,6 +444,23 @@ function buildInspectSummary(
       alias: imp.alias,
       path: imp.path,
     })),
+    ...(schema.outputs ? { outputConfig: schema.outputs } : {}),
+    generatedTargets: GENERATED_TARGETS.map((target) => ({
+      kind: target.kind,
+      group: target.group,
+      label: target.label,
+      path: target.path(paths),
+      enabled: target.enabled(schema),
+    })),
+    agent: {
+      preferredMutationTools,
+      safeLoop: [
+        'inspect_contexture',
+        'validate_contexture',
+        'emit_contexture',
+        'check_contexture_drift',
+      ],
+    },
   };
 }
 
@@ -370,20 +469,32 @@ function typeToInspectJson(type: TypeDef): z.infer<typeof InspectTypeSchema> {
     return {
       name: type.name,
       kind: 'object',
+      ...(type.description ? { description: type.description } : {}),
       ...(type.table ? { table: true } : {}),
+      ...(type.table ? { tableName: type.tableName ?? convexTableName(type.name) } : {}),
       fieldCount: type.fields.length,
       fields: type.fields.map((field) => ({
         name: field.name,
+        ...(field.description ? { description: field.description } : {}),
         type: fieldTypeToString(field.type),
         ...(field.optional ? { optional: true } : {}),
         ...(field.nullable ? { nullable: true } : {}),
       })),
+      ...((type.indexes?.length ?? 0) > 0
+        ? {
+            indexes: type.indexes?.map((index) => ({
+              name: index.name,
+              fields: index.fields,
+            })),
+          }
+        : {}),
     };
   }
   if (type.kind === 'enum') {
     return {
       name: type.name,
       kind: 'enum',
+      ...(type.description ? { description: type.description } : {}),
       values: type.values.map((value) => value.value),
     };
   }
@@ -391,11 +502,94 @@ function typeToInspectJson(type: TypeDef): z.infer<typeof InspectTypeSchema> {
     return {
       name: type.name,
       kind: 'discriminatedUnion',
+      ...(type.description ? { description: type.description } : {}),
       discriminator: type.discriminator,
       variants: type.variants,
     };
   }
-  return { name: type.name, kind: 'raw' };
+  return {
+    name: type.name,
+    kind: 'raw',
+    ...(type.description ? { description: type.description } : {}),
+  };
+}
+
+function convexTableName(typeName: string): string {
+  return `${typeName.charAt(0).toLowerCase()}${typeName.slice(1)}`;
+}
+
+async function applyTypedContextureOp(
+  opKind: string,
+  args: Record<string, unknown>,
+  catalog?: StdlibCatalog,
+): Promise<z.infer<z.ZodObject<typeof ApplyContextureOpOutput>>> {
+  const irPath = typeof args.irPath === 'string' ? args.irPath : '';
+  let path: string;
+  try {
+    path = assertContextureIrPath(irPath);
+  } catch (err) {
+    return {
+      path: irPath,
+      applied: false,
+      opKind,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const { irPath: _irPath, ...toolArgs } = args;
+  const tools = new Map(
+    createOpTools(createFileBackedForward(path, { stdlib: catalog, changeSource: 'mcp' })).map(
+      (tool) => [tool.name, tool],
+    ),
+  );
+  const tool = tools.get(opKind);
+  if (!tool) return { path, applied: false, opKind, error: `unknown op tool: ${opKind}` };
+
+  try {
+    const result = await tool.handler(toolArgs);
+    if ('error' in result) return { path, applied: false, opKind, error: result.error };
+    return {
+      path,
+      applied: true,
+      opKind,
+      typeCount: result.schema.types.length,
+    };
+  } catch (err) {
+    return {
+      path,
+      applied: false,
+      opKind,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function buildIntegrationGuidance(
+  irPath: string,
+): z.infer<z.ZodObject<typeof IntegrationGuidanceOutput>> {
+  const preferredMutationTools = createOpTools(async () => ({ error: 'guidance only' })).map(
+    (tool) => tool.name,
+  );
+  const safeLoop = [
+    'inspect_contexture',
+    'validate_contexture',
+    'emit_contexture',
+    'check_contexture_drift',
+  ];
+  return {
+    path: irPath,
+    sourceOfTruth: '.contexture.json',
+    safeLoop,
+    preferredMutationTools,
+    rules: [
+      'Treat the .contexture.json IR as the source of truth for domain-model changes.',
+      'Do not hand-edit generated files with a @contexture-generated marker; change the IR and emit instead.',
+      'Prefer typed op tools such as add_field, rename_type, set_table_flag, and add_index over apply_contexture_op when possible.',
+      'After any model mutation, validate, emit generated targets, and check drift before finishing.',
+      'Wire generated outputs into the existing app architecture; Contexture does not own arbitrary application code.',
+    ],
+    prompt: `Use the Contexture MCP server to inspect ${irPath}, make domain-model changes with typed op tools, validate the IR, emit generated Convex and supporting targets, and check drift before finishing.`,
+  };
 }
 
 function fieldTypeToString(type: FieldType): string {


### PR DESCRIPTION
## Summary
- expose Contexture's typed op registry as first-class MCP mutation tools
- enrich inspect_contexture with descriptions, table names, indexes, output config, generated target paths, and agent workflow metadata
- add integration guidance and make CLI MCP validation stdlib-aware by default

## Verification
- pre-commit hook ran turbo typecheck
- pre-commit hook ran turbo test
- bunx biome check packages/core/src/mcp-server.ts packages/cli/src/mcp-server.ts packages/cli/tests/mcp.test.ts packages/cli/package.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782716199&installation_id=136251083&pr_number=340&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F340&signature=df869eeddbecc4b0d4b754351a19afbb73f75f39a8fcd46b90d5fcf676eacdc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->