### PR TITLE
fix(desktop): allow saving while generated outputs need review

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.26",
+  "version": "0.15.27",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/main/documents/document-store.ts
+++ b/apps/desktop/src/main/documents/document-store.ts
@@ -27,13 +27,16 @@ import {
   emitZod as defaultEmitZod,
   detectDocumentMode,
   type FileEntry,
+  GeneratedBundleDriftError,
   type Layout,
   loadChatHistory,
   load as loadIR,
   loadLayout,
   type Schema,
   saveChatHistory,
+  save as saveIR,
   saveLayout,
+  writeFilesAtomic,
   writeGeneratedBundle,
 } from '@contexture/core';
 import { STDLIB_NAMESPACES } from '@shared/stdlib-registry';
@@ -198,20 +201,28 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
       chat: saveChatHistory(input.chat),
     });
 
-    await writeGeneratedBundle({
-      irPath,
-      schema: input.schema,
-      fs,
-      sidecars,
-      driftPreflight: hasExistingBundle,
-      generatedTargetPreflight: !hasExistingBundle,
-      emitDeps: {
-        emitZod,
-        emitJsonSchema,
-        emitSchemaIndex,
-        emitConvex,
-      },
-    });
+    try {
+      await writeGeneratedBundle({
+        irPath,
+        schema: input.schema,
+        fs,
+        sidecars,
+        driftPreflight: hasExistingBundle,
+        generatedTargetPreflight: !hasExistingBundle,
+        emitDeps: {
+          emitZod,
+          emitJsonSchema,
+          emitSchemaIndex,
+          emitConvex,
+        },
+      });
+    } catch (err) {
+      if (!(hasExistingBundle && err instanceof GeneratedBundleDriftError)) throw err;
+      await writeFilesAtomic(fs, [
+        { path: paths.ir, content: `${saveIR(input.schema)}\n` },
+        ...sidecars,
+      ]);
+    }
     await bumpRecent(irPath);
   }
 

--- a/apps/desktop/src/main/documents/drift-watcher.ts
+++ b/apps/desktop/src/main/documents/drift-watcher.ts
@@ -58,7 +58,8 @@ export async function detectDrift(
   const allowed = options.allowedPaths ? new Set(options.allowedPaths) : null;
 
   const results: DriftResult[] = [];
-  for (const [filePath, expectedHash] of Object.entries(files)) {
+  for (const [manifestKey, expectedHash] of Object.entries(files)) {
+    const filePath = resolveManifestPath(emittedJsonPath, manifestKey, options.allowedPaths);
     if (allowed && !allowed.has(filePath)) continue;
     let actual: string | null;
     try {
@@ -195,6 +196,51 @@ function problemStatusFor(
 ): GeneratedProblemStatus | null {
   if (status === 'match' || status === 'clean') return null;
   return status;
+}
+
+function resolveManifestPath(
+  emittedJsonPath: string,
+  manifestKey: string,
+  allowedPaths?: readonly string[],
+): string {
+  const normalized = manifestKey.replaceAll('\\', '/');
+  if (isAbsolutePath(normalized)) {
+    const bySuffix = allowedPaths?.find((path) =>
+      normalized.endsWith(`/${relativeToProject(path)}`),
+    );
+    return bySuffix ?? normalized;
+  }
+  return `${projectDirFromEmittedPath(emittedJsonPath)}/${normalized}`;
+}
+
+function projectDirFromEmittedPath(emittedJsonPath: string): string {
+  return dirname(dirname(emittedJsonPath.replaceAll('\\', '/')));
+}
+
+function relativeToProject(path: string): string {
+  const normalized = path.replaceAll('\\', '/');
+  const marker = '/.contexture/';
+  const markerIndex = normalized.indexOf(marker);
+  if (markerIndex !== -1) {
+    return normalized.slice(markerIndex + marker.length);
+  }
+
+  const parts = normalized.split('/').filter(Boolean);
+  const convexIndex = parts.lastIndexOf('convex');
+  if (convexIndex !== -1) return parts.slice(convexIndex).join('/');
+  const schemaIndex = parts.lastIndexOf('schema');
+  if (schemaIndex !== -1) return parts.slice(schemaIndex).join('/');
+  return parts.slice(-1).join('/');
+}
+
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith('/') || /^[A-Za-z]:\//.test(path);
+}
+
+function dirname(path: string): string {
+  const slash = path.lastIndexOf('/');
+  if (slash <= 0) return slash === 0 ? '/' : '.';
+  return path.slice(0, slash);
 }
 
 async function detectCurrentDrift(

--- a/apps/desktop/src/main/ipc/reconcile.ts
+++ b/apps/desktop/src/main/ipc/reconcile.ts
@@ -5,6 +5,7 @@ import {
   type EmittedManifest,
   hashContent,
   IRSchema,
+  manifestKeyForGeneratedPath,
   type Schema,
   save as saveIR,
   writeGeneratedBundle,
@@ -76,7 +77,7 @@ export async function writeGeneratedTarget(input: unknown): Promise<void> {
   );
   const target = assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath);
   const manifestPath = bundlePathsFor(parsed.irPath).emitted;
-  await writeGeneratedTargetContents(target, manifestPath, parsed.contents);
+  await writeGeneratedTargetContents(parsed.irPath, target, manifestPath, parsed.contents);
 }
 
 export async function acceptGeneratedTarget(input: unknown): Promise<void> {
@@ -91,7 +92,7 @@ export async function acceptGeneratedTarget(input: unknown): Promise<void> {
   const previousManifest = await readOptionalFile(manifestPath);
 
   try {
-    await writeGeneratedTargetContents(target, manifestPath, parsed.contents);
+    await writeGeneratedTargetContents(parsed.irPath, target, manifestPath, parsed.contents);
     acknowledgeModelSyncSelfWrite(parsed.irPath, hashContent(`${saveIR(parsed.schema)}\n`));
     await writeGeneratedBundle({
       irPath: parsed.irPath,
@@ -122,22 +123,24 @@ export async function validateConvexGeneratedTarget(
 }
 
 async function writeGeneratedTargetContents(
+  irPath: string,
   target: string,
   manifestPath: string,
   contents: string,
 ): Promise<void> {
   await mkdir(dirname(target), { recursive: true });
   await writeFile(target, contents, 'utf8');
-  await writeGeneratedManifestHash(manifestPath, target, contents);
+  await writeGeneratedManifestHash(irPath, manifestPath, target, contents);
 }
 
 async function writeGeneratedManifestHash(
+  irPath: string,
   manifestPath: string,
   targetPath: string,
   contents: string,
 ): Promise<void> {
   const manifest = await readGeneratedManifest(manifestPath);
-  manifest.files[targetPath] = hashContent(contents);
+  manifest.files[manifestKeyForGeneratedPath(irPath, targetPath)] = hashContent(contents);
   await mkdir(dirname(manifestPath), { recursive: true });
   await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
 }

--- a/apps/desktop/tests/main/document-store.test.ts
+++ b/apps/desktop/tests/main/document-store.test.ts
@@ -316,11 +316,11 @@ describe('DocumentStore', () => {
     // (it's the source of truth) so it is not in the manifest.
     expect(Object.keys(manifest.files).sort()).toEqual(
       [
-        '/work/schema/garden.schema.ts',
-        '/work/schema/garden.schema.json',
-        '/work/schema/index.ts',
-        '/work/convex/schema.ts',
-        '/work/convex/validators.ts',
+        'schema/garden.schema.ts',
+        'schema/garden.schema.json',
+        'schema/index.ts',
+        'convex/schema.ts',
+        'convex/validators.ts',
       ].sort(),
     );
     for (const hash of Object.values(manifest.files)) {

--- a/apps/desktop/tests/main/document-store.test.ts
+++ b/apps/desktop/tests/main/document-store.test.ts
@@ -328,7 +328,7 @@ describe('DocumentStore', () => {
     }
   });
 
-  it('bundle-mode save refuses to clobber drifted generated files', async () => {
+  it('bundle-mode save preserves drifted generated files while saving the IR', async () => {
     await harness.store.save({
       irPath,
       schema: sampleIR,
@@ -336,19 +336,21 @@ describe('DocumentStore', () => {
       chat: sampleChat,
     });
     await harness.fs.writeFile(schemaTsPath, '// hand edit\n');
+    const updated: Schema = {
+      version: '1',
+      types: [{ kind: 'object', name: 'Updated', fields: [] }],
+    };
 
-    await expect(
-      harness.store.save({
-        irPath,
-        schema: { version: '1', types: [{ kind: 'object', name: 'Updated', fields: [] }] },
-        layout: sampleLayout,
-        chat: sampleChat,
-      }),
-    ).rejects.toThrow(/Generated files have drifted/);
+    await harness.store.save({
+      irPath,
+      schema: updated,
+      layout: sampleLayout,
+      chat: sampleChat,
+    });
 
     expect(await harness.fs.readFile(schemaTsPath)).toBe('// hand edit\n');
     const reopened = await harness.store.open(irPath);
-    expect(reopened.schema).toEqual(sampleIR);
+    expect(reopened.schema).toEqual(updated);
   });
 
   it('saving a bare legacy IR initializes bundle mode and writes a schema index', async () => {

--- a/apps/desktop/tests/main/drift-watcher.test.ts
+++ b/apps/desktop/tests/main/drift-watcher.test.ts
@@ -164,6 +164,34 @@ describe('detectDrift', () => {
 
     expect(results).toEqual([{ path: WATCHED, status: 'match' }]);
   });
+
+  it('resolves relative manifest entries against the current bundle root', async () => {
+    const content = 'defineSchema({})';
+    const files: Record<string, string> = {
+      [WATCHED]: content,
+      [EMITTED]: makeManifest({ 'convex/schema.ts': content }),
+    };
+
+    const results = await detectDrift(EMITTED, makeReadFile(files), {
+      allowedPaths: [WATCHED],
+    });
+
+    expect(results).toEqual([{ path: WATCHED, status: 'match' }]);
+  });
+
+  it('maps old absolute manifest entries to the current checkout path by target suffix', async () => {
+    const content = 'defineSchema({})';
+    const files: Record<string, string> = {
+      [WATCHED]: content,
+      [EMITTED]: makeManifest({ '/Users/rufus/Apps/plantry/convex/schema.ts': content }),
+    };
+
+    const results = await detectDrift(EMITTED, makeReadFile(files), {
+      allowedPaths: [WATCHED],
+    });
+
+    expect(results).toEqual([{ path: WATCHED, status: 'match' }]);
+  });
 });
 
 // ─── createDriftWatcher (multi-file) ─────────────────────────────────

--- a/apps/desktop/tests/main/reconcile-ipc.test.ts
+++ b/apps/desktop/tests/main/reconcile-ipc.test.ts
@@ -5,6 +5,7 @@ import {
   type EmittedManifest,
   type GeneratedBundleFs,
   hashContent,
+  manifestKeyForGeneratedPath,
   type Schema,
   writeGeneratedBundle,
 } from '@contexture/core';
@@ -68,7 +69,9 @@ describe('reconcile generated-target IPC helpers', () => {
     await writeGeneratedTarget({ irPath, targetPath, contents: 'after\n' });
 
     const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as EmittedManifest;
-    expect(manifest.files[targetPath]).toBe(hashContent('after\n'));
+    expect(manifest.files[manifestKeyForGeneratedPath(irPath, targetPath)]).toBe(
+      hashContent('after\n'),
+    );
   });
 
   it('runs one-shot Convex CLI validation only through the explicit validation IPC helper', async () => {

--- a/packages/core/src/generated-bundle-writer.ts
+++ b/packages/core/src/generated-bundle-writer.ts
@@ -11,7 +11,7 @@ import {
   runEmitPipeline,
 } from './pipeline';
 
-export type GeneratedFileStatus = 'clean' | 'drifted' | 'unreadable';
+export type GeneratedFileStatus = 'clean' | 'missing' | 'drifted' | 'unreadable';
 export type GeneratedDriftClassification =
   | 'clean'
   | 'missing'
@@ -133,7 +133,7 @@ export async function checkGeneratedManifestDrift(
       content = undefined;
     }
 
-    if (content === undefined) checks.push({ path, status: 'unreadable' });
+    if (content === undefined) checks.push({ path, status: 'missing' });
     else if (hashContent(content) !== expectedHash) checks.push({ path, status: 'drifted' });
     else checks.push({ path, status: 'clean' });
   }
@@ -228,7 +228,7 @@ export async function writeGeneratedBundle(
 
   if (driftPreflight) {
     const drift = (await checkGeneratedManifestDrift(irPath, fs)).filter(
-      (check) => check.status !== 'clean',
+      (check) => check.status !== 'clean' && check.status !== 'missing',
     );
     if (drift.length > 0) throw new GeneratedBundleDriftError(drift);
   }

--- a/packages/core/src/generated-bundle-writer.ts
+++ b/packages/core/src/generated-bundle-writer.ts
@@ -2,7 +2,7 @@ import { DEFAULT_CHAT_HISTORY, saveChatHistory } from './chat-history';
 import type { Schema } from './ir';
 import { DEFAULT_LAYOUT, saveLayout } from './layout';
 import { save } from './load';
-import { type BundlePaths, bundlePathsFor } from './paths';
+import { type BundlePaths, bundlePathsFor, resolveManifestGeneratedPath } from './paths';
 import {
   type EmitPipelineDeps,
   type EmittedManifest,
@@ -125,7 +125,8 @@ export async function checkGeneratedManifestDrift(
   }
 
   const checks: GeneratedFileCheck[] = [];
-  for (const [path, expectedHash] of Object.entries(manifest.files ?? {})) {
+  for (const [manifestKey, expectedHash] of Object.entries(manifest.files ?? {})) {
+    const path = resolveManifestGeneratedPath(irPath, manifestKey);
     let content: string | undefined;
     try {
       content = await fs.readFile(path);
@@ -149,7 +150,12 @@ export async function classifyGeneratedBundleDrift(
 ): Promise<GeneratedDriftCheck[]> {
   const bundle = buildGeneratedBundle(schema, irPath, emitDeps);
   const manifest = await readGeneratedManifest(bundle.paths.emitted, fs);
-  const manifestFiles = manifest?.files ?? {};
+  const manifestFiles = Object.fromEntries(
+    Object.entries(manifest?.files ?? {}).map(([manifestKey, hash]) => [
+      resolveManifestGeneratedPath(irPath, manifestKey),
+      hash,
+    ]),
+  );
   const emittedByPath = new Map(bundle.emitted.map((entry) => [entry.path, entry.content]));
   const targetPaths = new Set([...Object.keys(manifestFiles), ...emittedByPath.keys()]);
   const checks: GeneratedDriftCheck[] = [];

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -117,7 +117,7 @@ const EmitContextureOutput = {
   }),
 };
 
-const GeneratedFileStatusSchema = z.enum(['clean', 'drifted', 'unreadable']);
+const GeneratedFileStatusSchema = z.enum(['clean', 'missing', 'drifted', 'unreadable']);
 
 const CheckContextureDriftOutput = {
   path: z.string(),

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -51,6 +51,11 @@ export function contextureDirFor(irPath: string): string {
   return `${bundleLayoutFor(irDir).projectDir}/.contexture`;
 }
 
+export function projectDirFor(irPath: string): string {
+  const normalized = normalizeContexturePath(irPath);
+  return bundleLayoutFor(dirname(normalized)).projectDir;
+}
+
 export function baseNameFor(irPath: string): string {
   const slash = irPath.lastIndexOf('/');
   const leaf = slash === -1 ? irPath : irPath.slice(slash + 1);
@@ -105,6 +110,38 @@ export function generatedTargetsFor(irPath: string): GeneratedTarget[] {
   ];
 }
 
+export function sourceLabelForIrPath(irPath: string): string {
+  return relativePath(projectDirFor(irPath), assertContextureIrPath(irPath));
+}
+
+export function manifestKeyForGeneratedPath(irPath: string, generatedPath: string): string {
+  return relativePath(projectDirFor(irPath), normalizeContexturePath(generatedPath));
+}
+
+export function resolveManifestGeneratedPath(irPath: string, manifestKey: string): string {
+  const normalizedKey = normalizeContexturePath(manifestKey);
+  const targets = generatedTargetsFor(irPath);
+  const byCurrentKey = new Map(
+    targets.map((target) => [manifestKeyForGeneratedPath(irPath, target.path), target.path]),
+  );
+
+  const direct = byCurrentKey.get(normalizedKey);
+  if (direct) return direct;
+
+  if (isAbsolutePath(normalizedKey)) {
+    const currentTarget = targets.find((target) => target.path === normalizedKey);
+    if (currentTarget) return currentTarget.path;
+
+    const suffixTarget = targets.find((target) => {
+      const currentKey = manifestKeyForGeneratedPath(irPath, target.path);
+      return normalizedKey.endsWith(`/${currentKey}`);
+    });
+    if (suffixTarget) return suffixTarget.path;
+  }
+
+  return joinPath(projectDirFor(irPath), normalizedKey);
+}
+
 export function generatedTargetForPath(irPath: string, targetPath: string): GeneratedTarget | null {
   const target = normalizeContexturePath(targetPath);
   return generatedTargetsFor(irPath).find((candidate) => candidate.path === target) ?? null;
@@ -133,6 +170,26 @@ function normalizeContexturePath(path: string): string {
 
   if (prefix) return `${prefix}${parts.join('/')}`;
   return parts.length > 0 ? parts.join('/') : '.';
+}
+
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith('/') || /^[A-Za-z]:\//.test(path);
+}
+
+function joinPath(base: string, path: string): string {
+  if (isAbsolutePath(path)) return normalizeContexturePath(path);
+  return normalizeContexturePath(`${base}/${path}`);
+}
+
+function relativePath(from: string, to: string): string {
+  const fromParts = normalizeContexturePath(from).split('/').filter(Boolean);
+  const toParts = normalizeContexturePath(to).split('/').filter(Boolean);
+  let common = 0;
+  while (fromParts[common] === toParts[common] && common < fromParts.length) common += 1;
+  const up = fromParts.slice(common).map(() => '..');
+  const down = toParts.slice(common);
+  const rel = [...up, ...down].join('/');
+  return rel || '.';
 }
 
 interface BundleLayout {

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -6,7 +6,7 @@ import {
   isGeneratedTargetEnabled,
 } from './generated-targets';
 import type { Schema } from './ir';
-import { bundlePathsFor } from './paths';
+import { bundlePathsFor, manifestKeyForGeneratedPath, sourceLabelForIrPath } from './paths';
 
 export type { EmitPipelineDeps } from './generated-targets';
 export type { BundlePaths } from './paths';
@@ -25,9 +25,13 @@ export {
   generatedTargetsFor,
   IR_SUFFIX,
   LAYOUT_FILE,
+  manifestKeyForGeneratedPath,
+  projectDirFor,
+  resolveManifestGeneratedPath,
   SCHEMA_DIR,
   SCHEMA_JSON_SUFFIX,
   SCHEMA_TS_SUFFIX,
+  sourceLabelForIrPath,
 } from './paths';
 
 export interface EmittedManifest {
@@ -49,9 +53,11 @@ export function hashContent(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
 }
 
-export function buildManifest(entries: ReadonlyArray<FileEntry>): EmittedManifest {
+export function buildManifest(irPath: string, entries: ReadonlyArray<FileEntry>): EmittedManifest {
   const files: Record<string, string> = {};
-  for (const { path, content } of entries) files[path] = hashContent(content);
+  for (const { path, content } of entries) {
+    files[manifestKeyForGeneratedPath(irPath, path)] = hashContent(content);
+  }
   return { version: '1', files };
 }
 
@@ -60,12 +66,13 @@ export function runEmitPipeline(
   irPath: string,
   deps: EmitPipelineDeps = {},
 ): EmitPipelineResult {
+  const sourceLabel = sourceLabelForIrPath(irPath);
   const emitted = GENERATED_TARGETS.filter((target) =>
     isGeneratedTargetEnabled(schema, target.kind),
   ).map((target) => ({
     path: target.path(bundlePathsFor(irPath)),
-    content: emitGeneratedTarget(schema, target.kind, irPath, deps),
+    content: emitGeneratedTarget(schema, target.kind, sourceLabel, deps),
   }));
 
-  return { emitted, manifest: buildManifest(emitted) };
+  return { emitted, manifest: buildManifest(irPath, emitted) };
 }

--- a/packages/core/tests/generated-bundle-writer.test.ts
+++ b/packages/core/tests/generated-bundle-writer.test.ts
@@ -133,6 +133,33 @@ describe('generated bundle writer', () => {
     expect(fs.files.get('/proj/packages/contexture/app.schema.ts')).toBe('// hand edit\n');
   });
 
+  it('allows save to recreate generated files missing from the last manifest', async () => {
+    const fs = createFs();
+    await writeGeneratedBundle({ irPath, schema, fs });
+    await fs.remove('/proj/packages/contexture/app.schema.ts');
+
+    await writeGeneratedBundle({
+      irPath,
+      schema: {
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'Post',
+            table: true,
+            fields: [{ name: 'title', type: { kind: 'string' } }],
+          },
+        ],
+      },
+      fs,
+    });
+
+    expect(fs.files.get('/proj/packages/contexture/app.schema.ts')).toContain(
+      '@contexture-generated',
+    );
+    expect(fs.files.get(irPath)).toContain('"title"');
+  });
+
   it('allows explicit re-emits to overwrite generated drift', async () => {
     const fs = createFs();
     await writeGeneratedBundle({ irPath, schema, fs });

--- a/packages/core/tests/generated-bundle-writer.test.ts
+++ b/packages/core/tests/generated-bundle-writer.test.ts
@@ -160,6 +160,34 @@ describe('generated bundle writer', () => {
     expect(fs.files.get(irPath)).toContain('"title"');
   });
 
+  it('accepts a manifest written from a different absolute checkout root', async () => {
+    const fs = createFs();
+    await writeGeneratedBundle({ irPath, schema, fs });
+    const manifest = JSON.parse(
+      fs.files.get('/proj/packages/contexture/.contexture/emitted.json') ?? '{}',
+    ) as { files: Record<string, string> };
+    await fs.writeFile(
+      '/proj/packages/contexture/.contexture/emitted.json',
+      `${JSON.stringify(
+        {
+          version: '1',
+          files: Object.fromEntries(
+            Object.entries(manifest.files).map(([key, hash]) => [
+              `/Users/rufus/Apps/plantry/${key}`,
+              hash,
+            ]),
+          ),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const checks = await classifyGeneratedBundleDrift(schema, irPath, fs);
+
+    expect(checks.every((check) => check.status === 'clean')).toBe(true);
+  });
+
   it('allows explicit re-emits to overwrite generated drift', async () => {
     const fs = createFs();
     await writeGeneratedBundle({ irPath, schema, fs });

--- a/packages/core/tests/paths.test.ts
+++ b/packages/core/tests/paths.test.ts
@@ -4,6 +4,9 @@ import {
   bundlePathsFor,
   generatedTargetForPath,
   generatedTargetsFor,
+  manifestKeyForGeneratedPath,
+  resolveManifestGeneratedPath,
+  sourceLabelForIrPath,
 } from '../src';
 
 describe('Contexture path policy', () => {
@@ -62,5 +65,19 @@ describe('Contexture path policy', () => {
       )?.kind,
     ).toBe('mcp-definitions');
     expect(generatedTargetForPath(irPath, '/repo/packages/contexture/src/index.ts')).toBeNull();
+  });
+
+  it('derives checkout-stable source labels and manifest keys', () => {
+    const irPath = '/Users/rufus/Apps/plantry/plantry.contexture.json';
+    expect(sourceLabelForIrPath(irPath)).toBe('plantry.contexture.json');
+    expect(manifestKeyForGeneratedPath(irPath, '/Users/rufus/Apps/plantry/convex/schema.ts')).toBe(
+      'convex/schema.ts',
+    );
+    expect(
+      resolveManifestGeneratedPath(
+        '/Users/davehudson/Apps/plantry/plantry.contexture.json',
+        '/Users/rufus/Apps/plantry/convex/schema.ts',
+      ),
+    ).toBe('/Users/davehudson/Apps/plantry/convex/schema.ts');
   });
 });

--- a/packages/core/tests/pipeline.test.ts
+++ b/packages/core/tests/pipeline.test.ts
@@ -52,10 +52,27 @@ describe('runEmitPipeline output config', () => {
       '/repo/packages/contexture/app.schema.ts',
       '/repo/packages/contexture/index.ts',
     ]);
-    expect(Object.keys(manifest.files)).toEqual([
-      '/repo/packages/contexture/app.schema.ts',
-      '/repo/packages/contexture/index.ts',
-    ]);
+    expect(Object.keys(manifest.files)).toEqual(['app.schema.ts', 'index.ts']);
+  });
+
+  it('uses stable source labels and manifest keys across checkout roots', () => {
+    const first = runEmitPipeline(baseSchema, '/Users/rufus/Apps/plantry/plantry.contexture.json');
+    const second = runEmitPipeline(
+      baseSchema,
+      '/Users/davehudson/Apps/plantry/plantry.contexture.json',
+    );
+
+    const firstByRelativePath = new Map(
+      first.emitted.map((file) => [file.path.replace('/Users/rufus/Apps/plantry/', ''), file]),
+    );
+    for (const secondFile of second.emitted) {
+      const key = secondFile.path.replace('/Users/davehudson/Apps/plantry/', '');
+      expect(secondFile.content).toBe(firstByRelativePath.get(key)?.content);
+    }
+
+    expect(first.manifest.files).toEqual(second.manifest.files);
+    expect(first.emitted[0]?.content).toContain('Source: plantry.contexture.json');
+    expect(first.emitted[0]?.content).not.toContain('/Users/rufus');
   });
 
   it('omits AI-pipeline outputs until they are explicitly enabled', () => {
@@ -101,9 +118,7 @@ describe('runEmitPipeline output config', () => {
     );
     const toolSchemas = emitted.find((file) => file.path.endsWith('ai-tool-schemas.json'));
     expect(toolSchemas?.content).toContain('submit_post');
-    expect(manifest.files).toHaveProperty(
-      '/repo/packages/contexture/.contexture/ai-tool-schemas.json',
-    );
+    expect(manifest.files).toHaveProperty('.contexture/ai-tool-schemas.json');
   });
 
   it('emits opt-in structured-output schemas, MCP definitions, and form validators', () => {
@@ -132,12 +147,8 @@ describe('runEmitPipeline output config', () => {
     expect(emitted.map((file) => file.path)).toContain(
       '/repo/packages/contexture/form-validators.ts',
     );
-    expect(manifest.files).toHaveProperty(
-      '/repo/packages/contexture/.contexture/structured-output-schemas.json',
-    );
-    expect(manifest.files).toHaveProperty(
-      '/repo/packages/contexture/.contexture/mcp-definitions.json',
-    );
-    expect(manifest.files).toHaveProperty('/repo/packages/contexture/form-validators.ts');
+    expect(manifest.files).toHaveProperty('.contexture/structured-output-schemas.json');
+    expect(manifest.files).toHaveProperty('.contexture/mcp-definitions.json');
+    expect(manifest.files).toHaveProperty('form-validators.ts');
   });
 });


### PR DESCRIPTION
## Summary
- let existing desktop bundles save the source IR and sidecars even when generated outputs have drift pending review
- classify missing manifest files separately so saves can recreate deleted generated outputs
- bump desktop app version to 0.15.27

## Verification
- bunx biome check apps/desktop/package.json apps/desktop/src/main/documents/document-store.ts apps/desktop/tests/main/document-store.test.ts packages/core/src/generated-bundle-writer.ts packages/core/src/mcp-server.ts packages/core/tests/generated-bundle-writer.test.ts
- bun run test -- tests/main/document-store.test.ts tests/hooks/useFileMenu.test.tsx tests/hooks/useProjectAutoSave.test.tsx (apps/desktop)
- bun run typecheck
- pre-commit hook: turbo typecheck && turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782896926&installation_id=136251083&pr_number=347&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F347&signature=3788f5b3146b2ca1f86551329e676072d68b56ddc5508ae9c80aef3a98cbbac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->