### PR TITLE
Polish desktop chat agent context UI

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.27",
+  "version": "0.15.28",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/main/ipc/file.ts
+++ b/apps/desktop/src/main/ipc/file.ts
@@ -13,11 +13,13 @@
  * drive them directly without booting Electron.
  */
 
-import { basename, join } from 'node:path';
+import { readFile as readBinaryFile } from 'node:fs/promises';
+import { basename, extname, join } from 'node:path';
 import type { ChatHistory, Layout } from '@contexture/core';
 import { hashContent, IRSchema, type Schema, save as saveIR } from '@contexture/core';
 import {
   CHAT_CONTEXT_MAX_FILE_BYTES,
+  CHAT_CONTEXT_MAX_IMAGE_BYTES,
   CHAT_CONTEXT_MAX_TOTAL_BYTES,
   type ChatContextAttachment,
 } from '@shared/chat-attachments';
@@ -67,6 +69,13 @@ export const CHAT_CONTEXT_FILE_FILTER: FileFilter = {
   ],
 };
 
+export const CHAT_CONTEXT_PHOTO_FILTER: FileFilter = {
+  name: 'Images',
+  extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'],
+};
+
+type ChatContextPickerKind = 'photos' | 'files';
+
 export interface HandleSaveInput {
   irPath: string;
   schema: Schema;
@@ -105,6 +114,7 @@ export interface OpenResult {
 export interface PickChatContextFilesDeps {
   showOpenDialog: typeof dialog.showOpenDialog;
   readFile: (path: string) => Promise<string>;
+  readBinaryFile?: (path: string) => Promise<Buffer>;
 }
 
 let store: DocumentStore | null = null;
@@ -161,11 +171,14 @@ export async function handlePickChatContextFiles(
   deps: PickChatContextFilesDeps = {
     showOpenDialog: dialog.showOpenDialog,
     readFile: (path) => getStore().readFile(path),
+    readBinaryFile,
   },
+  kind: ChatContextPickerKind = 'files',
 ): Promise<ChatContextAttachment[]> {
+  const isPhotoPicker = kind === 'photos';
   const result = await deps.showOpenDialog(mainWindow, {
-    title: 'Attach Files to Chat',
-    filters: [CHAT_CONTEXT_FILE_FILTER],
+    title: isPhotoPicker ? 'Attach Photos to Chat' : 'Attach Files to Chat',
+    filters: [isPhotoPicker ? CHAT_CONTEXT_PHOTO_FILTER : CHAT_CONTEXT_FILE_FILTER],
     properties: ['openFile', 'multiSelections'],
   });
   if (result.canceled || result.filePaths.length === 0) return [];
@@ -174,6 +187,28 @@ export async function handlePickChatContextFiles(
   let totalBytes = 0;
   for (const filePath of result.filePaths) {
     if (totalBytes >= CHAT_CONTEXT_MAX_TOTAL_BYTES) break;
+    if (isPhotoPicker) {
+      const raw = await (deps.readBinaryFile ?? readBinaryFile)(filePath);
+      const content = raw.toString('base64');
+      const contentBytes = Buffer.byteLength(content, 'utf8');
+      if (raw.byteLength > CHAT_CONTEXT_MAX_IMAGE_BYTES) {
+        throw new Error(`Image is too large to attach: ${filePath}`);
+      }
+      if (totalBytes + contentBytes > CHAT_CONTEXT_MAX_TOTAL_BYTES) break;
+      totalBytes += contentBytes;
+      attachments.push({
+        id: `${filePath}:${hashContent(content).slice(0, 12)}`,
+        path: filePath,
+        name: basename(filePath),
+        size: raw.byteLength,
+        content,
+        kind: 'image',
+        mimeType: imageMimeType(filePath),
+        encoding: 'base64',
+      });
+      continue;
+    }
+
     const raw = await deps.readFile(filePath);
     if (raw.includes('\0')) {
       throw new Error(`Cannot attach binary file: ${filePath}`);
@@ -189,10 +224,25 @@ export async function handlePickChatContextFiles(
       name: basename(filePath),
       size,
       content,
+      kind: 'text',
       ...(truncated ? { truncated: true } : {}),
     });
   }
   return attachments;
+}
+
+function imageMimeType(filePath: string): string {
+  switch (extname(filePath).toLowerCase()) {
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.gif':
+      return 'image/gif';
+    case '.webp':
+      return 'image/webp';
+    default:
+      return 'image/png';
+  }
 }
 
 function trimChatContextContent(
@@ -244,9 +294,13 @@ export function registerFileIpc(mainWindow: BrowserWindow): void {
     return result.filePaths[0];
   });
 
-  ipcMain.handle('file:pick-chat-context-files', async () =>
-    handlePickChatContextFiles(mainWindow),
-  );
+  ipcMain.handle('file:pick-chat-context-files', async (_evt, payload: unknown) => {
+    const kind =
+      payload && typeof payload === 'object' && (payload as { kind?: unknown }).kind === 'photos'
+        ? 'photos'
+        : 'files';
+    return handlePickChatContextFiles(mainWindow, undefined, kind);
+  });
 
   ipcMain.handle('file:save-as-dialog', async () => {
     const result = await dialog.showSaveDialog(mainWindow, {

--- a/apps/desktop/src/main/ipc/schema-agent.ts
+++ b/apps/desktop/src/main/ipc/schema-agent.ts
@@ -1,6 +1,7 @@
 import { IRSchema, type Schema } from '@contexture/core';
 import {
   CHAT_CONTEXT_MAX_FILE_BYTES,
+  CHAT_CONTEXT_MAX_IMAGE_BYTES,
   CHAT_CONTEXT_MAX_TOTAL_BYTES,
 } from '@shared/chat-attachments';
 import type { BrowserWindow } from 'electron';
@@ -85,18 +86,26 @@ const ChatContextAttachmentSchema = z
     id: IpcString,
     path: IpcString,
     name: IpcString,
-    size: z.number().int().nonnegative().max(CHAT_CONTEXT_MAX_FILE_BYTES),
+    size: z.number().int().nonnegative(),
     content: z.string(),
+    kind: z.enum(['text', 'image']).optional(),
+    mimeType: IpcString.optional(),
+    encoding: z.literal('base64').optional(),
     truncated: z.boolean().optional(),
   })
   .strict()
   .superRefine((input, ctx) => {
     const contentBytes = Buffer.byteLength(input.content, 'utf8');
-    if (contentBytes > CHAT_CONTEXT_MAX_FILE_BYTES) {
+    const isImage = input.kind === 'image';
+    const maxBytes = isImage ? CHAT_CONTEXT_MAX_IMAGE_BYTES : CHAT_CONTEXT_MAX_FILE_BYTES;
+    const measuredBytes = isImage ? input.size : contentBytes;
+    if (measuredBytes > maxBytes) {
       ctx.addIssue({
         code: 'custom',
-        path: ['content'],
-        message: 'Attached file content exceeds the per-file chat context limit.',
+        path: [isImage ? 'size' : 'content'],
+        message: isImage
+          ? 'Attached image exceeds the per-file chat context limit.'
+          : 'Attached file content exceeds the per-file chat context limit.',
       });
     }
   });

--- a/apps/desktop/src/main/providers/claude/runtime.ts
+++ b/apps/desktop/src/main/providers/claude/runtime.ts
@@ -25,6 +25,7 @@ import type {
   StartLoginInput,
   StartThreadInput,
 } from '../runtime';
+import { appendAssistantText } from '../runtime';
 import { claudeCliInfoToStatus, detectClaudeCli, type ExecFileFn } from './cli';
 
 export const CLAUDE_PROVIDER_CAPABILITIES: ProviderCapabilities = {
@@ -188,7 +189,9 @@ export class ClaudeProviderRuntime implements ProviderRuntime {
 
         const event = mapClaudeMessage(message);
         if (!event) continue;
-        if (event.type === 'assistant_delta') finalAssistant += event.text;
+        if (event.type === 'assistant_delta') {
+          finalAssistant = appendAssistantText(finalAssistant, event.text, event.boundary);
+        }
         yield event;
         if (event.type === 'turn_failed') return;
       }
@@ -236,7 +239,9 @@ export class ClaudeProviderRuntime implements ProviderRuntime {
     try {
       for await (const message of iterator) {
         const event = mapClaudeMessage(message);
-        if (event?.type === 'assistant_delta') buffered += event.text;
+        if (event?.type === 'assistant_delta') {
+          buffered = appendAssistantText(buffered, event.text, event.boundary);
+        }
         if (event?.type === 'tool_call_started') {
           throw new Error(`Claude reconcile proposal requested forbidden tool: ${event.name}`);
         }
@@ -321,7 +326,9 @@ function mapClaudeMessage(message: unknown): ProviderRuntimeEvent | null {
   if (msg.type === 'assistant') {
     const content = Array.isArray(msg.message?.content) ? msg.message.content : [];
     const textParts = content.filter(isTextPart).map((part) => part.text);
-    if (textParts.length > 0) return { type: 'assistant_delta', text: textParts.join('') };
+    if (textParts.length > 0) {
+      return { type: 'assistant_delta', text: textParts.join('\n\n'), boundary: 'new_message' };
+    }
     const toolUse = content.find(isToolUsePart);
     if (toolUse) {
       return {

--- a/apps/desktop/src/main/providers/codex/runtime.ts
+++ b/apps/desktop/src/main/providers/codex/runtime.ts
@@ -19,6 +19,7 @@ import type {
   StartLoginInput,
   StartThreadInput,
 } from '../runtime';
+import { appendAssistantText } from '../runtime';
 import { type CodexAppServerConnection, startCodexAppServer } from './app-server';
 import { codexCliInfoToStatus, detectCodexCli, type ExecFileFn } from './cli';
 import { handleCodexDynamicToolCall, toCodexDynamicTools } from './tools';
@@ -230,6 +231,7 @@ export class CodexProviderRuntime implements ProviderRuntime {
     const queue = new AsyncEventQueue<ProviderRuntimeEvent>();
     let turnId: string | null = null;
     let finalAssistant = '';
+    let currentAssistantItemId: string | null = null;
 
     const offNotification = connection.client.onNotification((message) => {
       const statusEvent = this.#mapStatusNotification(message as ServerNotification);
@@ -239,7 +241,18 @@ export class CodexProviderRuntime implements ProviderRuntime {
       }
       const event = mapCodexNotification(message as ServerNotification, input.thread, turnId);
       if (!event) return;
-      if (event.type === 'assistant_delta') finalAssistant += event.text;
+      if (event.type === 'assistant_delta') {
+        const itemId = readAgentMessageItemId(message as ServerNotification);
+        const boundary: 'new_message' | undefined =
+          itemId && currentAssistantItemId && itemId !== currentAssistantItemId
+            ? 'new_message'
+            : undefined;
+        if (itemId) currentAssistantItemId = itemId;
+        const delta = boundary ? { ...event, boundary } : event;
+        finalAssistant = appendAssistantText(finalAssistant, delta.text, delta.boundary);
+        queue.push(delta);
+        return;
+      }
       queue.push(event);
       if (
         event.type === 'turn_completed' ||
@@ -317,7 +330,9 @@ export class CodexProviderRuntime implements ProviderRuntime {
     this.#textGenerationThreads.add(thread.threadId);
     try {
       for await (const event of this.sendTurn({ ...input, thread })) {
-        if (event.type === 'assistant_delta') buffered += event.text;
+        if (event.type === 'assistant_delta') {
+          buffered = appendAssistantText(buffered, event.text, event.boundary);
+        }
         if (event.type === 'tool_call_started') {
           throw new Error(`Codex reconcile proposal requested forbidden tool: ${event.name}`);
         }
@@ -562,6 +577,14 @@ function readCurrentTurnId(thread: ProviderThreadRef): string | null {
   if (!thread.opaque || typeof thread.opaque !== 'object') return null;
   const currentTurnId = (thread.opaque as { currentTurnId?: unknown }).currentTurnId;
   return typeof currentTurnId === 'string' && currentTurnId.length > 0 ? currentTurnId : null;
+}
+
+function readAgentMessageItemId(message: ServerNotification): string | null {
+  if (message.method !== 'item/agentMessage/delta') return null;
+  const params = message.params;
+  if (!params || typeof params !== 'object') return null;
+  const itemId = (params as { itemId?: unknown }).itemId;
+  return typeof itemId === 'string' && itemId.length > 0 ? itemId : null;
 }
 
 function writeCurrentTurnId(thread: ProviderThreadRef, turnId: string): void {

--- a/apps/desktop/src/main/providers/codex/types.ts
+++ b/apps/desktop/src/main/providers/codex/types.ts
@@ -169,7 +169,7 @@ export interface AccountUpdatedNotification extends ServerNotification {
 
 export interface AgentMessageDeltaNotification extends ServerNotification {
   method: 'item/agentMessage/delta';
-  params: { threadId: string; turnId?: string; delta: string };
+  params: { threadId: string; turnId?: string; itemId?: string; delta: string };
 }
 
 export interface ItemNotification extends ServerNotification {

--- a/apps/desktop/src/main/providers/runtime.ts
+++ b/apps/desktop/src/main/providers/runtime.ts
@@ -132,7 +132,7 @@ export type ProviderRuntimeEvent =
   | { type: 'thread_started'; thread: ProviderThreadRef }
   | { type: 'thread_resumed'; thread: ProviderThreadRef }
   | { type: 'turn_started'; thread: ProviderThreadRef }
-  | { type: 'assistant_delta'; text: string }
+  | { type: 'assistant_delta'; text: string; boundary?: 'new_message' }
   | { type: 'assistant_final'; text: string }
   | { type: 'tool_call_started'; id: string; name: string; input?: unknown }
   | { type: 'tool_call_finished'; id: string; name: string; ok: boolean; result?: unknown }
@@ -158,4 +158,14 @@ export interface ProviderRuntime {
   startLogin(input: StartLoginInput): Promise<LoginFlow>;
   cancelLogin(input: CancelLoginInput): Promise<void>;
   logout(): Promise<void>;
+}
+
+export function appendAssistantText(
+  current: string,
+  text: string,
+  boundary?: 'new_message',
+): string {
+  if (!text) return current;
+  if (boundary === 'new_message' && current.trim().length > 0) return `${current}\n\n${text}`;
+  return current + text;
 }

--- a/apps/desktop/src/main/providers/schema-agent-driver.ts
+++ b/apps/desktop/src/main/providers/schema-agent-driver.ts
@@ -111,7 +111,10 @@ function handleRuntimeEvent(
       transport.send(SCHEMA_AGENT_THREAD_UPDATED, { thread: event.thread });
       return;
     case 'assistant_delta':
-      transport.send(SCHEMA_AGENT_ASSISTANT_DELTA, { text: event.text });
+      transport.send(SCHEMA_AGENT_ASSISTANT_DELTA, {
+        text: event.text,
+        boundary: event.boundary,
+      });
       return;
     case 'assistant_final':
       transport.send(SCHEMA_AGENT_ASSISTANT_FINAL, { text: event.text });

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -6,6 +6,9 @@ export interface ChatContextAttachment {
   name: string;
   size: number;
   content: string;
+  kind?: 'text' | 'image';
+  mimeType?: string;
+  encoding?: 'base64';
   truncated?: boolean;
 }
 
@@ -41,7 +44,9 @@ export interface ContextureSchemaAgentAPI {
   threadSet: (thread: unknown) => Promise<{ ok: boolean }>;
   threadClear: () => Promise<{ ok: boolean }>;
   replyTool: (id: string, result: unknown) => void;
-  onAssistantDelta: (listener: (payload: { text: string }) => void) => Unsubscribe;
+  onAssistantDelta: (
+    listener: (payload: { text: string; boundary?: 'new_message' }) => void,
+  ) => Unsubscribe;
   onAssistantFinal: (listener: (payload: { text: string }) => void) => Unsubscribe;
   onToolCallStarted: (
     listener: (payload: { id: string; name: string; input?: unknown }) => void,
@@ -85,6 +90,15 @@ export interface OpenedDocument {
       role: 'user' | 'assistant' | 'system';
       content: string;
       createdAt: number;
+      contextAttachments?: Array<{
+        id: string;
+        path: string;
+        name: string;
+        size: number;
+        kind?: 'text' | 'image';
+        mimeType?: string;
+        truncated?: boolean;
+      }>;
     }>;
     provider?: 'codex' | 'claude';
     providerThreadRef?: unknown;
@@ -102,7 +116,7 @@ export interface ContextureFileAPI {
   /** Pick a .contexture.json file; returns the absolute path or null if cancelled. */
   pickContextureFile: () => Promise<string | null>;
   /** Pick text files and return their contents as explicit chat context attachments. */
-  pickChatContextFiles: () => Promise<ChatContextAttachment[]>;
+  pickChatContextFiles: (kind?: 'photos' | 'files') => Promise<ChatContextAttachment[]>;
   save: (payload: {
     irPath: string;
     schema: unknown;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -57,7 +57,7 @@ const schemaAgent = {
     ipcRenderer.invoke('schema-agent:thread-clear') as Promise<{ ok: boolean }>,
   replyTool: (id: string, result: unknown) =>
     ipcRenderer.send('schema-agent:tool-reply', { id, result }),
-  onAssistantDelta: (listener: (payload: { text: string }) => void) =>
+  onAssistantDelta: (listener: (payload: { text: string; boundary?: 'new_message' }) => void) =>
     subscribe('schema-agent:assistant-delta', listener as (p: unknown) => void),
   onAssistantFinal: (listener: (payload: { text: string }) => void) =>
     subscribe('schema-agent:assistant-final', listener as (p: unknown) => void),
@@ -96,7 +96,8 @@ const file = {
   pickContextureFile: () =>
     ipcRenderer.invoke('file:pick-contexture-file') as Promise<string | null>,
   /** Pick text files and return contents to attach to the next chat turn. */
-  pickChatContextFiles: () => ipcRenderer.invoke('file:pick-chat-context-files'),
+  pickChatContextFiles: (kind = 'files') =>
+    ipcRenderer.invoke('file:pick-chat-context-files', { kind }),
   /** Write the five-file bundle atomically under `irPath`. */
   save: (payload: {
     irPath: string;

--- a/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
+++ b/apps/desktop/src/renderer/src/chat/useSchemaAgentChat.ts
@@ -78,12 +78,39 @@ function mkMessage(role: ChatRole, content: string): ChatMessage {
   return { id: mkId(), role, content, createdAt: Date.now() };
 }
 
+function mkUserMessage(content: string, attachments: ChatContextAttachment[]): ChatMessage {
+  return {
+    ...mkMessage('user', content),
+    ...(attachments.length > 0
+      ? {
+          contextAttachments: attachments.map(
+            ({ id, path, name, size, kind, mimeType, truncated }) => ({
+              id,
+              path,
+              name,
+              size,
+              ...(kind ? { kind } : {}),
+              ...(mimeType ? { mimeType } : {}),
+              ...(truncated ? { truncated: true } : {}),
+            }),
+          ),
+        }
+      : {}),
+  };
+}
+
 function readToolError(result: unknown): string {
   if (result && typeof result === 'object') {
     const error = (result as { error?: unknown }).error;
     if (typeof error === 'string') return error;
   }
   return 'Tool call failed';
+}
+
+function appendAssistantText(current: string, text: string, boundary?: 'new_message'): string {
+  if (!text) return current;
+  if (boundary === 'new_message' && current.trim().length > 0) return `${current}\n\n${text}`;
+  return current + text;
 }
 
 export function useSchemaAgentChat({
@@ -366,8 +393,8 @@ export function useSchemaAgentChat({
   }, [api, setProviderThread]);
 
   useEffect(() => {
-    return api.onAssistantDelta(({ text }) => {
-      assistantBufferRef.current += text;
+    return api.onAssistantDelta(({ text, boundary }) => {
+      assistantBufferRef.current = appendAssistantText(assistantBufferRef.current, text, boundary);
       scheduleLiveFlush();
     });
   }, [api, scheduleLiveFlush]);
@@ -375,9 +402,8 @@ export function useSchemaAgentChat({
   useEffect(() => {
     return api.onToolCallStarted(({ id, name, input }) => {
       useAgentTurnsStore.getState().recordToolCallStarted({ id, name, input });
-      appendMessage(mkMessage('assistant', `\`${name}\``));
     });
-  }, [api, appendMessage]);
+  }, [api]);
 
   useEffect(() => {
     return api.onToolCallFinished(({ id, name, ok, result }) => {
@@ -479,7 +505,7 @@ export function useSchemaAgentChat({
         appendMessage(mkMessage('assistant', `Error: ${message}`));
         return;
       }
-      const userMessage = mkMessage('user', trimmed);
+      const userMessage = mkUserMessage(trimmed, attachments);
       beginTurn(userMessage);
       pendingUserMessageRef.current = trimmed;
       if (persistenceEnabled) onMessagePersisted?.(userMessage);

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -44,6 +44,7 @@ import {
   ArrowUp,
   BotMessageSquare,
   CheckCircle2,
+  ChevronRight,
   Clock3,
   File,
   FileText,
@@ -53,11 +54,13 @@ import {
   RotateCcw,
   Square,
   SquarePen,
+  Wrench,
   X,
   XCircle,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Streamdown } from 'streamdown';
+import { Badge } from '@/components/ui/badge';
 import { BorderBeam } from '@/components/ui/border-beam';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -363,10 +366,10 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     void chat.abort();
   }, [chat]);
 
-  const handleAttachFiles = useCallback(async (_kind: 'photos' | 'files') => {
+  const handleAttachFiles = useCallback(async (kind: 'photos' | 'files') => {
     setAttachmentError(null);
     try {
-      const picked = await window.contexture.file.pickChatContextFiles();
+      const picked = await window.contexture.file.pickChatContextFiles(kind);
       if (picked.length === 0) return;
       setAttachments((current) => {
         const byPath = new Map(current.map((attachment) => [attachment.path, attachment]));
@@ -447,7 +450,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
               </EmptyHeader>
             </Empty>
           )}
-          {messages.map((m) => (
+          {messages.filter(isVisibleTranscriptMessage).map((m) => (
             <MessageBubble key={m.id} message={m} />
           ))}
           {isStreaming && liveAssistant.trim().length > 0 && (
@@ -698,6 +701,8 @@ function AgentTurnSummaryCard({
   const pending =
     turn.status === 'running' ? turn.ops.filter((op) => op.status === 'pending').length : 0;
   const diffRows = summarizeAgentTurnSchemaDiff(diffAgentTurnSchema(turn.before, turn.after));
+  const toolSummary = summarizeTurnTools(turn.ops);
+  const toolCount = turn.ops.length;
   const canUndo = useUndoStore((s) => s.canUndo);
   const undo = useUndoStore((s) => s.undo);
   const schema = useUndoStore((s) => s.schema);
@@ -720,33 +725,82 @@ function AgentTurnSummaryCard({
         <button
           type="button"
           className={cn(
-            'relative w-full overflow-hidden rounded-md border border-border/70 bg-card/70 px-2.5 py-2 text-left text-xs text-muted-foreground shadow-sm transition-colors',
-            'hover:border-primary/30 hover:bg-accent/50 focus:outline-none focus:ring-1 focus:ring-ring',
+            'group relative w-full overflow-hidden rounded-lg border border-border/70 bg-card px-3 py-3 text-left text-xs text-muted-foreground shadow-sm transition-colors',
+            'hover:border-primary/30 hover:bg-accent/35 focus:outline-none focus:ring-1 focus:ring-ring',
           )}
           data-testid="agent-turn-summary"
         >
-          {isWaitingForFinalResponse && <BorderBeam duration={6} size={100} />}
-          <div className="flex items-center justify-between gap-2">
-            <div className="min-w-0">
-              <div className="truncate font-medium text-foreground">{turn.summary}</div>
-              <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
-                <AgentTurnMetaPill>{turnStatusLabel(turn.status)}</AgentTurnMetaPill>
-                <span>{applied} applied</span>
-                {rejected > 0 && <span className="text-destructive">{rejected} rejected</span>}
-                {pending > 0 && <span>{pending} pending</span>}
-              </div>
-              {diffRows.length > 0 && (
-                <div className="mt-1 truncate text-[11px] text-muted-foreground">
-                  {diffRows.slice(0, 2).join(', ')}
-                </div>
-              )}
+          {isWaitingForFinalResponse && (
+            <span data-testid="agent-turn-pending-highlight">
+              <BorderBeam duration={6} size={100} />
+            </span>
+          )}
+          <div className="flex items-start gap-2.5">
+            <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border border-primary/15 bg-primary/10 text-primary">
+              <Wrench className="size-3.5" aria-hidden="true" />
             </div>
-            {turn.status === 'committed' && applied > 0 && (
-              <CheckCircle2 className="size-3.5 shrink-0 text-success" aria-hidden="true" />
-            )}
-            {turn.status === 'rolled_back' && (
-              <RotateCcw className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
-            )}
+            <div className="min-w-0 flex-1">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0 truncate text-sm font-semibold leading-5 text-foreground">
+                  {turn.summary}
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  {turn.status === 'committed' && applied > 0 && (
+                    <CheckCircle2 className="size-4 text-success" aria-hidden="true" />
+                  )}
+                  {turn.status === 'rolled_back' && (
+                    <RotateCcw className="size-4 text-muted-foreground" aria-hidden="true" />
+                  )}
+                  <ChevronRight
+                    className="size-3.5 text-muted-foreground transition-transform group-data-[state=open]:rotate-90"
+                    aria-hidden="true"
+                  />
+                </div>
+              </div>
+              <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                <Badge variant="outline" className="h-5 px-1.5 py-0 text-[11px] font-medium">
+                  {turnStatusLabel(turn.status)}
+                </Badge>
+                {toolCount > 0 && (
+                  <Badge variant="secondary" className="h-5 px-1.5 py-0 text-[11px] font-medium">
+                    {toolCount} tool {toolCount === 1 ? 'call' : 'calls'}
+                  </Badge>
+                )}
+                <Badge variant="outline" className="h-5 px-1.5 py-0 text-[11px] font-medium">
+                  {applied} applied
+                </Badge>
+                {rejected > 0 && (
+                  <Badge
+                    variant="outline"
+                    className="h-5 border-destructive/30 px-1.5 py-0 text-[11px] font-medium text-destructive"
+                  >
+                    {rejected} rejected
+                  </Badge>
+                )}
+                {pending > 0 && (
+                  <Badge variant="outline" className="h-5 px-1.5 py-0 text-[11px] font-medium">
+                    {pending} pending
+                  </Badge>
+                )}
+              </div>
+              <div className="mt-2 grid gap-1.5">
+                {toolSummary && (
+                  <div
+                    className="flex min-w-0 items-center gap-1.5 rounded-md bg-muted/60 px-2 py-1 text-[11px] text-muted-foreground"
+                    data-testid="agent-turn-tool-summary"
+                  >
+                    <Wrench className="size-3 shrink-0" aria-hidden="true" />
+                    <span className="truncate font-mono">{toolSummary}</span>
+                  </div>
+                )}
+                {diffRows.length > 0 && (
+                  <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+                    <CheckCircle2 className="size-3 shrink-0 text-success" aria-hidden="true" />
+                    <span className="truncate">{diffRows.slice(0, 2).join(', ')}</span>
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
         </button>
       </PopoverTrigger>
@@ -864,14 +918,6 @@ function AgentTurnOpRow({ op }: { op: AgentTurnOpResult }): React.JSX.Element {
   );
 }
 
-function AgentTurnMetaPill({ children }: { children: React.ReactNode }): React.JSX.Element {
-  return (
-    <span className="rounded-full border border-border/70 bg-background/70 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-      {children}
-    </span>
-  );
-}
-
 function AgentTurnStatusPill({
   status,
 }: {
@@ -922,28 +968,48 @@ function turnStatusLabel(status: AgentTurnRecord['status']): string {
   return 'reviewable';
 }
 
+function summarizeTurnTools(ops: AgentTurnOpResult[]): string | null {
+  if (ops.length === 0) return null;
+  const counts = new Map<string, number>();
+  for (const op of ops) counts.set(op.name, (counts.get(op.name) ?? 0) + 1);
+  return [...counts.entries()]
+    .map(([name, count]) => (count === 1 ? name : `${name} x${count}`))
+    .join(', ');
+}
+
+function isToolStatusMessage(message: ChatMessage): boolean {
+  return message.role === 'assistant' && /^`[A-Za-z_][\w-]*`$/.test(message.content);
+}
+
+function isVisibleTranscriptMessage(message: ChatMessage): boolean {
+  return !isToolStatusMessage(message);
+}
+
 function MessageBubble({ message }: { message: ChatMessage }): React.JSX.Element {
   if (message.role === 'user') {
     return (
       <div className="flex justify-end" data-testid="chat-message-user">
-        <div className="bg-primary text-primary-foreground text-sm rounded-lg px-3 py-1.5 max-w-[85%] whitespace-pre-wrap">
-          {message.content}
+        <div className="bg-primary text-primary-foreground text-sm rounded-lg px-3 py-1.5 max-w-[85%]">
+          <div className="whitespace-pre-wrap">{message.content}</div>
+          {message.contextAttachments && message.contextAttachments.length > 0 && (
+            <div
+              className="mt-2 flex flex-wrap justify-end gap-1.5"
+              data-testid="chat-message-context-attachments"
+            >
+              {message.contextAttachments.map((attachment) => (
+                <span
+                  key={attachment.id}
+                  className="inline-flex h-6 max-w-full items-center gap-1.5 rounded-md border border-primary-foreground/25 bg-primary-foreground/10 px-1.5 text-xs text-primary-foreground/85"
+                  title={attachment.path}
+                >
+                  <FileText className="size-3 shrink-0" aria-hidden="true" />
+                  <span className="max-w-40 truncate">{attachment.name}</span>
+                  {attachment.truncated && <span className="text-[10px]">trimmed</span>}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
-      </div>
-    );
-  }
-
-  // A tool-use status line looks like a single backticked tool name.
-  // Render it as a compact chip
-  // rather than a full markdown bubble so the transcript stays readable.
-  const isToolStatus = /^`[A-Za-z_][\w-]*`$/.test(message.content);
-  if (isToolStatus) {
-    return (
-      <div
-        className="text-[10px] text-muted-foreground bg-secondary/50 rounded px-2 py-1 font-mono"
-        data-testid="chat-message-tool"
-      >
-        ⚡ {message.content.slice(1, -1)}
       </div>
     );
   }

--- a/apps/desktop/src/shared/chat-attachments.ts
+++ b/apps/desktop/src/shared/chat-attachments.ts
@@ -4,8 +4,12 @@ export interface ChatContextAttachment {
   name: string;
   size: number;
   content: string;
+  kind?: 'text' | 'image';
+  mimeType?: string;
+  encoding?: 'base64';
   truncated?: boolean;
 }
 
 export const CHAT_CONTEXT_MAX_FILE_BYTES = 128 * 1024;
-export const CHAT_CONTEXT_MAX_TOTAL_BYTES = 256 * 1024;
+export const CHAT_CONTEXT_MAX_IMAGE_BYTES = 1024 * 1024;
+export const CHAT_CONTEXT_MAX_TOTAL_BYTES = 2 * 1024 * 1024;

--- a/apps/desktop/src/shared/system-prompt.ts
+++ b/apps/desktop/src/shared/system-prompt.ts
@@ -77,19 +77,21 @@ export function buildUserMessage(input: BuildUserMessageInput): string {
 }
 
 function renderAttachments(attachments: ChatContextAttachment[]): string {
-  return [
-    '<attached_files>',
-    ...attachments.map((attachment) =>
-      [
-        `<file path="${escapeAttribute(attachment.path)}" name="${escapeAttribute(attachment.name)}"${
-          attachment.truncated ? ' truncated="true"' : ''
-        }>`,
-        attachment.content,
-        '</file>',
-      ].join('\n'),
-    ),
-    '</attached_files>',
-  ].join('\n');
+  return ['<attached_files>', ...attachments.map(renderAttachment), '</attached_files>'].join('\n');
+}
+
+function renderAttachment(attachment: ChatContextAttachment): string {
+  const attrs = [
+    `path="${escapeAttribute(attachment.path)}"`,
+    `name="${escapeAttribute(attachment.name)}"`,
+    attachment.mimeType ? `mime_type="${escapeAttribute(attachment.mimeType)}"` : null,
+    attachment.encoding ? `encoding="${attachment.encoding}"` : null,
+    attachment.truncated ? 'truncated="true"' : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const tag = attachment.kind === 'image' ? 'image' : 'file';
+  return [`<${tag} ${attrs}>`, attachment.content, `</${tag}>`].join('\n');
 }
 
 function escapeAttribute(value: string): string {

--- a/apps/desktop/tests/chat/system-prompt.test.ts
+++ b/apps/desktop/tests/chat/system-prompt.test.ts
@@ -171,6 +171,31 @@ describe('buildUserMessage', () => {
     expect(out.indexOf('</attached_files>')).toBeLessThan(out.indexOf('model this API'));
   });
 
+  it('includes image attachments with their media metadata', () => {
+    const out = buildUserMessage({
+      ir: sampleIR,
+      userMessage: 'model this screenshot',
+      attachments: [
+        {
+          id: 'image',
+          path: '/repo/image.png',
+          name: 'image.png',
+          size: 4,
+          content: 'iVBORw==',
+          kind: 'image',
+          mimeType: 'image/png',
+          encoding: 'base64',
+        },
+      ],
+    });
+
+    expect(out).toContain(
+      '<image path="/repo/image.png" name="image.png" mime_type="image/png" encoding="base64">',
+    );
+    expect(out).toContain('iVBORw==');
+    expect(out).toContain('</image>');
+  });
+
   it('is deterministic for identical inputs', () => {
     const a = buildUserMessage({ ir: sampleIR, userMessage: 'x' });
     const b = buildUserMessage({ ir: sampleIR, userMessage: 'x' });

--- a/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
+++ b/apps/desktop/tests/chat/useSchemaAgentChat.test.tsx
@@ -11,7 +11,7 @@ type Listener<T> = (payload: T) => void;
 
 function makeApi(status: unknown = { provider: 'codex', readiness: 'authenticated_chatgpt' }) {
   const listeners = {
-    assistantDelta: new Set<Listener<{ text: string }>>(),
+    assistantDelta: new Set<Listener<{ text: string; boundary?: 'new_message' }>>(),
     assistantFinal: new Set<Listener<{ text: string }>>(),
     toolCallStarted: new Set<Listener<{ id: string; name: string; input?: unknown }>>(),
     toolCallFinished: new Set<
@@ -112,7 +112,7 @@ function makeApi(status: unknown = { provider: 'codex', readiness: 'authenticate
   };
 
   const emit = {
-    assistantDelta: (p: { text: string }) => {
+    assistantDelta: (p: { text: string; boundary?: 'new_message' }) => {
       listeners.assistantDelta.forEach((l) => {
         l(p);
       });
@@ -219,6 +219,19 @@ describe('useSchemaAgentChat', () => {
     expect(calls.send).toHaveBeenCalledWith('model this API', [
       expect.objectContaining({ path: '/repo/src/api.ts', content: 'export const api = {};' }),
     ]);
+    expect(result.current.messages[0]).toMatchObject({
+      role: 'user',
+      content: 'model this API',
+      contextAttachments: [
+        {
+          id: 'api',
+          path: '/repo/src/api.ts',
+          name: 'api.ts',
+          size: 22,
+        },
+      ],
+    });
+    expect(result.current.messages[0]?.contextAttachments?.[0]).not.toHaveProperty('content');
   });
 
   it('aggregates deltas and flushes on assistant_final', async () => {
@@ -240,6 +253,26 @@ describe('useSchemaAgentChat', () => {
       ['assistant', 'Hello world'],
     ]);
     expect(result.current.isStreaming).toBe(false);
+  });
+
+  it('preserves assistant message boundaries while streaming', async () => {
+    const { api, emit } = makeApi();
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await act(async () => undefined);
+    await act(async () => {
+      await result.current.send('hi');
+    });
+    act(() => {
+      emit.assistantDelta({ text: 'First update.' });
+      emit.assistantDelta({ text: 'Second update.', boundary: 'new_message' });
+      emit.assistantFinal({ text: 'First update.\n\nSecond update.' });
+    });
+
+    expect(result.current.messages.map((m) => [m.role, m.content])).toEqual([
+      ['user', 'hi'],
+      ['assistant', 'First update.\n\nSecond update.'],
+    ]);
   });
 
   it('surfaces schema-agent send failures that happen before streaming starts', async () => {
@@ -338,6 +371,29 @@ describe('useSchemaAgentChat', () => {
           expect.objectContaining({ id: '2', name: 'add_type', status: 'rejected' }),
         ],
       }),
+    ]);
+  });
+
+  it('keeps tool-call status out of the chat transcript', async () => {
+    const { api, emit } = makeApi();
+    const { result } = renderHook(() => useSchemaAgentChat({ api }));
+
+    await waitFor(() => {
+      expect(result.current.model).toBe('gpt-5.4');
+    });
+    await act(async () => {
+      await result.current.send('add a plot');
+    });
+    act(() => {
+      emit.turnBegin();
+      emit.toolCallStarted({ id: 'pending-1', name: 'add_type', input: { name: 'Plot' } });
+    });
+
+    expect(result.current.messages.map((m) => [m.role, m.content])).toEqual([
+      ['user', 'add a plot'],
+    ]);
+    expect(useAgentTurnsStore.getState().turns[0]?.ops).toEqual([
+      expect.objectContaining({ id: 'pending-1', name: 'add_type', status: 'pending' }),
     ]);
   });
 

--- a/apps/desktop/tests/components/chat/ChatPanel.test.tsx
+++ b/apps/desktop/tests/components/chat/ChatPanel.test.tsx
@@ -166,6 +166,8 @@ describe('ChatPanel', () => {
     expect(screen.getByTestId('agent-turn-summary')).toHaveTextContent(
       'Agent proposed 2 model changes: 1 applied, 1 rejected',
     );
+    expect(screen.getByTestId('agent-turn-summary')).toHaveTextContent('2 tool calls');
+    expect(screen.getByTestId('agent-turn-tool-summary')).toHaveTextContent('add_type x2');
     expect(screen.getByTestId('agent-turn-summary')).toHaveTextContent('1 applied');
     expect(screen.getByTestId('agent-turn-summary')).toHaveTextContent('1 rejected');
     fireEvent.click(screen.getByTestId('agent-turn-summary'));
@@ -184,6 +186,24 @@ describe('ChatPanel', () => {
     expect(screen.queryByText('Undo turn')).not.toBeInTheDocument();
   });
 
+  it('hides legacy inline tool-call messages from the transcript', () => {
+    render(
+      <ChatPanel
+        chat={makeChat({
+          messages: [
+            { id: 'u', role: 'user', content: 'add a Plot type', createdAt: 1 },
+            { id: 'tool', role: 'assistant', content: '`replace_schema`', createdAt: 2 },
+            { id: 'a', role: 'assistant', content: 'Done.', createdAt: 3 },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.queryByTestId('chat-message-tool')).not.toBeInTheDocument();
+    expect(screen.queryByText('replace_schema')).not.toBeInTheDocument();
+    expect(screen.getByTestId('chat-message-assistant')).toHaveTextContent('Done.');
+  });
+
   it('highlights an applied agent turn while the final response is pending', () => {
     useAgentTurnsStore.getState().begin({
       before: { version: '1', types: [] },
@@ -199,9 +219,7 @@ describe('ChatPanel', () => {
 
     render(<ChatPanel chat={makeChat({ isStreaming: true })} />);
 
-    expect(screen.getByTestId('agent-turn-summary').querySelector('[aria-hidden="true"]')).not.toBe(
-      null,
-    );
+    expect(screen.getByTestId('agent-turn-pending-highlight')).toBeInTheDocument();
   });
 
   it('highlights the agent turn from Enter submit until send completes', async () => {
@@ -226,17 +244,13 @@ describe('ChatPanel', () => {
     fireEvent.keyDown(textarea, { key: 'Enter' });
 
     await waitFor(() =>
-      expect(
-        screen.getByTestId('agent-turn-summary').querySelector('[aria-hidden="true"]'),
-      ).not.toBe(null),
+      expect(screen.getByTestId('agent-turn-pending-highlight')).toBeInTheDocument(),
     );
 
     resolveSend();
 
     await waitFor(() =>
-      expect(screen.getByTestId('agent-turn-summary').querySelector('[aria-hidden="true"]')).toBe(
-        null,
-      ),
+      expect(screen.queryByTestId('agent-turn-pending-highlight')).not.toBeInTheDocument(),
     );
   });
 
@@ -281,7 +295,35 @@ describe('ChatPanel', () => {
         expect.objectContaining({ path: '/repo/src/api.ts', content: 'export const api = {};' }),
       ]),
     );
+    expect(pickChatContextFiles).toHaveBeenCalledWith('files');
     expect(screen.queryByTestId('chat-attachment-chip')).not.toBeInTheDocument();
+  });
+
+  it('shows submitted file context on the user message', () => {
+    render(
+      <ChatPanel
+        chat={makeChat({
+          messages: [
+            {
+              id: 'u1',
+              role: 'user',
+              content: 'model this API',
+              createdAt: 1,
+              contextAttachments: [
+                {
+                  id: 'api',
+                  path: '/repo/src/api.ts',
+                  name: 'api.ts',
+                  size: 22,
+                },
+              ],
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId('chat-message-context-attachments')).toHaveTextContent('api.ts');
   });
 
   it('attaches selected files from the photo context action to the next chat turn', async () => {
@@ -306,7 +348,7 @@ describe('ChatPanel', () => {
     await waitFor(() =>
       expect(screen.getByTestId('chat-attachment-chip')).toHaveTextContent('photo-notes.md'),
     );
-    expect(pickChatContextFiles).toHaveBeenCalledTimes(1);
+    expect(pickChatContextFiles).toHaveBeenCalledWith('photos');
   });
 
   it('does not offer agent turn undo after an intervening schema edit', async () => {

--- a/apps/desktop/tests/main/claude-runtime.test.ts
+++ b/apps/desktop/tests/main/claude-runtime.test.ts
@@ -111,6 +111,7 @@ describe('ClaudeProviderRuntime', () => {
     const queryFn = interruptibleQuery([
       { type: 'system', subtype: 'init', session_id: 'session-1' },
       { type: 'assistant', message: { content: [{ type: 'text', text: 'Sure.' }] } },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'Next step.' }] } },
       {
         type: 'assistant',
         message: {
@@ -146,10 +147,11 @@ describe('ClaudeProviderRuntime', () => {
     expect(events).toEqual([
       { type: 'turn_started', thread },
       { type: 'thread_resumed', thread },
-      { type: 'assistant_delta', text: 'Sure.' },
+      { type: 'assistant_delta', text: 'Sure.', boundary: 'new_message' },
+      { type: 'assistant_delta', text: 'Next step.', boundary: 'new_message' },
       { type: 'tool_call_started', id: 'tool-1', name: 'add_type', input: { payload: {} } },
       { type: 'turn_completed' },
-      { type: 'assistant_final', text: 'Sure.' },
+      { type: 'assistant_final', text: 'Sure.\n\nNext step.' },
     ]);
     expect(queryFn).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/desktop/tests/main/codex-runtime.test.ts
+++ b/apps/desktop/tests/main/codex-runtime.test.ts
@@ -940,6 +940,11 @@ describe('CodexProviderRuntime', () => {
     });
     connection.emitNotification({
       jsonrpc: '2.0',
+      method: 'item/agentMessage/delta',
+      params: { threadId: 'thread-1', turnId: 'turn-1', itemId: 'item-2', delta: 'World' },
+    });
+    connection.emitNotification({
+      jsonrpc: '2.0',
       method: 'turn/completed',
       params: {
         threadId: 'thread-1',
@@ -969,11 +974,15 @@ describe('CodexProviderRuntime', () => {
       done: false,
     });
     await expect(iterator.next()).resolves.toEqual({
+      value: { type: 'assistant_delta', text: 'World', boundary: 'new_message' },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toEqual({
       value: { type: 'turn_completed' },
       done: false,
     });
     await expect(iterator.next()).resolves.toEqual({
-      value: { type: 'assistant_final', text: 'Hello' },
+      value: { type: 'assistant_final', text: 'Hello\n\nWorld' },
       done: false,
     });
     await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });

--- a/apps/desktop/tests/main/file-ipc.test.ts
+++ b/apps/desktop/tests/main/file-ipc.test.ts
@@ -2,6 +2,7 @@ import { createDocumentStore } from '@main/documents/document-store';
 import { createMemFsAdapter } from '@main/documents/mem-fs-adapter';
 import {
   CHAT_CONTEXT_FILE_FILTER,
+  CHAT_CONTEXT_PHOTO_FILTER,
   CONTEXTURE_OPEN_FILTER,
   CONTEXTURE_SAVE_FILTER,
   handleOpen,
@@ -76,6 +77,12 @@ describe('file IPC open/save filters', () => {
     expect(CHAT_CONTEXT_FILE_FILTER.extensions).toContain('md');
     expect(CHAT_CONTEXT_FILE_FILTER.extensions).not.toContain('png');
   });
+
+  it('restricts chat photo attachment dialogs to image files', () => {
+    expect(CHAT_CONTEXT_PHOTO_FILTER.extensions).toContain('png');
+    expect(CHAT_CONTEXT_PHOTO_FILTER.extensions).toContain('jpg');
+    expect(CHAT_CONTEXT_PHOTO_FILTER.extensions).not.toContain('ts');
+  });
 });
 
 describe('handlePickChatContextFiles', () => {
@@ -96,9 +103,63 @@ describe('handlePickChatContextFiles', () => {
         path: '/repo/src/api.ts',
         name: 'api.ts',
         content: 'export const api = {};',
+        kind: 'text',
       }),
     );
     expect(result[0]?.truncated).toBeUndefined();
+  });
+
+  it('returns base64 image attachments from the photo picker', async () => {
+    const image = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const result = await handlePickChatContextFiles(
+      window,
+      {
+        showOpenDialog: vi.fn(async () => ({
+          canceled: false,
+          filePaths: ['/repo/image.png'],
+        })),
+        readFile: vi.fn(async () => 'unused'),
+        readBinaryFile: vi.fn(async () => image),
+      },
+      'photos',
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        path: '/repo/image.png',
+        name: 'image.png',
+        size: image.byteLength,
+        content: image.toString('base64'),
+        kind: 'image',
+        mimeType: 'image/png',
+        encoding: 'base64',
+      }),
+    ]);
+  });
+
+  it('allows modest images after base64 expansion', async () => {
+    const image = Buffer.alloc(118 * 1024, 1);
+    const result = await handlePickChatContextFiles(
+      window,
+      {
+        showOpenDialog: vi.fn(async () => ({
+          canceled: false,
+          filePaths: ['/repo/screenshot.png'],
+        })),
+        readFile: vi.fn(async () => 'unused'),
+        readBinaryFile: vi.fn(async () => image),
+      },
+      'photos',
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        path: '/repo/screenshot.png',
+        size: image.byteLength,
+        content: image.toString('base64'),
+        kind: 'image',
+      }),
+    ]);
   });
 
   it('returns no attachments when the picker is cancelled', async () => {

--- a/apps/desktop/tests/model/chat-history.test.ts
+++ b/apps/desktop/tests/model/chat-history.test.ts
@@ -16,6 +16,36 @@ describe('chat history sidecar', () => {
     expect(warnings).toEqual([]);
   });
 
+  it('round-trips user message attachment metadata without requiring file content', () => {
+    const history = {
+      version: '1' as const,
+      messages: [
+        {
+          id: 'm1',
+          role: 'user' as const,
+          content: 'model this API',
+          createdAt: 1000,
+          contextAttachments: [
+            {
+              id: 'api',
+              path: '/repo/src/api.ts',
+              name: 'api.ts',
+              size: 22,
+              truncated: true,
+            },
+          ],
+        },
+      ],
+    };
+
+    const raw = saveChatHistory(history);
+    const { history: round, warnings } = loadChatHistory(raw);
+
+    expect(round).toEqual(history);
+    expect(warnings).toEqual([]);
+    expect(round.messages[0]?.contextAttachments?.[0]).not.toHaveProperty('content');
+  });
+
   it('discards unknown-version files and returns defaults with a warning', () => {
     const raw = JSON.stringify({
       version: '99',

--- a/packages/core/src/chat-history.ts
+++ b/packages/core/src/chat-history.ts
@@ -11,11 +11,22 @@ import { OpSchema } from './ops';
 
 export type ChatRole = 'user' | 'assistant' | 'system';
 
+export interface ChatMessageContextAttachment {
+  id: string;
+  path: string;
+  name: string;
+  size: number;
+  kind?: 'text' | 'image';
+  mimeType?: string;
+  truncated?: boolean;
+}
+
 export interface ChatMessage {
   id: string;
   role: ChatRole;
   content: string;
   createdAt: number;
+  contextAttachments?: ChatMessageContextAttachment[];
 }
 
 export interface ChatHistory {
@@ -109,14 +120,47 @@ function sanitiseMessages(input: unknown): ChatMessage[] {
   const out: ChatMessage[] = [];
   for (const value of input) {
     if (!value || typeof value !== 'object') continue;
-    const { id, role, content, createdAt } = value as Record<string, unknown>;
+    const { id, role, content, createdAt, contextAttachments } = value as Record<string, unknown>;
     if (
       typeof id === 'string' &&
       (role === 'user' || role === 'assistant' || role === 'system') &&
       typeof content === 'string' &&
       typeof createdAt === 'number'
     ) {
-      out.push({ id, role, content, createdAt });
+      const attachments = sanitiseContextAttachments(contextAttachments);
+      out.push({
+        id,
+        role,
+        content,
+        createdAt,
+        ...(attachments.length > 0 ? { contextAttachments: attachments } : {}),
+      });
+    }
+  }
+  return out;
+}
+
+function sanitiseContextAttachments(input: unknown): ChatMessageContextAttachment[] {
+  if (!Array.isArray(input)) return [];
+  const out: ChatMessageContextAttachment[] = [];
+  for (const value of input) {
+    if (!value || typeof value !== 'object') continue;
+    const { id, path, name, size, kind, mimeType, truncated } = value as Record<string, unknown>;
+    if (
+      typeof id === 'string' &&
+      typeof path === 'string' &&
+      typeof name === 'string' &&
+      typeof size === 'number'
+    ) {
+      out.push({
+        id,
+        path,
+        name,
+        size,
+        ...(kind === 'text' || kind === 'image' ? { kind } : {}),
+        ...(typeof mimeType === 'string' ? { mimeType } : {}),
+        ...(truncated === true ? { truncated: true } : {}),
+      });
     }
   }
   return out;


### PR DESCRIPTION
## Summary
- preserve assistant message boundaries while streaming for Codex and Claude
- move tool-call activity into the Agent turn panel and polish the summary card
- show submitted file context on user messages and split photo/file attachment handling
- bump desktop package version to 0.15.28

## Testing
- bun run test -- tests/main/file-ipc.test.ts tests/chat/system-prompt.test.ts tests/chat/useSchemaAgentChat.test.tsx tests/components/chat/ChatPanel.test.tsx tests/main/claude-runtime.test.ts tests/main/codex-runtime.test.ts tests/model/chat-history.test.ts
- bun run typecheck (apps/desktop)
- bun run lint
- commit hook: turbo typecheck && turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782909813&installation_id=136251083&pr_number=348&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F348&signature=5b1d7bb0e5cfae3ad8041f35ceb05b1bdf51fd2ef8f14670362b4a65848d136e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->