### PR TITLE
fix(desktop): respect system theme on startup

### DIFF
--- a/apps/desktop/e2e/app-launch.spec.ts
+++ b/apps/desktop/e2e/app-launch.spec.ts
@@ -21,7 +21,7 @@ test.describe('App Launch', () => {
   });
 
   test('toolbar is visible', async () => {
-    await expect(page.locator('[title="Toggle theme"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('button', { name: 'Theme' })).toBeVisible({ timeout: 10_000 });
   });
 
   test('main content area renders', async () => {

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -1,9 +1,22 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Contexture</title>
+    <script>
+      (() => {
+        const storedTheme = localStorage.getItem('theme');
+        const preference =
+          storedTheme === 'dark' || storedTheme === 'light' || storedTheme === 'system'
+            ? storedTheme
+            : 'system';
+        const useDarkTheme =
+          preference === 'dark' ||
+          (preference === 'system' && matchMedia('(prefers-color-scheme: dark)').matches);
+        document.documentElement.classList.toggle('dark', useDarkTheme);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/Toolbar.tsx
@@ -10,10 +10,17 @@ import {
   type SchemaAgentProvider,
   useSchemaAgentSettingsStore,
 } from '@renderer/store/schema-agent-settings';
-import { useUIChromeStore } from '@renderer/store/ui-chrome';
-import { Bot, ChevronDown, Moon, PanelRight, Plus, Sun } from 'lucide-react';
+import { type ThemePreference, useUIChromeStore } from '@renderer/store/ui-chrome';
+import { Bot, ChevronDown, Moon, PanelRight, Plus, Sun, SunMoon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
@@ -33,7 +40,8 @@ export function Toolbar({ onCreateType }: ToolbarProps): React.JSX.Element {
     return null;
   });
   const theme = useUIChromeStore((s) => s.theme);
-  const toggleTheme = useUIChromeStore((s) => s.toggleTheme);
+  const resolvedTheme = useUIChromeStore((s) => s.resolvedTheme);
+  const setTheme = useUIChromeStore((s) => s.setTheme);
   const sidebarVisible = useUIChromeStore((s) => s.sidebarVisible);
   const toggleSidebar = useUIChromeStore((s) => s.toggleSidebar);
   const provider = useSchemaAgentSettingsStore((s) => s.provider);
@@ -150,15 +158,39 @@ export function Toolbar({ onCreateType }: ToolbarProps): React.JSX.Element {
         </Popover>
       )}
 
-      <Button
-        variant="ghost"
-        size="icon"
-        className="size-8"
-        title="Toggle theme"
-        onClick={toggleTheme}
-      >
-        {theme === 'dark' ? <Sun /> : <Moon />}
-      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            title="Theme"
+            aria-label="Theme"
+            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+          >
+            {theme === 'system' ? <SunMoon /> : resolvedTheme === 'dark' ? <Moon /> : <Sun />}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuRadioGroup
+            value={theme}
+            onValueChange={(value) => setTheme(value as ThemePreference)}
+          >
+            <DropdownMenuRadioItem value="system" className="gap-2">
+              <SunMoon className="size-4" />
+              System
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="light" className="gap-2">
+              <Sun className="size-4" />
+              Light
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="dark" className="gap-2">
+              <Moon className="size-4" />
+              Dark
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       <Popover
         open={providerPopoverOpen}

--- a/apps/desktop/src/renderer/src/store/ui-chrome.ts
+++ b/apps/desktop/src/renderer/src/store/ui-chrome.ts
@@ -8,14 +8,19 @@
 import { create } from 'zustand';
 
 export type Theme = 'dark' | 'light';
+export type ThemePreference = Theme | 'system';
 export type SidebarTab = 'properties' | 'chat' | 'schema' | 'changes';
 
+const THEME_STORAGE_KEY = 'theme';
+
 interface UIChromeStoreShape {
-  theme: Theme;
+  theme: ThemePreference;
+  resolvedTheme: Theme;
   chatOpen: boolean;
   sidebarVisible: boolean;
   sidebarTab: SidebarTab;
 
+  setTheme(theme: ThemePreference): void;
   toggleTheme(): void;
   setChatOpen(open: boolean): void;
   toggleSidebar(): void;
@@ -23,20 +28,67 @@ interface UIChromeStoreShape {
   setSidebarTab(tab: SidebarTab): void;
 }
 
+function systemTheme(): Theme {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return 'dark';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function storedThemePreference(): ThemePreference {
+  if (typeof localStorage === 'undefined') return 'system';
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return stored === 'dark' || stored === 'light' || stored === 'system' ? stored : 'system';
+}
+
+function resolveTheme(theme: ThemePreference): Theme {
+  return theme === 'system' ? systemTheme() : theme;
+}
+
+function applyTheme(theme: Theme): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+}
+
+function persistTheme(theme: ThemePreference): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
+}
+
+const initialTheme = storedThemePreference();
+const initialResolvedTheme = resolveTheme(initialTheme);
+applyTheme(initialResolvedTheme);
+
 export const useUIChromeStore = create<UIChromeStoreShape>((set) => ({
-  theme: 'dark',
+  theme: initialTheme,
+  resolvedTheme: initialResolvedTheme,
   chatOpen: true,
   sidebarVisible: true,
   sidebarTab: 'chat',
 
+  setTheme: (theme) => {
+    const resolvedTheme = resolveTheme(theme);
+    persistTheme(theme);
+    applyTheme(resolvedTheme);
+    set({ theme, resolvedTheme });
+  },
   toggleTheme: () =>
     set((state) => {
-      const newTheme: Theme = state.theme === 'dark' ? 'light' : 'dark';
-      document.documentElement.classList.toggle('dark', newTheme === 'dark');
-      return { theme: newTheme };
+      const theme: Theme = state.resolvedTheme === 'dark' ? 'light' : 'dark';
+      persistTheme(theme);
+      applyTheme(theme);
+      return { theme, resolvedTheme: theme };
     }),
   setChatOpen: (open) => set({ chatOpen: open }),
   toggleSidebar: () => set((state) => ({ sidebarVisible: !state.sidebarVisible })),
   setSidebarVisible: (visible) => set({ sidebarVisible: visible }),
   setSidebarTab: (tab) => set({ sidebarTab: tab }),
 }));
+
+if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (event) => {
+    const state = useUIChromeStore.getState();
+    if (state.theme !== 'system') return;
+    const resolvedTheme = event.matches ? 'dark' : 'light';
+    applyTheme(resolvedTheme);
+    useUIChromeStore.setState({ resolvedTheme });
+  });
+}

--- a/apps/desktop/tests/store/ui-chrome.test.ts
+++ b/apps/desktop/tests/store/ui-chrome.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MatchMediaListener = (event: MediaQueryListEvent) => void;
+
+function installMatchMedia(matches: boolean): {
+  setMatches: (matches: boolean) => void;
+  emitChange: () => void;
+} {
+  let currentMatches = matches;
+  const listeners = new Set<MatchMediaListener>();
+
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn((query: string) => ({
+      matches: currentMatches,
+      media: query,
+      onchange: null,
+      addEventListener: (_type: 'change', listener: MatchMediaListener) => {
+        listeners.add(listener);
+      },
+      removeEventListener: (_type: 'change', listener: MatchMediaListener) => {
+        listeners.delete(listener);
+      },
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+
+  return {
+    setMatches: (matches) => {
+      currentMatches = matches;
+    },
+    emitChange: () => {
+      for (const listener of listeners) {
+        listener({ matches: currentMatches } as MediaQueryListEvent);
+      }
+    },
+  };
+}
+
+async function loadStore() {
+  vi.resetModules();
+  return import('@renderer/store/ui-chrome');
+}
+
+describe('UI chrome theme preference', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the system light theme on first startup', async () => {
+    installMatchMedia(false);
+
+    const { useUIChromeStore } = await loadStore();
+
+    expect(useUIChromeStore.getState().theme).toBe('system');
+    expect(useUIChromeStore.getState().resolvedTheme).toBe('light');
+    expect(document.documentElement).not.toHaveClass('dark');
+  });
+
+  it('uses the system dark theme on first startup', async () => {
+    installMatchMedia(true);
+
+    const { useUIChromeStore } = await loadStore();
+
+    expect(useUIChromeStore.getState().theme).toBe('system');
+    expect(useUIChromeStore.getState().resolvedTheme).toBe('dark');
+    expect(document.documentElement).toHaveClass('dark');
+  });
+
+  it('persists explicit light and dark choices', async () => {
+    installMatchMedia(true);
+    const { useUIChromeStore } = await loadStore();
+
+    useUIChromeStore.getState().setTheme('light');
+
+    expect(localStorage.getItem('theme')).toBe('light');
+    expect(useUIChromeStore.getState().resolvedTheme).toBe('light');
+    expect(document.documentElement).not.toHaveClass('dark');
+  });
+
+  it('tracks system changes while system is selected', async () => {
+    const matchMedia = installMatchMedia(false);
+    const { useUIChromeStore } = await loadStore();
+
+    matchMedia.setMatches(true);
+    matchMedia.emitChange();
+
+    expect(useUIChromeStore.getState().theme).toBe('system');
+    expect(useUIChromeStore.getState().resolvedTheme).toBe('dark');
+    expect(document.documentElement).toHaveClass('dark');
+  });
+});


### PR DESCRIPTION
## Summary
- default desktop theme preference to System and resolve it from the OS color scheme
- apply the resolved theme before React mounts to avoid dark-first startup
- replace the binary theme toggle with a System/Light/Dark menu and add regression coverage

## Verification
- bun run test -- tests/components/toolbar/Toolbar.test.tsx tests/store/ui-chrome.test.ts
- bun run lint
- bun run build
- bun run test:e2e -- e2e/app-launch.spec.ts
- pre-commit hook: turbo typecheck && turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782808183&installation_id=136251083&pr_number=341&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F341&signature=474e78d0c7f68b5ab1b269e6897ee38374ee973a898837fc0f9499f104a42846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->