### PR TITLE
fix: clean up Electron e2e app processes

### DIFF
--- a/apps/desktop/e2e/app-launch.spec.ts
+++ b/apps/desktop/e2e/app-launch.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { launchElectron } from './electron-launch';
+import { closeElectron, launchElectron } from './electron-launch';
 
 test.describe('App Launch', () => {
   let electronApp: Awaited<ReturnType<typeof launchElectron>>;
@@ -12,7 +12,7 @@ test.describe('App Launch', () => {
   });
 
   test.afterAll(async () => {
-    await electronApp?.close();
+    await closeElectron(electronApp);
   });
 
   test('window title contains Contexture', async () => {

--- a/apps/desktop/e2e/chat-cancel.spec.ts
+++ b/apps/desktop/e2e/chat-cancel.spec.ts
@@ -14,7 +14,7 @@
  * observable outcome of cancelling a turn: the graph reverts.
  */
 import { expect, test } from '@playwright/test';
-import { launchElectron } from './electron-launch';
+import { closeElectron, launchElectron } from './electron-launch';
 
 test.describe('Chat cancel rolls back mid-turn ops', () => {
   let electronApp: Awaited<ReturnType<typeof launchElectron>>;
@@ -27,7 +27,7 @@ test.describe('Chat cancel rolls back mid-turn ops', () => {
   });
 
   test.afterAll(async () => {
-    await electronApp?.close();
+    await closeElectron(electronApp);
   });
 
   test('begin + ops + rollback → graph state reverts to pre-turn', async () => {

--- a/apps/desktop/e2e/chat-ops.spec.ts
+++ b/apps/desktop/e2e/chat-ops.spec.ts
@@ -11,7 +11,7 @@
  * variant belongs to a separate, network-opted-in suite.
  */
 import { expect, test } from '@playwright/test';
-import { launchElectron } from './electron-launch';
+import { closeElectron, launchElectron } from './electron-launch';
 
 test.describe('Chat-ops turn collapses to one undo entry', () => {
   let electronApp: Awaited<ReturnType<typeof launchElectron>>;
@@ -24,7 +24,7 @@ test.describe('Chat-ops turn collapses to one undo entry', () => {
   });
 
   test.afterAll(async () => {
-    await electronApp?.close();
+    await closeElectron(electronApp);
   });
 
   test('3 ops in a transaction → 3 animations + 1 undo step', async () => {

--- a/apps/desktop/e2e/contexture-crud.spec.ts
+++ b/apps/desktop/e2e/contexture-crud.spec.ts
@@ -13,7 +13,7 @@
  * `tests/main/write-bundle-atomic.test.ts`.
  */
 import { expect, test } from '@playwright/test';
-import { launchElectron } from './electron-launch';
+import { closeElectron, launchElectron } from './electron-launch';
 
 test.describe('Contexture CRUD', () => {
   let electronApp: Awaited<ReturnType<typeof launchElectron>>;
@@ -42,7 +42,7 @@ test.describe('Contexture CRUD', () => {
   });
 
   test.afterAll(async () => {
-    await electronApp?.close();
+    await closeElectron(electronApp);
   });
 
   test('loads the allotment sample and renders TypeNodes', async () => {

--- a/apps/desktop/e2e/electron-launch.ts
+++ b/apps/desktop/e2e/electron-launch.ts
@@ -1,5 +1,13 @@
-import { _electron as electron } from '@playwright/test';
+import { once } from 'node:events';
+import nodeProcess from 'node:process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { type ElectronApplication, _electron as electron } from '@playwright/test';
 import { ELECTRON_MAIN } from '../playwright.config';
+
+const CLOSE_TIMEOUT_MS = 5_000;
+const KILL_TIMEOUT_MS = 2_000;
+const launchedApps = new Set<ElectronApplication>();
+let cleanupHooksInstalled = false;
 
 /** Shared Electron launch options — handles headless Linux CI (xvfb + no-sandbox). */
 export function electronLaunchOptions() {
@@ -16,5 +24,68 @@ export function electronLaunchOptions() {
 }
 
 export async function launchElectron() {
-  return electron.launch(electronLaunchOptions());
+  installCleanupHooks();
+  const electronApp = await electron.launch(electronLaunchOptions());
+  launchedApps.add(electronApp);
+  electronApp.once('close', () => launchedApps.delete(electronApp));
+  return electronApp;
+}
+
+export async function closeElectron(electronApp: ElectronApplication | undefined): Promise<void> {
+  if (!electronApp) return;
+
+  launchedApps.delete(electronApp);
+  const child = electronApp.process();
+  const closePromise = electronApp.close().catch(() => undefined);
+  const result = await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS, 'timeout')]);
+
+  if (result !== 'timeout' && !isAlive(child?.pid)) return;
+
+  child?.kill('SIGTERM');
+  await waitForProcessExit(child, KILL_TIMEOUT_MS);
+
+  if (isAlive(child?.pid)) {
+    child?.kill('SIGKILL');
+    await waitForProcessExit(child, KILL_TIMEOUT_MS);
+  }
+
+  await Promise.race([closePromise, delay(KILL_TIMEOUT_MS)]).catch(() => undefined);
+}
+
+function installCleanupHooks(): void {
+  if (cleanupHooksInstalled) return;
+  cleanupHooksInstalled = true;
+
+  nodeProcess.once('exit', killLaunchedApps);
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    nodeProcess.once(signal, () => {
+      killLaunchedApps();
+      nodeProcess.exit(signal === 'SIGINT' ? 130 : 143);
+    });
+  }
+}
+
+function killLaunchedApps(): void {
+  for (const electronApp of launchedApps) {
+    electronApp.process()?.kill('SIGKILL');
+  }
+  launchedApps.clear();
+}
+
+function isAlive(pid: number | undefined): boolean {
+  if (!pid) return false;
+  try {
+    nodeProcess.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(
+  child: ReturnType<ElectronApplication['process']>,
+  timeoutMs: number,
+): Promise<void> {
+  if (!child || !isAlive(child.pid)) return;
+  await Promise.race([once(child, 'exit'), delay(timeoutMs)]).catch(() => undefined);
 }

--- a/apps/desktop/e2e/import-export.spec.ts
+++ b/apps/desktop/e2e/import-export.spec.ts
@@ -10,7 +10,7 @@
  * UI would perform on save / reopen.
  */
 import { expect, test } from '@playwright/test';
-import { launchElectron } from './electron-launch';
+import { closeElectron, launchElectron } from './electron-launch';
 
 test.describe('Import / export round-trip', () => {
   let electronApp: Awaited<ReturnType<typeof launchElectron>>;
@@ -41,7 +41,7 @@ test.describe('Import / export round-trip', () => {
   });
 
   test.afterAll(async () => {
-    await electronApp?.close();
+    await closeElectron(electronApp);
   });
 
   test('round-trips the allotment sample through load + save', async () => {

--- a/apps/desktop/src/main/app-main.ts
+++ b/apps/desktop/src/main/app-main.ts
@@ -87,7 +87,7 @@ app.whenReady().then(() => {
 
   const mainWindow = createWindow();
   Menu.setApplicationMenu(createMenu(mainWindow));
-  registerUpdateIpc(mainWindow);
+  registerUpdateIpc(mainWindow, { autoCheck: !isE2E });
   registerFileIpc(mainWindow);
   registerShellIpc();
   registerReconcileIpc();

--- a/apps/desktop/src/main/ipc/update.ts
+++ b/apps/desktop/src/main/ipc/update.ts
@@ -13,12 +13,19 @@ export interface UpdateState {
 let state: UpdateState = { status: 'idle' };
 let win: BrowserWindow | null = null;
 
+interface RegisterUpdateIpcOptions {
+  autoCheck?: boolean;
+}
+
 function broadcast(next: UpdateState): void {
   state = next;
   win?.webContents.send('update:state', state);
 }
 
-export function registerUpdateIpc(mainWindow: BrowserWindow): void {
+export function registerUpdateIpc(
+  mainWindow: BrowserWindow,
+  options: RegisterUpdateIpcOptions = {},
+): void {
   win = mainWindow;
 
   autoUpdater.autoDownload = false;
@@ -78,6 +85,8 @@ export function registerUpdateIpc(mainWindow: BrowserWindow): void {
   });
 
   ipcMain.handle('update:get-state', () => state);
+
+  if (options.autoCheck === false) return;
 
   // Check on startup after a short delay, then every 4 hours
   setTimeout(() => autoUpdater.checkForUpdates().catch(() => {}), 5000);


### PR DESCRIPTION
## Summary
- add a shared Electron e2e closer that waits for app process exit and force-kills stranded processes
- install test-worker exit hooks for launched Electron apps
- keep update IPC registered in e2e while disabling background update timers

## Verification
- bun run build
- bun run typecheck:node
- bun run lint
- bun run test:e2e -- e2e/app-launch.spec.ts
- pre-commit: turbo typecheck, turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782809035&installation_id=136251083&pr_number=342&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F342&signature=5a72fde48a430cea3626434e20e00c27f950ca0b6ddc336ce6c3790f57fdc092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->