### PR TITLE
chore: bump desktop app version

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,7 +35,7 @@ Contexture is the domain-model control plane for AI-native TypeScript apps. Thes
 - **Provider runtime**: A concrete adapter for a model/provider, such as Codex or Claude, behind the schema-agent contract.
 - **Provider thread**: Provider-owned conversation state. Contexture stores only opaque thread references and marks them desynced when rollback or resume cannot be trusted.
 - **CLI surface**: The `contexture` command-line interface for inspecting, validating, mutating, emitting, and checking drift in downstream projects.
-- **MCP surface**: The `contexture-mcp` server, or packaged app `--mcp` entrypoint, exposing inspect, validate, apply-op, emit, and drift-check tools to agents.
+- **MCP surface**: The standalone `contexture-mcp` server packaged with the app, exposing inspect, validate, apply-op, emit, and drift-check tools to agents without launching the desktop UI.
 - **Schema-only mode**: The provider runtime posture where the model receives only Contexture schema tools, not filesystem, shell, browser, or repository mutation tools.
 
 ## Standard Library

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.25",
+  "version": "0.15.26",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/main/ipc/file.ts
+++ b/apps/desktop/src/main/ipc/file.ts
@@ -13,9 +13,14 @@
  * drive them directly without booting Electron.
  */
 
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import type { ChatHistory, Layout } from '@contexture/core';
 import { hashContent, IRSchema, type Schema, save as saveIR } from '@contexture/core';
+import {
+  CHAT_CONTEXT_MAX_FILE_BYTES,
+  CHAT_CONTEXT_MAX_TOTAL_BYTES,
+  type ChatContextAttachment,
+} from '@shared/chat-attachments';
 import { app, type BrowserWindow, dialog, type FileFilter, ipcMain } from 'electron';
 import { z } from 'zod';
 import {
@@ -38,6 +43,29 @@ export const CONTEXTURE_OPEN_FILTER: FileFilter = {
 };
 
 export const CONTEXTURE_SAVE_FILTER: FileFilter = CONTEXTURE_OPEN_FILTER;
+
+export const CHAT_CONTEXT_FILE_FILTER: FileFilter = {
+  name: 'Text Files',
+  extensions: [
+    'txt',
+    'md',
+    'json',
+    'jsonc',
+    'ts',
+    'tsx',
+    'js',
+    'jsx',
+    'mjs',
+    'cjs',
+    'css',
+    'html',
+    'yml',
+    'yaml',
+    'toml',
+    'xml',
+    'csv',
+  ],
+};
 
 export interface HandleSaveInput {
   irPath: string;
@@ -72,6 +100,11 @@ export interface OpenResult {
   chat: ChatHistory;
   /** Sidecar warnings (not IR — those come from renderer-side `load()`). */
   warnings: OpenWarning[];
+}
+
+export interface PickChatContextFilesDeps {
+  showOpenDialog: typeof dialog.showOpenDialog;
+  readFile: (path: string) => Promise<string>;
 }
 
 let store: DocumentStore | null = null;
@@ -123,6 +156,60 @@ export async function handleOpen(irPath: string): Promise<OpenResult | null> {
   };
 }
 
+export async function handlePickChatContextFiles(
+  mainWindow: BrowserWindow,
+  deps: PickChatContextFilesDeps = {
+    showOpenDialog: dialog.showOpenDialog,
+    readFile: (path) => getStore().readFile(path),
+  },
+): Promise<ChatContextAttachment[]> {
+  const result = await deps.showOpenDialog(mainWindow, {
+    title: 'Attach Files to Chat',
+    filters: [CHAT_CONTEXT_FILE_FILTER],
+    properties: ['openFile', 'multiSelections'],
+  });
+  if (result.canceled || result.filePaths.length === 0) return [];
+
+  const attachments: ChatContextAttachment[] = [];
+  let totalBytes = 0;
+  for (const filePath of result.filePaths) {
+    if (totalBytes >= CHAT_CONTEXT_MAX_TOTAL_BYTES) break;
+    const raw = await deps.readFile(filePath);
+    if (raw.includes('\0')) {
+      throw new Error(`Cannot attach binary file: ${filePath}`);
+    }
+    const { content, size, truncated } = trimChatContextContent(
+      raw,
+      Math.min(CHAT_CONTEXT_MAX_FILE_BYTES, CHAT_CONTEXT_MAX_TOTAL_BYTES - totalBytes),
+    );
+    totalBytes += size;
+    attachments.push({
+      id: `${filePath}:${hashContent(content).slice(0, 12)}`,
+      path: filePath,
+      name: basename(filePath),
+      size,
+      content,
+      ...(truncated ? { truncated: true } : {}),
+    });
+  }
+  return attachments;
+}
+
+function trimChatContextContent(
+  content: string,
+  maxBytes: number,
+): { content: string; size: number; truncated: boolean } {
+  const bytes = Buffer.byteLength(content, 'utf8');
+  if (bytes <= maxBytes) return { content, size: bytes, truncated: false };
+
+  let trimmed = content;
+  while (Buffer.byteLength(trimmed, 'utf8') > maxBytes && trimmed.length > 0) {
+    const excess = Buffer.byteLength(trimmed, 'utf8') - maxBytes;
+    trimmed = trimmed.slice(0, Math.max(0, trimmed.length - Math.ceil(excess / 2)));
+  }
+  return { content: trimmed, size: Buffer.byteLength(trimmed, 'utf8'), truncated: true };
+}
+
 /**
  * Register `ipcMain` handlers for file operations. Call once at app start
  * with the main window so dialogs anchor correctly.
@@ -156,6 +243,10 @@ export function registerFileIpc(mainWindow: BrowserWindow): void {
     if (result.canceled || result.filePaths.length === 0) return null;
     return result.filePaths[0];
   });
+
+  ipcMain.handle('file:pick-chat-context-files', async () =>
+    handlePickChatContextFiles(mainWindow),
+  );
 
   ipcMain.handle('file:save-as-dialog', async () => {
     const result = await dialog.showSaveDialog(mainWindow, {

--- a/apps/desktop/src/main/ipc/schema-agent.ts
+++ b/apps/desktop/src/main/ipc/schema-agent.ts
@@ -1,4 +1,8 @@
 import { IRSchema, type Schema } from '@contexture/core';
+import {
+  CHAT_CONTEXT_MAX_FILE_BYTES,
+  CHAT_CONTEXT_MAX_TOTAL_BYTES,
+} from '@shared/chat-attachments';
 import type { BrowserWindow } from 'electron';
 import { ipcMain } from 'electron';
 import { z } from 'zod';
@@ -76,6 +80,45 @@ const ProviderThreadRefSchema = z
     opaque: z.unknown().optional(),
   })
   .strict();
+const ChatContextAttachmentSchema = z
+  .object({
+    id: IpcString,
+    path: IpcString,
+    name: IpcString,
+    size: z.number().int().nonnegative().max(CHAT_CONTEXT_MAX_FILE_BYTES),
+    content: z.string(),
+    truncated: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((input, ctx) => {
+    const contentBytes = Buffer.byteLength(input.content, 'utf8');
+    if (contentBytes > CHAT_CONTEXT_MAX_FILE_BYTES) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['content'],
+        message: 'Attached file content exceeds the per-file chat context limit.',
+      });
+    }
+  });
+const SchemaAgentSendPayloadSchema = z
+  .object({
+    message: IpcString,
+    attachments: z.array(ChatContextAttachmentSchema).default([]),
+  })
+  .strict()
+  .superRefine((input, ctx) => {
+    const total = input.attachments.reduce(
+      (sum, attachment) => sum + Buffer.byteLength(attachment.content, 'utf8'),
+      0,
+    );
+    if (total > CHAT_CONTEXT_MAX_TOTAL_BYTES) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['attachments'],
+        message: 'Attached files exceed the chat context size limit.',
+      });
+    }
+  });
 const ReconcileProposalPayloadSchema = z
   .object({
     irJson: z.string(),
@@ -153,9 +196,13 @@ export function registerSchemaAgentIpc(mainWindow: BrowserWindow): SchemaAgentIp
     }
   });
 
-  ipcMain.handle('schema-agent:send', async (_evt, userMessage: unknown) => {
+  ipcMain.handle('schema-agent:send', async (_evt, payload: unknown) => {
     try {
-      await driver.send(parseIpcPayload('schema-agent:send', IpcString, userMessage));
+      const parsed =
+        typeof payload === 'string'
+          ? { message: parseIpcPayload('schema-agent:send', IpcString, payload), attachments: [] }
+          : parseIpcPayload('schema-agent:send', SchemaAgentSendPayloadSchema, payload);
+      await driver.send(parsed.message, parsed.attachments);
       return { ok: true };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/apps/desktop/src/main/providers/codex/runtime.ts
+++ b/apps/desktop/src/main/providers/codex/runtime.ts
@@ -553,6 +553,7 @@ function buildSchemaOnlyInstructions(): string {
     'You are Contexture schema chat.',
     'Use only the Contexture schema tools provided by this client.',
     'Do not read files, write files, run shell commands, browse, or mutate a repository.',
+    'You may use file contents explicitly attached inside the user message as context.',
     'Treat the current Contexture IR in the user message as authoritative.',
   ].join('\n');
 }

--- a/apps/desktop/src/main/providers/runtime.ts
+++ b/apps/desktop/src/main/providers/runtime.ts
@@ -1,4 +1,5 @@
 import type { Schema } from '@contexture/core';
+import type { ChatContextAttachment } from '@shared/chat-attachments';
 
 export type ProviderKind = 'codex' | 'claude';
 
@@ -79,6 +80,7 @@ export interface SendTurnInput {
   thread: ProviderThreadRef;
   message: string;
   schema: Schema;
+  attachments?: ChatContextAttachment[];
   model?: string;
   effort?: string;
   options?: ModelOptions;

--- a/apps/desktop/src/main/providers/schema-agent-driver.ts
+++ b/apps/desktop/src/main/providers/schema-agent-driver.ts
@@ -1,4 +1,5 @@
 import type { Schema } from '@contexture/core';
+import type { ChatContextAttachment } from '@shared/chat-attachments';
 import { buildUserMessage } from '@shared/system-prompt';
 import type { ChatTurnController } from '../ipc/chat-turn';
 import type {
@@ -40,7 +41,7 @@ export class SchemaAgentDriver {
     this.#deps = deps;
   }
 
-  async send(userMessage: string): Promise<void> {
+  async send(userMessage: string, attachments: ChatContextAttachment[] = []): Promise<void> {
     const {
       runtime: staticRuntime,
       getRuntime,
@@ -68,7 +69,8 @@ export class SchemaAgentDriver {
         for await (const event of runtime.sendTurn({
           thread,
           schema,
-          message: buildUserMessage({ ir: schema, userMessage }),
+          message: buildUserMessage({ ir: schema, userMessage, attachments }),
+          attachments,
           ...modelOptions,
         })) {
           handleRuntimeEvent(event, transport, setThreadRef);

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1,5 +1,14 @@
 type Unsubscribe = () => void;
 
+export interface ChatContextAttachment {
+  id: string;
+  path: string;
+  name: string;
+  size: number;
+  content: string;
+  truncated?: boolean;
+}
+
 export type UpdateState =
   | { status: 'idle' }
   | { status: 'checking' }
@@ -9,7 +18,10 @@ export type UpdateState =
   | { status: 'error'; message?: string };
 
 export interface ContextureSchemaAgentAPI {
-  send: (message: string) => Promise<{ ok: boolean; error?: string }>;
+  send: (
+    message: string,
+    attachments?: ChatContextAttachment[],
+  ) => Promise<{ ok: boolean; error?: string }>;
   setIR: (ir: unknown) => void;
   abort: () => Promise<{ ok: boolean; error?: string }>;
   getStatus: () => Promise<unknown>;
@@ -89,6 +101,8 @@ export interface ContextureFileAPI {
   pickDirectory: () => Promise<string | null>;
   /** Pick a .contexture.json file; returns the absolute path or null if cancelled. */
   pickContextureFile: () => Promise<string | null>;
+  /** Pick text files and return their contents as explicit chat context attachments. */
+  pickChatContextFiles: () => Promise<ChatContextAttachment[]>;
   save: (payload: {
     irPath: string;
     schema: unknown;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -24,8 +24,11 @@ function subscribe(channel: string, listener: (payload: unknown) => void): Unsub
 }
 
 const schemaAgent = {
-  send: (message: string) =>
-    ipcRenderer.invoke('schema-agent:send', message) as Promise<{ ok: boolean; error?: string }>,
+  send: (message: string, attachments = []) =>
+    ipcRenderer.invoke('schema-agent:send', { message, attachments }) as Promise<{
+      ok: boolean;
+      error?: string;
+    }>,
   setIR: (ir: unknown) => ipcRenderer.send('schema-agent:set-ir', ir),
   abort: (): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('schema-agent:abort') as Promise<{ ok: boolean; error?: string }>,
@@ -92,6 +95,8 @@ const file = {
   /** Show a file picker filtered to .contexture.json; returns path or null if cancelled. */
   pickContextureFile: () =>
     ipcRenderer.invoke('file:pick-contexture-file') as Promise<string | null>,
+  /** Pick text files and return contents to attach to the next chat turn. */
+  pickChatContextFiles: () => ipcRenderer.invoke('file:pick-chat-context-files'),
   /** Write the five-file bundle atomically under `irPath`. */
   save: (payload: {
     irPath: string;

--- a/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
+++ b/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
@@ -1,6 +1,6 @@
 import type { ChatHistory, ChatMessage, ChatRole } from '@contexture/core';
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
-import type { ContextureSchemaAgentAPI } from '../../../preload/index.d';
+import type { ChatContextAttachment, ContextureSchemaAgentAPI } from '../../../preload/index.d';
 import { useAgentTurnsStore } from '../store/agent-turns';
 import { useChatComposerStore } from '../store/chat-composer';
 import type { ApplyResult, Op } from '../store/ops';
@@ -25,6 +25,7 @@ import { useSchemaAgentSessionStore } from './schemaAgentSessionStore';
 import { bindTurnToUndo, type IpcSubscriber } from './turn-binder';
 
 export type {
+  ChatContextAttachment,
   SchemaAgentModelInfo,
   SchemaAgentModelOptionDescriptor,
   SchemaAgentModelOptions,
@@ -55,7 +56,7 @@ export interface SchemaAgentChatState {
   providerThreadRef: unknown;
   desynced: boolean;
   clearAuthRequired: () => void;
-  send: (text: string) => Promise<void>;
+  send: (text: string, attachments?: ChatContextAttachment[]) => Promise<void>;
   abort: () => Promise<void>;
   hydrate: (messages: ChatMessage[]) => void;
   hydrateHistory: (history: ChatHistory) => void;
@@ -455,7 +456,7 @@ export function useSchemaAgentChat({
   }, [api]);
 
   const send = useCallback(
-    async (text: string) => {
+    async (text: string, attachments: ChatContextAttachment[] = []) => {
       const trimmed = text.trim();
       if (!trimmed || isStreaming || !isReady) return;
       if (!selectedModel) {
@@ -484,7 +485,7 @@ export function useSchemaAgentChat({
       if (persistenceEnabled) onMessagePersisted?.(userMessage);
       assistantBufferRef.current = '';
       api.setIR(schema);
-      const result = await api.send(trimmed);
+      const result = await api.send(trimmed, attachments);
       if (!result.ok) {
         const message = result.error ?? 'Schema-agent send failed';
         const errorMessage = mkMessage('assistant', `Error: ${message}`);

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -32,6 +32,7 @@ import {
 } from '@contexture/core/agent-turn-ledger';
 import { type ChatThread, useChatThreads } from '@renderer/chat/useChatThreads';
 import type {
+  ChatContextAttachment,
   SchemaAgentChatState,
   SchemaAgentModelOptionDescriptor,
 } from '@renderer/chat/useSchemaAgentChat';
@@ -44,10 +45,15 @@ import {
   BotMessageSquare,
   CheckCircle2,
   Clock3,
+  File,
+  FileText,
+  Image,
   List,
+  Plus,
   RotateCcw,
   Square,
   SquarePen,
+  X,
   XCircle,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -55,6 +61,12 @@ import { Streamdown } from 'streamdown';
 import { BorderBeam } from '@/components/ui/border-beam';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import {
   Empty,
   EmptyDescription,
@@ -145,6 +157,8 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   } = history;
 
   const [input, setInput] = useState('');
+  const [attachments, setAttachments] = useState<ChatContextAttachment[]>([]);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [responsePending, setResponsePending] = useState(false);
   const isWaitingForFinalResponse = responsePending || isStreaming;
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -322,14 +336,17 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
       const text = input.trim();
       if (!text || !canCompose) return;
       setInput('');
+      const turnAttachments = attachments;
+      setAttachments([]);
+      setAttachmentError(null);
       setResponsePending(true);
       try {
-        await send(text);
+        await send(text, turnAttachments);
       } finally {
         setResponsePending(false);
       }
     },
-    [canCompose, input, send],
+    [attachments, canCompose, input, send],
   );
 
   const handleKeyDown = useCallback(
@@ -345,6 +362,25 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   const handleAbort = useCallback(() => {
     void chat.abort();
   }, [chat]);
+
+  const handleAttachFiles = useCallback(async (_kind: 'photos' | 'files') => {
+    setAttachmentError(null);
+    try {
+      const picked = await window.contexture.file.pickChatContextFiles();
+      if (picked.length === 0) return;
+      setAttachments((current) => {
+        const byPath = new Map(current.map((attachment) => [attachment.path, attachment]));
+        for (const attachment of picked) byPath.set(attachment.path, attachment);
+        return [...byPath.values()];
+      });
+    } catch (err) {
+      setAttachmentError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments((current) => current.filter((attachment) => attachment.id !== id));
+  }, []);
 
   return (
     <div className="flex-1 flex flex-col min-h-0" data-testid="chat-panel">
@@ -476,7 +512,66 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
             )}
             data-testid="chat-input"
           />
+          {(attachments.length > 0 || attachmentError) && (
+            <div className="flex flex-wrap gap-1.5 px-2 pb-1">
+              {attachments.map((attachment) => (
+                <span
+                  key={attachment.id}
+                  className="inline-flex h-6 max-w-full items-center gap-1.5 rounded-md border border-border bg-muted/60 px-1.5 text-xs text-muted-foreground"
+                  data-testid="chat-attachment-chip"
+                  title={attachment.path}
+                >
+                  <FileText className="size-3 shrink-0" />
+                  <span className="max-w-40 truncate">{attachment.name}</span>
+                  {attachment.truncated && <span className="text-[10px]">trimmed</span>}
+                  <button
+                    type="button"
+                    className="rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    onClick={() => removeAttachment(attachment.id)}
+                    aria-label={`Remove ${attachment.name}`}
+                  >
+                    <X className="size-3" />
+                  </button>
+                </span>
+              ))}
+              {attachmentError && (
+                <span className="text-xs text-destructive" data-testid="chat-attachment-error">
+                  {attachmentError}
+                </span>
+              )}
+            </div>
+          )}
           <div className="flex items-center gap-1.5 px-2 pb-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  disabled={!canCompose}
+                  className="size-7 rounded-lg flex items-center justify-center text-muted-foreground hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                  title="Add context"
+                  aria-label="Add context"
+                  data-testid="chat-add-context"
+                >
+                  <Plus className="size-4" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" side="top" className="w-48">
+                <DropdownMenuItem
+                  onSelect={() => void handleAttachFiles('photos')}
+                  data-testid="chat-add-photos"
+                >
+                  <Image className="size-4" />
+                  Add photos
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => void handleAttachFiles('files')}
+                  data-testid="chat-add-files"
+                >
+                  <File className="size-4" />
+                  Add files
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
             <Select value={modelSelectValue} onValueChange={setModel}>
               <SelectTrigger className="w-24 h-7 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5">
                 <SelectValue />

--- a/apps/desktop/src/shared/chat-attachments.ts
+++ b/apps/desktop/src/shared/chat-attachments.ts
@@ -1,0 +1,11 @@
+export interface ChatContextAttachment {
+  id: string;
+  path: string;
+  name: string;
+  size: number;
+  content: string;
+  truncated?: boolean;
+}
+
+export const CHAT_CONTEXT_MAX_FILE_BYTES = 128 * 1024;
+export const CHAT_CONTEXT_MAX_TOTAL_BYTES = 256 * 1024;

--- a/apps/desktop/src/shared/system-prompt.ts
+++ b/apps/desktop/src/shared/system-prompt.ts
@@ -22,6 +22,7 @@
  */
 
 import type { Schema } from '@contexture/core/ir';
+import type { ChatContextAttachment } from './chat-attachments';
 
 export interface StdlibEntry {
   /** Namespace path, e.g. `'common'` or `'place'`. */
@@ -58,6 +59,7 @@ export function buildSystemPromptAppend(input: BuildSystemPromptAppendInput): st
 export interface BuildUserMessageInput {
   ir: Schema;
   userMessage: string;
+  attachments?: ChatContextAttachment[];
 }
 
 /**
@@ -66,13 +68,36 @@ export interface BuildUserMessageInput {
  * replays the original system prompt) Claude always sees the current schema.
  */
 export function buildUserMessage(input: BuildUserMessageInput): string {
+  const parts = ['<current_ir>', JSON.stringify(input.ir, null, 2), '</current_ir>', ''];
+  if (input.attachments && input.attachments.length > 0) {
+    parts.push(renderAttachments(input.attachments), '');
+  }
+  parts.push(input.userMessage);
+  return parts.join('\n');
+}
+
+function renderAttachments(attachments: ChatContextAttachment[]): string {
   return [
-    '<current_ir>',
-    JSON.stringify(input.ir, null, 2),
-    '</current_ir>',
-    '',
-    input.userMessage,
+    '<attached_files>',
+    ...attachments.map((attachment) =>
+      [
+        `<file path="${escapeAttribute(attachment.path)}" name="${escapeAttribute(attachment.name)}"${
+          attachment.truncated ? ' truncated="true"' : ''
+        }>`,
+        attachment.content,
+        '</file>',
+      ].join('\n'),
+    ),
+    '</attached_files>',
   ].join('\n');
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
 }
 
 const HEADER = `
@@ -92,6 +117,9 @@ The current IR is supplied at the top of each user message inside a
 \`<current_ir>\` block — parse it directly to understand the existing
 model before proposing edits. Prefer surgical ops over
 \`replace_schema\`; the bulk rewrite is an escape hatch, not a default.
+When the user explicitly attaches files, their contents appear in an
+\`<attached_files>\` block after the IR; use them as context, but keep edits
+inside the Contexture op tools.
 
 Skills are available and auto-load on topic match:
 - \`model-domain\` — use when the user asks to model a new domain from

--- a/apps/desktop/tests/chat/__snapshots__/system-prompt.test.ts.snap
+++ b/apps/desktop/tests/chat/__snapshots__/system-prompt.test.ts.snap
@@ -17,6 +17,9 @@ The current IR is supplied at the top of each user message inside a
 \`<current_ir>\` block — parse it directly to understand the existing
 model before proposing edits. Prefer surgical ops over
 \`replace_schema\`; the bulk rewrite is an escape hatch, not a default.
+When the user explicitly attaches files, their contents appear in an
+\`<attached_files>\` block after the IR; use them as context, but keep edits
+inside the Contexture op tools.
 
 Skills are available and auto-load on topic match:
 - \`model-domain\` — use when the user asks to model a new domain from

--- a/apps/desktop/tests/chat/system-prompt.test.ts
+++ b/apps/desktop/tests/chat/system-prompt.test.ts
@@ -149,6 +149,28 @@ describe('buildUserMessage', () => {
     expect(out.endsWith(weird)).toBe(true);
   });
 
+  it('includes explicit attached files between the IR and user message', () => {
+    const out = buildUserMessage({
+      ir: sampleIR,
+      userMessage: 'model this API',
+      attachments: [
+        {
+          id: 'a',
+          path: '/repo/src/api.ts',
+          name: 'api.ts',
+          size: 17,
+          content: 'export const api = {};',
+        },
+      ],
+    });
+
+    expect(out).toContain('<attached_files>');
+    expect(out).toContain('<file path="/repo/src/api.ts" name="api.ts">');
+    expect(out).toContain('export const api = {};');
+    expect(out.indexOf('</current_ir>')).toBeLessThan(out.indexOf('<attached_files>'));
+    expect(out.indexOf('</attached_files>')).toBeLessThan(out.indexOf('model this API'));
+  });
+
   it('is deterministic for identical inputs', () => {
     const a = buildUserMessage({ ir: sampleIR, userMessage: 'x' });
     const b = buildUserMessage({ ir: sampleIR, userMessage: 'x' });

--- a/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
+++ b/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
@@ -195,8 +195,30 @@ describe('useSchemaAgentChat', () => {
 
     expect(result.current.messages.map((m) => [m.role, m.content])).toEqual([['user', 'hello']]);
     expect(calls.setIR).toHaveBeenCalledTimes(1);
-    expect(calls.send).toHaveBeenCalledWith('hello');
+    expect(calls.send).toHaveBeenCalledWith('hello', []);
     expect(result.current.isStreaming).toBe(true);
+  });
+
+  it('forwards explicit file attachments with the user message', async () => {
+    const { api, calls } = makeApi();
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await act(async () => undefined);
+    await act(async () => {
+      await result.current.send('model this API', [
+        {
+          id: 'api',
+          path: '/repo/src/api.ts',
+          name: 'api.ts',
+          size: 22,
+          content: 'export const api = {};',
+        },
+      ]);
+    });
+
+    expect(calls.send).toHaveBeenCalledWith('model this API', [
+      expect.objectContaining({ path: '/repo/src/api.ts', content: 'export const api = {};' }),
+    ]);
   });
 
   it('aggregates deltas and flushes on assistant_final', async () => {

--- a/apps/desktop/tests/components/App.codex.test.tsx
+++ b/apps/desktop/tests/components/App.codex.test.tsx
@@ -22,6 +22,7 @@ beforeEach(() => {
       saveAsDialog: vi.fn(async () => null),
       pickDirectory: vi.fn(async () => null),
       pickContextureFile: vi.fn(async () => null),
+      pickChatContextFiles: vi.fn(async () => []),
       save: vi.fn(async () => undefined),
       read: vi.fn(async () => null),
       getRecentFiles: vi.fn(async () => []),

--- a/apps/desktop/tests/components/chat/ChatPanel.test.tsx
+++ b/apps/desktop/tests/components/chat/ChatPanel.test.tsx
@@ -71,6 +71,9 @@ function mockBridge(): void {
       threadSet: vi.fn(async () => ({ ok: true })),
       threadClear: vi.fn(async () => ({ ok: true })),
     },
+    file: {
+      pickChatContextFiles: vi.fn(async () => []),
+    },
   };
 }
 
@@ -237,6 +240,75 @@ describe('ChatPanel', () => {
     );
   });
 
+  it('opens a plus menu with separate photo and file context actions', async () => {
+    render(<ChatPanel chat={makeChat()} />);
+
+    fireEvent.pointerDown(screen.getByTestId('chat-add-context'));
+
+    expect(await screen.findByTestId('chat-add-photos')).toHaveTextContent('Add photos');
+    expect(screen.getByTestId('chat-add-files')).toHaveTextContent('Add files');
+  });
+
+  it('attaches selected files from the file context action to the next chat turn', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const pickChatContextFiles = vi.fn(async () => [
+      {
+        id: 'api',
+        path: '/repo/src/api.ts',
+        name: 'api.ts',
+        size: 22,
+        content: 'export const api = {};',
+      },
+    ]);
+    (
+      window as unknown as { contexture: { file: { pickChatContextFiles: unknown } } }
+    ).contexture.file.pickChatContextFiles = pickChatContextFiles;
+
+    render(<ChatPanel chat={makeChat({ send })} />);
+
+    fireEvent.pointerDown(screen.getByTestId('chat-add-context'));
+    fireEvent.click(await screen.findByTestId('chat-add-files'));
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-attachment-chip')).toHaveTextContent('api.ts'),
+    );
+
+    const textarea = screen.getByTestId('chat-input');
+    fireEvent.change(textarea, { target: { value: 'model this API' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(send).toHaveBeenCalledWith('model this API', [
+        expect.objectContaining({ path: '/repo/src/api.ts', content: 'export const api = {};' }),
+      ]),
+    );
+    expect(screen.queryByTestId('chat-attachment-chip')).not.toBeInTheDocument();
+  });
+
+  it('attaches selected files from the photo context action to the next chat turn', async () => {
+    const pickChatContextFiles = vi.fn(async () => [
+      {
+        id: 'photo-note',
+        path: '/repo/photo-notes.md',
+        name: 'photo-notes.md',
+        size: 28,
+        content: 'Screenshot notes for the model.',
+      },
+    ]);
+    (
+      window as unknown as { contexture: { file: { pickChatContextFiles: unknown } } }
+    ).contexture.file.pickChatContextFiles = pickChatContextFiles;
+
+    render(<ChatPanel chat={makeChat()} />);
+
+    fireEvent.pointerDown(screen.getByTestId('chat-add-context'));
+    fireEvent.click(await screen.findByTestId('chat-add-photos'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-attachment-chip')).toHaveTextContent('photo-notes.md'),
+    );
+    expect(pickChatContextFiles).toHaveBeenCalledTimes(1);
+  });
+
   it('does not offer agent turn undo after an intervening schema edit', async () => {
     useUndoStore.getState().apply({
       kind: 'add_type',
@@ -279,7 +351,7 @@ describe('ChatPanel', () => {
     const textarea = screen.getByTestId('chat-input');
     fireEvent.change(textarea, { target: { value: '  hello  ' } });
     fireEvent.keyDown(textarea, { key: 'Enter' });
-    expect(send).toHaveBeenCalledWith('hello');
+    expect(send).toHaveBeenCalledWith('hello', []);
   });
 
   it('Shift+Enter inserts a newline instead of submitting', async () => {

--- a/apps/desktop/tests/hooks/useFileMenu.test.tsx
+++ b/apps/desktop/tests/hooks/useFileMenu.test.tsx
@@ -33,6 +33,8 @@ function mockFileBridge(): {
       onMenuSave: () => () => undefined,
       onMenuSaveAs: () => () => undefined,
       pickDirectory: vi.fn(async () => null),
+      pickContextureFile: vi.fn(async () => null),
+      pickChatContextFiles: vi.fn(async () => []),
     },
     shell: {
       reveal: vi.fn(async () => undefined),

--- a/apps/desktop/tests/hooks/useProjectAutoSave.test.tsx
+++ b/apps/desktop/tests/hooks/useProjectAutoSave.test.tsx
@@ -23,6 +23,8 @@ function mockFileBridge(): { save: ReturnType<typeof vi.fn> } {
       onMenuSave: () => () => undefined,
       onMenuSaveAs: () => () => undefined,
       pickDirectory: vi.fn(async () => null),
+      pickContextureFile: vi.fn(async () => null),
+      pickChatContextFiles: vi.fn(async () => []),
     },
   };
   return { save };

--- a/apps/desktop/tests/main/file-ipc.test.ts
+++ b/apps/desktop/tests/main/file-ipc.test.ts
@@ -1,12 +1,14 @@
 import { createDocumentStore } from '@main/documents/document-store';
 import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
 import {
+  CHAT_CONTEXT_FILE_FILTER,
   CONTEXTURE_OPEN_FILTER,
   CONTEXTURE_SAVE_FILTER,
   handleOpen,
+  handlePickChatContextFiles,
   setDocumentStoreForTesting,
 } from '@main/ipc/file';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 describe('handleOpen (routes through DocumentStore)', () => {
   const irPath = '/work/garden.contexture.json';
@@ -67,5 +69,59 @@ describe('file IPC open/save filters', () => {
 
   it('restricts Save dialogs to .json', () => {
     expect(CONTEXTURE_SAVE_FILTER.extensions).toEqual(['json']);
+  });
+
+  it('restricts chat context attachment dialogs to text-like files', () => {
+    expect(CHAT_CONTEXT_FILE_FILTER.extensions).toContain('ts');
+    expect(CHAT_CONTEXT_FILE_FILTER.extensions).toContain('md');
+    expect(CHAT_CONTEXT_FILE_FILTER.extensions).not.toContain('png');
+  });
+});
+
+describe('handlePickChatContextFiles', () => {
+  const window = {} as Parameters<typeof handlePickChatContextFiles>[0];
+
+  it('returns explicit text attachments for selected files', async () => {
+    const result = await handlePickChatContextFiles(window, {
+      showOpenDialog: vi.fn(async () => ({
+        canceled: false,
+        filePaths: ['/repo/src/api.ts'],
+      })),
+      readFile: vi.fn(async () => 'export const api = {};'),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        path: '/repo/src/api.ts',
+        name: 'api.ts',
+        content: 'export const api = {};',
+      }),
+    );
+    expect(result[0]?.truncated).toBeUndefined();
+  });
+
+  it('returns no attachments when the picker is cancelled', async () => {
+    const result = await handlePickChatContextFiles(window, {
+      showOpenDialog: vi.fn(async () => ({
+        canceled: true,
+        filePaths: [],
+      })),
+      readFile: vi.fn(async () => 'unused'),
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('rejects binary-looking files before adding them to context', async () => {
+    await expect(
+      handlePickChatContextFiles(window, {
+        showOpenDialog: vi.fn(async () => ({
+          canceled: false,
+          filePaths: ['/repo/image.png'],
+        })),
+        readFile: vi.fn(async () => 'abc\0def'),
+      }),
+    ).rejects.toThrow(/binary file/);
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.25",
+      "version": "0.15.26",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",


### PR DESCRIPTION
## Summary
- bump @contexture/desktop to 0.15.26
- update the MCP glossary entry to prefer the standalone packaged contexture-mcp server
- refresh bun.lock workspace metadata

## Verification
- bun run --filter @contexture/desktop typecheck
- bun run check -- CONTEXT.md apps/desktop/package.json bun.lock
- pre-commit hook: turbo typecheck && turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782890578&installation_id=136251083&pr_number=346&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F346&signature=0eeedbb1a10ed3c15693bb98451cee7789408bc8ee0a95dcc6e9c55b4fedf1d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->