### PR TITLE
feat(desktop): add Claude Code and Claude Desktop tabs to Agent setup

### DIFF
--- a/apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx
@@ -58,6 +58,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import { getHighlighter, SHIKI_THEMES } from './shiki-highlighter';
 
@@ -128,8 +129,31 @@ const OUTPUT_GROUPS: { group: GeneratedTargetGroup; label: string }[] = [
   { group: 'agent', label: 'Agent and form targets' },
 ];
 
-const CODEX_MCP_INSTALL_COMMAND =
-  'codex mcp add contexture -- /Applications/Contexture.app/Contents/Resources/bin/contexture-mcp';
+const CONTEXTURE_MCP_BIN_PATH =
+  '/Applications/Contexture.app/Contents/Resources/bin/contexture-mcp';
+
+const CODEX_MCP_INSTALL_COMMAND = `codex mcp add contexture -- ${CONTEXTURE_MCP_BIN_PATH}`;
+
+const CLAUDE_CODE_MCP_INSTALL_COMMAND = `claude mcp add --transport stdio --scope user contexture -- ${CONTEXTURE_MCP_BIN_PATH}`;
+
+const CLAUDE_DESKTOP_CONFIG_PATH =
+  '~/Library/Application Support/Claude/claude_desktop_config.json';
+
+const CLAUDE_DESKTOP_CONFIG_SNIPPET = `{
+  "mcpServers": {
+    "contexture": {
+      "command": "${CONTEXTURE_MCP_BIN_PATH}"
+    }
+  }
+}`;
+
+type AgentClient = 'codex' | 'claude-code' | 'claude-desktop';
+
+const AGENT_CLIENT_LABEL: Record<AgentClient, string> = {
+  codex: 'Codex',
+  'claude-code': 'Claude Code',
+  'claude-desktop': 'Claude Desktop',
+};
 
 const CONTEXTURE_MCP_TOOLS = [
   'inspect_contexture',
@@ -626,14 +650,15 @@ function AgentSetupPopover({
   onRequestSave?: () => void;
   compact?: boolean;
 }): React.JSX.Element {
+  const [activeClient, setActiveClient] = useState<AgentClient>('codex');
   const savedPrompt =
     documentFilePath === null
       ? null
       : `Use the Contexture MCP server to inspect ${documentFilePath}, propose reviewable Convex model changes, emit convex/schema.ts and convex/validators.ts, then check drift before finishing.`;
   const smokeTest =
     documentFilePath === null
-      ? 'Ask Codex: "List the contexture MCP tools."'
-      : `Ask Codex: "List the contexture MCP tools, then inspect ${documentFilePath} and summarize the Convex tables."`;
+      ? 'Ask your agent: "List the contexture MCP tools."'
+      : `Ask your agent: "List the contexture MCP tools, then inspect ${documentFilePath} and summarize the Convex tables."`;
   const copiedLabel =
     copied === 'install'
       ? 'Copied install command'
@@ -667,26 +692,101 @@ function AgentSetupPopover({
           {compact ? <span className="text-xs">Agent</span> : null}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-80 p-2" align="end" data-testid="agent-setup-content">
+      <PopoverContent className="w-96 p-2" align="end" data-testid="agent-setup-content">
         <div className="mb-2 px-1">
           <h3 id="agent-setup-title" className="text-xs font-semibold text-foreground">
             Agent setup
           </h3>
           <p className="text-[11px] leading-snug text-muted-foreground">
-            Let Codex or another MCP-capable agent review and evolve this Convex model.
+            Connect Contexture's MCP server to your agent and evolve this Convex model.
           </p>
         </div>
 
-        <div className="space-y-1.5">
-          <AgentCopyRow
-            label="Codex install command"
-            value={CODEX_MCP_INSTALL_COMMAND}
-            copied={copied === 'install'}
-            onCopy={() => onCopy('install', CODEX_MCP_INSTALL_COMMAND)}
-            copyLabel="Copy Codex MCP install command"
-            testId="agent-setup-install"
-          />
+        <Tabs
+          value={activeClient}
+          onValueChange={(value) => setActiveClient(value as AgentClient)}
+          className="mb-2"
+        >
+          <TabsList
+            className="grid h-8 w-full grid-cols-3 p-0.5"
+            aria-label="MCP client install instructions"
+          >
+            <TabsTrigger
+              value="codex"
+              className="h-7 px-1 text-[11px]"
+              data-testid="agent-setup-tab-codex"
+            >
+              {AGENT_CLIENT_LABEL.codex}
+            </TabsTrigger>
+            <TabsTrigger
+              value="claude-code"
+              className="h-7 px-1 text-[11px]"
+              data-testid="agent-setup-tab-claude-code"
+            >
+              {AGENT_CLIENT_LABEL['claude-code']}
+            </TabsTrigger>
+            <TabsTrigger
+              value="claude-desktop"
+              className="h-7 px-1 text-[11px]"
+              data-testid="agent-setup-tab-claude-desktop"
+            >
+              {AGENT_CLIENT_LABEL['claude-desktop']}
+            </TabsTrigger>
+          </TabsList>
 
+          <TabsContent value="codex" className="mt-2">
+            <AgentCopyRow
+              label="Codex install command"
+              value={CODEX_MCP_INSTALL_COMMAND}
+              copied={copied === 'install'}
+              onCopy={() => onCopy('install', CODEX_MCP_INSTALL_COMMAND)}
+              copyLabel="Copy Codex MCP install command"
+              testId="agent-setup-install"
+            />
+            <p className="mt-1.5 px-1 text-[10px] leading-snug text-muted-foreground">
+              Run in a terminal. Codex picks the server up on the next session.
+            </p>
+          </TabsContent>
+
+          <TabsContent value="claude-code" className="mt-2">
+            <AgentCopyRow
+              label="Claude Code install command"
+              value={CLAUDE_CODE_MCP_INSTALL_COMMAND}
+              copied={copied === 'install'}
+              onCopy={() => onCopy('install', CLAUDE_CODE_MCP_INSTALL_COMMAND)}
+              copyLabel="Copy Claude Code MCP install command"
+              testId="agent-setup-claude-code-install"
+            />
+            <p className="mt-1.5 px-1 text-[10px] leading-snug text-muted-foreground">
+              Run in a terminal. <code className="font-mono">--scope user</code> makes the server
+              available in every project; drop it to scope to the current directory. Verify with{' '}
+              <code className="font-mono">/mcp</code> inside Claude Code.
+            </p>
+          </TabsContent>
+
+          <TabsContent value="claude-desktop" className="mt-2">
+            <AgentCopyRow
+              label="claude_desktop_config.json"
+              value={CLAUDE_DESKTOP_CONFIG_SNIPPET}
+              copied={copied === 'install'}
+              onCopy={() => onCopy('install', CLAUDE_DESKTOP_CONFIG_SNIPPET)}
+              copyLabel="Copy Claude Desktop MCP config"
+              testId="agent-setup-claude-desktop-install"
+            />
+            <p className="mt-1.5 px-1 text-[10px] leading-snug text-muted-foreground">
+              Merge into{' '}
+              <code
+                className="font-mono break-all"
+                data-testid="agent-setup-claude-desktop-config-path"
+              >
+                {CLAUDE_DESKTOP_CONFIG_PATH}
+              </code>{' '}
+              (Settings → Developer → Edit Config), then restart Claude Desktop.
+            </p>
+          </TabsContent>
+        </Tabs>
+
+        <div className="space-y-1.5">
           {savedPrompt === null ? (
             <div
               className="rounded border border-dashed border-border/80 bg-background/60 p-2 text-[11px] leading-snug text-muted-foreground"

--- a/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
+++ b/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
@@ -92,6 +92,49 @@ describe('SchemaPanel', () => {
     expect(screen.getByText('Copied install command')).toBeInTheDocument();
   });
 
+  it('exposes Claude Code install instructions on the Claude Code tab', async () => {
+    const user = userEvent.setup();
+    const onCopy = vi.fn();
+    render(<SchemaPanel {...DEFAULT_PROPS} zodSource="zod" onCopy={onCopy} />);
+
+    await user.click(screen.getByTestId('agent-setup'));
+    await user.click(screen.getByTestId('agent-setup-tab-claude-code'));
+    expect(screen.getByTestId('agent-setup-claude-code-install-value')).toHaveTextContent(
+      'claude mcp add --transport stdio --scope user contexture -- /Applications/Contexture.app/Contents/Resources/bin/contexture-mcp',
+    );
+
+    await user.click(screen.getByTestId('agent-setup-claude-code-install-copy'));
+    expect(onCopy).toHaveBeenCalledWith(
+      'claude mcp add --transport stdio --scope user contexture -- /Applications/Contexture.app/Contents/Resources/bin/contexture-mcp',
+    );
+  });
+
+  it('exposes a Claude Desktop config snippet and its file path', async () => {
+    const user = userEvent.setup();
+    const onCopy = vi.fn();
+    render(<SchemaPanel {...DEFAULT_PROPS} zodSource="zod" onCopy={onCopy} />);
+
+    await user.click(screen.getByTestId('agent-setup'));
+    await user.click(screen.getByTestId('agent-setup-tab-claude-desktop'));
+    const snippet = screen.getByTestId('agent-setup-claude-desktop-install-value');
+    expect(snippet).toHaveTextContent('"mcpServers"');
+    expect(snippet).toHaveTextContent('"contexture"');
+    expect(snippet).toHaveTextContent(
+      '"command": "/Applications/Contexture.app/Contents/Resources/bin/contexture-mcp"',
+    );
+    expect(screen.getByTestId('agent-setup-claude-desktop-config-path')).toHaveTextContent(
+      '~/Library/Application Support/Claude/claude_desktop_config.json',
+    );
+
+    await user.click(screen.getByTestId('agent-setup-claude-desktop-install-copy'));
+    expect(onCopy).toHaveBeenCalledTimes(1);
+    const copied = onCopy.mock.calls[0]?.[0] ?? '';
+    expect(copied).toContain('"mcpServers"');
+    expect(copied).toContain(
+      '"command": "/Applications/Contexture.app/Contents/Resources/bin/contexture-mcp"',
+    );
+  });
+
   it('uses the saved document path in the Agent setup prompt and smoke test', () => {
     const onCopy = vi.fn();
     render(
@@ -108,7 +151,7 @@ describe('SchemaPanel', () => {
       'Use the Contexture MCP server to inspect /repo/garden.contexture.json, propose reviewable Convex model changes, emit convex/schema.ts and convex/validators.ts, then check drift before finishing.',
     );
     expect(screen.getByTestId('agent-setup-smoke-value')).toHaveTextContent(
-      'Ask Codex: "List the contexture MCP tools, then inspect /repo/garden.contexture.json and summarize the Convex tables."',
+      'Ask your agent: "List the contexture MCP tools, then inspect /repo/garden.contexture.json and summarize the Convex tables."',
     );
 
     fireEvent.click(screen.getByTestId('agent-setup-prompt-copy'));
@@ -134,7 +177,7 @@ describe('SchemaPanel', () => {
     );
     expect(screen.queryByLabelText('Saved-document prompt')).not.toBeInTheDocument();
     expect(screen.getByTestId('agent-setup-smoke-value')).toHaveTextContent(
-      'Ask Codex: "List the contexture MCP tools."',
+      'Ask your agent: "List the contexture MCP tools."',
     );
 
     fireEvent.click(screen.getByText('Save first'));


### PR DESCRIPTION
## Summary
- The Agent setup popover in the Schema panel only documented Codex; Claude users had no install guidance.
- Replaced the single install row with a 3-tab strip (Codex / Claude Code / Claude Desktop). Each tab shows its own copyable install instructions:
  - **Codex** — existing `codex mcp add contexture -- …` command.
  - **Claude Code** — `claude mcp add --transport stdio --scope user contexture -- …` with a note explaining `--scope` and how to verify via `/mcp`.
  - **Claude Desktop** — full `claude_desktop_config.json` snippet plus the macOS config path (`~/Library/Application Support/Claude/claude_desktop_config.json`) and a "restart Claude Desktop" hint.
- Smoke-test wording changed from `Ask Codex:` → `Ask your agent:` now that the popover serves multiple clients.

## Test plan
- [x] `bun run test -- tests/components/schema/SchemaPanel.test.tsx` (28/28 passing, including two new tests for the Claude Code and Claude Desktop tabs).
- [x] `bun run typecheck` and `bun run lint` clean.
- [ ] Open a saved `.contexture.json`, click **Agent setup**, switch through all three tabs, and copy each install command to verify clipboard payload.
- [ ] In Claude Code: run the copied command, restart, and confirm `/mcp` lists `contexture` with the five `*_contexture*` tools.
- [ ] In Claude Desktop: merge the snippet into `claude_desktop_config.json`, restart, and confirm the server appears in Settings → Developer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782810235&installation_id=136251083&pr_number=343&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F343&signature=803a5fca938d5bee74bcb1682ad730c4ea1f9ad1ee9fb52c9385020a2716d8c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->