### PR TITLE
feat: add domain playground

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -45,6 +45,7 @@
     "@pierre/diffs": "^1.1.19",
     "@playwright/test": "^1.58.2",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,9 +33,11 @@
     "@contexture/stdlib": "workspace:*",
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^4.0.0",
+    "@hookform/resolvers": "^5.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@sentry/electron": "^7.10.0",
     "electron-updater": "^6.8.3",
+    "react-hook-form": "^7.76.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -58,6 +58,7 @@ import { type CreateTypeKind, createFieldOp, createTypeOp } from './components/g
 import { TYPE_NODE_EVENT, TYPE_NODE_OBJECT_EVENT } from './components/graph/nodes/TypeNode';
 import { DriftBanner } from './components/hud/DriftBanner';
 import { ModelSyncBanner } from './components/hud/ModelSyncBanner';
+import { PlaygroundPanel } from './components/playground/PlaygroundPanel';
 import { SchemaPanel, type SchemaPanelSource } from './components/schema/SchemaPanel';
 import { StatusBar } from './components/status-bar/StatusBar';
 import { GraphControlsPanel } from './components/toolbar/GraphControlsPanel';
@@ -569,6 +570,11 @@ export default function App(): React.JSX.Element {
                   onRequestSave={() => void fileMenu.handleSave()}
                   schemaFileName={schemaFileName}
                 />
+              </div>
+              <div
+                className={activeTab !== 'playground' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}
+              >
+                <PlaygroundPanel schema={schema} />
               </div>
               <div className={activeTab !== 'changes' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
                 <ChangesPanel />

--- a/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
+++ b/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
@@ -1,5 +1,11 @@
 import type { SidebarTab } from '@renderer/store/ui-chrome';
-import { FileBracesCorner, History, MessageSquare, MousePointer2 } from 'lucide-react';
+import {
+  FileBracesCorner,
+  FlaskConical,
+  History,
+  MessageSquare,
+  MousePointer2,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ActivityBarProps {
@@ -11,6 +17,7 @@ const TABS: Array<{ id: SidebarTab; icon: React.ReactNode; label: string }> = [
   { id: 'properties', icon: <MousePointer2 className="size-4" />, label: 'Properties' },
   { id: 'chat', icon: <MessageSquare className="size-4" />, label: 'Chat' },
   { id: 'schema', icon: <FileBracesCorner className="size-4" />, label: 'Schema' },
+  { id: 'playground', icon: <FlaskConical className="size-4" />, label: 'Playground' },
   { id: 'changes', icon: <History className="size-4" />, label: 'Changes' },
 ];
 

--- a/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
@@ -153,6 +153,7 @@ export function DetailPanel({
   return (
     <TypeDetail
       type={type}
+      schema={schema}
       dispatch={dispatch}
       dispatchBatch={dispatchBatch}
       modelingHints={modelingHints.filter((hint) => hint.typeName === type.name)}

--- a/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
@@ -137,6 +137,11 @@ export function DetailPanel({
         onCreateAndSelectRefTarget={(selectTarget) =>
           createReferencedObjectTypeAndSelect(field.name, selectTarget)
         }
+        onBackToType={() => {
+          onClearSelectedField?.();
+          useGraphSelectionStore.getState().selectField(null);
+          useGraphSelectionStore.getState().focus(type.name);
+        }}
         validationErrors={validationErrorsForField(validationErrors, typeIndex, fieldIndex)}
         validationRepairForIssue={repairForIssue}
         availableTypeNames={schema.types

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -37,15 +37,7 @@ import {
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from '../ui/select';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Textarea } from '../ui/textarea';
 import { ModelShapeHints } from './ModelShapeHints';
 import { type ValidationIssueRepair, ValidationIssues } from './ValidationIssues';
@@ -221,11 +213,13 @@ function FieldSampleDataSection({
   field: FieldDef;
   update: (patch: Partial<FieldDef>) => void;
 }) {
+  const [open, setOpen] = useState(false);
   const generators = listFixtureGenerators({ valueType: fixtureValueTypeForField(field.type) });
   const modules = listFixtureModules().filter((module) =>
     generators.some((generator) => generator.module === module.id),
   );
   const selectedGenerator = field.sampleData?.generator ?? AUTO_SAMPLE_DATA;
+  const selected = generators.find((generator) => generator.id === selectedGenerator);
 
   return (
     <section className="space-y-2 rounded-md border border-border px-3 py-2">
@@ -233,34 +227,59 @@ function FieldSampleDataSection({
         Sample data
       </Label>
       <div className="space-y-1">
-        <Select
-          value={selectedGenerator}
-          onValueChange={(value) => {
-            const generator = value === AUTO_SAMPLE_DATA ? undefined : value;
-            update({
-              sampleData: generator ? { ...field.sampleData, generator } : undefined,
-            });
-          }}
-        >
-          <SelectTrigger id="field-sample-data-generator" className="h-8 text-xs">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent className="max-h-72">
-            <SelectItem value={AUTO_SAMPLE_DATA}>Auto</SelectItem>
-            {modules.map((module) => (
-              <SelectGroup key={module.id}>
-                <SelectLabel>{module.label}</SelectLabel>
-                {generators
-                  .filter((generator) => generator.module === module.id)
-                  .map((generator) => (
-                    <SelectItem key={generator.id} value={generator.id}>
-                      {generator.label}
-                    </SelectItem>
-                  ))}
-              </SelectGroup>
-            ))}
-          </SelectContent>
-        </Select>
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              id="field-sample-data-generator"
+              type="button"
+              variant="outline"
+              aria-expanded={open}
+              className="h-8 w-full justify-between px-2 text-xs font-normal"
+            >
+              <span className="truncate">{selected ? selected.label : 'Auto'}</span>
+              <ChevronsUpDown aria-hidden="true" className="size-3.5 opacity-60" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Find a generator..." />
+              <CommandList className="max-h-72">
+                <CommandEmpty>No generators found.</CommandEmpty>
+                <CommandGroup>
+                  <CommandItem
+                    value="auto"
+                    onSelect={() => {
+                      update({ sampleData: undefined });
+                      setOpen(false);
+                    }}
+                  >
+                    Auto
+                  </CommandItem>
+                </CommandGroup>
+                {modules.map((module) => (
+                  <CommandGroup key={module.id} heading={module.label}>
+                    {generators
+                      .filter((generator) => generator.module === module.id)
+                      .map((generator) => (
+                        <CommandItem
+                          key={generator.id}
+                          value={`${generator.moduleLabel} ${generator.label} ${generator.id}`}
+                          onSelect={() => {
+                            update({
+                              sampleData: { ...field.sampleData, generator: generator.id },
+                            });
+                            setOpen(false);
+                          }}
+                        >
+                          {generator.label}
+                        </CommandItem>
+                      ))}
+                  </CommandGroup>
+                ))}
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
       </div>
     </section>
   );

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -228,42 +228,41 @@ function FieldSampleDataSection({
   const selectedGenerator = field.sampleData?.generator ?? AUTO_SAMPLE_DATA;
 
   return (
-    <details className="space-y-2 rounded-md border border-border px-3 py-2">
-      <summary className="cursor-default select-none text-xs font-medium">Sample data</summary>
-      <div className="space-y-2 pt-2">
-        <div className="space-y-1">
-          <Label htmlFor="field-sample-data-generator">Generator</Label>
-          <Select
-            value={selectedGenerator}
-            onValueChange={(value) => {
-              const generator = value === AUTO_SAMPLE_DATA ? undefined : value;
-              update({
-                sampleData: generator ? { ...field.sampleData, generator } : undefined,
-              });
-            }}
-          >
-            <SelectTrigger id="field-sample-data-generator" className="h-8 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={AUTO_SAMPLE_DATA}>Auto</SelectItem>
-              {modules.map((module) => (
-                <SelectGroup key={module.id}>
-                  <SelectLabel>{module.label}</SelectLabel>
-                  {generators
-                    .filter((generator) => generator.module === module.id)
-                    .map((generator) => (
-                      <SelectItem key={generator.id} value={generator.id}>
-                        {generator.label}
-                      </SelectItem>
-                    ))}
-                </SelectGroup>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+    <section className="space-y-2 rounded-md border border-border px-3 py-2">
+      <Label htmlFor="field-sample-data-generator" className="text-xs">
+        Sample data
+      </Label>
+      <div className="space-y-1">
+        <Select
+          value={selectedGenerator}
+          onValueChange={(value) => {
+            const generator = value === AUTO_SAMPLE_DATA ? undefined : value;
+            update({
+              sampleData: generator ? { ...field.sampleData, generator } : undefined,
+            });
+          }}
+        >
+          <SelectTrigger id="field-sample-data-generator" className="h-8 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="max-h-72">
+            <SelectItem value={AUTO_SAMPLE_DATA}>Auto</SelectItem>
+            {modules.map((module) => (
+              <SelectGroup key={module.id}>
+                <SelectLabel>{module.label}</SelectLabel>
+                {generators
+                  .filter((generator) => generator.module === module.id)
+                  .map((generator) => (
+                    <SelectItem key={generator.id} value={generator.id}>
+                      {generator.label}
+                    </SelectItem>
+                  ))}
+              </SelectGroup>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
-    </details>
+    </section>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -10,6 +10,12 @@
  * Every edit dispatches `update_field` through the shared op vocabulary;
  * nothing here mutates the store directly.
  */
+
+import {
+  type FixtureValueType,
+  listFixtureGenerators,
+  listFixtureModules,
+} from '@contexture/core/fixture-generators';
 import type { FieldDef, FieldType, IndexDef } from '@contexture/core/ir';
 import type { ModelingHint } from '@contexture/core/modeling-hints';
 import { TYPE_NODE_REF_PREVIEW_EVENT } from '@renderer/components/graph/ref-preview-event';
@@ -31,10 +37,20 @@ import {
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
 import { Textarea } from '../ui/textarea';
 import { ModelShapeHints } from './ModelShapeHints';
 import { type ValidationIssueRepair, ValidationIssues } from './ValidationIssues';
+
+const AUTO_SAMPLE_DATA = '__auto__';
 
 export interface FieldDetailProps {
   typeName: string;
@@ -192,9 +208,80 @@ export function FieldDetail({
         onCreateRefTarget={onCreateRefTarget}
         onCreateAndSelectRefTarget={onCreateAndSelectRefTarget}
       />
+      <FieldSampleDataSection field={field} update={update} />
       <ModelShapeHints hints={modelingHints} />
     </div>
   );
+}
+
+function FieldSampleDataSection({
+  field,
+  update,
+}: {
+  field: FieldDef;
+  update: (patch: Partial<FieldDef>) => void;
+}) {
+  const generators = listFixtureGenerators({ valueType: fixtureValueTypeForField(field.type) });
+  const modules = listFixtureModules().filter((module) =>
+    generators.some((generator) => generator.module === module.id),
+  );
+  const selectedGenerator = field.sampleData?.generator ?? AUTO_SAMPLE_DATA;
+
+  return (
+    <details className="space-y-2 rounded-md border border-border px-3 py-2">
+      <summary className="cursor-default select-none text-xs font-medium">Sample data</summary>
+      <div className="space-y-2 pt-2">
+        <div className="space-y-1">
+          <Label htmlFor="field-sample-data-generator">Generator</Label>
+          <Select
+            value={selectedGenerator}
+            onValueChange={(value) => {
+              const generator = value === AUTO_SAMPLE_DATA ? undefined : value;
+              update({
+                sampleData: generator ? { ...field.sampleData, generator } : undefined,
+              });
+            }}
+          >
+            <SelectTrigger id="field-sample-data-generator" className="h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={AUTO_SAMPLE_DATA}>Auto</SelectItem>
+              {modules.map((module) => (
+                <SelectGroup key={module.id}>
+                  <SelectLabel>{module.label}</SelectLabel>
+                  {generators
+                    .filter((generator) => generator.module === module.id)
+                    .map((generator) => (
+                      <SelectItem key={generator.id} value={generator.id}>
+                        {generator.label}
+                      </SelectItem>
+                    ))}
+                </SelectGroup>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </details>
+  );
+}
+
+function fixtureValueTypeForField(fieldType: FieldType): FixtureValueType {
+  switch (fieldType.kind) {
+    case 'string':
+    case 'literal':
+    case 'ref':
+      return 'string';
+    case 'number':
+      return 'number';
+    case 'boolean':
+      return 'boolean';
+    case 'date':
+      return 'date';
+    case 'array':
+      return 'unknown';
+  }
 }
 
 /**

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -21,7 +21,8 @@ import type { ModelingHint } from '@contexture/core/modeling-hints';
 import { TYPE_NODE_REF_PREVIEW_EVENT } from '@renderer/components/graph/ref-preview-event';
 import type { ValidationError } from '@renderer/services/validation';
 import { STDLIB_TYPE_OPTIONS, type StdlibTypeOption } from '@shared/stdlib-registry';
-import { ChevronsUpDown, Trash2 } from 'lucide-react';
+import { ArrowLeft, ChevronsUpDown, Trash2 } from 'lucide-react';
+import type React from 'react';
 import { useState } from 'react';
 import type { Op } from '../../store/ops';
 import { Button } from '../ui/button';
@@ -55,6 +56,7 @@ export interface FieldDetailProps {
   tableIndexes?: readonly IndexDef[];
   onCreateRefTarget?: () => string | undefined;
   onCreateAndSelectRefTarget?: (selectTarget: (typeName: string) => void) => void;
+  onBackToType?: () => void;
 }
 
 export function FieldDetail({
@@ -68,6 +70,7 @@ export function FieldDetail({
   tableIndexes,
   onCreateRefTarget,
   onCreateAndSelectRefTarget,
+  onBackToType,
 }: FieldDetailProps) {
   const update = (patch: Partial<FieldDef>) =>
     dispatch({ kind: 'update_field', typeName, fieldName: field.name, patch });
@@ -85,124 +88,171 @@ export function FieldDetail({
   };
 
   return (
-    <div className="space-y-4 p-3 pt-0" data-testid="field-detail">
+    <div className="flex h-full min-h-0 flex-col" data-testid="field-detail">
       <header
-        className="-mx-3 flex min-h-20 items-center justify-between border-b bg-muted/20 px-3 py-3"
+        className="flex min-h-20 shrink-0 items-center justify-between border-b bg-muted/20 px-3 py-3"
         data-testid="field-detail-header"
       >
-        <div className="min-w-0">
+        <div className="min-w-0 space-y-1">
           <div className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             {parentKindLabel}
           </div>
           <div className="truncate text-lg font-semibold leading-tight text-foreground">
             {typeName}
           </div>
-          <h2 className="truncate text-sm font-medium leading-snug text-muted-foreground">
-            {field.name}
-          </h2>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label={`Delete field ${field.name}`}
-            onClick={() => dispatch({ kind: 'remove_field', typeName, fieldName: field.name })}
-            className="h-7 w-7 text-muted-foreground hover:text-destructive"
-          >
-            <Trash2 aria-hidden="true" />
-          </Button>
+          <div className="flex min-w-0 items-center gap-2">
+            {onBackToType && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={onBackToType}
+                className="h-7 shrink-0 px-1.5 text-xs text-muted-foreground hover:text-foreground"
+                aria-label="Back to table fields"
+              >
+                <ArrowLeft aria-hidden="true" className="size-3.5" />
+                Fields
+              </Button>
+            )}
+            <h2 className="truncate text-sm font-medium leading-snug text-muted-foreground">
+              {field.name}
+            </h2>
+          </div>
         </div>
       </header>
 
-      <ValidationIssues errors={validationErrors} repairForIssue={validationRepairForIssue} />
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <div className="space-y-4">
+          <ValidationIssues errors={validationErrors} repairForIssue={validationRepairForIssue} />
 
-      <div className="space-y-1">
-        <Label htmlFor="field-name">Name</Label>
-        <Input
-          id="field-name"
-          defaultValue={field.name}
-          onBlur={(ev) => {
-            const next = ev.target.value.trim();
-            if (next && next !== field.name) update({ name: next });
-          }}
-        />
-      </div>
+          <FieldSection title="Basics">
+            <div className="space-y-1">
+              <Label htmlFor="field-name">Name</Label>
+              <Input
+                id="field-name"
+                defaultValue={field.name}
+                onBlur={(ev) => {
+                  const next = ev.target.value.trim();
+                  if (next && next !== field.name) update({ name: next });
+                }}
+              />
+            </div>
+            <FieldTypeBody
+              sourceType={typeName}
+              sourceField={field.name}
+              fieldType={field.type}
+              onChange={(nextType) => update({ type: nextType })}
+              availableTypeNames={availableTypeNames}
+              onCreateRefTarget={onCreateRefTarget}
+              onCreateAndSelectRefTarget={onCreateAndSelectRefTarget}
+            />
+            <div className="grid gap-2 sm:grid-cols-3">
+              <CheckboxOption
+                id="field-optional"
+                label="Optional"
+                description="May be omitted"
+                checked={field.optional === true}
+                onCheckedChange={(v) => update({ optional: v === true })}
+              />
+              <CheckboxOption
+                id="field-nullable"
+                label="Nullable"
+                description="Allows null"
+                checked={field.nullable === true}
+                onCheckedChange={(v) => update({ nullable: v === true })}
+              />
+              <CheckboxOption
+                id="field-server-derived"
+                label="Server derived"
+                description="Computed by backend"
+                checked={field.serverDerived === true}
+                onCheckedChange={(v) => update({ serverDerived: v === true ? true : undefined })}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="field-description">Description</Label>
+              <Textarea
+                id="field-description"
+                defaultValue={field.description ?? ''}
+                rows={2}
+                onBlur={(ev) => {
+                  const next = ev.target.value;
+                  if (next !== (field.description ?? '')) {
+                    update({ description: next || undefined });
+                  }
+                }}
+              />
+            </div>
+          </FieldSection>
 
-      <div className="space-y-1">
-        <Label htmlFor="field-default">Default value</Label>
-        <Input
-          id="field-default"
-          defaultValue={defaultInputValue(field.default)}
-          onBlur={(ev) => {
-            const next = parseDefaultInput(ev.target.value, field.type);
-            if (!Object.is(next, field.default)) update({ default: next });
-          }}
-        />
-      </div>
+          <FieldSection title="Behavior">
+            <div className="space-y-1">
+              <Label htmlFor="field-default">Default value</Label>
+              <Input
+                id="field-default"
+                defaultValue={defaultInputValue(field.default)}
+                onBlur={(ev) => {
+                  const next = parseDefaultInput(ev.target.value, field.type);
+                  if (!Object.is(next, field.default)) update({ default: next });
+                }}
+              />
+            </div>
+          </FieldSection>
 
-      <div className="grid gap-2 sm:grid-cols-3">
-        <CheckboxOption
-          id="field-optional"
-          label="Optional"
-          description="May be omitted"
-          checked={field.optional === true}
-          onCheckedChange={(v) => update({ optional: v === true })}
-        />
-        <CheckboxOption
-          id="field-nullable"
-          label="Nullable"
-          description="Allows null"
-          checked={field.nullable === true}
-          onCheckedChange={(v) => update({ nullable: v === true })}
-        />
-        <CheckboxOption
-          id="field-server-derived"
-          label="Server derived"
-          description="Computed by backend"
-          checked={field.serverDerived === true}
-          onCheckedChange={(v) => update({ serverDerived: v === true ? true : undefined })}
-        />
-      </div>
+          <FieldSection title="Output & generation">
+            {tableIndexes && (
+              <div className="flex items-center justify-between gap-2 rounded-md border border-border px-2 py-1.5 text-xs">
+                <span className="font-medium">Index</span>
+                {hasSingleFieldIndex ? (
+                  <span className="text-muted-foreground">Indexed</span>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7"
+                    onClick={addIndex}
+                  >
+                    Add index
+                  </Button>
+                )}
+              </div>
+            )}
+            <FieldSampleDataSection field={field} update={update} />
+            <ModelShapeHints hints={modelingHints} />
+          </FieldSection>
 
-      {tableIndexes && (
-        <div className="flex items-center justify-between gap-2 rounded-md border border-border px-2 py-1.5 text-xs">
-          <span className="font-medium">Index</span>
-          {hasSingleFieldIndex ? (
-            <span className="text-muted-foreground">Indexed</span>
-          ) : (
-            <Button type="button" variant="outline" size="sm" className="h-7" onClick={addIndex}>
-              Add index
-            </Button>
-          )}
+          <FieldSection title="Danger zone">
+            <div className="flex items-center justify-between gap-3 rounded-md border border-destructive/25 px-3 py-2 text-xs">
+              <div className="min-w-0">
+                <div className="font-medium text-foreground">Delete field</div>
+                <p className="mt-0.5 text-muted-foreground">Remove this field from {typeName}.</p>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label={`Delete field ${field.name}`}
+                onClick={() => dispatch({ kind: 'remove_field', typeName, fieldName: field.name })}
+                className="h-7 shrink-0 px-2 text-xs text-destructive hover:text-destructive"
+              >
+                <Trash2 aria-hidden="true" />
+                Delete
+              </Button>
+            </div>
+          </FieldSection>
         </div>
-      )}
-
-      <div className="space-y-1">
-        <Label htmlFor="field-description">Description</Label>
-        <Textarea
-          id="field-description"
-          defaultValue={field.description ?? ''}
-          rows={2}
-          onBlur={(ev) => {
-            const next = ev.target.value;
-            if (next !== (field.description ?? '')) update({ description: next || undefined });
-          }}
-        />
       </div>
-
-      <FieldTypeBody
-        sourceType={typeName}
-        sourceField={field.name}
-        fieldType={field.type}
-        onChange={(nextType) => update({ type: nextType })}
-        availableTypeNames={availableTypeNames}
-        onCreateRefTarget={onCreateRefTarget}
-        onCreateAndSelectRefTarget={onCreateAndSelectRefTarget}
-      />
-      <FieldSampleDataSection field={field} update={update} />
-      <ModelShapeHints hints={modelingHints} />
     </div>
+  );
+}
+
+function FieldSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-2" aria-label={title}>
+      <h3 className="text-xs font-semibold text-foreground">{title}</h3>
+      <div className="space-y-3">{children}</div>
+    </section>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -21,12 +21,21 @@ import type { ModelingHint } from '@contexture/core/modeling-hints';
 import { TYPE_NODE_REF_PREVIEW_EVENT } from '@renderer/components/graph/ref-preview-event';
 import type { ValidationError } from '@renderer/services/validation';
 import { STDLIB_TYPE_OPTIONS, type StdlibTypeOption } from '@shared/stdlib-registry';
-import { ArrowLeft, ChevronsUpDown, Trash2 } from 'lucide-react';
+import {
+  ArrowLeft,
+  ChevronDown,
+  ChevronsUpDown,
+  Lightbulb,
+  MoreHorizontal,
+  Trash2,
+} from 'lucide-react';
 import type React from 'react';
 import { useState } from 'react';
 import type { Op } from '../../store/ops';
+import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Checkbox } from '../ui/checkbox';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
 import {
   Command,
   CommandEmpty,
@@ -35,12 +44,20 @@ import {
   CommandItem,
   CommandList,
 } from '../ui/command';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
+import { Field, FieldGroup, FieldLabel } from '../ui/field';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { Separator } from '../ui/separator';
 import { Textarea } from '../ui/textarea';
-import { ModelShapeHints } from './ModelShapeHints';
+import { HintBody } from './ModelShapeHints';
 import { type ValidationIssueRepair, ValidationIssues } from './ValidationIssues';
 
 const AUTO_SAMPLE_DATA = '__auto__';
@@ -77,7 +94,13 @@ export function FieldDetail({
   const hasSingleFieldIndex =
     tableIndexes?.some((index) => index.fields.length === 1 && index.fields[0] === field.name) ??
     false;
+  const indexMemberships =
+    tableIndexes
+      ?.filter((index) => index.fields.includes(field.name))
+      .map((index) => ({ index, position: index.fields.indexOf(field.name) })) ?? [];
+  const primaryIndex = indexMemberships[0];
   const parentKindLabel = tableIndexes ? 'table' : 'object';
+  const sampleLabel = sampleDataLabel(field);
   const addIndex = () => {
     if (!tableIndexes || hasSingleFieldIndex) return;
     dispatch({
@@ -90,15 +113,12 @@ export function FieldDetail({
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="field-detail">
       <header
-        className="flex min-h-20 shrink-0 items-center justify-between border-b bg-muted/20 px-3 py-3"
+        className="flex min-h-20 shrink-0 items-start justify-between gap-3 border-b bg-muted/20 px-3 py-3"
         data-testid="field-detail-header"
       >
-        <div className="min-w-0 space-y-1">
+        <div className="min-w-0 space-y-2">
           <div className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-            {parentKindLabel}
-          </div>
-          <div className="truncate text-lg font-semibold leading-tight text-foreground">
-            {typeName}
+            {parentKindLabel} / {typeName}
           </div>
           <div className="flex min-w-0 items-center gap-2">
             {onBackToType && (
@@ -114,29 +134,78 @@ export function FieldDetail({
                 Fields
               </Button>
             )}
-            <h2 className="truncate text-sm font-medium leading-snug text-muted-foreground">
+            <h2 className="truncate text-lg font-semibold leading-tight text-foreground">
               {field.name}
             </h2>
           </div>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
+              {fieldTypeSummary(field.type)}
+            </Badge>
+            <Badge variant="secondary" className="h-5 rounded-md px-1.5 text-[11px]">
+              {field.optional ? 'optional' : 'required'}
+            </Badge>
+            {field.nullable && (
+              <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
+                nullable
+              </Badge>
+            )}
+            {field.serverDerived && (
+              <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
+                server derived
+              </Badge>
+            )}
+            {primaryIndex && (
+              <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
+                indexed
+              </Badge>
+            )}
+            <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
+              sample: {sampleLabel}
+            </Badge>
+          </div>
         </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={`Field actions for ${field.name}`}
+              className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+            >
+              <MoreHorizontal aria-hidden="true" className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onSelect={() => dispatch({ kind: 'remove_field', typeName, fieldName: field.name })}
+            >
+              <Trash2 aria-hidden="true" />
+              Delete field
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-3">
-        <div className="space-y-4">
+        <div className="space-y-3">
           <ValidationIssues errors={validationErrors} repairForIssue={validationRepairForIssue} />
 
-          <FieldSection title="Basics">
-            <div className="space-y-1">
-              <Label htmlFor="field-name">Name</Label>
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="field-name">Name</FieldLabel>
               <Input
                 id="field-name"
+                className="h-8 text-xs"
                 defaultValue={field.name}
                 onBlur={(ev) => {
                   const next = ev.target.value.trim();
                   if (next && next !== field.name) update({ name: next });
                 }}
               />
-            </div>
+            </Field>
             <FieldTypeBody
               sourceType={typeName}
               sourceField={field.name}
@@ -146,117 +215,286 @@ export function FieldDetail({
               onCreateRefTarget={onCreateRefTarget}
               onCreateAndSelectRefTarget={onCreateAndSelectRefTarget}
             />
-            <div className="grid gap-2 sm:grid-cols-3">
-              <CheckboxOption
-                id="field-optional"
-                label="Optional"
-                description="May be omitted"
-                checked={field.optional === true}
-                onCheckedChange={(v) => update({ optional: v === true })}
-              />
-              <CheckboxOption
-                id="field-nullable"
-                label="Nullable"
-                description="Allows null"
-                checked={field.nullable === true}
-                onCheckedChange={(v) => update({ nullable: v === true })}
-              />
-              <CheckboxOption
-                id="field-server-derived"
-                label="Server derived"
-                description="Computed by backend"
-                checked={field.serverDerived === true}
-                onCheckedChange={(v) => update({ serverDerived: v === true ? true : undefined })}
-              />
-            </div>
-            <div className="space-y-1">
-              <Label htmlFor="field-description">Description</Label>
-              <Textarea
-                id="field-description"
-                defaultValue={field.description ?? ''}
-                rows={2}
-                onBlur={(ev) => {
-                  const next = ev.target.value;
-                  if (next !== (field.description ?? '')) {
-                    update({ description: next || undefined });
-                  }
-                }}
-              />
-            </div>
-          </FieldSection>
+          </FieldGroup>
 
-          <FieldSection title="Behavior">
-            <div className="space-y-1">
-              <Label htmlFor="field-default">Default value</Label>
-              <Input
-                id="field-default"
-                defaultValue={defaultInputValue(field.default)}
-                onBlur={(ev) => {
-                  const next = parseDefaultInput(ev.target.value, field.type);
-                  if (!Object.is(next, field.default)) update({ default: next });
-                }}
-              />
-            </div>
-          </FieldSection>
+          <Separator />
 
-          <FieldSection title="Output & generation">
-            {tableIndexes && (
-              <div className="flex items-center justify-between gap-2 rounded-md border border-border px-2 py-1.5 text-xs">
-                <span className="font-medium">Index</span>
-                {hasSingleFieldIndex ? (
-                  <span className="text-muted-foreground">Indexed</span>
-                ) : (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="h-7"
-                    onClick={addIndex}
-                  >
-                    Add index
-                  </Button>
-                )}
-              </div>
-            )}
-            <FieldSampleDataSection field={field} update={update} />
-            <ModelShapeHints hints={modelingHints} />
-          </FieldSection>
+          <PresenceRow field={field} update={update} />
+          <DescriptionRow field={field} update={update} />
+          <DefaultValueRow field={field} update={update} />
 
-          <FieldSection title="Danger zone">
-            <div className="flex items-center justify-between gap-3 rounded-md border border-destructive/25 px-3 py-2 text-xs">
-              <div className="min-w-0">
-                <div className="font-medium text-foreground">Delete field</div>
-                <p className="mt-0.5 text-muted-foreground">Remove this field from {typeName}.</p>
-              </div>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                aria-label={`Delete field ${field.name}`}
-                onClick={() => dispatch({ kind: 'remove_field', typeName, fieldName: field.name })}
-                className="h-7 shrink-0 px-2 text-xs text-destructive hover:text-destructive"
-              >
-                <Trash2 aria-hidden="true" />
-                Delete
-              </Button>
-            </div>
-          </FieldSection>
+          <Separator />
+
+          {tableIndexes && (
+            <IndexSummaryRow
+              fieldName={field.name}
+              indexes={indexMemberships}
+              hasSingleFieldIndex={hasSingleFieldIndex}
+              onAddIndex={addIndex}
+            />
+          )}
+          <SampleDataRow field={field} update={update} />
+          <ModelAdviceRow hints={modelingHints} />
         </div>
       </div>
     </div>
   );
 }
 
-function FieldSection({ title, children }: { title: string; children: React.ReactNode }) {
+function PresenceRow({
+  field,
+  update,
+}: {
+  field: FieldDef;
+  update: (patch: Partial<FieldDef>) => void;
+}) {
   return (
-    <section className="space-y-2" aria-label={title}>
-      <h3 className="text-xs font-semibold text-foreground">{title}</h3>
-      <div className="space-y-3">{children}</div>
-    </section>
+    <InspectorRow label="Presence">
+      <div className="flex flex-wrap justify-end gap-2">
+        <CheckboxOption
+          id="field-optional"
+          label="Optional"
+          description="May be omitted"
+          checked={field.optional === true}
+          onCheckedChange={(v) => update({ optional: v === true })}
+        />
+        <CheckboxOption
+          id="field-nullable"
+          label="Nullable"
+          description="Allows null"
+          checked={field.nullable === true}
+          onCheckedChange={(v) => update({ nullable: v === true })}
+        />
+        <CheckboxOption
+          id="field-server-derived"
+          label="Server derived"
+          description="Computed by backend"
+          checked={field.serverDerived === true}
+          onCheckedChange={(v) => update({ serverDerived: v === true ? true : undefined })}
+        />
+      </div>
+    </InspectorRow>
   );
 }
 
-function FieldSampleDataSection({
+function DescriptionRow({
+  field,
+  update,
+}: {
+  field: FieldDef;
+  update: (patch: Partial<FieldDef>) => void;
+}) {
+  const hasDescription = Boolean(field.description);
+  return (
+    <Collapsible defaultOpen={hasDescription}>
+      <InspectorRow label="Description">
+        <CollapsibleTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label={hasDescription ? 'Edit description' : 'Add description'}
+            className="h-7 min-w-0 px-2 text-xs"
+          >
+            <span className="max-w-64 truncate text-muted-foreground">
+              {field.description || 'None'}
+            </span>
+            <span className="text-foreground">{hasDescription ? 'Edit' : 'Add'}</span>
+          </Button>
+        </CollapsibleTrigger>
+      </InspectorRow>
+      <CollapsibleContent className="pt-2">
+        <Textarea
+          id="field-description"
+          aria-label="Description"
+          defaultValue={field.description ?? ''}
+          rows={2}
+          className="text-xs"
+          onBlur={(ev) => {
+            const next = ev.target.value;
+            if (next !== (field.description ?? '')) {
+              update({ description: next || undefined });
+            }
+          }}
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function DefaultValueRow({
+  field,
+  update,
+}: {
+  field: FieldDef;
+  update: (patch: Partial<FieldDef>) => void;
+}) {
+  const hasDefault = field.default !== undefined;
+  return (
+    <Collapsible defaultOpen={hasDefault}>
+      <InspectorRow label="Default value">
+        <CollapsibleTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label={hasDefault ? 'Edit default value' : 'Set default value'}
+            className="h-7 min-w-0 px-2 text-xs"
+          >
+            <span className="max-w-64 truncate text-muted-foreground">
+              {hasDefault ? defaultInputValue(field.default) : 'None'}
+            </span>
+            <span className="text-foreground">{hasDefault ? 'Edit' : 'Set'}</span>
+          </Button>
+        </CollapsibleTrigger>
+      </InspectorRow>
+      <CollapsibleContent className="pt-2">
+        <Input
+          id="field-default"
+          aria-label="Default value"
+          className="h-8 text-xs"
+          defaultValue={defaultInputValue(field.default)}
+          onBlur={(ev) => {
+            const next = parseDefaultInput(ev.target.value, field.type);
+            if (!Object.is(next, field.default)) update({ default: next });
+          }}
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function IndexSummaryRow({
+  fieldName,
+  indexes,
+  hasSingleFieldIndex,
+  onAddIndex,
+}: {
+  fieldName: string;
+  indexes: Array<{ index: IndexDef; position: number }>;
+  hasSingleFieldIndex: boolean;
+  onAddIndex: () => void;
+}) {
+  const primary = indexes[0];
+  return (
+    <InspectorRow label="Index">
+      {primary ? (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button type="button" variant="ghost" size="sm" className="h-7 px-2 text-xs">
+              <span className="font-mono text-muted-foreground">{primary.index.name}</span>
+              {indexes.length > 1 && (
+                <Badge variant="secondary" className="ml-1 h-5 rounded-md px-1.5 text-[10px]">
+                  {indexes.length}
+                </Badge>
+              )}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-72 p-3 text-xs">
+            <div className="space-y-2">
+              <div className="font-medium text-foreground">Index usage</div>
+              {indexes.map(({ index, position }) => (
+                <div key={index.name} className="rounded-md border px-2 py-1.5">
+                  <div className="font-mono text-[11px]">{index.name}</div>
+                  <div className="mt-0.5 text-[11px] text-muted-foreground">
+                    {index.fields.length === 1
+                      ? 'Single-field index'
+                      : `Position ${position + 1} of ${index.fields.length}: ${index.fields.join(
+                          ' -> ',
+                        )}`}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+      ) : (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">Not indexed</span>
+          {!hasSingleFieldIndex && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 px-2 text-xs"
+              aria-label={`Add index for ${fieldName}`}
+              onClick={onAddIndex}
+            >
+              Add index
+            </Button>
+          )}
+        </div>
+      )}
+      <span className="sr-only">{fieldName}</span>
+    </InspectorRow>
+  );
+}
+
+function SampleDataRow({
+  field,
+  update,
+}: {
+  field: FieldDef;
+  update: (patch: Partial<FieldDef>) => void;
+}) {
+  return (
+    <InspectorRow label="Sample data">
+      <FieldSampleDataPicker field={field} update={update} />
+    </InspectorRow>
+  );
+}
+
+function ModelAdviceRow({ hints }: { hints: readonly ModelingHint[] }) {
+  if (hints.length === 0) return null;
+  const [primary, ...secondary] = hints;
+  if (!primary) return null;
+  return (
+    <InspectorRow label="Model advice">
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label="Model advice"
+            className="h-7 px-2 text-xs"
+          >
+            <Lightbulb aria-hidden="true" className="size-3.5 text-primary" />
+            <span>{primary.title}</span>
+            {secondary.length > 0 && (
+              <Badge variant="secondary" className="h-5 rounded-md px-1.5 text-[10px]">
+                {hints.length}
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" side="left" className="w-80 p-3 text-xs">
+          <div className="space-y-3">
+            <HintBody hint={primary} />
+            {secondary.length > 0 && (
+              <div className="space-y-2 border-t border-border/70 pt-2">
+                {secondary.map((hint) => (
+                  <HintBody key={hint.id} hint={hint} compact />
+                ))}
+              </div>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </InspectorRow>
+  );
+}
+
+function InspectorRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="grid min-h-9 grid-cols-[112px_1fr] items-center gap-3 text-xs">
+      <div className="text-muted-foreground">{label}</div>
+      <div className="flex min-w-0 justify-end">{children}</div>
+    </div>
+  );
+}
+
+function FieldSampleDataPicker({
   field,
   update,
 }: {
@@ -272,66 +510,61 @@ function FieldSampleDataSection({
   const selected = generators.find((generator) => generator.id === selectedGenerator);
 
   return (
-    <section className="space-y-2 rounded-md border border-border px-3 py-2">
-      <Label htmlFor="field-sample-data-generator" className="text-xs">
-        Sample data
-      </Label>
-      <div className="space-y-1">
-        <Popover open={open} onOpenChange={setOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              id="field-sample-data-generator"
-              type="button"
-              variant="outline"
-              aria-expanded={open}
-              className="h-8 w-full justify-between px-2 text-xs font-normal"
-            >
-              <span className="truncate">{selected ? selected.label : 'Auto'}</span>
-              <ChevronsUpDown aria-hidden="true" className="size-3.5 opacity-60" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
-            <Command>
-              <CommandInput placeholder="Find a generator..." />
-              <CommandList className="max-h-72">
-                <CommandEmpty>No generators found.</CommandEmpty>
-                <CommandGroup>
-                  <CommandItem
-                    value="auto"
-                    onSelect={() => {
-                      update({ sampleData: undefined });
-                      setOpen(false);
-                    }}
-                  >
-                    Auto
-                  </CommandItem>
-                </CommandGroup>
-                {modules.map((module) => (
-                  <CommandGroup key={module.id} heading={module.label}>
-                    {generators
-                      .filter((generator) => generator.module === module.id)
-                      .map((generator) => (
-                        <CommandItem
-                          key={generator.id}
-                          value={`${generator.moduleLabel} ${generator.label} ${generator.id}`}
-                          onSelect={() => {
-                            update({
-                              sampleData: { ...field.sampleData, generator: generator.id },
-                            });
-                            setOpen(false);
-                          }}
-                        >
-                          {generator.label}
-                        </CommandItem>
-                      ))}
-                  </CommandGroup>
-                ))}
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-      </div>
-    </section>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id="field-sample-data-generator"
+          type="button"
+          variant="ghost"
+          aria-expanded={open}
+          className="h-7 min-w-0 px-2 text-xs font-normal"
+        >
+          <span className="max-w-64 truncate text-muted-foreground">
+            {selected ? selected.label : 'Auto'}
+          </span>
+          <ChevronsUpDown aria-hidden="true" className="size-3.5 opacity-60" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-72 p-0" align="end">
+        <Command>
+          <CommandInput placeholder="Find a generator..." />
+          <CommandList className="max-h-72">
+            <CommandEmpty>No generators found.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value="auto"
+                onSelect={() => {
+                  update({ sampleData: undefined });
+                  setOpen(false);
+                }}
+              >
+                Auto
+              </CommandItem>
+            </CommandGroup>
+            {modules.map((module) => (
+              <CommandGroup key={module.id} heading={module.label}>
+                {generators
+                  .filter((generator) => generator.module === module.id)
+                  .map((generator) => (
+                    <CommandItem
+                      key={generator.id}
+                      value={`${generator.moduleLabel} ${generator.label} ${generator.id}`}
+                      onSelect={() => {
+                        update({
+                          sampleData: { ...field.sampleData, generator: generator.id },
+                        });
+                        setOpen(false);
+                      }}
+                    >
+                      {generator.label}
+                    </CommandItem>
+                  ))}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -350,6 +583,22 @@ function fixtureValueTypeForField(fieldType: FieldType): FixtureValueType {
     case 'array':
       return 'unknown';
   }
+}
+
+function fieldTypeSummary(fieldType: FieldType): string {
+  if (fieldType.kind === 'array') return `list<${fieldTypeSummary(fieldType.element)}>`;
+  if (fieldType.kind === 'ref') return `ref ${fieldType.typeName}`;
+  return fieldType.kind;
+}
+
+function sampleDataLabel(field: FieldDef): string {
+  const generatorId = field.sampleData?.generator;
+  if (!generatorId) return 'Auto';
+  return (
+    listFixtureGenerators({ valueType: fixtureValueTypeForField(field.type) }).find(
+      (generator) => generator.id === generatorId,
+    )?.label ?? generatorId
+  );
 }
 
 /**
@@ -484,26 +733,6 @@ function StringBody({
 }) {
   return (
     <div className="space-y-2 text-xs">
-      <Row label="min">
-        <Input
-          type="number"
-          defaultValue={value.min ?? ''}
-          onBlur={(ev) => onChange({ ...value, min: parseOptInt(ev.target.value) })}
-        />
-      </Row>
-      <Row label="max">
-        <Input
-          type="number"
-          defaultValue={value.max ?? ''}
-          onBlur={(ev) => onChange({ ...value, max: parseOptInt(ev.target.value) })}
-        />
-      </Row>
-      <Row label="regex">
-        <Input
-          defaultValue={value.regex ?? ''}
-          onBlur={(ev) => onChange({ ...value, regex: ev.target.value || undefined })}
-        />
-      </Row>
       <Row label="format">
         <Select
           value={value.format ?? 'none'}
@@ -535,6 +764,48 @@ function StringBody({
           </SelectContent>
         </Select>
       </Row>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Label className="space-y-1 text-[11px] text-muted-foreground">
+          <span>min</span>
+          <Input
+            type="number"
+            className="h-8 text-xs"
+            defaultValue={value.min ?? ''}
+            onBlur={(ev) => onChange({ ...value, min: parseOptInt(ev.target.value) })}
+          />
+        </Label>
+        <Label className="space-y-1 text-[11px] text-muted-foreground">
+          <span>max</span>
+          <Input
+            type="number"
+            className="h-8 text-xs"
+            defaultValue={value.max ?? ''}
+            onBlur={(ev) => onChange({ ...value, max: parseOptInt(ev.target.value) })}
+          />
+        </Label>
+      </div>
+      <Collapsible defaultOpen={Boolean(value.regex)}>
+        <CollapsibleTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-full justify-between px-2 text-xs"
+          >
+            Pattern
+            <ChevronDown aria-hidden="true" className="size-3.5" />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="pt-1">
+          <Row label="regex">
+            <Input
+              className="h-8 text-xs"
+              defaultValue={value.regex ?? ''}
+              onBlur={(ev) => onChange({ ...value, regex: ev.target.value || undefined })}
+            />
+          </Row>
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 }
@@ -548,20 +819,26 @@ function NumberBody({
 }) {
   return (
     <div className="space-y-2 text-xs">
-      <Row label="min">
-        <Input
-          type="number"
-          defaultValue={value.min ?? ''}
-          onBlur={(ev) => onChange({ ...value, min: parseOptNum(ev.target.value) })}
-        />
-      </Row>
-      <Row label="max">
-        <Input
-          type="number"
-          defaultValue={value.max ?? ''}
-          onBlur={(ev) => onChange({ ...value, max: parseOptNum(ev.target.value) })}
-        />
-      </Row>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Label className="space-y-1 text-[11px] text-muted-foreground">
+          <span>min</span>
+          <Input
+            type="number"
+            className="h-8 text-xs"
+            defaultValue={value.min ?? ''}
+            onBlur={(ev) => onChange({ ...value, min: parseOptNum(ev.target.value) })}
+          />
+        </Label>
+        <Label className="space-y-1 text-[11px] text-muted-foreground">
+          <span>max</span>
+          <Input
+            type="number"
+            className="h-8 text-xs"
+            defaultValue={value.max ?? ''}
+            onBlur={(ev) => onChange({ ...value, max: parseOptNum(ev.target.value) })}
+          />
+        </Label>
+      </div>
       <CheckboxOption
         id="field-int"
         label="Integer"
@@ -922,7 +1199,7 @@ function CheckboxOption({
   return (
     <Label
       htmlFor={checkboxId}
-      className="flex cursor-pointer items-start gap-2 rounded-md border border-border/70 bg-card/50 p-2 transition-colors hover:border-border hover:bg-muted/30 focus-within:border-ring focus-within:bg-muted/30"
+      className="inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-md border border-border/70 px-2 text-xs transition-colors hover:border-border hover:bg-muted/30 focus-within:border-ring focus-within:bg-muted/30"
     >
       <Checkbox
         id={checkboxId}
@@ -930,18 +1207,16 @@ function CheckboxOption({
         aria-labelledby={labelId}
         aria-describedby={descriptionId}
         onCheckedChange={onCheckedChange}
+        className="size-3.5"
       />
-      <div className="min-w-0 space-y-0.5">
-        <span id={labelId} className="block text-xs font-medium leading-none">
+      <span className="min-w-0">
+        <span id={labelId} className="block leading-none">
           {label}
         </span>
-        <p
-          id={descriptionId}
-          className="text-[11px] font-normal leading-snug text-muted-foreground"
-        >
+        <p id={descriptionId} className="sr-only">
           {description}
         </p>
-      </div>
+      </span>
     </Label>
   );
 }

--- a/apps/desktop/src/renderer/src/components/detail/ModelShapeHints.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/ModelShapeHints.tsx
@@ -49,7 +49,7 @@ export function ModelShapeHints({ hints }: ModelShapeHintsProps) {
   );
 }
 
-function HintBody({ hint, compact = false }: { hint: ModelingHint; compact?: boolean }) {
+export function HintBody({ hint, compact = false }: { hint: ModelingHint; compact?: boolean }) {
   const tone = toneForHint(hint.kind);
   return (
     <div className={compact ? 'space-y-1 border-t border-border/70 pt-2' : 'space-y-2'}>

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -14,7 +14,7 @@
  */
 
 import { listFixtureModules } from '@contexture/core/fixture-generators';
-import type { FieldDef, FieldType, IndexDef, TypeDef } from '@contexture/core/ir';
+import type { FieldDef, FieldType, IndexDef, Schema, TypeDef } from '@contexture/core/ir';
 import type { ModelingHint } from '@contexture/core/modeling-hints';
 import type { TypeUpdatePatch } from '@contexture/core/ops';
 import type { ValidationError } from '@renderer/services/validation';
@@ -23,6 +23,7 @@ import { ChevronDown, ChevronUp, Plus, SlidersHorizontal, Trash2, X } from 'luci
 import { useEffect, useId, useRef, useState } from 'react';
 import type { Op } from '../../store/ops';
 import { nextFieldName } from '../graph/interactions';
+import { ScopedPlaygroundWorkbench } from '../playground/PlaygroundPanel';
 import { Button } from '../ui/button';
 import { Checkbox } from '../ui/checkbox';
 import {
@@ -61,6 +62,7 @@ function selectFieldFromValidationIssue(type: TypeDef, error: ValidationError): 
 
 export interface TypeDetailProps {
   type: TypeDef;
+  schema?: Schema;
   /** Dispatch an op. In production this is `useUndoStore.getState().apply`. */
   dispatch: (op: Op) => void;
   /** Dispatch a multi-op user action as one undoable edit. */
@@ -74,6 +76,7 @@ export interface TypeDetailProps {
 
 export function TypeDetail({
   type,
+  schema,
   dispatch,
   dispatchBatch,
   modelingHints = [],
@@ -128,6 +131,7 @@ export function TypeDetail({
 
       {type.kind === 'object' && <ObjectBody type={type} dispatch={dispatch} />}
       <SampleDataSection type={type} dispatch={dispatch} />
+      {isTable && schema && <ScopedPlaygroundWorkbench schema={schema} typeName={type.name} />}
       {type.kind === 'object' && (
         <ConvexSection type={type} dispatch={dispatch} validationErrors={validationErrors} />
       )}

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -23,6 +23,7 @@ import { useGraphSelectionStore } from '@renderer/store/selection';
 import {
   ChevronDown,
   ChevronUp,
+  Hash,
   Lightbulb,
   Play,
   Plus,
@@ -211,6 +212,9 @@ function TableTypeDetail({
     (sum, hints) => sum + hints.length,
     0,
   );
+  const fieldIndexInsights = useMemo(() => fieldIndexInsightsForType(type), [type]);
+  const indexCount = type.indexes?.length ?? 0;
+  const suggestionCount = suggestedIndexes(type).length;
 
   return (
     <Tabs key={type.name} defaultValue={defaultMode} className="flex h-full min-h-0 flex-col">
@@ -274,6 +278,7 @@ function TableTypeDetail({
             quietControls
             fieldHintsByName={fieldHintsByName}
             fieldHintCount={fieldHintCount}
+            fieldIndexInsights={fieldIndexInsights}
           />
           <Collapsible
             defaultOpen
@@ -287,6 +292,16 @@ function TableTypeDetail({
                 className="group h-8 w-full justify-start px-2 text-xs"
               >
                 Advanced schema output
+                {(indexCount > 0 || suggestionCount > 0) && (
+                  <span className="ml-1 truncate text-muted-foreground">
+                    · {indexCount} {indexCount === 1 ? 'index' : 'indexes'}
+                    {suggestionCount > 0
+                      ? ` · ${suggestionCount} ${
+                          suggestionCount === 1 ? 'suggestion' : 'suggestions'
+                        }`
+                      : ''}
+                  </span>
+                )}
                 <ChevronDown
                   aria-hidden="true"
                   className="ml-auto size-3.5 transition-transform group-data-[state=open]:rotate-180"
@@ -483,12 +498,14 @@ function ObjectBody({
   quietControls = false,
   fieldHintsByName,
   fieldHintCount = 0,
+  fieldIndexInsights,
 }: {
   type: Extract<TypeDef, { kind: 'object' }>;
   dispatch: (op: Op) => void;
   quietControls?: boolean;
   fieldHintsByName?: ReadonlyMap<string, readonly ModelingHint[]>;
   fieldHintCount?: number;
+  fieldIndexInsights?: ReadonlyMap<string, FieldIndexInsight>;
 }) {
   const fieldOrder = type.fields.map((field) => field.name);
   const addField = () => {
@@ -560,7 +577,7 @@ function ObjectBody({
                 <span className="sr-only">Advice</span>
               </TableHead>
             )}
-            <TableHead className="h-7 w-28 px-1 text-right">
+            <TableHead className="h-7 w-36 px-1 text-right">
               <span className="sr-only">Actions</span>
             </TableHead>
           </TableRow>
@@ -569,6 +586,7 @@ function ObjectBody({
           {type.fields.map((f, fieldIndex) => {
             const reserved = isTable && isConvexReservedName(f.name);
             const fieldHints = fieldHintsByName?.get(f.name) ?? [];
+            const fieldIndexInsight = fieldIndexInsights?.get(f.name);
             return (
               <TableRow
                 key={f.name}
@@ -617,66 +635,76 @@ function ObjectBody({
                     <FieldAdvicePopover fieldName={f.name} hints={fieldHints} />
                   </TableCell>
                 )}
-                <TableCell className="w-28 px-1 py-1.5 text-right">
-                  <div
-                    className={cn(
-                      'inline-flex items-center gap-0.5 transition-opacity',
-                      quietControls &&
-                        'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
+                <TableCell className="w-36 px-1 py-1.5 text-right">
+                  <div className="inline-flex items-center justify-end gap-0.5">
+                    {fieldIndexInsight && (
+                      <FieldIndexPopover
+                        typeName={type.name}
+                        fieldName={f.name}
+                        insight={fieldIndexInsight}
+                        dispatch={dispatch}
+                      />
                     )}
-                  >
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Edit field ${f.name}`}
-                      onClick={() =>
-                        useGraphSelectionStore
-                          .getState()
-                          .selectField({ typeName: type.name, fieldName: f.name })
-                      }
-                      className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                    <div
+                      className={cn(
+                        'inline-flex items-center gap-0.5 transition-opacity',
+                        quietControls &&
+                          'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
+                      )}
                     >
-                      <SlidersHorizontal aria-hidden="true" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Move field ${f.name} earlier`}
-                      disabled={fieldIndex === 0}
-                      onClick={() => moveField(fieldIndex, fieldIndex - 1)}
-                      className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                    >
-                      <ChevronUp aria-hidden="true" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Move field ${f.name} later`}
-                      disabled={fieldIndex === type.fields.length - 1}
-                      onClick={() => moveField(fieldIndex, fieldIndex + 1)}
-                      className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                    >
-                      <ChevronDown aria-hidden="true" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Delete field ${f.name}`}
-                      onClick={() =>
-                        dispatch({
-                          kind: 'remove_field',
-                          typeName: type.name,
-                          fieldName: f.name,
-                        })
-                      }
-                      className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                    >
-                      <Trash2 aria-hidden="true" />
-                    </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Edit field ${f.name}`}
+                        onClick={() =>
+                          useGraphSelectionStore
+                            .getState()
+                            .selectField({ typeName: type.name, fieldName: f.name })
+                        }
+                        className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                      >
+                        <SlidersHorizontal aria-hidden="true" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Move field ${f.name} earlier`}
+                        disabled={fieldIndex === 0}
+                        onClick={() => moveField(fieldIndex, fieldIndex - 1)}
+                        className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                      >
+                        <ChevronUp aria-hidden="true" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Move field ${f.name} later`}
+                        disabled={fieldIndex === type.fields.length - 1}
+                        onClick={() => moveField(fieldIndex, fieldIndex + 1)}
+                        className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                      >
+                        <ChevronDown aria-hidden="true" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Delete field ${f.name}`}
+                        onClick={() =>
+                          dispatch({
+                            kind: 'remove_field',
+                            typeName: type.name,
+                            fieldName: f.name,
+                          })
+                        }
+                        className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                      >
+                        <Trash2 aria-hidden="true" />
+                      </Button>
+                    </div>
                   </div>
                 </TableCell>
               </TableRow>
@@ -736,6 +764,99 @@ function FieldAdvicePopover({
 
 function LightbulbIcon(): React.JSX.Element {
   return <Lightbulb aria-hidden="true" className="size-3.5" />;
+}
+
+function FieldIndexPopover({
+  typeName,
+  fieldName,
+  insight,
+  dispatch,
+}: {
+  typeName: string;
+  fieldName: string;
+  insight: FieldIndexInsight;
+  dispatch: (op: Op) => void;
+}) {
+  const isIndexed = insight.memberships.length > 0;
+  const suggestion = insight.suggestion;
+  if (!isIndexed && !suggestion) return null;
+
+  const triggerLabel = isIndexed ? `Index details for ${fieldName}` : `Add index for ${fieldName}`;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={triggerLabel}
+          className={cn(
+            'h-7 w-7 text-muted-foreground hover:text-primary data-[state=open]:text-primary',
+            !isIndexed &&
+              'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100',
+          )}
+        >
+          {isIndexed ? (
+            <Hash aria-hidden="true" className="size-3.5" />
+          ) : (
+            <Plus aria-hidden="true" />
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" side="left" className="w-72 p-3 text-xs">
+        <div className="space-y-3">
+          {isIndexed && (
+            <div className="space-y-2">
+              <div className="font-medium text-foreground">Indexed field</div>
+              <div className="space-y-1.5">
+                {insight.memberships.map((membership) => (
+                  <div key={membership.indexName} className="rounded-md border px-2 py-1.5">
+                    <div className="font-mono text-[11px] text-foreground">
+                      {membership.indexName}
+                    </div>
+                    <div className="mt-0.5 text-[11px] text-muted-foreground">
+                      {membership.total === 1
+                        ? 'Single-field index'
+                        : `Position ${membership.position + 1} of ${membership.total}: ${membership.fields.join(
+                            ' -> ',
+                          )}`}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {suggestion && (
+            <div className={cn('space-y-2', isIndexed && 'border-t border-border/70 pt-2')}>
+              <div>
+                <div className="font-medium text-foreground">Suggested index</div>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">
+                  Useful for lookups, filtering, or sorting on this field.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  dispatch({
+                    kind: 'add_index',
+                    typeName,
+                    index: { name: suggestion.name, fields: suggestion.fields },
+                  })
+                }
+                className="h-7 px-2 text-xs"
+              >
+                <Plus aria-hidden="true" />
+                Add {suggestion.name}
+              </Button>
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 // TODO(#119): gate on output config mode once Contexture supports multiple emit targets.
@@ -828,31 +949,16 @@ function ConvexSection({
             <p className="text-xs text-muted-foreground">Add a field before creating an index.</p>
           )}
           {suggestions.length > 0 && (
-            <div className="space-y-1">
-              <p className="text-[11px] text-muted-foreground">
-                Suggested from refs and likely lookup fields.
+            <div className="flex items-center justify-between gap-3 rounded-md border border-border/70 px-2 py-1.5">
+              <p className="min-w-0 text-[11px] text-muted-foreground">
+                {suggestions.length}{' '}
+                {suggestions.length === 1 ? 'suggested index' : 'suggested indexes'}
               </p>
-              <div className="flex flex-wrap gap-1.5">
-                {suggestions.map((suggestion) => (
-                  <Button
-                    key={suggestion.name}
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() =>
-                      dispatch({
-                        kind: 'add_index',
-                        typeName: type.name,
-                        index: { name: suggestion.name, fields: suggestion.fields },
-                      })
-                    }
-                    className="h-7 px-2 text-xs"
-                  >
-                    <Plus aria-hidden="true" />
-                    {suggestion.name}
-                  </Button>
-                ))}
-              </div>
+              <SuggestedIndexesPopover
+                typeName={type.name}
+                suggestions={suggestions}
+                dispatch={dispatch}
+              />
             </div>
           )}
           {indexes.length === 0 ? (
@@ -890,6 +996,72 @@ function ConvexSection({
         </div>
       )}
     </div>
+  );
+}
+
+function SuggestedIndexesPopover({
+  typeName,
+  suggestions,
+  dispatch,
+}: {
+  typeName: string;
+  suggestions: readonly SuggestedIndex[];
+  dispatch: (op: Op) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" size="sm" className="h-7 px-2 text-xs">
+          Review
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-3 text-xs">
+        <div className="space-y-3">
+          <div>
+            <div className="font-medium text-foreground">Suggested indexes</div>
+            <p className="mt-0.5 text-[11px] text-muted-foreground">
+              Suggested from refs and likely lookup fields.
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            {suggestions.map((suggestion) => (
+              <div
+                key={suggestion.name}
+                className="flex items-start justify-between gap-3 rounded-md border px-2 py-1.5"
+              >
+                <div className="min-w-0">
+                  <div className="truncate font-mono text-[11px] text-foreground">
+                    {suggestion.name}
+                  </div>
+                  <div className="mt-0.5 text-[11px] text-muted-foreground">
+                    {suggestionReason(suggestion)}
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    dispatch({
+                      kind: 'add_index',
+                      typeName,
+                      index: { name: suggestion.name, fields: suggestion.fields },
+                    });
+                    setOpen(false);
+                  }}
+                  className="h-7 shrink-0 px-2 text-xs"
+                >
+                  <Plus aria-hidden="true" />
+                  Add
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -1159,6 +1331,51 @@ interface SuggestedIndex {
   fields: string[];
 }
 
+interface FieldIndexMembership {
+  indexName: string;
+  fields: string[];
+  position: number;
+  total: number;
+}
+
+interface FieldIndexInsight {
+  memberships: FieldIndexMembership[];
+  suggestion?: SuggestedIndex;
+}
+
+function fieldIndexInsightsForType(
+  type: Extract<TypeDef, { kind: 'object' }>,
+): Map<string, FieldIndexInsight> {
+  const insights = new Map<string, FieldIndexInsight>();
+  const ensureInsight = (fieldName: string) => {
+    const existing = insights.get(fieldName);
+    if (existing) return existing;
+    const insight: FieldIndexInsight = { memberships: [] };
+    insights.set(fieldName, insight);
+    return insight;
+  };
+
+  for (const index of type.indexes ?? []) {
+    index.fields.forEach((fieldName, position) => {
+      ensureInsight(fieldName).memberships.push({
+        indexName: index.name,
+        fields: index.fields,
+        position,
+        total: index.fields.length,
+      });
+    });
+  }
+
+  for (const suggestion of suggestedIndexes(type)) {
+    const [fieldName] = suggestion.fields;
+    if (fieldName && suggestion.fields.length === 1) {
+      ensureInsight(fieldName).suggestion = suggestion;
+    }
+  }
+
+  return insights;
+}
+
 function suggestedIndexes(type: Extract<TypeDef, { kind: 'object' }>): SuggestedIndex[] {
   if (type.table !== true) return [];
   const existing = type.indexes ?? [];
@@ -1173,6 +1390,13 @@ function suggestedIndexes(type: Extract<TypeDef, { kind: 'object' }>): Suggested
   }
 
   return suggestions;
+}
+
+function suggestionReason(suggestion: SuggestedIndex): string {
+  if (suggestion.fields.length === 1) {
+    return `Lookup and filter by ${suggestion.fields[0]}.`;
+  }
+  return `Compound query prefix: ${suggestion.fields.join(' -> ')}.`;
 }
 
 function isIndexSuggestionField(field: FieldDef): boolean {

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -12,6 +12,8 @@
  * direct edits interleave cleanly with chat-driven ops. Edits fire on
  * `blur` (not `change`) to avoid a history entry per keystroke.
  */
+
+import { listFixtureModules } from '@contexture/core/fixture-generators';
 import type { FieldDef, FieldType, IndexDef, TypeDef } from '@contexture/core/ir';
 import type { ModelingHint } from '@contexture/core/modeling-hints';
 import type { TypeUpdatePatch } from '@contexture/core/ops';
@@ -34,6 +36,7 @@ import {
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import { Textarea } from '../ui/textarea';
 import { ModelShapeHints } from './ModelShapeHints';
@@ -41,6 +44,7 @@ import { type ValidationIssueRepair, ValidationIssues } from './ValidationIssues
 
 const CONVEX_RESERVED_PREFIX_MSG = "Convex reserves names starting with '_'";
 export const FOCUS_TYPE_NAME_EVENT = 'contexture:focus-type-name';
+const AUTO_SAMPLE_DATA = '__auto__';
 
 function isConvexReservedName(name: string): boolean {
   return name.startsWith('_');
@@ -123,6 +127,7 @@ export function TypeDetail({
       <ModelShapeHints hints={modelingHints} />
 
       {type.kind === 'object' && <ObjectBody type={type} dispatch={dispatch} />}
+      <SampleDataSection type={type} dispatch={dispatch} />
       {type.kind === 'object' && (
         <ConvexSection type={type} dispatch={dispatch} validationErrors={validationErrors} />
       )}
@@ -138,6 +143,49 @@ export function TypeDetail({
       )}
       {type.kind === 'raw' && <RawBody type={type} dispatch={dispatch} />}
     </div>
+  );
+}
+
+function SampleDataSection({ type, dispatch }: TypeDetailProps) {
+  const modules = listFixtureModules();
+  const category = type.sampleData?.category ?? AUTO_SAMPLE_DATA;
+
+  return (
+    <details className="space-y-2 rounded-md border border-border px-3 py-2">
+      <summary className="cursor-default select-none text-xs font-medium">Sample data</summary>
+      <div className="space-y-2 pt-2">
+        <div className="space-y-1">
+          <Label htmlFor="type-sample-data-category">Category</Label>
+          <Select
+            value={category}
+            onValueChange={(value) => {
+              const nextCategory = value === AUTO_SAMPLE_DATA ? undefined : value;
+              dispatch({
+                kind: 'update_type',
+                name: type.name,
+                patch: typePatch({
+                  sampleData: nextCategory
+                    ? { ...type.sampleData, category: nextCategory }
+                    : undefined,
+                }),
+              });
+            }}
+          >
+            <SelectTrigger id="type-sample-data-category" className="h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={AUTO_SAMPLE_DATA}>Auto</SelectItem>
+              {modules.map((module) => (
+                <SelectItem key={module.id} value={module.id}>
+                  {module.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </details>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -18,9 +18,11 @@ import type { FieldDef, FieldType, IndexDef, Schema, TypeDef } from '@contexture
 import type { ModelingHint } from '@contexture/core/modeling-hints';
 import type { TypeUpdatePatch } from '@contexture/core/ops';
 import type { ValidationError } from '@renderer/services/validation';
+import { usePlaygroundStore } from '@renderer/store/playground';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { ChevronDown, ChevronUp, Plus, SlidersHorizontal, Trash2, X } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
 import type { Op } from '../../store/ops';
 import { nextFieldName } from '../graph/interactions';
 import { ScopedPlaygroundWorkbench } from '../playground/PlaygroundPanel';
@@ -39,6 +41,7 @@ import { Label } from '../ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Textarea } from '../ui/textarea';
 import { ModelShapeHints } from './ModelShapeHints';
 import { type ValidationIssueRepair, ValidationIssues } from './ValidationIssues';
@@ -46,6 +49,7 @@ import { type ValidationIssueRepair, ValidationIssues } from './ValidationIssues
 const CONVEX_RESERVED_PREFIX_MSG = "Convex reserves names starting with '_'";
 export const FOCUS_TYPE_NAME_EVENT = 'contexture:focus-type-name';
 const AUTO_SAMPLE_DATA = '__auto__';
+const EMPTY_TABLE_RECORDS: readonly unknown[] = [];
 
 function isConvexReservedName(name: string): boolean {
   return name.startsWith('_');
@@ -87,6 +91,25 @@ export function TypeDetail({
 }: TypeDetailProps) {
   const isTable = type.kind === 'object' && type.table === true;
   const nameReserved = isTable && isConvexReservedName(type.name);
+  const recordsByType = usePlaygroundStore((state) => state.recordsByType);
+  const tableRecords = isTable
+    ? (recordsByType[type.name] ?? EMPTY_TABLE_RECORDS)
+    : EMPTY_TABLE_RECORDS;
+
+  if (isTable && type.kind === 'object') {
+    return (
+      <TableTypeDetail
+        type={type}
+        schema={schema}
+        dispatch={dispatch}
+        modelingHints={modelingHints}
+        validationErrors={validationErrors}
+        validationRepairForIssue={validationRepairForIssue}
+        recordsCount={tableRecords.length}
+        reserved={nameReserved}
+      />
+    );
+  }
 
   return (
     <div className="space-y-4 p-3 pt-0">
@@ -131,7 +154,6 @@ export function TypeDetail({
 
       {type.kind === 'object' && <ObjectBody type={type} dispatch={dispatch} />}
       <SampleDataSection type={type} dispatch={dispatch} />
-      {isTable && schema && <ScopedPlaygroundWorkbench schema={schema} typeName={type.name} />}
       {type.kind === 'object' && (
         <ConvexSection type={type} dispatch={dispatch} validationErrors={validationErrors} />
       )}
@@ -150,12 +172,125 @@ export function TypeDetail({
   );
 }
 
-function SampleDataSection({ type, dispatch }: TypeDetailProps) {
+function TableTypeDetail({
+  type,
+  schema,
+  dispatch,
+  modelingHints,
+  validationErrors,
+  validationRepairForIssue,
+  recordsCount,
+  reserved,
+}: {
+  type: Extract<TypeDef, { kind: 'object' }>;
+  schema?: Schema;
+  dispatch: (op: Op) => void;
+  modelingHints: readonly ModelingHint[];
+  validationErrors: readonly ValidationError[];
+  validationRepairForIssue?: (error: ValidationError) => ValidationIssueRepair | null;
+  recordsCount: number;
+  reserved: boolean;
+}) {
+  const defaultMode = recordsCount > 0 ? 'try' : 'shape';
+
+  return (
+    <Tabs key={type.name} defaultValue={defaultMode} className="flex h-full min-h-0 flex-col">
+      <header
+        className="flex min-h-20 shrink-0 items-center justify-between border-b bg-muted/20 px-3 py-3"
+        data-testid="type-detail-header"
+      >
+        <div className="min-w-0">
+          <div className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            table
+          </div>
+          <h2 className="truncate text-lg font-semibold leading-tight text-foreground">
+            {type.name}
+          </h2>
+          <div className="mt-2">
+            <TabsList className="h-8 bg-background p-0.5">
+              <TabsTrigger value="shape" className="h-7 px-3 text-xs">
+                Shape
+              </TabsTrigger>
+              <TabsTrigger value="try" className="h-7 px-3 text-xs">
+                Try
+              </TabsTrigger>
+            </TabsList>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={`Delete type ${type.name}`}
+          onClick={() => dispatch({ kind: 'delete_type', name: type.name })}
+          className="h-7 w-7 text-muted-foreground hover:text-destructive"
+        >
+          <Trash2 aria-hidden="true" />
+        </Button>
+      </header>
+
+      <TabsContent value="shape" className="m-0 min-h-0 flex-1 overflow-y-auto p-3">
+        <div className="space-y-4">
+          <ValidationIssues
+            errors={validationErrors}
+            onIssueClick={(error) => selectFieldFromValidationIssue(type, error)}
+            repairForIssue={validationRepairForIssue}
+          />
+          <NameField type={type} dispatch={dispatch} reserved={reserved} />
+          <DescriptionField type={type} dispatch={dispatch} />
+          <ModelShapeHints hints={modelingHints} />
+          <ObjectBody type={type} dispatch={dispatch} quietControls />
+          <details className="group border-t pt-3">
+            <summary className="cursor-pointer list-none text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
+              Advanced schema output
+            </summary>
+            <div className="mt-3">
+              <ConvexSection type={type} dispatch={dispatch} validationErrors={validationErrors} />
+            </div>
+          </details>
+        </div>
+      </TabsContent>
+
+      <TabsContent value="try" className="m-0 min-h-0 flex-1 overflow-hidden">
+        <div className="flex h-full min-h-0 flex-col">
+          <ValidationIssues
+            errors={validationErrors}
+            onIssueClick={(error) => selectFieldFromValidationIssue(type, error)}
+            repairForIssue={validationRepairForIssue}
+          />
+          <details className="shrink-0 border-b bg-muted/10 px-3 py-2">
+            <summary className="cursor-pointer list-none text-xs font-medium text-muted-foreground transition-colors hover:text-foreground">
+              Generation settings
+            </summary>
+            <div className="mt-2">
+              <SampleDataSection type={type} dispatch={dispatch} compact />
+            </div>
+          </details>
+          {schema ? (
+            <ScopedPlaygroundWorkbench schema={schema} typeName={type.name} className="flex-1" />
+          ) : (
+            <div className="grid flex-1 place-items-center p-6 text-center text-sm text-muted-foreground">
+              Sample records need a schema context.
+            </div>
+          )}
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function SampleDataSection({
+  type,
+  dispatch,
+  compact = false,
+}: Pick<TypeDetailProps, 'type' | 'dispatch'> & { compact?: boolean }) {
   const modules = listFixtureModules();
   const category = type.sampleData?.category ?? AUTO_SAMPLE_DATA;
 
   return (
-    <section className="space-y-2 rounded-md border border-border px-3 py-2">
+    <section
+      className={compact ? 'space-y-2' : 'space-y-2 rounded-md border border-border px-3 py-2'}
+    >
       <Label htmlFor="type-sample-data-category" className="text-xs">
         Sample data
       </Label>
@@ -251,9 +386,11 @@ function DescriptionField({ type, dispatch }: TypeDetailProps) {
 function ObjectBody({
   type,
   dispatch,
+  quietControls = false,
 }: {
   type: Extract<TypeDef, { kind: 'object' }>;
   dispatch: (op: Op) => void;
+  quietControls?: boolean;
 }) {
   const fieldOrder = type.fields.map((field) => field.name);
   const addField = () => {
@@ -326,7 +463,7 @@ function ObjectBody({
                 data-testid="object-field-summary"
                 data-reserved={reserved || undefined}
                 title={reserved ? CONVEX_RESERVED_PREFIX_MSG : undefined}
-                className={reserved ? 'text-destructive' : undefined}
+                className={cn('group', reserved && 'text-destructive')}
               >
                 <TableCell className="px-2 py-1.5 font-medium">
                   <Input
@@ -364,7 +501,13 @@ function ObjectBody({
                   {summariseKind(f.type.kind)}
                 </TableCell>
                 <TableCell className="w-28 px-1 py-1.5 text-right">
-                  <div className="inline-flex items-center gap-0.5">
+                  <div
+                    className={cn(
+                      'inline-flex items-center gap-0.5 transition-opacity',
+                      quietControls &&
+                        'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
+                    )}
+                  >
                     <Button
                       type="button"
                       variant="ghost"

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -20,8 +20,17 @@ import type { TypeUpdatePatch } from '@contexture/core/ops';
 import type { ValidationError } from '@renderer/services/validation';
 import { usePlaygroundStore } from '@renderer/store/playground';
 import { useGraphSelectionStore } from '@renderer/store/selection';
-import { ChevronDown, ChevronUp, Play, Plus, SlidersHorizontal, Trash2, X } from 'lucide-react';
-import { useEffect, useId, useRef, useState } from 'react';
+import {
+  ChevronDown,
+  ChevronUp,
+  Lightbulb,
+  Play,
+  Plus,
+  SlidersHorizontal,
+  Trash2,
+  X,
+} from 'lucide-react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import type { Op } from '../../store/ops';
 import { nextFieldName } from '../graph/interactions';
@@ -45,7 +54,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Textarea } from '../ui/textarea';
-import { ModelShapeHints } from './ModelShapeHints';
+import { HintBody, ModelShapeHints } from './ModelShapeHints';
 import { type ValidationIssueRepair, ValidationIssues } from './ValidationIssues';
 
 const CONVEX_RESERVED_PREFIX_MSG = "Convex reserves names starting with '_'";
@@ -194,6 +203,14 @@ function TableTypeDetail({
   reserved: boolean;
 }) {
   const defaultMode = recordsCount > 0 ? 'try' : 'shape';
+  const { tableHints, fieldHintsByName } = useMemo(
+    () => splitTableModelingHints(modelingHints),
+    [modelingHints],
+  );
+  const fieldHintCount = Array.from(fieldHintsByName.values()).reduce(
+    (sum, hints) => sum + hints.length,
+    0,
+  );
 
   return (
     <Tabs key={type.name} defaultValue={defaultMode} className="flex h-full min-h-0 flex-col">
@@ -250,8 +267,14 @@ function TableTypeDetail({
           />
           <NameField type={type} dispatch={dispatch} reserved={reserved} />
           <DescriptionField type={type} dispatch={dispatch} />
-          <ModelShapeHints hints={modelingHints} />
-          <ObjectBody type={type} dispatch={dispatch} quietControls />
+          <TableModelingAdvisoryStrip hints={tableHints} />
+          <ObjectBody
+            type={type}
+            dispatch={dispatch}
+            quietControls
+            fieldHintsByName={fieldHintsByName}
+            fieldHintCount={fieldHintCount}
+          />
           <Collapsible
             defaultOpen
             className="rounded-md border border-border/70 data-[state=open]:bg-muted/20"
@@ -353,6 +376,51 @@ function SampleDataSection({
   );
 }
 
+function splitTableModelingHints(hints: readonly ModelingHint[]): {
+  tableHints: ModelingHint[];
+  fieldHintsByName: Map<string, ModelingHint[]>;
+} {
+  const tableHints: ModelingHint[] = [];
+  const fieldHintsByName = new Map<string, ModelingHint[]>();
+
+  for (const hint of hints) {
+    if (!hint.fieldName) {
+      tableHints.push(hint);
+      continue;
+    }
+    const existing = fieldHintsByName.get(hint.fieldName) ?? [];
+    existing.push(hint);
+    fieldHintsByName.set(hint.fieldName, existing);
+  }
+
+  return { tableHints, fieldHintsByName };
+}
+
+function TableModelingAdvisoryStrip({ hints }: { hints: readonly ModelingHint[] }) {
+  if (hints.length === 0) return null;
+  const [primary, ...secondary] = hints;
+  if (!primary) return null;
+
+  return (
+    <section
+      aria-label="Model shape"
+      className="rounded-md border border-border/70 bg-muted/15 px-3 py-2 text-xs"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <div className="font-medium text-foreground">{primary.title}</div>
+          <p className="text-muted-foreground">{primary.message}</p>
+        </div>
+        {secondary.length > 0 && (
+          <span className="shrink-0 text-[11px] text-muted-foreground">
+            +{secondary.length} more
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}
+
 function NameField({ type, dispatch, reserved }: TypeDetailProps & { reserved: boolean }) {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -413,10 +481,14 @@ function ObjectBody({
   type,
   dispatch,
   quietControls = false,
+  fieldHintsByName,
+  fieldHintCount = 0,
 }: {
   type: Extract<TypeDef, { kind: 'object' }>;
   dispatch: (op: Op) => void;
   quietControls?: boolean;
+  fieldHintsByName?: ReadonlyMap<string, readonly ModelingHint[]>;
+  fieldHintCount?: number;
 }) {
   const fieldOrder = type.fields.map((field) => field.name);
   const addField = () => {
@@ -460,10 +532,18 @@ function ObjectBody({
     );
   }
   const isTable = type.table === true;
+  const showAdviceColumn = Boolean(fieldHintsByName && fieldHintsByName.size > 0);
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between">
-        <Label>Fields</Label>
+        <div className="flex items-center gap-2">
+          <Label>Fields</Label>
+          {fieldHintCount > 0 && (
+            <span className="text-[11px] text-muted-foreground">
+              {fieldHintCount} {fieldHintCount === 1 ? 'advisory' : 'advisories'}
+            </span>
+          )}
+        </div>
         <Button type="button" variant="ghost" size="sm" onClick={addField} className="h-7 text-xs">
           <Plus aria-hidden="true" />
           Add field
@@ -475,6 +555,11 @@ function ObjectBody({
             <TableHead className="h-7 px-2">Name</TableHead>
             <TableHead className="h-7 w-20 px-2 text-center">Optional</TableHead>
             <TableHead className="h-7 px-2 text-right">Type</TableHead>
+            {showAdviceColumn && (
+              <TableHead className="h-7 w-14 px-1 text-center">
+                <span className="sr-only">Advice</span>
+              </TableHead>
+            )}
             <TableHead className="h-7 w-28 px-1 text-right">
               <span className="sr-only">Actions</span>
             </TableHead>
@@ -483,6 +568,7 @@ function ObjectBody({
         <TableBody>
           {type.fields.map((f, fieldIndex) => {
             const reserved = isTable && isConvexReservedName(f.name);
+            const fieldHints = fieldHintsByName?.get(f.name) ?? [];
             return (
               <TableRow
                 key={f.name}
@@ -526,6 +612,11 @@ function ObjectBody({
                 <TableCell className="px-2 py-1.5 text-right text-muted-foreground">
                   {summariseKind(f.type.kind)}
                 </TableCell>
+                {showAdviceColumn && (
+                  <TableCell className="w-14 px-1 py-1.5 text-center">
+                    <FieldAdvicePopover fieldName={f.name} hints={fieldHints} />
+                  </TableCell>
+                )}
                 <TableCell className="w-28 px-1 py-1.5 text-right">
                   <div
                     className={cn(
@@ -595,6 +686,56 @@ function ObjectBody({
       </Table>
     </div>
   );
+}
+
+function FieldAdvicePopover({
+  fieldName,
+  hints,
+}: {
+  fieldName: string;
+  hints: readonly ModelingHint[];
+}) {
+  if (hints.length === 0) return <span aria-hidden="true" className="inline-block h-7 w-7" />;
+
+  const [primary, ...secondary] = hints;
+  if (!primary) return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={`Modeling advice for ${fieldName}`}
+          className="relative h-7 w-7 text-muted-foreground hover:text-primary data-[state=open]:text-primary"
+        >
+          <LightbulbIcon />
+          {secondary.length > 0 && (
+            <span className="absolute -right-0.5 -top-0.5 grid h-3.5 min-w-3.5 place-items-center rounded-full bg-primary px-1 text-[9px] leading-none text-primary-foreground">
+              {hints.length}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" side="left" className="w-80 p-3 text-xs">
+        <div className="space-y-3">
+          <HintBody hint={primary} />
+          {secondary.length > 0 && (
+            <div className="space-y-2 border-t border-border/70 pt-2">
+              {secondary.map((hint) => (
+                <HintBody key={hint.id} hint={hint} compact />
+              ))}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function LightbulbIcon(): React.JSX.Element {
+  return <Lightbulb aria-hidden="true" className="size-3.5" />;
 }
 
 // TODO(#119): gate on output config mode once Contexture supports multiple emit targets.

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -20,16 +20,7 @@ import type { TypeUpdatePatch } from '@contexture/core/ops';
 import type { ValidationError } from '@renderer/services/validation';
 import { usePlaygroundStore } from '@renderer/store/playground';
 import { useGraphSelectionStore } from '@renderer/store/selection';
-import {
-  ChevronDown,
-  ChevronRight,
-  ChevronUp,
-  Play,
-  Plus,
-  SlidersHorizontal,
-  Trash2,
-  X,
-} from 'lucide-react';
+import { ChevronDown, ChevronUp, Play, Plus, SlidersHorizontal, Trash2, X } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import type { Op } from '../../store/ops';
@@ -261,22 +252,25 @@ function TableTypeDetail({
           <DescriptionField type={type} dispatch={dispatch} />
           <ModelShapeHints hints={modelingHints} />
           <ObjectBody type={type} dispatch={dispatch} quietControls />
-          <Collapsible defaultOpen className="border-t pt-3">
+          <Collapsible
+            defaultOpen
+            className="rounded-md border border-border/70 data-[state=open]:bg-muted/20"
+          >
             <CollapsibleTrigger asChild>
               <Button
                 type="button"
-                variant="outline"
+                variant="ghost"
                 size="sm"
-                className="group h-8 w-full justify-between px-2 text-xs"
+                className="group h-8 w-full justify-start px-2 text-xs"
               >
-                <span>Advanced schema output</span>
-                <ChevronRight
+                Advanced schema output
+                <ChevronDown
                   aria-hidden="true"
-                  className="size-3.5 transition-transform group-data-[state=open]:rotate-90"
+                  className="ml-auto size-3.5 transition-transform group-data-[state=open]:rotate-180"
                 />
               </Button>
             </CollapsibleTrigger>
-            <CollapsibleContent className="mt-3">
+            <CollapsibleContent className="flex flex-col items-stretch gap-2 p-2.5 pt-0">
               <ConvexSection type={type} dispatch={dispatch} validationErrors={validationErrors} />
             </CollapsibleContent>
           </Collapsible>

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -20,14 +20,25 @@ import type { TypeUpdatePatch } from '@contexture/core/ops';
 import type { ValidationError } from '@renderer/services/validation';
 import { usePlaygroundStore } from '@renderer/store/playground';
 import { useGraphSelectionStore } from '@renderer/store/selection';
-import { ChevronDown, ChevronUp, Plus, SlidersHorizontal, Trash2, X } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Play,
+  Plus,
+  SlidersHorizontal,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import type { Op } from '../../store/ops';
 import { nextFieldName } from '../graph/interactions';
 import { ScopedPlaygroundWorkbench } from '../playground/PlaygroundPanel';
 import { Button } from '../ui/button';
+import { ButtonGroup } from '../ui/button-group';
 import { Checkbox } from '../ui/checkbox';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
 import {
   Command,
   CommandEmpty,
@@ -207,13 +218,23 @@ function TableTypeDetail({
             {type.name}
           </h2>
           <div className="mt-2">
-            <TabsList className="h-8 bg-background p-0.5">
-              <TabsTrigger value="shape" className="h-7 px-3 text-xs">
-                Shape
-              </TabsTrigger>
-              <TabsTrigger value="try" className="h-7 px-3 text-xs">
-                Try
-              </TabsTrigger>
+            <TabsList asChild>
+              <ButtonGroup aria-label="Table inspector mode">
+                <TabsTrigger
+                  value="shape"
+                  className="h-8 rounded-none border-0 px-3 text-xs first:rounded-l-md last:rounded-r-md data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-none"
+                >
+                  <SlidersHorizontal aria-hidden="true" className="size-3.5" />
+                  Shape
+                </TabsTrigger>
+                <TabsTrigger
+                  value="try"
+                  className="h-8 rounded-none border-0 px-3 text-xs first:rounded-l-md last:rounded-r-md data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-none"
+                >
+                  <Play aria-hidden="true" className="size-3.5" />
+                  Try
+                </TabsTrigger>
+              </ButtonGroup>
             </TabsList>
           </div>
         </div>
@@ -240,14 +261,25 @@ function TableTypeDetail({
           <DescriptionField type={type} dispatch={dispatch} />
           <ModelShapeHints hints={modelingHints} />
           <ObjectBody type={type} dispatch={dispatch} quietControls />
-          <details className="group border-t pt-3">
-            <summary className="cursor-pointer list-none text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
-              Advanced schema output
-            </summary>
-            <div className="mt-3">
+          <Collapsible defaultOpen className="border-t pt-3">
+            <CollapsibleTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="group h-8 w-full justify-between px-2 text-xs"
+              >
+                <span>Advanced schema output</span>
+                <ChevronRight
+                  aria-hidden="true"
+                  className="size-3.5 transition-transform group-data-[state=open]:rotate-90"
+                />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-3">
               <ConvexSection type={type} dispatch={dispatch} validationErrors={validationErrors} />
-            </div>
-          </details>
+            </CollapsibleContent>
+          </Collapsible>
         </div>
       </TabsContent>
 

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -151,41 +151,40 @@ function SampleDataSection({ type, dispatch }: TypeDetailProps) {
   const category = type.sampleData?.category ?? AUTO_SAMPLE_DATA;
 
   return (
-    <details className="space-y-2 rounded-md border border-border px-3 py-2">
-      <summary className="cursor-default select-none text-xs font-medium">Sample data</summary>
-      <div className="space-y-2 pt-2">
-        <div className="space-y-1">
-          <Label htmlFor="type-sample-data-category">Category</Label>
-          <Select
-            value={category}
-            onValueChange={(value) => {
-              const nextCategory = value === AUTO_SAMPLE_DATA ? undefined : value;
-              dispatch({
-                kind: 'update_type',
-                name: type.name,
-                patch: typePatch({
-                  sampleData: nextCategory
-                    ? { ...type.sampleData, category: nextCategory }
-                    : undefined,
-                }),
-              });
-            }}
-          >
-            <SelectTrigger id="type-sample-data-category" className="h-8 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={AUTO_SAMPLE_DATA}>Auto</SelectItem>
-              {modules.map((module) => (
-                <SelectItem key={module.id} value={module.id}>
-                  {module.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+    <section className="space-y-2 rounded-md border border-border px-3 py-2">
+      <Label htmlFor="type-sample-data-category" className="text-xs">
+        Sample data
+      </Label>
+      <div className="space-y-1">
+        <Select
+          value={category}
+          onValueChange={(value) => {
+            const nextCategory = value === AUTO_SAMPLE_DATA ? undefined : value;
+            dispatch({
+              kind: 'update_type',
+              name: type.name,
+              patch: typePatch({
+                sampleData: nextCategory
+                  ? { ...type.sampleData, category: nextCategory }
+                  : undefined,
+              }),
+            });
+          }}
+        >
+          <SelectTrigger id="type-sample-data-category" className="h-8 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="max-h-72">
+            <SelectItem value={AUTO_SAMPLE_DATA}>Auto</SelectItem>
+            {modules.map((module) => (
+              <SelectItem key={module.id} value={module.id}>
+                {module.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
-    </details>
+    </section>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -233,6 +233,131 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
   );
 }
 
+export function ScopedPlaygroundWorkbench({
+  schema,
+  typeName,
+  className,
+}: {
+  schema: Schema;
+  typeName: string;
+  className?: string;
+}): React.JSX.Element | null {
+  const [panelRef, isCompact] = useCompactPanel(680);
+  const [formOpen, setFormOpen] = useState(false);
+  const [seedNotice, setSeedNotice] = useState<string | null>(null);
+  const contract = useMemo(() => buildPlaygroundContract(schema), [schema]);
+  const selectedRecordId = usePlaygroundStore((state) => state.selectedRecordId);
+  const recordsByType = usePlaygroundStore((state) => state.recordsByType);
+  const selectRecord = usePlaygroundStore((state) => state.selectRecord);
+  const upsertRecord = usePlaygroundStore((state) => state.upsertRecord);
+  const insertRecords = usePlaygroundStore((state) => state.insertRecords);
+  const deleteRecord = usePlaygroundStore((state) => state.deleteRecord);
+  const clearType = usePlaygroundStore((state) => state.clearType);
+  const pruneTypes = usePlaygroundStore((state) => state.pruneTypes);
+
+  useEffect(() => {
+    pruneTypes(contract.entities.map((entity) => entity.typeName));
+  }, [contract.entities, pruneTypes]);
+
+  const entity = contract.entities.find((candidate) => candidate.typeName === typeName) ?? null;
+  if (!entity) return null;
+
+  const records = recordsByType[entity.typeName] ?? [];
+  const selectedRecord = records.find((record) => record.id === selectedRecordId) ?? null;
+  const formRecord = formOpen ? selectedRecord : null;
+
+  const openNewRecord = () => {
+    selectRecord(entity.typeName, null);
+    setFormOpen(true);
+  };
+
+  const openExistingRecord = (recordId: string) => {
+    selectRecord(entity.typeName, recordId);
+    setFormOpen(true);
+  };
+
+  const seedRecords = () => {
+    const result = generatePlaygroundFixtures(schema, {
+      seed: `table-workbench:${entity.typeName}:${Date.now()}`,
+      count: 5,
+      typeNames: [entity.typeName],
+      existingRecordsByType: recordsByType,
+    });
+    insertRecords(result.recordsByType);
+    const generatedCount = Object.values(result.recordsByType).reduce(
+      (sum, list) => sum + list.length,
+      0,
+    );
+    setSeedNotice(
+      result.warnings.length > 0
+        ? `Seeded ${generatedCount} records with ${result.warnings.length} warnings.`
+        : `Seeded ${generatedCount} records.`,
+    );
+  };
+
+  return (
+    <section
+      ref={panelRef}
+      className={cn(
+        'flex h-[min(44rem,calc(100vh-8rem))] min-h-[30rem] flex-col overflow-hidden rounded-md border bg-background',
+        className,
+      )}
+      aria-label={`${entity.typeName} sample records`}
+    >
+      <EntityToolbar
+        entity={entity}
+        records={records}
+        onNew={openNewRecord}
+        onSeedCurrent={seedRecords}
+        onSeedAll={seedRecords}
+        onClear={() => clearType(entity.typeName)}
+        scoped
+      />
+      {seedNotice && <SeedNotice message={seedNotice} onDismiss={() => setSeedNotice(null)} />}
+      <div
+        className={cn(
+          'relative grid min-h-0 flex-1 bg-muted/10',
+          formOpen && !isCompact ? 'grid-cols-[minmax(0,1fr)_minmax(18rem,0.85fr)]' : 'grid-cols-1',
+        )}
+      >
+        <div className="min-h-0">
+          <RecordTable
+            entity={entity}
+            records={records}
+            selectedRecordId={selectedRecordId}
+            recordsByType={recordsByType}
+            entities={contract.entities}
+            onSelect={openExistingRecord}
+            compact={isCompact}
+          />
+        </div>
+        {formOpen && (
+          <InlineRecordEditor
+            entity={entity}
+            record={formRecord}
+            recordsByType={recordsByType}
+            entities={contract.entities}
+            onClose={() => setFormOpen(false)}
+            onSubmit={(value) => {
+              upsertRecord(entity.typeName, formRecord?.id ?? null, value);
+              setFormOpen(false);
+            }}
+            onDelete={
+              formRecord
+                ? () => {
+                    deleteRecord(entity.typeName, formRecord.id);
+                    setFormOpen(false);
+                  }
+                : undefined
+            }
+            compact={isCompact}
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
 function useCompactPanel(threshold = 760): readonly [RefObject<HTMLDivElement | null>, boolean] {
   const ref = useRef<HTMLDivElement>(null);
   const [isCompact, setIsCompact] = useState(false);
@@ -350,6 +475,7 @@ function EntityToolbar({
   onSeedCurrent,
   onSeedAll,
   onClear,
+  scoped = false,
 }: {
   entity: PlaygroundEntity;
   records: PlaygroundRecord[];
@@ -357,6 +483,7 @@ function EntityToolbar({
   onSeedCurrent: () => void;
   onSeedAll: () => void;
   onClear: () => void;
+  scoped?: boolean;
 }): React.JSX.Element {
   return (
     <div className="flex min-h-14 items-center justify-between gap-3 border-b px-3">
@@ -372,7 +499,14 @@ function EntityToolbar({
         </p>
       </div>
       <div className="flex shrink-0 items-center gap-1">
-        <Button type="button" variant="ghost" size="icon" title="New record" onClick={onNew}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          title="New record"
+          aria-label="New record"
+          onClick={onNew}
+        >
           <Plus aria-hidden="true" />
         </Button>
         <Button
@@ -380,19 +514,30 @@ function EntityToolbar({
           variant="ghost"
           size="icon"
           title="Seed current entity"
+          aria-label="Seed current entity"
           onClick={onSeedCurrent}
         >
           <Sparkles aria-hidden="true" />
         </Button>
-        <Button type="button" variant="ghost" size="sm" className="h-8 px-2" onClick={onSeedAll}>
-          <Sparkles aria-hidden="true" />
-          All
-        </Button>
+        {!scoped && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2"
+            aria-label="Seed all entities"
+            onClick={onSeedAll}
+          >
+            <Sparkles aria-hidden="true" />
+            All
+          </Button>
+        )}
         <Button
           type="button"
           variant="ghost"
           size="icon"
           title="Clear records"
+          aria-label="Clear records"
           onClick={onClear}
           disabled={records.length === 0}
         >
@@ -400,6 +545,65 @@ function EntityToolbar({
         </Button>
       </div>
     </div>
+  );
+}
+
+function InlineRecordEditor({
+  entity,
+  record,
+  recordsByType,
+  entities,
+  onSubmit,
+  onDelete,
+  onClose,
+  compact,
+}: {
+  entity: PlaygroundEntity;
+  record: PlaygroundRecord | null;
+  recordsByType: Record<string, PlaygroundRecord[]>;
+  entities: PlaygroundEntity[];
+  onSubmit: (value: Record<string, unknown>) => void;
+  onDelete?: () => void;
+  onClose: () => void;
+  compact: boolean;
+}): React.JSX.Element {
+  return (
+    <aside
+      className={cn(
+        'flex min-h-0 flex-col border-l bg-background',
+        compact && 'absolute inset-0 z-20 border-l-0',
+      )}
+    >
+      <header className="flex min-h-14 shrink-0 items-center justify-between gap-3 border-b px-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-sm font-semibold">
+              {record ? `Edit ${entity.typeName}` : `New ${entity.typeName}`}
+            </h3>
+            <Badge variant="secondary" className="shrink-0">
+              {entity.tableName}
+            </Badge>
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            {record ? recordLabel(entity, record) : 'Create a sample record'}
+          </p>
+        </div>
+        <Button type="button" variant="ghost" size="icon" aria-label="Close form" onClick={onClose}>
+          <X aria-hidden="true" />
+        </Button>
+      </header>
+      <div className="min-h-0 flex-1">
+        <PlaygroundRecordForm
+          key={`${entity.typeName}:${record?.id ?? 'new'}`}
+          entity={entity}
+          record={record}
+          recordsByType={recordsByType}
+          entities={entities}
+          onSubmit={onSubmit}
+          onDelete={onDelete}
+        />
+      </div>
+    </aside>
   );
 }
 
@@ -413,7 +617,14 @@ function SeedNotice({
   return (
     <div className="flex items-center justify-between gap-2 border-b bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
       <span className="min-w-0 truncate">{message}</span>
-      <Button type="button" variant="ghost" size="icon" className="h-6 w-6" onClick={onDismiss}>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        aria-label="Dismiss seed notice"
+        onClick={onDismiss}
+      >
         <X aria-hidden="true" className="size-3" />
       </Button>
     </div>
@@ -522,7 +733,14 @@ function PlaygroundFormOverlay({
             {record ? recordLabel(entity, record) : 'Create a sample record'}
           </p>
         </div>
-        <Button type="button" variant="ghost" size="icon" title="Close form" onClick={onClose}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          title="Close form"
+          aria-label="Close form"
+          onClick={onClose}
+        >
           <X aria-hidden="true" />
         </Button>
       </header>
@@ -861,6 +1079,14 @@ function RecordTable({
                 <TableRow
                   key={record.id}
                   onClick={() => onSelect(record.id)}
+                  onKeyDown={(event) => {
+                    if (event.key !== 'Enter' && event.key !== ' ') return;
+                    event.preventDefault();
+                    onSelect(record.id);
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Edit ${recordLabel(entity, record)}`}
                   className={cn(
                     'cursor-pointer',
                     selectedRecordId === record.id && 'bg-primary/10 hover:bg-primary/10',

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -1,0 +1,1073 @@
+import type { Schema } from '@contexture/core/ir';
+import {
+  buildPlaygroundContract,
+  emptyEntityValue,
+  type PlaygroundArrayControl,
+  type PlaygroundControl,
+  type PlaygroundEntity,
+  type PlaygroundRefControl,
+} from '@contexture/core/playground-contract';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Check, Database, FileJson2, Plus, RotateCcw, Trash2, X } from 'lucide-react';
+import type { RefObject } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Controller, type FieldValues, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { cn } from '@/lib/utils';
+import { type PlaygroundRecord, usePlaygroundStore } from '@/store/playground';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+import { Checkbox } from '../ui/checkbox';
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from '../ui/field';
+import { Input } from '../ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
+import { Textarea } from '../ui/textarea';
+
+interface PlaygroundPanelProps {
+  schema: Schema;
+}
+
+export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Element {
+  const [panelRef, isCompact] = useCompactPanel();
+  const [formOpen, setFormOpen] = useState(false);
+  const contract = useMemo(() => buildPlaygroundContract(schema), [schema]);
+  const selectedTypeName = usePlaygroundStore((state) => state.selectedTypeName);
+  const selectedRecordId = usePlaygroundStore((state) => state.selectedRecordId);
+  const recordsByType = usePlaygroundStore((state) => state.recordsByType);
+  const selectType = usePlaygroundStore((state) => state.selectType);
+  const selectRecord = usePlaygroundStore((state) => state.selectRecord);
+  const upsertRecord = usePlaygroundStore((state) => state.upsertRecord);
+  const deleteRecord = usePlaygroundStore((state) => state.deleteRecord);
+  const clearType = usePlaygroundStore((state) => state.clearType);
+  const pruneTypes = usePlaygroundStore((state) => state.pruneTypes);
+
+  useEffect(() => {
+    const typeNames = contract.entities.map((entity) => entity.typeName);
+    pruneTypes(typeNames);
+    if (typeNames.length > 0 && (!selectedTypeName || !typeNames.includes(selectedTypeName))) {
+      selectType(typeNames[0] ?? null);
+    }
+  }, [contract.entities, pruneTypes, selectType, selectedTypeName]);
+
+  const selectedEntity =
+    contract.entities.find((entity) => entity.typeName === selectedTypeName) ??
+    contract.entities[0] ??
+    null;
+  const records = selectedEntity ? (recordsByType[selectedEntity.typeName] ?? []) : [];
+  const selectedRecord = records.find((record) => record.id === selectedRecordId) ?? null;
+  const recordCount = Object.values(recordsByType).reduce((sum, list) => sum + list.length, 0);
+  const formRecord = formOpen ? selectedRecord : null;
+
+  const openNewRecord = () => {
+    if (!selectedEntity) return;
+    selectRecord(selectedEntity.typeName, null);
+    setFormOpen(true);
+  };
+
+  const openExistingRecord = (recordId: string) => {
+    if (!selectedEntity) return;
+    selectRecord(selectedEntity.typeName, recordId);
+    setFormOpen(true);
+  };
+
+  const closeForm = () => setFormOpen(false);
+
+  if (contract.entities.length === 0) {
+    return (
+      <div ref={panelRef} className="flex h-full flex-col">
+        <PanelHeader recordCount={0} />
+        <div className="grid flex-1 place-items-center p-6 text-center">
+          <div className="max-w-sm space-y-2">
+            <Database className="mx-auto size-8 text-muted-foreground" />
+            <h2 className="text-base font-semibold">No table types yet</h2>
+            <p className="text-sm text-muted-foreground">
+              Mark an object type as a table to create sample records and test how the model feels.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={panelRef} className="flex h-full min-h-0 flex-col overflow-hidden">
+      <PanelHeader recordCount={recordCount} />
+      {isCompact ? (
+        <div className="flex min-h-0 flex-1 flex-col border-t">
+          <EntityNav
+            entities={contract.entities}
+            selectedTypeName={selectedEntity?.typeName ?? null}
+            recordsByType={recordsByType}
+            onSelect={selectType}
+            compact
+          />
+          {selectedEntity && (
+            <section className="flex min-h-0 flex-1 flex-col">
+              <EntityToolbar
+                entity={selectedEntity}
+                records={records}
+                onNew={openNewRecord}
+                onClear={() => clearType(selectedEntity.typeName)}
+              />
+              <div className="relative min-h-0 flex-1">
+                <RecordTable
+                  entity={selectedEntity}
+                  records={records}
+                  selectedRecordId={selectedRecordId}
+                  recordsByType={recordsByType}
+                  entities={contract.entities}
+                  onSelect={openExistingRecord}
+                  compact
+                />
+                {formOpen && (
+                  <PlaygroundFormOverlay
+                    entity={selectedEntity}
+                    record={formRecord}
+                    recordsByType={recordsByType}
+                    entities={contract.entities}
+                    onClose={closeForm}
+                    onSubmit={(value) => {
+                      upsertRecord(selectedEntity.typeName, formRecord?.id ?? null, value);
+                      closeForm();
+                    }}
+                    onDelete={
+                      formRecord
+                        ? () => {
+                            deleteRecord(selectedEntity.typeName, formRecord.id);
+                            closeForm();
+                          }
+                        : undefined
+                    }
+                  />
+                )}
+              </div>
+            </section>
+          )}
+        </div>
+      ) : (
+        <div className="grid min-h-0 flex-1 grid-cols-[12rem_minmax(0,1fr)] border-t">
+          <EntityNav
+            entities={contract.entities}
+            selectedTypeName={selectedEntity?.typeName ?? null}
+            recordsByType={recordsByType}
+            onSelect={selectType}
+          />
+          {selectedEntity && (
+            <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+              <EntityToolbar
+                entity={selectedEntity}
+                records={records}
+                onNew={openNewRecord}
+                onClear={() => clearType(selectedEntity.typeName)}
+              />
+              <div className="relative min-h-0">
+                <RecordTable
+                  entity={selectedEntity}
+                  records={records}
+                  selectedRecordId={selectedRecordId}
+                  recordsByType={recordsByType}
+                  entities={contract.entities}
+                  onSelect={openExistingRecord}
+                />
+                {formOpen && (
+                  <PlaygroundFormOverlay
+                    entity={selectedEntity}
+                    record={formRecord}
+                    recordsByType={recordsByType}
+                    entities={contract.entities}
+                    onClose={closeForm}
+                    onSubmit={(value) => {
+                      upsertRecord(selectedEntity.typeName, formRecord?.id ?? null, value);
+                      closeForm();
+                    }}
+                    onDelete={
+                      formRecord
+                        ? () => {
+                            deleteRecord(selectedEntity.typeName, formRecord.id);
+                            closeForm();
+                          }
+                        : undefined
+                    }
+                  />
+                )}
+              </div>
+            </section>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function useCompactPanel(threshold = 760): readonly [RefObject<HTMLDivElement | null>, boolean] {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isCompact, setIsCompact] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const update = () => setIsCompact(node.getBoundingClientRect().width < threshold);
+    update();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(update);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [threshold]);
+
+  return [ref, isCompact] as const;
+}
+
+function EntityNav({
+  entities,
+  selectedTypeName,
+  recordsByType,
+  onSelect,
+  compact = false,
+}: {
+  entities: PlaygroundEntity[];
+  selectedTypeName: string | null;
+  recordsByType: Record<string, PlaygroundRecord[]>;
+  onSelect: (typeName: string | null) => void;
+  compact?: boolean;
+}): React.JSX.Element {
+  if (compact) {
+    const selectedEntity = entities.find((entity) => entity.typeName === selectedTypeName);
+    const selectedCount = selectedEntity
+      ? (recordsByType[selectedEntity.typeName]?.length ?? 0)
+      : 0;
+
+    return (
+      <section className="border-b bg-muted/15 p-2">
+        <div className="mb-2 flex items-center justify-between gap-2 px-1">
+          <div className="text-xs font-medium uppercase text-muted-foreground">Entity</div>
+          <Badge variant="outline">{selectedCount}</Badge>
+        </div>
+        <Select value={selectedTypeName ?? undefined} onValueChange={(value) => onSelect(value)}>
+          <SelectTrigger aria-label="Select entity" className="bg-background">
+            <SelectValue placeholder="Select entity" />
+          </SelectTrigger>
+          <SelectContent>
+            {entities.map((entity) => {
+              const count = recordsByType[entity.typeName]?.length ?? 0;
+              return (
+                <SelectItem key={entity.typeName} value={entity.typeName}>
+                  {entity.typeName} ({count})
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </section>
+    );
+  }
+
+  const buttons = entities.map((entity) => {
+    const count = recordsByType[entity.typeName]?.length ?? 0;
+    return (
+      <button
+        type="button"
+        key={entity.typeName}
+        onClick={() => onSelect(entity.typeName)}
+        className={cn(
+          'flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm transition-colors',
+          selectedTypeName === entity.typeName
+            ? 'bg-primary/10 text-primary'
+            : 'text-foreground hover:bg-muted',
+        )}
+      >
+        <span className="min-w-0 truncate">{entity.typeName}</span>
+        <Badge variant="secondary" className="ml-2 shrink-0">
+          {count}
+        </Badge>
+      </button>
+    );
+  });
+
+  return (
+    <aside className="min-h-0 overflow-y-auto border-r bg-muted/15 p-2">
+      <div className="mb-2 flex items-center justify-between px-1">
+        <div className="text-xs font-medium uppercase text-muted-foreground">Entities</div>
+      </div>
+      <div className="space-y-1">{buttons}</div>
+    </aside>
+  );
+}
+
+function PanelHeader({ recordCount }: { recordCount: number }): React.JSX.Element {
+  return (
+    <header className="flex h-14 items-center justify-between px-3">
+      <div className="min-w-0">
+        <h2 className="text-sm font-semibold">Playground</h2>
+        <p className="truncate text-xs text-muted-foreground">
+          Create sample records from the model.
+        </p>
+      </div>
+      <Badge variant="outline">{recordCount} records</Badge>
+    </header>
+  );
+}
+
+function EntityToolbar({
+  entity,
+  records,
+  onNew,
+  onClear,
+}: {
+  entity: PlaygroundEntity;
+  records: PlaygroundRecord[];
+  onNew: () => void;
+  onClear: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="flex min-h-14 items-center justify-between gap-3 border-b px-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <h3 className="truncate text-sm font-semibold">{entity.typeName}</h3>
+          <Badge variant="secondary" className="shrink-0">
+            {entity.tableName}
+          </Badge>
+        </div>
+        <p className="truncate text-xs text-muted-foreground">
+          {records.length} sample {records.length === 1 ? 'record' : 'records'}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <Button type="button" variant="ghost" size="icon" title="New record" onClick={onNew}>
+          <Plus aria-hidden="true" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          title="Clear records"
+          onClick={onClear}
+          disabled={records.length === 0}
+        >
+          <RotateCcw aria-hidden="true" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function PlaygroundRecordForm({
+  entity,
+  record,
+  recordsByType,
+  entities,
+  onSubmit,
+  onDelete,
+}: {
+  entity: PlaygroundEntity;
+  record: PlaygroundRecord | null;
+  recordsByType: Record<string, PlaygroundRecord[]>;
+  entities: PlaygroundEntity[];
+  onSubmit: (value: Record<string, unknown>) => void;
+  onDelete?: () => void;
+}): React.JSX.Element {
+  const resolver = useMemo(() => zodResolver(zodSchemaForControls(entity.fields)), [entity]);
+  const form = useForm<FieldValues>({
+    mode: 'onChange',
+    defaultValues: formValuesFor(entity, record?.value ?? emptyEntityValue(entity)),
+    resolver,
+  });
+
+  return (
+    <form
+      className="flex h-full min-h-0 flex-col"
+      onSubmit={form.handleSubmit((value) => onSubmit(normalizeSubmitValue(entity.fields, value)))}
+    >
+      <FieldGroup className="min-h-0 flex-1 overflow-y-auto p-3">
+        {entity.fields.map((control) => (
+          <PlaygroundControlField
+            key={control.fieldName}
+            control={control}
+            controlPath={control.fieldName}
+            form={form}
+            recordsByType={recordsByType}
+            entities={entities}
+          />
+        ))}
+      </FieldGroup>
+      <div className="sticky bottom-0 flex items-center justify-between gap-2 border-t bg-background/95 p-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => form.reset(formValuesFor(entity, emptyEntityValue(entity)))}
+        >
+          Reset
+        </Button>
+        <div className="flex items-center gap-2">
+          {onDelete && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onDelete}
+              className="text-destructive hover:text-destructive"
+            >
+              <Trash2 aria-hidden="true" />
+              Delete
+            </Button>
+          )}
+          <Button type="submit">
+            <Check aria-hidden="true" />
+            Save
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+function PlaygroundFormOverlay({
+  entity,
+  record,
+  recordsByType,
+  entities,
+  onSubmit,
+  onDelete,
+  onClose,
+}: {
+  entity: PlaygroundEntity;
+  record: PlaygroundRecord | null;
+  recordsByType: Record<string, PlaygroundRecord[]>;
+  entities: PlaygroundEntity[];
+  onSubmit: (value: Record<string, unknown>) => void;
+  onDelete?: () => void;
+  onClose: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="absolute inset-0 z-30 flex flex-col bg-background">
+      <header className="flex min-h-14 items-center justify-between gap-3 border-b px-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-sm font-semibold">
+              {record ? `Edit ${entity.typeName}` : `New ${entity.typeName}`}
+            </h3>
+            <Badge variant="secondary" className="shrink-0">
+              {entity.tableName}
+            </Badge>
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            {record ? recordLabel(entity, record) : 'Create a sample record'}
+          </p>
+        </div>
+        <Button type="button" variant="ghost" size="icon" title="Close form" onClick={onClose}>
+          <X aria-hidden="true" />
+        </Button>
+      </header>
+      <div className="min-h-0 flex-1">
+        <PlaygroundRecordForm
+          key={`${entity.typeName}:${record?.id ?? 'new'}`}
+          entity={entity}
+          record={record}
+          recordsByType={recordsByType}
+          entities={entities}
+          onSubmit={onSubmit}
+          onDelete={onDelete}
+        />
+      </div>
+    </div>
+  );
+}
+
+function PlaygroundControlField({
+  control,
+  controlPath,
+  form,
+  recordsByType,
+  entities,
+}: {
+  control: PlaygroundControl;
+  controlPath: string;
+  form: ReturnType<typeof useForm<FieldValues>>;
+  recordsByType: Record<string, PlaygroundRecord[]>;
+  entities: PlaygroundEntity[];
+}): React.JSX.Element {
+  if (control.serverDerived) {
+    return (
+      <Field>
+        <FieldLabel>{control.label}</FieldLabel>
+        <Input value="Server derived" disabled />
+        <FieldDescription>This field is generated by the runtime.</FieldDescription>
+      </Field>
+    );
+  }
+
+  if (control.kind === 'object') {
+    return (
+      <div className="rounded-md border bg-muted/10 p-3">
+        <div className="mb-3">
+          <div className="text-sm font-medium">{control.label}</div>
+          {control.description && (
+            <p className="text-xs text-muted-foreground">{control.description}</p>
+          )}
+        </div>
+        <FieldGroup>
+          {control.fields.map((field) => (
+            <PlaygroundControlField
+              key={field.fieldName}
+              control={field}
+              controlPath={`${controlPath}.${field.fieldName}`}
+              form={form}
+              recordsByType={recordsByType}
+              entities={entities}
+            />
+          ))}
+        </FieldGroup>
+      </div>
+    );
+  }
+
+  if (control.kind === 'boolean') {
+    return (
+      <Controller
+        name={controlPath}
+        control={form.control}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid}>
+            <div className="flex items-start gap-2">
+              <Checkbox
+                id={controlPath}
+                checked={field.value === true}
+                onCheckedChange={(checked) => field.onChange(checked === true)}
+                aria-invalid={fieldState.invalid}
+              />
+              <div className="grid gap-1">
+                <FieldLabel htmlFor={controlPath}>{control.label}</FieldLabel>
+                {control.description && <FieldDescription>{control.description}</FieldDescription>}
+                <FieldError errors={[fieldState.error]} />
+              </div>
+            </div>
+          </Field>
+        )}
+      />
+    );
+  }
+
+  if (control.kind === 'enum') {
+    return (
+      <Controller
+        name={controlPath}
+        control={form.control}
+        rules={rulesFor(control)}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid}>
+            <FieldLabel htmlFor={controlPath}>{control.label}</FieldLabel>
+            <Select value={field.value ?? ''} onValueChange={field.onChange}>
+              <SelectTrigger id={controlPath} aria-invalid={fieldState.invalid}>
+                <SelectValue placeholder="Select value" />
+              </SelectTrigger>
+              <SelectContent>
+                {control.options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {control.description && <FieldDescription>{control.description}</FieldDescription>}
+            <FieldError errors={[fieldState.error]} />
+          </Field>
+        )}
+      />
+    );
+  }
+
+  if (control.kind === 'ref') {
+    return (
+      <RefField
+        control={control}
+        controlPath={controlPath}
+        form={form}
+        recordsByType={recordsByType}
+        entities={entities}
+      />
+    );
+  }
+
+  if (control.kind === 'array') {
+    return <ArrayField control={control} controlPath={controlPath} form={form} />;
+  }
+
+  if (control.kind === 'unsupported') {
+    return (
+      <Field>
+        <FieldLabel>{control.label}</FieldLabel>
+        <Input value={control.reason} disabled />
+      </Field>
+    );
+  }
+
+  return (
+    <Controller
+      name={controlPath}
+      control={form.control}
+      rules={rulesFor(control)}
+      render={({ field, fieldState }) => (
+        <Field data-invalid={fieldState.invalid}>
+          <FieldLabel htmlFor={controlPath}>{control.label}</FieldLabel>
+          <Input
+            id={controlPath}
+            value={field.value ?? ''}
+            type={inputTypeFor(control)}
+            min={control.constraints.min}
+            max={control.constraints.max}
+            readOnly={control.kind === 'literal'}
+            aria-invalid={fieldState.invalid}
+            onChange={(event) => {
+              if (control.kind === 'number') {
+                field.onChange(event.target.value === '' ? '' : Number(event.target.value));
+                return;
+              }
+              field.onChange(event.target.value);
+            }}
+          />
+          {control.description && <FieldDescription>{control.description}</FieldDescription>}
+          <FieldError errors={[fieldState.error]} />
+        </Field>
+      )}
+    />
+  );
+}
+
+function RefField({
+  control,
+  controlPath,
+  form,
+  recordsByType,
+  entities,
+}: {
+  control: PlaygroundRefControl;
+  controlPath: string;
+  form: ReturnType<typeof useForm<FieldValues>>;
+  recordsByType: Record<string, PlaygroundRecord[]>;
+  entities: PlaygroundEntity[];
+}): React.JSX.Element {
+  const targetEntity = entities.find((entity) => entity.typeName === control.targetTypeName);
+  const records = recordsByType[control.targetTypeName] ?? [];
+
+  return (
+    <Controller
+      name={controlPath}
+      control={form.control}
+      rules={rulesFor(control)}
+      render={({ field, fieldState }) => (
+        <Field data-invalid={fieldState.invalid}>
+          <FieldLabel htmlFor={controlPath}>{control.label}</FieldLabel>
+          <Select value={field.value ?? ''} onValueChange={field.onChange}>
+            <SelectTrigger id={controlPath} aria-invalid={fieldState.invalid}>
+              <SelectValue placeholder={`Select ${control.targetTypeName}`} />
+            </SelectTrigger>
+            <SelectContent>
+              {records.map((record) => (
+                <SelectItem key={record.id} value={record.id}>
+                  {targetEntity ? recordLabel(targetEntity, record) : record.id}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FieldDescription>
+            {records.length === 0
+              ? `Create a ${control.targetTypeName} record before linking this field.`
+              : `Links to ${control.targetTypeName}.`}
+          </FieldDescription>
+          <FieldError errors={[fieldState.error]} />
+        </Field>
+      )}
+    />
+  );
+}
+
+function ArrayField({
+  control,
+  controlPath,
+  form,
+}: {
+  control: PlaygroundArrayControl;
+  controlPath: string;
+  form: ReturnType<typeof useForm<FieldValues>>;
+}): React.JSX.Element {
+  return (
+    <Controller
+      name={controlPath}
+      control={form.control}
+      rules={{
+        validate: (value) => {
+          if (!control.required && !value) return true;
+          try {
+            const parsed = JSON.parse(String(value || '[]'));
+            if (!Array.isArray(parsed)) return 'Enter a JSON array.';
+            if (control.min !== undefined && parsed.length < control.min) {
+              return `Use at least ${control.min} items.`;
+            }
+            if (control.max !== undefined && parsed.length > control.max) {
+              return `Use at most ${control.max} items.`;
+            }
+            return true;
+          } catch {
+            return 'Enter valid JSON.';
+          }
+        },
+      }}
+      render={({ field, fieldState }) => (
+        <Field data-invalid={fieldState.invalid}>
+          <div className="flex items-center justify-between gap-2">
+            <FieldLabel htmlFor={controlPath}>{control.label}</FieldLabel>
+            <Badge variant="outline" className="gap-1">
+              <FileJson2 className="size-3" />
+              JSON
+            </Badge>
+          </div>
+          <Textarea
+            id={controlPath}
+            value={
+              typeof field.value === 'string'
+                ? field.value
+                : JSON.stringify(field.value ?? [], null, 2)
+            }
+            rows={4}
+            className="font-mono text-xs"
+            aria-invalid={fieldState.invalid}
+            onChange={field.onChange}
+          />
+          {control.description && <FieldDescription>{control.description}</FieldDescription>}
+          <FieldError errors={[fieldState.error]} />
+        </Field>
+      )}
+    />
+  );
+}
+
+function RecordTable({
+  entity,
+  records,
+  selectedRecordId,
+  onSelect,
+  recordsByType,
+  entities,
+  compact = false,
+}: {
+  entity: PlaygroundEntity;
+  records: PlaygroundRecord[];
+  selectedRecordId: string | null;
+  onSelect: (recordId: string) => void;
+  recordsByType: Record<string, PlaygroundRecord[]>;
+  entities: PlaygroundEntity[];
+  compact?: boolean;
+}): React.JSX.Element {
+  const columns = recordTableColumns(entity, compact ? 3 : 5);
+
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-muted/10">
+      <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+        <div className="text-xs font-medium uppercase text-muted-foreground">Records</div>
+        <Badge variant="outline">{records.length}</Badge>
+      </div>
+      {records.length === 0 ? (
+        <div className="grid min-h-0 flex-1 place-items-center px-4 py-8 text-center">
+          <div className="max-w-64 space-y-1">
+            <p className="text-sm font-medium">No sample records yet</p>
+            <p className="text-xs text-muted-foreground">
+              Use the plus button to create the first {entity.typeName} record.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1 overflow-auto">
+          <Table className="min-w-[34rem] text-xs">
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="w-40">Record</TableHead>
+                {columns.map((control) => (
+                  <TableHead key={control.fieldName} className="min-w-28">
+                    {control.label}
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {records.map((record) => (
+                <TableRow
+                  key={record.id}
+                  onClick={() => onSelect(record.id)}
+                  className={cn(
+                    'cursor-pointer',
+                    selectedRecordId === record.id && 'bg-primary/10 hover:bg-primary/10',
+                  )}
+                >
+                  <TableCell className="max-w-40">
+                    <div className="truncate font-medium">{recordLabel(entity, record)}</div>
+                    <div className="truncate text-muted-foreground">{record.id.slice(0, 8)}</div>
+                  </TableCell>
+                  {columns.map((control) => (
+                    <TableCell key={control.fieldName} className="max-w-36 truncate">
+                      {formatRecordValue(
+                        control,
+                        record.value[control.fieldName],
+                        recordsByType,
+                        entities,
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function recordTableColumns(entity: PlaygroundEntity, limit: number): readonly PlaygroundControl[] {
+  const display = entity.displayFieldName
+    ? entity.fields.find((field) => field.fieldName === entity.displayFieldName)
+    : undefined;
+  const fields = entity.fields.filter(
+    (field) =>
+      !field.serverDerived &&
+      field.fieldName !== entity.displayFieldName &&
+      field.kind !== 'object' &&
+      field.kind !== 'array' &&
+      field.kind !== 'unsupported',
+  );
+  return [display, ...fields]
+    .filter((field): field is PlaygroundControl => Boolean(field))
+    .slice(0, limit);
+}
+
+function formatRecordValue(
+  control: PlaygroundControl,
+  value: unknown,
+  recordsByType: Record<string, PlaygroundRecord[]>,
+  entities: readonly PlaygroundEntity[],
+): string {
+  if (value === undefined || value === null || value === '') return '—';
+  if (control.kind === 'boolean') return value === true ? 'Yes' : 'No';
+  if (control.kind === 'ref' && typeof value === 'string') {
+    const targetEntity = entities.find((entity) => entity.typeName === control.targetTypeName);
+    const targetRecord = recordsByType[control.targetTypeName]?.find(
+      (record) => record.id === value,
+    );
+    return targetEntity && targetRecord
+      ? recordLabel(targetEntity, targetRecord)
+      : value.slice(0, 8);
+  }
+  if (Array.isArray(value)) return `${value.length} items`;
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function rulesFor(control: PlaygroundControl) {
+  const rules: {
+    required?: string;
+    minLength?: { value: number; message: string };
+    maxLength?: { value: number; message: string };
+    min?: { value: number; message: string };
+    max?: { value: number; message: string };
+    pattern?: { value: RegExp; message: string };
+    validate?: (value: unknown) => true | string;
+  } = {};
+
+  if (control.required) rules.required = `${control.label} is required.`;
+  if (control.kind === 'text') {
+    if (control.constraints.min !== undefined) {
+      rules.minLength = {
+        value: control.constraints.min,
+        message: `Use at least ${control.constraints.min} characters.`,
+      };
+    }
+    if (control.constraints.max !== undefined) {
+      rules.maxLength = {
+        value: control.constraints.max,
+        message: `Use at most ${control.constraints.max} characters.`,
+      };
+    }
+    if (control.constraints.regex) {
+      rules.pattern = {
+        value: new RegExp(control.constraints.regex),
+        message: 'Use the required format.',
+      };
+    }
+  }
+  if (control.kind === 'number') {
+    if (control.constraints.min !== undefined) {
+      rules.min = {
+        value: control.constraints.min,
+        message: `Use ${control.constraints.min} or more.`,
+      };
+    }
+    if (control.constraints.max !== undefined) {
+      rules.max = {
+        value: control.constraints.max,
+        message: `Use ${control.constraints.max} or less.`,
+      };
+    }
+    if (control.constraints.int) {
+      rules.validate = (value) => Number.isInteger(Number(value)) || 'Use a whole number.';
+    }
+  }
+  if (control.kind === 'literal') {
+    rules.validate = (value) =>
+      value === control.constraints.literalValue ||
+      `Must equal ${String(control.constraints.literalValue)}.`;
+  }
+
+  return rules;
+}
+
+function inputTypeFor(control: PlaygroundControl): string {
+  if (control.kind === 'number') return 'number';
+  if (control.kind === 'date') return 'date';
+  if (control.kind === 'text' && control.constraints.format === 'email') return 'email';
+  if (control.kind === 'text' && control.constraints.format === 'url') return 'url';
+  return 'text';
+}
+
+function formValuesFor(entity: PlaygroundEntity, value: Record<string, unknown>): FieldValues {
+  return arrayValuesToJson(entity.fields, value);
+}
+
+function arrayValuesToJson(
+  controls: readonly PlaygroundControl[],
+  value: Record<string, unknown>,
+): FieldValues {
+  const next: FieldValues = { ...value };
+  for (const control of controls) {
+    if (control.kind === 'array') {
+      next[control.fieldName] = JSON.stringify(value[control.fieldName] ?? [], null, 2);
+    }
+    if (control.kind === 'object') {
+      next[control.fieldName] = arrayValuesToJson(
+        control.fields,
+        (value[control.fieldName] as Record<string, unknown> | undefined) ?? {},
+      );
+    }
+  }
+  return next;
+}
+
+function normalizeSubmitValue(
+  controls: readonly PlaygroundControl[],
+  value: FieldValues,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = {};
+  for (const control of controls) {
+    const raw = value[control.fieldName];
+    if (!control.required && (raw === '' || raw === undefined || raw === null)) continue;
+    if (control.kind === 'array') {
+      next[control.fieldName] = JSON.parse(String(raw || '[]'));
+      continue;
+    }
+    if (control.kind === 'object') {
+      next[control.fieldName] = normalizeSubmitValue(
+        control.fields,
+        (raw as FieldValues | undefined) ?? {},
+      );
+      continue;
+    }
+    next[control.fieldName] = raw;
+  }
+  return next;
+}
+
+function zodSchemaForControls(controls: readonly PlaygroundControl[]): z.ZodObject<z.ZodRawShape> {
+  const shape: Record<string, z.ZodType> = {};
+  for (const control of controls) {
+    shape[control.fieldName] = zodSchemaForControl(control);
+  }
+  return z.object(shape);
+}
+
+function zodSchemaForControl(control: PlaygroundControl): z.ZodType {
+  let schema: z.ZodType;
+
+  switch (control.kind) {
+    case 'text': {
+      let stringSchema = z.string();
+      if (control.constraints.min !== undefined)
+        stringSchema = stringSchema.min(control.constraints.min);
+      if (control.constraints.max !== undefined)
+        stringSchema = stringSchema.max(control.constraints.max);
+      if (control.constraints.regex)
+        stringSchema = stringSchema.regex(new RegExp(control.constraints.regex));
+      if (control.constraints.format === 'email') stringSchema = stringSchema.email();
+      if (control.constraints.format === 'url') stringSchema = stringSchema.url();
+      if (control.constraints.format === 'uuid') stringSchema = stringSchema.uuid();
+      if (control.constraints.format === 'datetime') stringSchema = stringSchema.datetime();
+      schema = stringSchema;
+      break;
+    }
+    case 'number': {
+      let numberSchema = z.number();
+      if (control.constraints.int) numberSchema = numberSchema.int();
+      if (control.constraints.min !== undefined)
+        numberSchema = numberSchema.min(control.constraints.min);
+      if (control.constraints.max !== undefined)
+        numberSchema = numberSchema.max(control.constraints.max);
+      schema = z.preprocess((value) => {
+        if (value === '') return undefined;
+        return typeof value === 'number' ? value : Number(value);
+      }, numberSchema);
+      break;
+    }
+    case 'boolean':
+      schema = z.boolean();
+      break;
+    case 'date':
+      schema = z.string();
+      break;
+    case 'literal':
+      schema = z.literal(control.constraints.literalValue);
+      break;
+    case 'enum':
+      schema =
+        control.options.length > 0
+          ? z.enum(control.options.map((option) => option.value) as [string, ...string[]])
+          : z.string();
+      break;
+    case 'ref':
+      schema = z.string();
+      break;
+    case 'array':
+      schema = z.string().refine((value) => {
+        try {
+          const parsed = JSON.parse(value || '[]');
+          if (!Array.isArray(parsed)) return false;
+          if (control.min !== undefined && parsed.length < control.min) return false;
+          if (control.max !== undefined && parsed.length > control.max) return false;
+          return true;
+        } catch {
+          return false;
+        }
+      }, 'Enter a valid JSON array.');
+      break;
+    case 'object':
+      schema = zodSchemaForControls(control.fields);
+      break;
+    case 'unsupported':
+      schema = z.unknown();
+      break;
+  }
+
+  if (control.nullable) schema = schema.nullable();
+  if (!control.required || control.serverDerived)
+    schema = emptyStringToUndefined(schema.optional());
+  return schema;
+}
+
+function emptyStringToUndefined(schema: z.ZodType): z.ZodType {
+  return z.preprocess((value) => (value === '' ? undefined : value), schema);
+}
+
+function recordLabel(entity: PlaygroundEntity, record: PlaygroundRecord): string {
+  const displayValue: string | null =
+    entity.displayFieldName && typeof record.value[entity.displayFieldName] === 'string'
+      ? String(record.value[entity.displayFieldName])
+      : null;
+  return displayValue || `${entity.typeName} ${record.id.slice(0, 8)}`;
+}

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -1214,7 +1214,7 @@ function formatRecordValue(
   recordsByType: Record<string, PlaygroundRecord[]>,
   entities: readonly PlaygroundEntity[],
 ): string {
-  if (value === undefined || value === null || value === '') return '—';
+  if (value === undefined || value === null || value === '') return '-';
   if (control.kind === 'boolean') return value === true ? 'Yes' : 'No';
   if (control.kind === 'ref' && typeof value === 'string') {
     const targetEntity = entities.find((entity) => entity.typeName === control.targetTypeName);

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -7,8 +7,9 @@ import {
   type PlaygroundEntity,
   type PlaygroundRefControl,
 } from '@contexture/core/playground-contract';
+import { generatePlaygroundFixtures } from '@contexture/core/playground-fixtures';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Check, Database, FileJson2, Plus, RotateCcw, Trash2, X } from 'lucide-react';
+import { Check, Database, FileJson2, Plus, RotateCcw, Sparkles, Trash2, X } from 'lucide-react';
 import type { RefObject } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Controller, type FieldValues, useForm } from 'react-hook-form';
@@ -38,6 +39,7 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
   const selectType = usePlaygroundStore((state) => state.selectType);
   const selectRecord = usePlaygroundStore((state) => state.selectRecord);
   const upsertRecord = usePlaygroundStore((state) => state.upsertRecord);
+  const insertRecords = usePlaygroundStore((state) => state.insertRecords);
   const deleteRecord = usePlaygroundStore((state) => state.deleteRecord);
   const clearType = usePlaygroundStore((state) => state.clearType);
   const pruneTypes = usePlaygroundStore((state) => state.pruneTypes);
@@ -58,6 +60,7 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
   const selectedRecord = records.find((record) => record.id === selectedRecordId) ?? null;
   const recordCount = Object.values(recordsByType).reduce((sum, list) => sum + list.length, 0);
   const formRecord = formOpen ? selectedRecord : null;
+  const [seedNotice, setSeedNotice] = useState<string | null>(null);
 
   const openNewRecord = () => {
     if (!selectedEntity) return;
@@ -72,6 +75,26 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
   };
 
   const closeForm = () => setFormOpen(false);
+
+  const seedRecords = (scope: 'current' | 'all') => {
+    if (scope === 'current' && !selectedEntity) return;
+    const result = generatePlaygroundFixtures(schema, {
+      seed: `${scope}:${Date.now()}`,
+      count: 5,
+      typeNames: scope === 'current' && selectedEntity ? [selectedEntity.typeName] : undefined,
+      existingRecordsByType: recordsByType,
+    });
+    insertRecords(result.recordsByType);
+    const generatedCount = Object.values(result.recordsByType).reduce(
+      (sum, list) => sum + list.length,
+      0,
+    );
+    setSeedNotice(
+      result.warnings.length > 0
+        ? `Seeded ${generatedCount} records with ${result.warnings.length} warnings.`
+        : `Seeded ${generatedCount} records.`,
+    );
+  };
 
   if (contract.entities.length === 0) {
     return (
@@ -108,8 +131,13 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
                 entity={selectedEntity}
                 records={records}
                 onNew={openNewRecord}
+                onSeedCurrent={() => seedRecords('current')}
+                onSeedAll={() => seedRecords('all')}
                 onClear={() => clearType(selectedEntity.typeName)}
               />
+              {seedNotice && (
+                <SeedNotice message={seedNotice} onDismiss={() => setSeedNotice(null)} />
+              )}
               <div className="relative min-h-0 flex-1">
                 <RecordTable
                   entity={selectedEntity}
@@ -154,13 +182,18 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
             onSelect={selectType}
           />
           {selectedEntity && (
-            <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+            <section className="flex min-h-0 flex-col">
               <EntityToolbar
                 entity={selectedEntity}
                 records={records}
                 onNew={openNewRecord}
+                onSeedCurrent={() => seedRecords('current')}
+                onSeedAll={() => seedRecords('all')}
                 onClear={() => clearType(selectedEntity.typeName)}
               />
+              {seedNotice && (
+                <SeedNotice message={seedNotice} onDismiss={() => setSeedNotice(null)} />
+              )}
               <div className="relative min-h-0">
                 <RecordTable
                   entity={selectedEntity}
@@ -314,11 +347,15 @@ function EntityToolbar({
   entity,
   records,
   onNew,
+  onSeedCurrent,
+  onSeedAll,
   onClear,
 }: {
   entity: PlaygroundEntity;
   records: PlaygroundRecord[];
   onNew: () => void;
+  onSeedCurrent: () => void;
+  onSeedAll: () => void;
   onClear: () => void;
 }): React.JSX.Element {
   return (
@@ -342,6 +379,19 @@ function EntityToolbar({
           type="button"
           variant="ghost"
           size="icon"
+          title="Seed current entity"
+          onClick={onSeedCurrent}
+        >
+          <Sparkles aria-hidden="true" />
+        </Button>
+        <Button type="button" variant="ghost" size="sm" className="h-8 px-2" onClick={onSeedAll}>
+          <Sparkles aria-hidden="true" />
+          All
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
           title="Clear records"
           onClick={onClear}
           disabled={records.length === 0}
@@ -349,6 +399,23 @@ function EntityToolbar({
           <RotateCcw aria-hidden="true" />
         </Button>
       </div>
+    </div>
+  );
+}
+
+function SeedNotice({
+  message,
+  onDismiss,
+}: {
+  message: string;
+  onDismiss: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="flex items-center justify-between gap-2 border-b bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
+      <span className="min-w-0 truncate">{message}</span>
+      <Button type="button" variant="ghost" size="icon" className="h-6 w-6" onClick={onDismiss}>
+        <X aria-hidden="true" className="size-3" />
+      </Button>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -194,7 +194,7 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
               {seedNotice && (
                 <SeedNotice message={seedNotice} onDismiss={() => setSeedNotice(null)} />
               )}
-              <div className="relative min-h-0">
+              <div className="relative min-h-0 flex-1">
                 <RecordTable
                   entity={selectedEntity}
                   records={records}
@@ -459,7 +459,7 @@ function PlaygroundRecordForm({
           />
         ))}
       </FieldGroup>
-      <div className="sticky bottom-0 flex items-center justify-between gap-2 border-t bg-background/95 p-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-t bg-background p-3">
         <Button
           type="button"
           variant="outline"

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -9,7 +9,17 @@ import {
 } from '@contexture/core/playground-contract';
 import { generatePlaygroundFixtures } from '@contexture/core/playground-fixtures';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Check, Database, FileJson2, Plus, RotateCcw, Sparkles, Trash2, X } from 'lucide-react';
+import {
+  Check,
+  Database,
+  FileJson2,
+  MoreHorizontal,
+  Plus,
+  RotateCcw,
+  Sparkles,
+  Trash2,
+  X,
+} from 'lucide-react';
 import type { RefObject } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Controller, type FieldValues, useForm } from 'react-hook-form';
@@ -19,6 +29,13 @@ import { type PlaygroundRecord, usePlaygroundStore } from '@/store/playground';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Checkbox } from '../ui/checkbox';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
 import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from '../ui/field';
 import { Input } from '../ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
@@ -298,10 +315,7 @@ export function ScopedPlaygroundWorkbench({
   return (
     <section
       ref={panelRef}
-      className={cn(
-        'flex h-[min(44rem,calc(100vh-8rem))] min-h-[30rem] flex-col overflow-hidden rounded-md border bg-background',
-        className,
-      )}
+      className={cn('flex min-h-[24rem] flex-col overflow-hidden bg-background', className)}
       aria-label={`${entity.typeName} sample records`}
     >
       <EntityToolbar
@@ -485,6 +499,67 @@ function EntityToolbar({
   onClear: () => void;
   scoped?: boolean;
 }): React.JSX.Element {
+  if (scoped) {
+    return (
+      <div className="flex min-h-14 items-center justify-between gap-3 border-b px-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-sm font-semibold">{entity.typeName}</h3>
+            <Badge variant="secondary" className="shrink-0">
+              {entity.tableName}
+            </Badge>
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            {records.length} sample {records.length === 1 ? 'record' : 'records'}
+          </p>
+        </div>
+        {records.length === 0 ? (
+          <div className="flex shrink-0 items-center gap-1.5">
+            <Button type="button" size="sm" className="h-8" onClick={onSeedCurrent}>
+              <Sparkles aria-hidden="true" />
+              Generate 5 records
+            </Button>
+            <Button type="button" variant="ghost" size="sm" className="h-8" onClick={onNew}>
+              <Plus aria-hidden="true" />
+              Add manually
+            </Button>
+          </div>
+        ) : (
+          <div className="flex shrink-0 items-center gap-1">
+            <Button type="button" size="sm" className="h-8" onClick={onNew}>
+              <Plus aria-hidden="true" />
+              Add record
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label="Record actions"
+                >
+                  <MoreHorizontal aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={onSeedCurrent}>
+                  <Sparkles aria-hidden="true" />
+                  Generate 5 more
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={onClear} className="text-destructive">
+                  <RotateCcw aria-hidden="true" />
+                  Clear records
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-14 items-center justify-between gap-3 border-b px-3">
       <div className="min-w-0">

--- a/apps/desktop/src/renderer/src/components/ui/button-group.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/button-group.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const ButtonGroup = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & {
+    orientation?: 'horizontal' | 'vertical';
+  }
+>(({ className, orientation = 'horizontal', ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="button-group"
+    data-orientation={orientation}
+    className={cn(
+      'inline-flex items-stretch rounded-md border border-input bg-background shadow-sm',
+      orientation === 'vertical' ? 'flex-col' : 'flex-row',
+      className,
+    )}
+    {...props}
+  />
+));
+ButtonGroup.displayName = 'ButtonGroup';
+
+const ButtonGroupSeparator = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & {
+    orientation?: 'horizontal' | 'vertical';
+  }
+>(({ className, orientation = 'vertical', ...props }, ref) => (
+  <div
+    ref={ref}
+    aria-hidden="true"
+    data-slot="button-group-separator"
+    className={cn('shrink-0 bg-border', orientation === 'vertical' ? 'w-px' : 'h-px', className)}
+    {...props}
+  />
+));
+ButtonGroupSeparator.displayName = 'ButtonGroupSeparator';
+
+const ButtonGroupText = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="button-group-text"
+      className={cn('flex items-center px-3 text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  ),
+);
+ButtonGroupText.displayName = 'ButtonGroupText';
+
+export { ButtonGroup, ButtonGroupSeparator, ButtonGroupText };

--- a/apps/desktop/src/renderer/src/components/ui/collapsible.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/collapsible.tsx
@@ -1,0 +1,9 @@
+import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
+
+const Collapsible = CollapsiblePrimitive.Root;
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/apps/desktop/src/renderer/src/components/ui/field.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/field.tsx
@@ -1,0 +1,65 @@
+import * as LabelPrimitive from '@radix-ui/react-label';
+import type * as React from 'react';
+import { cn } from '@/lib/utils';
+
+function Field({ className, ...props }: React.ComponentProps<'div'>): React.ReactNode {
+  return (
+    <div
+      data-slot="field"
+      className={cn('grid gap-1.5 data-[invalid=true]:text-destructive', className)}
+      {...props}
+    />
+  );
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<'div'>): React.ReactNode {
+  return <div data-slot="field-group" className={cn('grid gap-3', className)} {...props} />;
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>): React.ReactNode {
+  return (
+    <LabelPrimitive.Root
+      data-slot="field-label"
+      className={cn('text-sm font-medium leading-none text-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<'p'>): React.ReactNode {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn('text-xs leading-snug text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+interface FieldErrorProps extends React.ComponentProps<'div'> {
+  errors?: Array<{ message?: string } | undefined>;
+}
+
+function FieldError({ className, errors, children, ...props }: FieldErrorProps): React.ReactNode {
+  const messages = errors
+    ?.map((error) => error?.message)
+    .filter((message): message is string => Boolean(message));
+  const body = messages && messages.length > 0 ? messages.join(' ') : children;
+
+  if (!body) return null;
+
+  return (
+    <div
+      data-slot="field-error"
+      className={cn('text-xs font-medium leading-snug text-destructive', className)}
+      {...props}
+    >
+      {body}
+    </div>
+  );
+}
+
+export { Field, FieldDescription, FieldError, FieldGroup, FieldLabel };

--- a/apps/desktop/src/renderer/src/store/playground.ts
+++ b/apps/desktop/src/renderer/src/store/playground.ts
@@ -1,0 +1,104 @@
+import { create } from 'zustand';
+
+export interface PlaygroundRecord {
+  id: string;
+  typeName: string;
+  value: Record<string, unknown>;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface PlaygroundStoreShape {
+  selectedTypeName: string | null;
+  selectedRecordId: string | null;
+  recordsByType: Record<string, PlaygroundRecord[]>;
+
+  selectType(typeName: string | null): void;
+  selectRecord(typeName: string, recordId: string | null): void;
+  upsertRecord(typeName: string, recordId: string | null, value: Record<string, unknown>): string;
+  deleteRecord(typeName: string, recordId: string): void;
+  clearType(typeName: string): void;
+  clearAll(): void;
+  pruneTypes(typeNames: readonly string[]): void;
+}
+
+export const usePlaygroundStore = create<PlaygroundStoreShape>((set, get) => ({
+  selectedTypeName: null,
+  selectedRecordId: null,
+  recordsByType: {},
+
+  selectType: (typeName) => {
+    const records = typeName ? (get().recordsByType[typeName] ?? []) : [];
+    set({
+      selectedTypeName: typeName,
+      selectedRecordId: records[0]?.id ?? null,
+    });
+  },
+
+  selectRecord: (typeName, recordId) => {
+    set({ selectedTypeName: typeName, selectedRecordId: recordId });
+  },
+
+  upsertRecord: (typeName, recordId, value) => {
+    const now = Date.now();
+    const id = recordId ?? crypto.randomUUID();
+    const records = get().recordsByType[typeName] ?? [];
+    const existing = records.find((record) => record.id === id);
+    const nextRecord: PlaygroundRecord = {
+      id,
+      typeName,
+      value,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    const nextRecords = existing
+      ? records.map((record) => (record.id === id ? nextRecord : record))
+      : [nextRecord, ...records];
+
+    set((state) => ({
+      recordsByType: { ...state.recordsByType, [typeName]: nextRecords },
+      selectedTypeName: typeName,
+      selectedRecordId: id,
+    }));
+    return id;
+  },
+
+  deleteRecord: (typeName, recordId) => {
+    const records = get().recordsByType[typeName] ?? [];
+    const nextRecords = records.filter((record) => record.id !== recordId);
+    set((state) => ({
+      recordsByType: { ...state.recordsByType, [typeName]: nextRecords },
+      selectedTypeName: typeName,
+      selectedRecordId:
+        state.selectedRecordId === recordId ? (nextRecords[0]?.id ?? null) : state.selectedRecordId,
+    }));
+  },
+
+  clearType: (typeName) => {
+    set((state) => ({
+      recordsByType: { ...state.recordsByType, [typeName]: [] },
+      selectedRecordId: state.selectedTypeName === typeName ? null : state.selectedRecordId,
+    }));
+  },
+
+  clearAll: () => set({ recordsByType: {}, selectedRecordId: null }),
+
+  pruneTypes: (typeNames) => {
+    const allowed = new Set(typeNames);
+    set((state) => {
+      const recordsByType: Record<string, PlaygroundRecord[]> = {};
+      for (const [typeName, records] of Object.entries(state.recordsByType)) {
+        if (allowed.has(typeName)) recordsByType[typeName] = records;
+      }
+      const selectedTypeName =
+        state.selectedTypeName && allowed.has(state.selectedTypeName)
+          ? state.selectedTypeName
+          : null;
+      return {
+        recordsByType,
+        selectedTypeName,
+        selectedRecordId: selectedTypeName ? state.selectedRecordId : null,
+      };
+    });
+  },
+}));

--- a/apps/desktop/src/renderer/src/store/playground.ts
+++ b/apps/desktop/src/renderer/src/store/playground.ts
@@ -16,6 +16,10 @@ interface PlaygroundStoreShape {
   selectType(typeName: string | null): void;
   selectRecord(typeName: string, recordId: string | null): void;
   upsertRecord(typeName: string, recordId: string | null, value: Record<string, unknown>): string;
+  insertRecords(
+    recordsByType: Record<string, Array<{ id: string; value: Record<string, unknown> }>>,
+    mode?: 'append' | 'replace',
+  ): void;
   deleteRecord(typeName: string, recordId: string): void;
   clearType(typeName: string): void;
   clearAll(): void;
@@ -61,6 +65,38 @@ export const usePlaygroundStore = create<PlaygroundStoreShape>((set, get) => ({
       selectedRecordId: id,
     }));
     return id;
+  },
+
+  insertRecords: (incoming, mode = 'append') => {
+    const now = Date.now();
+    const nextRecordsByType = Object.fromEntries(
+      Object.entries(incoming).map(([typeName, records]) => [
+        typeName,
+        records.map((record) => ({
+          id: record.id,
+          typeName,
+          value: record.value,
+          createdAt: now,
+          updatedAt: now,
+        })),
+      ]),
+    );
+
+    set((state) => {
+      const recordsByType = { ...state.recordsByType };
+      for (const [typeName, records] of Object.entries(nextRecordsByType)) {
+        recordsByType[typeName] =
+          mode === 'replace' ? records : [...records, ...(recordsByType[typeName] ?? [])];
+      }
+      const selectedTypeName = state.selectedTypeName ?? Object.keys(nextRecordsByType)[0] ?? null;
+      return {
+        recordsByType,
+        selectedTypeName,
+        selectedRecordId: selectedTypeName
+          ? (recordsByType[selectedTypeName]?.[0]?.id ?? null)
+          : null,
+      };
+    });
   },
 
   deleteRecord: (typeName, recordId) => {

--- a/apps/desktop/src/renderer/src/store/ui-chrome.ts
+++ b/apps/desktop/src/renderer/src/store/ui-chrome.ts
@@ -9,7 +9,7 @@ import { create } from 'zustand';
 
 export type Theme = 'dark' | 'light';
 export type ThemePreference = Theme | 'system';
-export type SidebarTab = 'properties' | 'chat' | 'schema' | 'changes';
+export type SidebarTab = 'properties' | 'chat' | 'schema' | 'playground' | 'changes';
 
 const THEME_STORAGE_KEY = 'theme';
 

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -93,6 +93,18 @@ describe('DetailPanel', () => {
     expect(header).toHaveTextContent('object');
   });
 
+  it('shows the scoped sample-record workbench when a table type is selected', () => {
+    seed(artworkSchema);
+    render(<DetailPanel selection={{ typeName: 'Artwork' }} />);
+
+    const workbench = screen.getByRole('region', { name: 'Artwork sample records' });
+    expect(within(workbench).getByRole('button', { name: 'New record' })).toBeInTheDocument();
+    expect(
+      within(workbench).getByRole('button', { name: 'Seed current entity' }),
+    ).toBeInTheDocument();
+    expect(within(workbench).getByText('No sample records yet')).toBeInTheDocument();
+  });
+
   it('renders FieldDetail when a type + field are selected', () => {
     seed(plotSchema);
     render(<DetailPanel selection={{ typeName: 'Plot', fieldName: 'name' }} />);

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -14,6 +14,7 @@ import type { RefEdgeData } from '@renderer/components/graph/schema-to-graph';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { useUndoStore } from '@renderer/store/undo';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 function seed(schema: Schema) {
@@ -93,15 +94,19 @@ describe('DetailPanel', () => {
     expect(header).toHaveTextContent('object');
   });
 
-  it('shows the scoped sample-record workbench when a table type is selected', () => {
+  it('shows the scoped sample-record workbench when a table type is selected', async () => {
+    const user = userEvent.setup();
     seed(artworkSchema);
     render(<DetailPanel selection={{ typeName: 'Artwork' }} />);
 
+    expect(screen.getByRole('tab', { name: 'Shape' })).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'Try' }));
+
     const workbench = screen.getByRole('region', { name: 'Artwork sample records' });
-    expect(within(workbench).getByRole('button', { name: 'New record' })).toBeInTheDocument();
     expect(
-      within(workbench).getByRole('button', { name: 'Seed current entity' }),
+      within(workbench).getByRole('button', { name: 'Generate 5 records' }),
     ).toBeInTheDocument();
+    expect(within(workbench).getByRole('button', { name: 'Add manually' })).toBeInTheDocument();
     expect(within(workbench).getByText('No sample records yet')).toBeInTheDocument();
   });
 

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -147,9 +147,9 @@ describe('DetailPanel', () => {
     seed(artworkSchema);
     render(<DetailPanel selection={{ typeName: 'Artwork', fieldName: 'sourceSearchText' }} />);
     expect(screen.getByTestId('field-detail')).toBeInTheDocument();
-    const guidance = screen.getByRole('region', { name: 'Model shape' });
-    expect(within(guidance).getByText('Query handle')).toBeInTheDocument();
-    expect(within(guidance).getByText(/denormalized/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Model advice' }));
+    expect(screen.getAllByText('Query handle').length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/denormalized/i).length).toBeGreaterThan(0);
   });
 
   it('creates a referenced object type from the field target picker', () => {
@@ -308,7 +308,8 @@ describe('DetailPanel', () => {
     expect(onClearSelection).toHaveBeenCalledOnce();
   });
 
-  it('returns to the type selection after deleting the selected field from details', () => {
+  it('returns to the type selection after deleting the selected field from details', async () => {
+    const user = userEvent.setup();
     seed(plotSchema);
     useGraphSelectionStore.getState().click('Plot', 'replace');
     const onClearSelectedField = vi.fn();
@@ -319,7 +320,8 @@ describe('DetailPanel', () => {
         onClearSelectedField={onClearSelectedField}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Delete field name' }));
+    await user.click(screen.getByRole('button', { name: 'Field actions for name' }));
+    await user.click(await screen.findByRole('menuitem', { name: 'Delete field' }));
 
     expect(useUndoStore.getState().schema.types[0]).toMatchObject({
       kind: 'object',

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -116,6 +116,25 @@ describe('DetailPanel', () => {
     expect(screen.getByTestId('field-detail')).toBeInTheDocument();
   });
 
+  it('returns from field detail to the selected type when Back to table fields is clicked', () => {
+    seed(plotSchema);
+    useGraphSelectionStore.getState().selectField({ typeName: 'Plot', fieldName: 'name' });
+    const onClearSelectedField = vi.fn();
+
+    render(
+      <DetailPanel
+        selection={{ typeName: 'Plot', fieldName: 'name' }}
+        onClearSelectedField={onClearSelectedField}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Back to table fields' }));
+
+    expect(useGraphSelectionStore.getState().state.selectedField).toBeNull();
+    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('Plot');
+    expect(useGraphSelectionStore.getState().state.focusTarget).toEqual({ nodeId: 'Plot' });
+    expect(onClearSelectedField).toHaveBeenCalledOnce();
+  });
+
   it('derives model shape guidance for the selected type from the schema', () => {
     seed(artworkSchema);
     render(<DetailPanel selection={{ typeName: 'ArtworkMedia' }} />);

--- a/apps/desktop/tests/components/detail/FieldDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/FieldDetail.test.tsx
@@ -18,6 +18,7 @@ function setup(
   availableTypeNames: readonly string[] = [],
   onCreateRefTarget?: () => string | undefined,
   tableIndexes?: readonly IndexDef[],
+  onBackToType?: () => void,
 ) {
   const dispatch = vi.fn<(op: Op) => void>();
   render(
@@ -29,6 +30,7 @@ function setup(
       availableTypeNames={availableTypeNames}
       onCreateRefTarget={onCreateRefTarget}
       tableIndexes={tableIndexes}
+      onBackToType={onBackToType}
     />,
   );
   return { dispatch };
@@ -44,16 +46,37 @@ describe('FieldDetail', () => {
   afterEach(cleanup);
 
   it('renders the selected field title as a panel header', () => {
-    setup({ name: 'showPrice', type: { kind: 'boolean' } });
+    setup({ name: 'showPrice', type: { kind: 'boolean' } }, [], [], undefined, undefined, vi.fn());
 
     const header = screen.getByTestId('field-detail-header');
     expect(header).toContainElement(screen.getByRole('heading', { name: 'showPrice' }));
     expect(header).toHaveTextContent('Plot');
     expect(header).toHaveTextContent('object');
+    expect(screen.getByRole('button', { name: 'Back to table fields' })).toHaveTextContent(
+      'Fields',
+    );
     expect(screen.getByText('Plot')).toHaveClass('text-lg');
     expect(screen.getByRole('heading', { name: 'showPrice' })).toHaveClass('text-sm');
     expect(header).toHaveClass('border-b');
     expect(header).toHaveClass('bg-muted/20');
+    expect(screen.getByRole('region', { name: 'Basics' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Behavior' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Output & generation' })).toBeInTheDocument();
+  });
+
+  it('calls the back handler from the field sub-view header', () => {
+    const onBackToType = vi.fn();
+    setup(
+      { name: 'showPrice', type: { kind: 'boolean' } },
+      [],
+      [],
+      undefined,
+      undefined,
+      onBackToType,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to table fields' }));
+    expect(onBackToType).toHaveBeenCalledOnce();
   });
 
   it('string: min/max/regex/format controls; blur dispatches update_field', () => {

--- a/apps/desktop/tests/components/detail/FieldDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/FieldDetail.test.tsx
@@ -50,18 +50,19 @@ describe('FieldDetail', () => {
 
     const header = screen.getByTestId('field-detail-header');
     expect(header).toContainElement(screen.getByRole('heading', { name: 'showPrice' }));
-    expect(header).toHaveTextContent('Plot');
-    expect(header).toHaveTextContent('object');
+    expect(header).toHaveTextContent('object / Plot');
     expect(screen.getByRole('button', { name: 'Back to table fields' })).toHaveTextContent(
       'Fields',
     );
-    expect(screen.getByText('Plot')).toHaveClass('text-lg');
-    expect(screen.getByRole('heading', { name: 'showPrice' })).toHaveClass('text-sm');
+    expect(screen.getByRole('heading', { name: 'showPrice' })).toHaveClass('text-lg');
+    expect(screen.getAllByText('boolean').length).toBeGreaterThan(0);
+    expect(screen.getByText('required')).toBeInTheDocument();
+    expect(screen.getByText(/sample:/)).toBeInTheDocument();
     expect(header).toHaveClass('border-b');
     expect(header).toHaveClass('bg-muted/20');
-    expect(screen.getByRole('region', { name: 'Basics' })).toBeInTheDocument();
-    expect(screen.getByRole('region', { name: 'Behavior' })).toBeInTheDocument();
-    expect(screen.getByRole('region', { name: 'Output & generation' })).toBeInTheDocument();
+    expect(screen.getByText('Presence')).toBeInTheDocument();
+    expect(screen.getByText('Default value')).toBeInTheDocument();
+    expect(screen.getByText('Sample data')).toBeInTheDocument();
   });
 
   it('calls the back handler from the field sub-view header', () => {
@@ -120,6 +121,7 @@ describe('FieldDetail', () => {
 
   it('dispatches update_field when the description changes', () => {
     const { dispatch } = setup({ name: 'name', type: { kind: 'string' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add description' }));
     const textarea = screen.getByLabelText('Description');
     fireEvent.change(textarea, { target: { value: 'Display name for the plot.' } });
     fireEvent.blur(textarea);
@@ -144,9 +146,11 @@ describe('FieldDetail', () => {
     });
   });
 
-  it('dispatches remove_field when the field delete action is clicked', () => {
+  it('dispatches remove_field when the field delete action is clicked', async () => {
+    const user = userEvent.setup();
     const { dispatch } = setup({ name: 'name', type: { kind: 'string' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Delete field name' }));
+    await user.click(screen.getByRole('button', { name: 'Field actions for name' }));
+    await user.click(await screen.findByRole('menuitem', { name: 'Delete field' }));
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'remove_field',
       typeName: 'Plot',
@@ -156,6 +160,7 @@ describe('FieldDetail', () => {
 
   it('dispatches update_field when a string default changes', () => {
     const { dispatch } = setup({ name: 'name', type: { kind: 'string' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Set default value' }));
     const input = screen.getByLabelText('Default value');
     fireEvent.change(input, { target: { value: 'Untitled' } });
     fireEvent.blur(input);
@@ -169,6 +174,7 @@ describe('FieldDetail', () => {
 
   it('parses numeric and boolean defaults by field type', () => {
     const number = setup({ name: 'count', type: { kind: 'number' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Set default value' }));
     fireEvent.change(screen.getByLabelText('Default value'), { target: { value: '42' } });
     fireEvent.blur(screen.getByLabelText('Default value'));
     expect(number.dispatch).toHaveBeenCalledWith({
@@ -180,6 +186,7 @@ describe('FieldDetail', () => {
 
     cleanup();
     const boolean = setup({ name: 'published', type: { kind: 'boolean' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Set default value' }));
     fireEvent.change(screen.getByLabelText('Default value'), { target: { value: 'false' } });
     fireEvent.blur(screen.getByLabelText('Default value'));
     expect(boolean.dispatch).toHaveBeenCalledWith({
@@ -215,7 +222,7 @@ describe('FieldDetail', () => {
       undefined,
       [],
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Add index' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add index for author' }));
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'add_index',
       typeName: 'Plot',
@@ -231,7 +238,7 @@ describe('FieldDetail', () => {
       undefined,
       [{ name: 'by_author', fields: ['name'] }],
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Add index' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add index for author' }));
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'add_index',
       typeName: 'Plot',
@@ -243,8 +250,9 @@ describe('FieldDetail', () => {
     setup({ name: 'author', type: { kind: 'ref', typeName: 'User' } }, [], [], undefined, [
       { name: 'by_author', fields: ['author'] },
     ]);
-    expect(screen.getByText('Indexed')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Add index' })).not.toBeInTheDocument();
+    expect(screen.getByText('indexed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'by_author' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add index for author' })).not.toBeInTheDocument();
   });
 
   it('type picker creates a ref to the first available type', async () => {
@@ -524,8 +532,8 @@ describe('FieldDetail', () => {
       },
     ]);
 
-    expect(screen.getByRole('region', { name: 'Model shape' })).toBeInTheDocument();
-    expect(screen.getByText('Query handle')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Model advice' }));
+    expect(screen.getAllByText('Query handle').length).toBeGreaterThan(0);
     expect(screen.getByText(/stay denormalized/i)).toBeInTheDocument();
   });
 });

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -294,6 +294,29 @@ describe('TypeDetail', () => {
       expect(screen.getByRole('button', { name: /add index/i })).toBeInTheDocument();
     });
 
+    it('shows field-level modeling advice from the field row popover', () => {
+      setup({ ...base, table: true }, [
+        {
+          id: 'v1:query_handle:Post:title',
+          kind: 'query_handle',
+          signals: ['query_pressure'],
+          path: 'types.0.fields.1',
+          typeName: 'Post',
+          fieldName: 'title',
+          title: 'Query handle',
+          message: 'This field looks useful for filtering, sorting, indexing, or search.',
+          rationale: 'A top-level query handle can preserve common queries.',
+          fieldNames: ['title'],
+        },
+      ]);
+
+      expect(screen.getByText('1 advisory')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Modeling advice for title' }));
+
+      expect(screen.getByText('Query handle')).toBeInTheDocument();
+      expect(screen.getByText(/useful for filtering/i)).toBeInTheDocument();
+    });
+
     it('shows and edits the emitted Convex table name when table:true', () => {
       const { dispatch } = setup({ ...base, table: true, tableName: 'posts' });
       const input = screen.getByLabelText('Emitted table name') as HTMLInputElement;

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -521,12 +521,16 @@ describe('TypeDetail', () => {
         ],
       });
 
-      expect(screen.getByText('Suggested from refs and likely lookup fields.')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'by_author' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'by_status' })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'by_body' })).not.toBeInTheDocument();
+      expect(screen.getByText('2 suggested indexes')).toBeInTheDocument();
+      expect(screen.getByText(/Advanced schema output/)).toHaveTextContent('2 suggestions');
 
-      fireEvent.click(screen.getByRole('button', { name: 'by_author' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Review' }));
+      expect(screen.getByText('Suggested from refs and likely lookup fields.')).toBeInTheDocument();
+      expect(screen.getByText('by_author')).toBeInTheDocument();
+      expect(screen.getByText('by_status')).toBeInTheDocument();
+      expect(screen.queryByText('by_body')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0]);
       expect(dispatch).toHaveBeenCalledWith({
         kind: 'add_index',
         typeName: 'Post',

--- a/apps/web/src/components/ui/animated-theme-toggler.tsx
+++ b/apps/web/src/components/ui/animated-theme-toggler.tsx
@@ -46,7 +46,7 @@ export const AnimatedThemeToggler = ({
     const maxRadius = Math.hypot(Math.max(x, viewportWidth - x), Math.max(y, viewportHeight - y));
 
     const applyTheme = () => {
-      const newTheme = !isDark;
+      const newTheme = !document.documentElement.classList.contains('dark');
       setIsDark(newTheme);
       document.documentElement.classList.toggle('dark', newTheme);
       localStorage.setItem('theme', newTheme ? 'dark' : 'light');
@@ -81,7 +81,7 @@ export const AnimatedThemeToggler = ({
         );
       });
     }
-  }, [isDark, duration]);
+  }, [duration]);
 
   return (
     <button

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@pierre/diffs": "^1.1.19",
         "@playwright/test": "^1.58.2",
         "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -781,6 +782,8 @@
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
     "@radix-ui/react-checkbox": ["@radix-ui/react-checkbox@1.3.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw=="],
+
+    "@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA=="],
 
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.26",
+      "version": "0.15.28",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.138",
         "@contexture/core": "workspace:*",
@@ -30,9 +30,11 @@
         "@contexture/stdlib": "workspace:*",
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^4.0.0",
+        "@hookform/resolvers": "^5.4.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@sentry/electron": "^7.10.0",
         "electron-updater": "^6.8.3",
+        "react-hook-form": "^7.76.1",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -488,6 +490,8 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@hookform/resolvers": ["@hookform/resolvers@5.4.0", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -984,6 +988,8 @@
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@storybook/addon-actions": ["@storybook/addon-actions@8.6.14", "", { "dependencies": { "@storybook/global": "^5.0.0", "@types/uuid": "^9.0.1", "dequal": "^2.0.2", "polished": "^4.2.2", "uuid": "^9.0.0" }, "peerDependencies": { "storybook": "^8.6.14" } }, "sha512-mDQxylxGGCQSK7tJPkD144J8jWh9IU9ziJMHfB84PKpI/V5ZgqMDnpr2bssTrUaGDqU5e1/z8KcRF+Melhs9pQ=="],
 
@@ -2520,6 +2526,8 @@
     "react-docgen-typescript": ["react-docgen-typescript@2.4.0", "", { "peerDependencies": { "typescript": ">= 4.3.x" } }, "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg=="],
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
+
+    "react-hook-form": ["react-hook-form@7.76.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -161,6 +161,7 @@
       "name": "@contexture/core",
       "version": "0.0.0",
       "dependencies": {
+        "@faker-js/faker": "^10.4.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.3.6",
       },
@@ -478,6 +479,8 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
+
+    "@faker-js/faker": ["@faker-js/faker@10.4.0", "", {}, "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw=="],
 
     "@fastify/otel": ["@fastify/otel@0.18.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.212.0", "@opentelemetry/semantic-conventions": "^1.28.0", "minimatch": "^10.2.4" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "./op-tools": "./src/op-tools.ts",
     "./paths": "./src/paths.ts",
     "./pipeline": "./src/pipeline.ts",
+    "./playground-contract": "./src/playground-contract.ts",
     "./semantic-validation": "./src/semantic-validation.ts",
     "./validation-repairs": "./src/validation-repairs.ts"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
     "./paths": "./src/paths.ts",
     "./pipeline": "./src/pipeline.ts",
     "./playground-contract": "./src/playground-contract.ts",
+    "./playground-fixtures": "./src/playground-fixtures.ts",
     "./semantic-validation": "./src/semantic-validation.ts",
     "./validation-repairs": "./src/validation-repairs.ts"
   },
@@ -39,6 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@faker-js/faker": "^10.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.3.6"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "./emit-zod": "./src/emit-zod.ts",
     "./document-bundle": "./src/document-bundle.ts",
     "./file-forward": "./src/file-forward.ts",
+    "./fixture-generators": "./src/fixture-generators.ts",
     "./generated-bundle-writer": "./src/generated-bundle-writer.ts",
     "./generated-targets": "./src/generated-targets.ts",
     "./ir": "./src/ir.ts",

--- a/packages/core/src/fixture-generators.ts
+++ b/packages/core/src/fixture-generators.ts
@@ -1,0 +1,166 @@
+import { faker } from '@faker-js/faker';
+
+export type FixtureValueType = 'string' | 'number' | 'boolean' | 'date' | 'object' | 'unknown';
+
+export interface FixtureGenerator {
+  id: string;
+  module: string;
+  method: string;
+  label: string;
+  moduleLabel: string;
+  valueType: FixtureValueType;
+}
+
+export interface FixtureModule {
+  id: string;
+  label: string;
+  generators: FixtureGenerator[];
+}
+
+const HIDDEN_MODULES = new Set(['_randomizer', 'definitions', 'rawDefinitions', 'helpers']);
+const HIDDEN_METHODS = new Set(['faker']);
+const HIDDEN_GENERATORS = new Set(['date.between', 'date.betweens', 'string.fromCharacters']);
+
+const VALUE_TYPE_OVERRIDES: Record<string, FixtureValueType> = {
+  'datatype.boolean': 'boolean',
+  'date.anytime': 'date',
+  'date.between': 'date',
+  'date.birthdate': 'date',
+  'date.future': 'date',
+  'date.past': 'date',
+  'date.recent': 'date',
+  'date.soon': 'date',
+  'finance.amount': 'string',
+  'location.latitude': 'number',
+  'location.longitude': 'number',
+  'number.bigInt': 'number',
+  'number.float': 'number',
+  'number.int': 'number',
+};
+
+const MODULE_VALUE_TYPES: Record<string, FixtureValueType> = {
+  airline: 'string',
+  animal: 'string',
+  book: 'string',
+  color: 'string',
+  commerce: 'string',
+  company: 'string',
+  database: 'string',
+  finance: 'string',
+  food: 'string',
+  git: 'string',
+  hacker: 'string',
+  internet: 'string',
+  lorem: 'string',
+  music: 'string',
+  person: 'string',
+  phone: 'string',
+  science: 'string',
+  string: 'string',
+  system: 'string',
+  vehicle: 'string',
+  word: 'string',
+};
+
+const LABEL_OVERRIDES: Record<string, string> = {
+  'commerce.productName': 'Product name',
+  'datatype.boolean': 'True or false',
+  'food.dish': 'Dish',
+  'food.ingredient': 'Ingredient',
+  'internet.email': 'Email address',
+  'internet.url': 'URL',
+  'location.streetAddress': 'Street address',
+  'person.fullName': 'Full name',
+  'phone.number': 'Phone number',
+  'string.uuid': 'UUID',
+};
+
+export function listFixtureModules(): FixtureModule[] {
+  const root = faker as unknown as Record<string, unknown>;
+  return Object.entries(root)
+    .filter(([moduleName, moduleValue]) => isPublicFakerModule(moduleName, moduleValue))
+    .map(([moduleName, moduleValue]) => fixtureModuleFrom(moduleName, moduleValue))
+    .filter((module) => module.generators.length > 0)
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export function listFixtureGenerators(options: { valueType?: FixtureValueType } = {}) {
+  const generators = listFixtureModules().flatMap((module) => module.generators);
+  if (!options.valueType) return generators;
+  return generators.filter(
+    (generator) => generator.valueType === options.valueType || generator.valueType === 'unknown',
+  );
+}
+
+export function fixtureGeneratorById(id: string): FixtureGenerator | undefined {
+  return listFixtureGenerators().find((generator) => generator.id === id);
+}
+
+export function generateFixtureValue(id: string): unknown {
+  const [moduleName, methodName] = id.split('.');
+  if (!moduleName || !methodName) return undefined;
+  const moduleValue = (faker as unknown as Record<string, Record<string, unknown>>)[moduleName];
+  const method = moduleValue?.[methodName];
+  if (typeof method !== 'function') return undefined;
+  try {
+    return method.call(moduleValue);
+  } catch {
+    return undefined;
+  }
+}
+
+function fixtureModuleFrom(moduleName: string, moduleValue: unknown): FixtureModule {
+  const moduleRecord = moduleValue as Record<string, unknown>;
+  const generators = Object.entries(moduleRecord)
+    .filter(([methodName, methodValue]) => isPublicFakerMethod(moduleName, methodName, methodValue))
+    .map(([methodName]) => fixtureGeneratorFrom(moduleName, methodName))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  return {
+    id: moduleName,
+    label: labelFromIdentifier(moduleName),
+    generators,
+  };
+}
+
+function fixtureGeneratorFrom(moduleName: string, methodName: string): FixtureGenerator {
+  const id = `${moduleName}.${methodName}`;
+  return {
+    id,
+    module: moduleName,
+    method: methodName,
+    label: LABEL_OVERRIDES[id] ?? labelFromIdentifier(methodName),
+    moduleLabel: labelFromIdentifier(moduleName),
+    valueType: VALUE_TYPE_OVERRIDES[id] ?? MODULE_VALUE_TYPES[moduleName] ?? 'unknown',
+  };
+}
+
+function isPublicFakerModule(moduleName: string, moduleValue: unknown): boolean {
+  return (
+    !HIDDEN_MODULES.has(moduleName) &&
+    !moduleName.startsWith('_') &&
+    typeof moduleValue === 'object' &&
+    moduleValue !== null
+  );
+}
+
+function isPublicFakerMethod(
+  moduleName: string,
+  methodName: string,
+  methodValue: unknown,
+): boolean {
+  return (
+    !HIDDEN_METHODS.has(methodName) &&
+    !HIDDEN_GENERATORS.has(`${moduleName}.${methodName}`) &&
+    !methodName.startsWith('_') &&
+    typeof methodValue === 'function'
+  );
+}
+
+function labelFromIdentifier(identifier: string): string {
+  const spaced = identifier
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]/g, ' ')
+    .trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,5 +22,6 @@ export * from './op-tools';
 export * from './ops';
 export * from './pipeline';
 export * from './playground-contract';
+export * from './playground-fixtures';
 export * from './semantic-validation';
 export * from './validation-repairs';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export { emit as emitSchemaIndex } from './emit-schema-index';
 export { emitStructuredOutputSchemas } from './emit-structured-output-schemas';
 export { emit as emitZod } from './emit-zod';
 export * from './file-forward';
+export * from './fixture-generators';
 export * from './generated-bundle-writer';
 export * from './generated-targets';
 export * from './ir';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,5 +21,6 @@ export * from './modeling-hints';
 export * from './op-tools';
 export * from './ops';
 export * from './pipeline';
+export * from './playground-contract';
 export * from './semantic-validation';
 export * from './validation-repairs';

--- a/packages/core/src/ir.ts
+++ b/packages/core/src/ir.ts
@@ -41,6 +41,13 @@ const RefFieldTypeSchema = z.object({
   typeName: z.string().min(1),
 });
 
+const SampleDataHintSchema = z.object({
+  category: z.string().min(1).optional(),
+  generator: z.string().min(1).optional(),
+});
+
+export type SampleDataHint = z.infer<typeof SampleDataHintSchema>;
+
 // Recursive discriminated union: `array.element` refers back to `FieldType`.
 // The explicit `z.ZodType<FieldType>` annotation breaks the circularity for
 // TypeScript; the `FieldType` itself is inferred further down.
@@ -85,6 +92,7 @@ export const FieldDefSchema = z.object({
   nullable: z.boolean().optional(),
   default: z.unknown().optional(),
   serverDerived: z.boolean().optional(),
+  sampleData: SampleDataHintSchema.optional(),
 });
 
 export type FieldDef = z.infer<typeof FieldDefSchema>;
@@ -104,12 +112,14 @@ const ObjectTypeDefSchema = z.object({
   table: z.boolean().optional(),
   tableName: z.string().min(1).optional(),
   indexes: z.array(IndexDefSchema).optional(),
+  sampleData: SampleDataHintSchema.optional(),
 });
 
 const EnumTypeDefSchema = z.object({
   kind: z.literal('enum'),
   name: z.string().min(1),
   description: z.string().optional(),
+  sampleData: SampleDataHintSchema.optional(),
   values: z.array(
     z.object({
       value: z.string().min(1),
@@ -122,6 +132,7 @@ const DiscriminatedUnionTypeDefSchema = z.object({
   kind: z.literal('discriminatedUnion'),
   name: z.string().min(1),
   description: z.string().optional(),
+  sampleData: SampleDataHintSchema.optional(),
   discriminator: z.string().min(1),
   variants: z.array(z.string().min(1)),
 });
@@ -130,6 +141,7 @@ const RawTypeDefSchema = z.object({
   kind: z.literal('raw'),
   name: z.string().min(1),
   description: z.string().optional(),
+  sampleData: SampleDataHintSchema.optional(),
   zod: z.string().min(1),
   jsonSchema: z.record(z.string(), z.unknown()),
   import: z

--- a/packages/core/src/op-tools.ts
+++ b/packages/core/src/op-tools.ts
@@ -99,6 +99,12 @@ const FieldDefSchema = z.object({
   optional: z.boolean().optional(),
   nullable: z.boolean().optional(),
   default: z.unknown().optional(),
+  sampleData: z
+    .object({
+      category: z.string().min(1).optional(),
+      generator: z.string().min(1).optional(),
+    })
+    .optional(),
 });
 
 // ---- Tool builders ------------------------------------------------------

--- a/packages/core/src/playground-contract.ts
+++ b/packages/core/src/playground-contract.ts
@@ -1,0 +1,333 @@
+import type { FieldDef, FieldType, Schema, TypeDef } from './ir';
+
+export type PlaygroundControlKind =
+  | 'text'
+  | 'number'
+  | 'boolean'
+  | 'date'
+  | 'literal'
+  | 'enum'
+  | 'ref'
+  | 'array'
+  | 'object'
+  | 'unsupported';
+
+export type PlaygroundControl =
+  | PlaygroundScalarControl
+  | PlaygroundEnumControl
+  | PlaygroundRefControl
+  | PlaygroundArrayControl
+  | PlaygroundObjectControl
+  | PlaygroundUnsupportedControl;
+
+type PlaygroundControlShape =
+  | Pick<PlaygroundScalarControl, 'kind' | 'constraints'>
+  | Pick<PlaygroundEnumControl, 'kind' | 'options'>
+  | Pick<PlaygroundRefControl, 'kind' | 'targetTypeName' | 'targetTableName'>
+  | Pick<PlaygroundArrayControl, 'kind' | 'element' | 'min' | 'max'>
+  | Pick<PlaygroundObjectControl, 'kind' | 'typeName' | 'fields'>
+  | Pick<PlaygroundUnsupportedControl, 'kind' | 'reason'>;
+
+export interface PlaygroundFieldBase {
+  kind: PlaygroundControlKind;
+  fieldName: string;
+  label: string;
+  description?: string;
+  required: boolean;
+  nullable: boolean;
+  defaultValue?: unknown;
+  serverDerived: boolean;
+}
+
+export interface PlaygroundScalarControl extends PlaygroundFieldBase {
+  kind: 'text' | 'number' | 'boolean' | 'date' | 'literal';
+  constraints: PlaygroundFieldConstraints;
+}
+
+export interface PlaygroundEnumControl extends PlaygroundFieldBase {
+  kind: 'enum';
+  options: PlaygroundEnumOption[];
+}
+
+export interface PlaygroundRefControl extends PlaygroundFieldBase {
+  kind: 'ref';
+  targetTypeName: string;
+  targetTableName?: string;
+}
+
+export interface PlaygroundArrayControl extends PlaygroundFieldBase {
+  kind: 'array';
+  element: PlaygroundArrayElementControl;
+  min?: number;
+  max?: number;
+}
+
+export interface PlaygroundObjectControl extends PlaygroundFieldBase {
+  kind: 'object';
+  typeName: string;
+  fields: PlaygroundControl[];
+}
+
+export interface PlaygroundUnsupportedControl extends PlaygroundFieldBase {
+  kind: 'unsupported';
+  reason: string;
+}
+
+export type PlaygroundArrayElementControl = PlaygroundControlShape;
+
+export interface PlaygroundFieldConstraints {
+  min?: number;
+  max?: number;
+  int?: boolean;
+  regex?: string;
+  format?: 'email' | 'url' | 'uuid' | 'datetime';
+  literalValue?: string | number | boolean;
+}
+
+export interface PlaygroundEnumOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface PlaygroundEntity {
+  typeName: string;
+  tableName: string;
+  description?: string;
+  fields: PlaygroundControl[];
+  indexes: readonly string[];
+  displayFieldName?: string;
+}
+
+export interface PlaygroundContract {
+  entities: PlaygroundEntity[];
+  embeddedTypes: PlaygroundObjectControl[];
+  enums: Array<{ typeName: string; options: PlaygroundEnumOption[] }>;
+}
+
+type ObjectType = Extract<TypeDef, { kind: 'object' }>;
+type EnumType = Extract<TypeDef, { kind: 'enum' }>;
+
+const DISPLAY_FIELD_CANDIDATES = ['name', 'title', 'label', 'slug', 'email', 'key'];
+
+export function buildPlaygroundContract(schema: Schema): PlaygroundContract {
+  const typeByName = new Map(schema.types.map((type) => [type.name, type]));
+  const entities = schema.types
+    .filter((type): type is ObjectType => type.kind === 'object' && type.table === true)
+    .map((type) => buildEntity(type, typeByName, [type.name]));
+
+  const embeddedTypes = schema.types
+    .filter((type): type is ObjectType => type.kind === 'object' && type.table !== true)
+    .map((type) => buildObjectControl(type.name, type.fields, typeByName, [type.name]));
+
+  const enums = schema.types
+    .filter((type): type is EnumType => type.kind === 'enum')
+    .map((type) => ({ typeName: type.name, options: enumOptions(type) }));
+
+  return { entities, embeddedTypes, enums };
+}
+
+export function emptyPlaygroundValue(control: PlaygroundControl): unknown {
+  if (control.defaultValue !== undefined) return control.defaultValue;
+  if (!control.required) return undefined;
+
+  switch (control.kind) {
+    case 'text':
+      return '';
+    case 'number':
+      return 0;
+    case 'boolean':
+      return false;
+    case 'date':
+      return new Date().toISOString().slice(0, 10);
+    case 'literal':
+      return control.constraints.literalValue;
+    case 'enum':
+      return control.options[0]?.value ?? '';
+    case 'ref':
+      return '';
+    case 'array':
+      return [];
+    case 'object':
+      return emptyObjectValue(control.fields);
+    case 'unsupported':
+      return undefined;
+  }
+}
+
+export function emptyEntityValue(entity: PlaygroundEntity): Record<string, unknown> {
+  return emptyObjectValue(entity.fields);
+}
+
+function emptyObjectValue(fields: readonly PlaygroundControl[]): Record<string, unknown> {
+  const value: Record<string, unknown> = {};
+  for (const field of fields) {
+    if (field.serverDerived) continue;
+    const empty = emptyPlaygroundValue(field);
+    if (empty !== undefined) value[field.fieldName] = empty;
+  }
+  return value;
+}
+
+function buildEntity(
+  type: ObjectType,
+  typeByName: ReadonlyMap<string, TypeDef>,
+  stack: readonly string[],
+): PlaygroundEntity {
+  return {
+    typeName: type.name,
+    tableName: tableName(type),
+    description: type.description,
+    fields: type.fields.map((field) => buildControl(field, typeByName, stack)),
+    indexes: (type.indexes ?? []).map((index) => index.name),
+    displayFieldName: displayFieldName(type),
+  };
+}
+
+function buildControl(
+  field: FieldDef,
+  typeByName: ReadonlyMap<string, TypeDef>,
+  stack: readonly string[],
+): PlaygroundControl {
+  const base = {
+    fieldName: field.name,
+    label: labelFor(field.name),
+    description: field.description,
+    required: field.optional !== true && field.serverDerived !== true,
+    nullable: field.nullable === true,
+    defaultValue: field.default,
+    serverDerived: field.serverDerived === true,
+  };
+  return { ...base, ...buildControlShape(field.type, typeByName, stack) } as PlaygroundControl;
+}
+
+function buildControlShape(
+  fieldType: FieldType,
+  typeByName: ReadonlyMap<string, TypeDef>,
+  stack: readonly string[],
+): PlaygroundControlShape {
+  switch (fieldType.kind) {
+    case 'string':
+      return {
+        kind: 'text',
+        constraints: {
+          min: fieldType.min,
+          max: fieldType.max,
+          regex: fieldType.regex,
+          format: fieldType.format,
+        },
+      };
+    case 'number':
+      return {
+        kind: 'number',
+        constraints: { min: fieldType.min, max: fieldType.max, int: fieldType.int },
+      };
+    case 'boolean':
+      return { kind: 'boolean', constraints: {} };
+    case 'date':
+      return { kind: 'date', constraints: {} };
+    case 'literal':
+      return { kind: 'literal', constraints: { literalValue: fieldType.value } };
+    case 'ref':
+      return refControlShape(fieldType.typeName, typeByName, stack);
+    case 'array':
+      return {
+        kind: 'array',
+        element: buildArrayElement(fieldType.element, typeByName, stack),
+        min: fieldType.min,
+        max: fieldType.max,
+      };
+  }
+}
+
+function buildArrayElement(
+  fieldType: FieldType,
+  typeByName: ReadonlyMap<string, TypeDef>,
+  stack: readonly string[],
+): PlaygroundArrayElementControl {
+  return buildControlShape(fieldType, typeByName, stack);
+}
+
+function refControlShape(
+  typeName: string,
+  typeByName: ReadonlyMap<string, TypeDef>,
+  stack: readonly string[],
+): PlaygroundControlShape {
+  const target = typeByName.get(typeName);
+  if (target?.kind === 'enum') return { kind: 'enum', options: enumOptions(target) };
+  if (target?.kind === 'object' && target.table === true) {
+    return {
+      kind: 'ref',
+      targetTypeName: target.name,
+      targetTableName: tableName(target),
+    };
+  }
+  if (target?.kind === 'object') {
+    if (stack.includes(target.name)) {
+      return { kind: 'unsupported', reason: `Recursive embedded reference: ${target.name}` };
+    }
+    return buildObjectShape(target, typeByName, [...stack, target.name]);
+  }
+  return { kind: 'unsupported', reason: `Unknown reference target: ${typeName}` };
+}
+
+function buildObjectControl(
+  typeName: string,
+  fields: FieldDef[],
+  typeByName: ReadonlyMap<string, TypeDef>,
+  stack: readonly string[],
+): PlaygroundObjectControl {
+  return {
+    kind: 'object',
+    typeName,
+    fieldName: typeName,
+    label: labelFor(typeName),
+    required: true,
+    nullable: false,
+    serverDerived: false,
+    fields: fields.map((field) => buildControl(field, typeByName, stack)),
+  };
+}
+
+function buildObjectShape(
+  type: ObjectType,
+  typeByName: ReadonlyMap<string, TypeDef>,
+  stack: readonly string[],
+): Pick<PlaygroundObjectControl, 'kind' | 'typeName' | 'fields'> {
+  return {
+    kind: 'object',
+    typeName: type.name,
+    fields: type.fields.map((field) => buildControl(field, typeByName, stack)),
+  };
+}
+
+function enumOptions(type: EnumType): PlaygroundEnumOption[] {
+  return type.values.map((value) => ({
+    value: value.value,
+    label: labelFor(value.value),
+    description: value.description,
+  }));
+}
+
+function tableName(type: ObjectType): string {
+  return type.tableName ?? lowerFirst(type.name);
+}
+
+function displayFieldName(type: ObjectType): string | undefined {
+  return DISPLAY_FIELD_CANDIDATES.find((candidate) =>
+    type.fields.some((field) => field.name === candidate && field.type.kind === 'string'),
+  );
+}
+
+function labelFor(name: string): string {
+  const words = name
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .trim();
+  if (!words) return name;
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+function lowerFirst(name: string): string {
+  return `${name.charAt(0).toLowerCase()}${name.slice(1)}`;
+}

--- a/packages/core/src/playground-contract.ts
+++ b/packages/core/src/playground-contract.ts
@@ -1,4 +1,4 @@
-import type { FieldDef, FieldType, Schema, TypeDef } from './ir';
+import type { FieldDef, FieldType, SampleDataHint, Schema, TypeDef } from './ir';
 
 export type PlaygroundControlKind =
   | 'text'
@@ -37,6 +37,7 @@ export interface PlaygroundFieldBase {
   nullable: boolean;
   defaultValue?: unknown;
   serverDerived: boolean;
+  sampleData?: SampleDataHint;
 }
 
 export interface PlaygroundScalarControl extends PlaygroundFieldBase {
@@ -94,6 +95,7 @@ export interface PlaygroundEntity {
   typeName: string;
   tableName: string;
   description?: string;
+  sampleData?: SampleDataHint;
   fields: PlaygroundControl[];
   indexes: readonly string[];
   displayFieldName?: string;
@@ -178,6 +180,7 @@ function buildEntity(
     typeName: type.name,
     tableName: tableName(type),
     description: type.description,
+    sampleData: type.sampleData,
     fields: type.fields.map((field) => buildControl(field, typeByName, stack)),
     indexes: (type.indexes ?? []).map((index) => index.name),
     displayFieldName: displayFieldName(type),
@@ -197,6 +200,7 @@ function buildControl(
     nullable: field.nullable === true,
     defaultValue: field.default,
     serverDerived: field.serverDerived === true,
+    sampleData: field.sampleData,
   };
   return { ...base, ...buildControlShape(field.type, typeByName, stack) } as PlaygroundControl;
 }

--- a/packages/core/src/playground-fixtures.ts
+++ b/packages/core/src/playground-fixtures.ts
@@ -1,0 +1,379 @@
+import { faker } from '@faker-js/faker';
+import { z } from 'zod';
+import type { Schema } from './ir';
+import {
+  buildPlaygroundContract,
+  type PlaygroundControl,
+  type PlaygroundEntity,
+  type PlaygroundRefControl,
+  type PlaygroundScalarControl,
+} from './playground-contract';
+
+export interface PlaygroundFixtureRecord {
+  id: string;
+  typeName: string;
+  value: Record<string, unknown>;
+}
+
+export interface PlaygroundFixtureOptions {
+  seed?: string;
+  count?: number;
+  countsByType?: Record<string, number>;
+  typeNames?: readonly string[];
+  existingRecordsByType?: Record<string, Array<{ id: string; value: Record<string, unknown> }>>;
+}
+
+export interface PlaygroundFixtureResult {
+  recordsByType: Record<string, PlaygroundFixtureRecord[]>;
+  warnings: PlaygroundFixtureWarning[];
+}
+
+export interface PlaygroundFixtureWarning {
+  typeName: string;
+  fieldName?: string;
+  message: string;
+}
+
+const DEFAULT_COUNT = 5;
+
+export function generatePlaygroundFixtures(
+  schema: Schema,
+  options: PlaygroundFixtureOptions = {},
+): PlaygroundFixtureResult {
+  const contract = buildPlaygroundContract(schema);
+  const requestedTypeNames = new Set(
+    options.typeNames ?? contract.entities.map((entity) => entity.typeName),
+  );
+  const entities = orderEntitiesForRefs(contract.entities).filter((entity) =>
+    requestedTypeNames.has(entity.typeName),
+  );
+  const random = createFixtureRandom(options.seed ?? 'contexture-playground');
+  const recordsByType: PlaygroundFixtureResult['recordsByType'] = {};
+  const warnings: PlaygroundFixtureWarning[] = [];
+
+  for (const entity of entities) {
+    const count = options.countsByType?.[entity.typeName] ?? options.count ?? DEFAULT_COUNT;
+    const generated: PlaygroundFixtureRecord[] = [];
+
+    for (let index = 0; index < count; index += 1) {
+      const record: PlaygroundFixtureRecord = {
+        id: fixtureId(entity.typeName, index, random),
+        typeName: entity.typeName,
+        value: generateEntityValue({
+          entity,
+          index,
+          random,
+          recordsByType: { ...options.existingRecordsByType, ...recordsByType },
+          warnings,
+        }),
+      };
+      validateGeneratedRecord(entity, record, warnings);
+      generated.push(record);
+    }
+
+    recordsByType[entity.typeName] = generated;
+  }
+
+  return { recordsByType, warnings };
+}
+
+interface GenerateValueContext {
+  entity: PlaygroundEntity;
+  index: number;
+  random: FixtureRandom;
+  recordsByType: Record<string, Array<{ id: string; value: Record<string, unknown> }>>;
+  warnings: PlaygroundFixtureWarning[];
+}
+
+interface FixtureRandom {
+  stringUuid(): string;
+  personName(): string;
+  email(): string;
+  url(): string;
+  words(options: { min: number; max: number }): string;
+  sentence(): string;
+  number(options: { min: number; max: number; int?: boolean }): number;
+  boolean(): boolean;
+  recentDate(): string;
+  soonDate(): string;
+  pick<T>(items: readonly T[]): T | undefined;
+  slug(value: string): string;
+}
+
+function createFixtureRandom(seed: string): FixtureRandom {
+  faker.seed(hashSeed(seed));
+  return {
+    stringUuid: () => faker.string.uuid(),
+    personName: () => faker.person.fullName(),
+    email: () => faker.internet.email().toLowerCase(),
+    url: () => faker.internet.url(),
+    words: (options) => faker.lorem.words({ min: options.min, max: options.max }),
+    sentence: () => faker.lorem.sentence(),
+    number: (options) =>
+      faker.number.float({
+        min: options.min,
+        max: options.max,
+        fractionDigits: options.int ? 0 : 2,
+      }),
+    boolean: () => faker.datatype.boolean(),
+    recentDate: () => faker.date.recent({ days: 21 }).toISOString().slice(0, 10),
+    soonDate: () => faker.date.soon({ days: 21 }).toISOString().slice(0, 10),
+    pick: (items) => (items.length > 0 ? faker.helpers.arrayElement([...items]) : undefined),
+    slug: (value) => faker.helpers.slugify(value).toLowerCase(),
+  };
+}
+
+function generateEntityValue(ctx: GenerateValueContext): Record<string, unknown> {
+  const value: Record<string, unknown> = {};
+  for (const control of ctx.entity.fields) {
+    if (control.serverDerived || control.kind === 'unsupported') continue;
+    const generated = generateControlValue(control, ctx);
+    if (generated === undefined && !control.required) continue;
+    value[control.fieldName] = generated;
+  }
+  return value;
+}
+
+function generateControlValue(control: PlaygroundControl, ctx: GenerateValueContext): unknown {
+  if (control.defaultValue !== undefined) return control.defaultValue;
+
+  switch (control.kind) {
+    case 'text':
+      return generateText(control as PlaygroundScalarControl & { kind: 'text' }, ctx);
+    case 'number':
+      return ctx.random.number({
+        min: control.constraints.min ?? 1,
+        max: control.constraints.max ?? 100,
+        int: control.constraints.int,
+      });
+    case 'boolean':
+      return ctx.random.boolean();
+    case 'date':
+      return dateFieldLooksFuture(control.fieldName)
+        ? ctx.random.soonDate()
+        : ctx.random.recentDate();
+    case 'literal':
+      return control.constraints.literalValue;
+    case 'enum':
+      return control.options.length > 0
+        ? control.options[ctx.index % control.options.length]?.value
+        : undefined;
+    case 'ref':
+      return generateRef(control, ctx);
+    case 'array':
+      return [];
+    case 'object': {
+      const objectValue: Record<string, unknown> = {};
+      for (const field of control.fields) {
+        if (field.serverDerived || field.kind === 'unsupported') continue;
+        const generated = generateControlValue(field, ctx);
+        if (generated === undefined && !field.required) continue;
+        objectValue[field.fieldName] = generated;
+      }
+      return objectValue;
+    }
+    case 'unsupported':
+      return undefined;
+  }
+}
+
+function generateText(
+  control: PlaygroundScalarControl & { kind: 'text' },
+  ctx: GenerateValueContext,
+): string {
+  const field = control.fieldName.toLowerCase();
+  const label = control.label.toLowerCase();
+
+  if (control.constraints.format === 'email' || field.includes('email')) return ctx.random.email();
+  if (control.constraints.format === 'url' || field.includes('url')) return ctx.random.url();
+  if (control.constraints.format === 'uuid' || field === 'uuid') return ctx.random.stringUuid();
+  if (field.includes('slug')) return ctx.random.slug(`${ctx.entity.typeName} ${ctx.index + 1}`);
+  if (field === 'name' || label.endsWith(' name')) return ctx.random.personName();
+  if (field === 'title' || field.endsWith('title')) return titleForEntity(ctx.entity, ctx);
+  if (field.includes('description') || field.includes('notes') || field.includes('summary')) {
+    return ctx.random.sentence();
+  }
+  if (field.includes('status') || field.includes('state'))
+    return ctx.random.pick(['draft', 'active', 'done']) ?? 'active';
+  if (field.includes('priority')) return ctx.random.pick(['low', 'normal', 'high']) ?? 'normal';
+
+  return ctx.random.words({
+    min: control.constraints.min !== undefined && control.constraints.min > 10 ? 3 : 1,
+    max: control.constraints.max !== undefined && control.constraints.max < 12 ? 2 : 5,
+  });
+}
+
+function titleForEntity(entity: PlaygroundEntity, ctx: GenerateValueContext): string {
+  const typeName = entity.typeName.toLowerCase();
+  if (typeName.includes('todo') || typeName.includes('task')) {
+    return (
+      ctx.random.pick([
+        'Review onboarding flow',
+        'Draft release notes',
+        'Check supplier invoice',
+        'Prepare planning notes',
+        'Tidy model relationships',
+      ]) ?? ctx.random.words({ min: 2, max: 5 })
+    );
+  }
+  return ctx.random.words({ min: 2, max: 5 });
+}
+
+function generateRef(control: PlaygroundRefControl, ctx: GenerateValueContext): string | undefined {
+  const records = ctx.recordsByType[control.targetTypeName] ?? [];
+  const record = ctx.random.pick(records);
+  if (!record) {
+    if (control.required) {
+      ctx.warnings.push({
+        typeName: ctx.entity.typeName,
+        fieldName: control.fieldName,
+        message: `No ${control.targetTypeName} records were available for required reference.`,
+      });
+    }
+    return undefined;
+  }
+  return record.id;
+}
+
+function validateGeneratedRecord(
+  entity: PlaygroundEntity,
+  record: PlaygroundFixtureRecord,
+  warnings: PlaygroundFixtureWarning[],
+): void {
+  const schema = zodSchemaForEntity(entity);
+  const result = schema.safeParse(record.value);
+  if (result.success) return;
+  warnings.push({
+    typeName: entity.typeName,
+    message: `Generated record ${record.id.slice(0, 8)} did not pass fixture validation.`,
+  });
+}
+
+function zodSchemaForEntity(entity: PlaygroundEntity): z.ZodObject<z.ZodRawShape> {
+  const shape: Record<string, z.ZodType> = {};
+  for (const field of entity.fields) {
+    if (field.serverDerived || field.kind === 'unsupported') continue;
+    shape[field.fieldName] = zodSchemaForControl(field);
+  }
+  return z.object(shape);
+}
+
+function zodSchemaForControl(control: PlaygroundControl): z.ZodType {
+  let schema: z.ZodType;
+
+  switch (control.kind) {
+    case 'text': {
+      let stringSchema = z.string();
+      if (control.constraints.min !== undefined)
+        stringSchema = stringSchema.min(control.constraints.min);
+      if (control.constraints.max !== undefined)
+        stringSchema = stringSchema.max(control.constraints.max);
+      if (control.constraints.regex)
+        stringSchema = stringSchema.regex(new RegExp(control.constraints.regex));
+      if (control.constraints.format === 'email') stringSchema = stringSchema.email();
+      if (control.constraints.format === 'url') stringSchema = stringSchema.url();
+      if (control.constraints.format === 'uuid') stringSchema = stringSchema.uuid();
+      if (control.constraints.format === 'datetime') stringSchema = stringSchema.datetime();
+      schema = stringSchema;
+      break;
+    }
+    case 'number': {
+      let numberSchema = z.number();
+      if (control.constraints.int) numberSchema = numberSchema.int();
+      if (control.constraints.min !== undefined)
+        numberSchema = numberSchema.min(control.constraints.min);
+      if (control.constraints.max !== undefined)
+        numberSchema = numberSchema.max(control.constraints.max);
+      schema = numberSchema;
+      break;
+    }
+    case 'boolean':
+      schema = z.boolean();
+      break;
+    case 'date':
+      schema = z.string();
+      break;
+    case 'literal':
+      schema = z.literal(control.constraints.literalValue);
+      break;
+    case 'enum':
+      schema =
+        control.options.length > 0
+          ? z.enum(control.options.map((option) => option.value) as [string, ...string[]])
+          : z.string();
+      break;
+    case 'ref':
+      schema = z.string();
+      break;
+    case 'array':
+      schema = z.array(z.unknown());
+      break;
+    case 'object':
+      schema = z.object(
+        Object.fromEntries(
+          control.fields
+            .filter((field) => !field.serverDerived && field.kind !== 'unsupported')
+            .map((field) => [field.fieldName, zodSchemaForControl(field)]),
+        ),
+      );
+      break;
+    case 'unsupported':
+      schema = z.unknown();
+      break;
+  }
+
+  if (control.nullable) schema = schema.nullable();
+  if (!control.required) schema = schema.optional();
+  return schema;
+}
+
+function orderEntitiesForRefs(entities: readonly PlaygroundEntity[]): PlaygroundEntity[] {
+  const byName = new Map(entities.map((entity) => [entity.typeName, entity]));
+  const sorted: PlaygroundEntity[] = [];
+  const temporary = new Set<string>();
+  const permanent = new Set<string>();
+
+  function visit(entity: PlaygroundEntity): void {
+    if (permanent.has(entity.typeName)) return;
+    if (temporary.has(entity.typeName)) return;
+    temporary.add(entity.typeName);
+    for (const refName of tableRefNames(entity.fields)) {
+      const dep = byName.get(refName);
+      if (dep) visit(dep);
+    }
+    temporary.delete(entity.typeName);
+    permanent.add(entity.typeName);
+    sorted.push(entity);
+  }
+
+  for (const entity of entities) visit(entity);
+  return sorted;
+}
+
+function tableRefNames(fields: readonly PlaygroundControl[]): string[] {
+  const refs = new Set<string>();
+  for (const field of fields) {
+    if (field.kind === 'ref') refs.add(field.targetTypeName);
+    if (field.kind === 'object') {
+      for (const nested of tableRefNames(field.fields)) refs.add(nested);
+    }
+  }
+  return [...refs].sort();
+}
+
+function fixtureId(typeName: string, index: number, random: FixtureRandom): string {
+  return `${typeName}_${index + 1}_${random.stringUuid().slice(0, 8)}`;
+}
+
+function dateFieldLooksFuture(fieldName: string): boolean {
+  const lower = fieldName.toLowerCase();
+  return lower.includes('due') || lower.includes('deadline') || lower.includes('expires');
+}
+
+function hashSeed(seed: string): number {
+  let hash = 0;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash = Math.imul(31, hash) + seed.charCodeAt(index);
+  }
+  return Math.abs(hash);
+}

--- a/packages/core/src/playground-fixtures.ts
+++ b/packages/core/src/playground-fixtures.ts
@@ -61,6 +61,7 @@ export function generatePlaygroundFixtures(
         typeName: entity.typeName,
         value: generateEntityValue({
           entity,
+          entityCategory: inferEntityCategory(entity),
           index,
           random,
           recordsByType: { ...options.existingRecordsByType, ...recordsByType },
@@ -79,6 +80,7 @@ export function generatePlaygroundFixtures(
 
 interface GenerateValueContext {
   entity: PlaygroundEntity;
+  entityCategory: EntityCategory;
   index: number;
   random: FixtureRandom;
   recordsByType: Record<string, Array<{ id: string; value: Record<string, unknown> }>>;
@@ -90,6 +92,13 @@ interface FixtureRandom {
   personName(): string;
   email(): string;
   url(): string;
+  ingredient(): string;
+  dish(): string;
+  productName(): string;
+  companyName(): string;
+  city(): string;
+  streetAddress(): string;
+  lastName(): string;
   words(options: { min: number; max: number }): string;
   sentence(): string;
   number(options: { min: number; max: number; int?: boolean }): number;
@@ -100,6 +109,17 @@ interface FixtureRandom {
   slug(value: string): string;
 }
 
+type EntityCategory =
+  | 'household'
+  | 'person'
+  | 'pantry'
+  | 'recipe'
+  | 'todo'
+  | 'list'
+  | 'company'
+  | 'place'
+  | 'generic';
+
 function createFixtureRandom(seed: string): FixtureRandom {
   faker.seed(hashSeed(seed));
   return {
@@ -107,6 +127,13 @@ function createFixtureRandom(seed: string): FixtureRandom {
     personName: () => faker.person.fullName(),
     email: () => faker.internet.email().toLowerCase(),
     url: () => faker.internet.url(),
+    ingredient: () => faker.food.ingredient(),
+    dish: () => faker.food.dish(),
+    productName: () => faker.commerce.productName(),
+    companyName: () => faker.company.name(),
+    city: () => faker.location.city(),
+    streetAddress: () => faker.location.streetAddress(),
+    lastName: () => faker.person.lastName(),
     words: (options) => faker.lorem.words({ min: options.min, max: options.max }),
     sentence: () => faker.lorem.sentence(),
     number: (options) =>
@@ -188,10 +215,14 @@ function generateText(
   if (control.constraints.format === 'url' || field.includes('url')) return ctx.random.url();
   if (control.constraints.format === 'uuid' || field === 'uuid') return ctx.random.stringUuid();
   if (field.includes('slug')) return ctx.random.slug(`${ctx.entity.typeName} ${ctx.index + 1}`);
-  if (field === 'name' || label.endsWith(' name')) return ctx.random.personName();
+  if (isNameField(field, label)) return nameForEntity(ctx);
   if (field === 'title' || field.endsWith('title')) return titleForEntity(ctx.entity, ctx);
+  if (field.includes('quantity') || field.includes('amount')) return quantityForEntity(ctx);
+  if (field.includes('unit')) return unitForEntity(ctx);
+  if (field.includes('address')) return ctx.random.streetAddress();
+  if (field.includes('city')) return ctx.random.city();
   if (field.includes('description') || field.includes('notes') || field.includes('summary')) {
-    return ctx.random.sentence();
+    return sentenceForEntity(ctx);
   }
   if (field.includes('status') || field.includes('state'))
     return ctx.random.pick(['draft', 'active', 'done']) ?? 'active';
@@ -203,9 +234,34 @@ function generateText(
   });
 }
 
-function titleForEntity(entity: PlaygroundEntity, ctx: GenerateValueContext): string {
-  const typeName = entity.typeName.toLowerCase();
-  if (typeName.includes('todo') || typeName.includes('task')) {
+function nameForEntity(ctx: GenerateValueContext): string {
+  switch (ctx.entityCategory) {
+    case 'household':
+      return `The ${ctx.random.lastName()} Household`;
+    case 'person':
+      return ctx.random.personName();
+    case 'pantry':
+      return ctx.random.ingredient();
+    case 'recipe':
+      return ctx.random.dish();
+    case 'todo':
+      return titleForEntity(ctx.entity, ctx);
+    case 'list':
+      return (
+        ctx.random.pick(['Weekly groceries', 'Weekend jobs', 'Launch checklist', 'House admin']) ??
+        ctx.random.words({ min: 2, max: 4 })
+      );
+    case 'company':
+      return ctx.random.companyName();
+    case 'place':
+      return ctx.random.city();
+    case 'generic':
+      return ctx.random.words({ min: 2, max: 4 });
+  }
+}
+
+function titleForEntity(_entity: PlaygroundEntity, ctx: GenerateValueContext): string {
+  if (ctx.entityCategory === 'todo') {
     return (
       ctx.random.pick([
         'Review onboarding flow',
@@ -216,7 +272,47 @@ function titleForEntity(entity: PlaygroundEntity, ctx: GenerateValueContext): st
       ]) ?? ctx.random.words({ min: 2, max: 5 })
     );
   }
+  if (ctx.entityCategory === 'recipe') return ctx.random.dish();
+  if (ctx.entityCategory === 'pantry') return ctx.random.ingredient();
+  if (ctx.entityCategory === 'household') return nameForEntity(ctx);
   return ctx.random.words({ min: 2, max: 5 });
+}
+
+function sentenceForEntity(ctx: GenerateValueContext): string {
+  if (ctx.entityCategory === 'pantry') {
+    return (
+      ctx.random.pick([
+        'Stored for quick weeknight meals.',
+        'Check the quantity before the next shop.',
+        'Usually kept in the main pantry.',
+      ]) ?? ctx.random.sentence()
+    );
+  }
+  if (ctx.entityCategory === 'recipe') {
+    return (
+      ctx.random.pick([
+        'Simple enough for a weeknight dinner.',
+        'Works well with pantry staples.',
+        'Best served fresh with a side salad.',
+      ]) ?? ctx.random.sentence()
+    );
+  }
+  return ctx.random.sentence();
+}
+
+function quantityForEntity(ctx: GenerateValueContext): string {
+  if (ctx.entityCategory === 'pantry' || ctx.entityCategory === 'recipe') {
+    const amount = ctx.random.pick(['1', '2', '3', '500', '750']) ?? '1';
+    return `${amount} ${unitForEntity(ctx)}`;
+  }
+  return String(ctx.random.number({ min: 1, max: 20, int: true }));
+}
+
+function unitForEntity(ctx: GenerateValueContext): string {
+  if (ctx.entityCategory === 'pantry' || ctx.entityCategory === 'recipe') {
+    return ctx.random.pick(['kg', 'g', 'ml', 'jar', 'tin', 'pack']) ?? 'pack';
+  }
+  return ctx.random.pick(['item', 'unit', 'pack']) ?? 'item';
 }
 
 function generateRef(control: PlaygroundRefControl, ctx: GenerateValueContext): string | undefined {
@@ -359,6 +455,32 @@ function tableRefNames(fields: readonly PlaygroundControl[]): string[] {
     }
   }
   return [...refs].sort();
+}
+
+function inferEntityCategory(entity: PlaygroundEntity): EntityCategory {
+  const haystack =
+    `${entity.typeName} ${entity.tableName} ${entity.description ?? ''}`.toLowerCase();
+  if (matchesAny(haystack, ['household', 'family', 'home'])) return 'household';
+  if (matchesAny(haystack, ['user', 'person', 'member', 'contact', 'assignee'])) return 'person';
+  if (matchesAny(haystack, ['pantry', 'ingredient', 'grocery', 'food', 'stock', 'inventory'])) {
+    return 'pantry';
+  }
+  if (matchesAny(haystack, ['recipe', 'meal', 'dish', 'menu'])) return 'recipe';
+  if (matchesAny(haystack, ['todo', 'task', 'checklist', 'issue'])) return 'todo';
+  if (matchesAny(haystack, ['list', 'collection'])) return 'list';
+  if (matchesAny(haystack, ['company', 'organisation', 'organization', 'vendor', 'supplier'])) {
+    return 'company';
+  }
+  if (matchesAny(haystack, ['place', 'address', 'location', 'venue'])) return 'place';
+  return 'generic';
+}
+
+function matchesAny(value: string, needles: readonly string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
+}
+
+function isNameField(field: string, label: string): boolean {
+  return field === 'name' || field.endsWith('name') || label.endsWith(' name');
 }
 
 function fixtureId(typeName: string, index: number, random: FixtureRandom): string {

--- a/packages/core/src/playground-fixtures.ts
+++ b/packages/core/src/playground-fixtures.ts
@@ -4,8 +4,10 @@ import { generateFixtureValue } from './fixture-generators';
 import type { Schema } from './ir';
 import {
   buildPlaygroundContract,
+  type PlaygroundArrayElementControl,
   type PlaygroundControl,
   type PlaygroundEntity,
+  type PlaygroundFieldConstraints,
   type PlaygroundRefControl,
   type PlaygroundScalarControl,
 } from './playground-contract';
@@ -240,7 +242,7 @@ function generateControlValue(control: PlaygroundControl, ctx: GenerateValueCont
     case 'ref':
       return generateRef(control, ctx);
     case 'array':
-      return [];
+      return generateArray(control, ctx);
     case 'object': {
       const objectValue: Record<string, unknown> = {};
       for (const field of control.fields) {
@@ -254,6 +256,79 @@ function generateControlValue(control: PlaygroundControl, ctx: GenerateValueCont
     case 'unsupported':
       return undefined;
   }
+}
+
+function generateArray(control: PlaygroundControl & { kind: 'array' }, ctx: GenerateValueContext) {
+  const min = control.min ?? 0;
+  const max = control.max ?? Math.max(min, 3);
+  const count = Math.max(min, Math.min(max, defaultArrayCount(control)));
+  return Array.from({ length: count }, () =>
+    generateArrayElement(control.element, control.fieldName, ctx),
+  ).filter((value) => value !== undefined);
+}
+
+function defaultArrayCount(control: PlaygroundControl & { kind: 'array' }): number {
+  if (control.min !== undefined && control.min > 0) return control.min;
+  if (fieldLooksLike(control.fieldName, ['tag', 'keyword', 'label'])) return 3;
+  return 2;
+}
+
+function generateArrayElement(
+  element: PlaygroundArrayElementControl,
+  fieldName: string,
+  ctx: GenerateValueContext,
+): unknown {
+  switch (element.kind) {
+    case 'text':
+      return generateText(arrayScalarControl(element, fieldName), ctx);
+    case 'number':
+      return ctx.random.number({
+        min: element.constraints.min ?? 1,
+        max: element.constraints.max ?? 20,
+        int: element.constraints.int,
+      });
+    case 'boolean':
+      return ctx.random.boolean();
+    case 'date':
+      return dateFieldLooksFuture(fieldName) ? ctx.random.soonDate() : ctx.random.recentDate();
+    case 'literal':
+      return element.constraints.literalValue;
+    case 'enum':
+      return ctx.random.pick(element.options.map((option) => option.value));
+    case 'ref': {
+      const record = ctx.random.pick(ctx.recordsByType[element.targetTypeName] ?? []);
+      return record?.id;
+    }
+    case 'object': {
+      const objectValue: Record<string, unknown> = {};
+      for (const field of element.fields) {
+        if (field.serverDerived || field.kind === 'unsupported') continue;
+        const generated = generateControlValue(field, ctx);
+        if (generated === undefined && !field.required) continue;
+        objectValue[field.fieldName] = generated;
+      }
+      return objectValue;
+    }
+    case 'array':
+      return [];
+    case 'unsupported':
+      return undefined;
+  }
+}
+
+function arrayScalarControl(
+  element: { constraints: PlaygroundFieldConstraints },
+  fieldName: string,
+): PlaygroundScalarControl & { kind: 'text' } {
+  return {
+    kind: 'text',
+    fieldName: singularFieldName(fieldName),
+    label: fieldName,
+    required: true,
+    nullable: false,
+    serverDerived: false,
+    constraints: element.constraints,
+  };
 }
 
 function generateHintedValue(control: PlaygroundControl): unknown {
@@ -678,6 +753,12 @@ function isNameField(field: string, label: string): boolean {
 function fieldLooksLike(fieldName: string, needles: readonly string[]): boolean {
   const field = fieldName.toLowerCase();
   return needles.some((needle) => field.includes(needle));
+}
+
+function singularFieldName(fieldName: string): string {
+  if (fieldName.endsWith('ies')) return `${fieldName.slice(0, -3)}y`;
+  if (fieldName.endsWith('s') && fieldName.length > 1) return fieldName.slice(0, -1);
+  return fieldName;
 }
 
 function fixtureId(typeName: string, index: number, random: FixtureRandom): string {

--- a/packages/core/src/playground-fixtures.ts
+++ b/packages/core/src/playground-fixtures.ts
@@ -94,10 +94,23 @@ interface FixtureRandom {
   url(): string;
   ingredient(): string;
   dish(): string;
+  fruit(): string;
+  vegetable(): string;
+  meat(): string;
+  product(): string;
   productName(): string;
+  productDescription(): string;
   companyName(): string;
+  jobTitle(): string;
   city(): string;
+  country(): string;
   streetAddress(): string;
+  phoneNumber(): string;
+  amount(): string;
+  currencyCode(): string;
+  vehicle(): string;
+  bookTitle(): string;
+  musicSong(): string;
   lastName(): string;
   words(options: { min: number; max: number }): string;
   sentence(): string;
@@ -112,12 +125,18 @@ interface FixtureRandom {
 type EntityCategory =
   | 'household'
   | 'person'
+  | 'food'
   | 'pantry'
   | 'recipe'
   | 'todo'
   | 'list'
+  | 'commerce'
   | 'company'
+  | 'finance'
   | 'place'
+  | 'vehicle'
+  | 'book'
+  | 'music'
   | 'generic';
 
 function createFixtureRandom(seed: string): FixtureRandom {
@@ -129,10 +148,23 @@ function createFixtureRandom(seed: string): FixtureRandom {
     url: () => faker.internet.url(),
     ingredient: () => faker.food.ingredient(),
     dish: () => faker.food.dish(),
+    fruit: () => faker.food.fruit(),
+    vegetable: () => faker.food.vegetable(),
+    meat: () => faker.food.meat(),
+    product: () => faker.commerce.product(),
     productName: () => faker.commerce.productName(),
+    productDescription: () => faker.commerce.productDescription(),
     companyName: () => faker.company.name(),
+    jobTitle: () => faker.person.jobTitle(),
     city: () => faker.location.city(),
+    country: () => faker.location.country(),
     streetAddress: () => faker.location.streetAddress(),
+    phoneNumber: () => faker.phone.number(),
+    amount: () => faker.finance.amount({ min: 10, max: 250, dec: 2 }),
+    currencyCode: () => faker.finance.currencyCode(),
+    vehicle: () => faker.vehicle.vehicle(),
+    bookTitle: () => faker.book.title(),
+    musicSong: () => faker.music.songName(),
     lastName: () => faker.person.lastName(),
     words: (options) => faker.lorem.words({ min: options.min, max: options.max }),
     sentence: () => faker.lorem.sentence(),
@@ -169,7 +201,7 @@ function generateControlValue(control: PlaygroundControl, ctx: GenerateValueCont
       return generateText(control as PlaygroundScalarControl & { kind: 'text' }, ctx);
     case 'number':
       if (fieldLooksLike(control.fieldName, ['quantity', 'amount', 'count'])) {
-        return ctx.entityCategory === 'pantry' || ctx.entityCategory === 'recipe'
+        return entityCategoryUsesFood(ctx.entityCategory)
           ? ctx.random.number({ min: 1, max: 12, int: true })
           : ctx.random.number({
               min: control.constraints.min ?? 1,
@@ -224,6 +256,12 @@ function generateText(
   if (control.constraints.format === 'url' || field.includes('url')) return ctx.random.url();
   if (control.constraints.format === 'uuid' || field === 'uuid') return ctx.random.stringUuid();
   if (field.includes('slug')) return ctx.random.slug(`${ctx.entity.typeName} ${ctx.index + 1}`);
+  if (field.includes('phone') || field.includes('mobile')) return ctx.random.phoneNumber();
+  if (field.includes('currency')) return ctx.random.currencyCode();
+  if (field.includes('price') || field.includes('cost') || field.includes('total')) {
+    return ctx.random.amount();
+  }
+  if (field.includes('country')) return ctx.random.country();
   if (field.includes('storagelocation') || field.includes('storage_location')) {
     return storageLocationForEntity(ctx);
   }
@@ -254,6 +292,7 @@ function nameForEntity(ctx: GenerateValueContext): string {
       return `The ${ctx.random.lastName()} Household`;
     case 'person':
       return ctx.random.personName();
+    case 'food':
     case 'pantry':
       return ctx.random.ingredient();
     case 'recipe':
@@ -265,10 +304,20 @@ function nameForEntity(ctx: GenerateValueContext): string {
         ctx.random.pick(['Weekly groceries', 'Weekend jobs', 'Launch checklist', 'House admin']) ??
         ctx.random.words({ min: 2, max: 4 })
       );
+    case 'commerce':
+      return ctx.random.productName();
     case 'company':
       return ctx.random.companyName();
+    case 'finance':
+      return ctx.random.amount();
     case 'place':
       return ctx.random.city();
+    case 'vehicle':
+      return ctx.random.vehicle();
+    case 'book':
+      return ctx.random.bookTitle();
+    case 'music':
+      return ctx.random.musicSong();
     case 'generic':
       return ctx.random.words({ min: 2, max: 4 });
   }
@@ -287,13 +336,14 @@ function titleForEntity(_entity: PlaygroundEntity, ctx: GenerateValueContext): s
     );
   }
   if (ctx.entityCategory === 'recipe') return ctx.random.dish();
-  if (ctx.entityCategory === 'pantry') return ctx.random.ingredient();
+  if (entityCategoryUsesFood(ctx.entityCategory)) return ctx.random.ingredient();
+  if (ctx.entityCategory === 'commerce') return ctx.random.productName();
   if (ctx.entityCategory === 'household') return nameForEntity(ctx);
   return ctx.random.words({ min: 2, max: 5 });
 }
 
 function sentenceForEntity(ctx: GenerateValueContext): string {
-  if (ctx.entityCategory === 'pantry') {
+  if (ctx.entityCategory === 'pantry' || ctx.entityCategory === 'food') {
     return (
       ctx.random.pick([
         'Stored for quick weeknight meals.',
@@ -302,6 +352,7 @@ function sentenceForEntity(ctx: GenerateValueContext): string {
       ]) ?? ctx.random.sentence()
     );
   }
+  if (ctx.entityCategory === 'commerce') return ctx.random.productDescription();
   if (ctx.entityCategory === 'recipe') {
     return (
       ctx.random.pick([
@@ -315,7 +366,7 @@ function sentenceForEntity(ctx: GenerateValueContext): string {
 }
 
 function quantityForEntity(ctx: GenerateValueContext): string {
-  if (ctx.entityCategory === 'pantry' || ctx.entityCategory === 'recipe') {
+  if (entityCategoryUsesFood(ctx.entityCategory)) {
     const amount = ctx.random.pick(['1', '2', '3', '500', '750']) ?? '1';
     return `${amount} ${unitForEntity(ctx)}`;
   }
@@ -323,14 +374,14 @@ function quantityForEntity(ctx: GenerateValueContext): string {
 }
 
 function unitForEntity(ctx: GenerateValueContext): string {
-  if (ctx.entityCategory === 'pantry' || ctx.entityCategory === 'recipe') {
+  if (entityCategoryUsesFood(ctx.entityCategory)) {
     return ctx.random.pick(['kg', 'g', 'ml', 'jar', 'tin', 'pack']) ?? 'pack';
   }
   return ctx.random.pick(['item', 'unit', 'pack']) ?? 'item';
 }
 
 function storageLocationForEntity(ctx: GenerateValueContext): string {
-  if (ctx.entityCategory === 'pantry') {
+  if (entityCategoryUsesFood(ctx.entityCategory)) {
     return (
       ctx.random.pick(['Pantry', 'Fridge', 'Freezer', 'Cupboard', 'Allotment shed']) ?? 'Pantry'
     );
@@ -339,7 +390,7 @@ function storageLocationForEntity(ctx: GenerateValueContext): string {
 }
 
 function sourceTypeForEntity(ctx: GenerateValueContext): string {
-  if (ctx.entityCategory === 'pantry') {
+  if (entityCategoryUsesFood(ctx.entityCategory)) {
     return ctx.random.pick(['manual', 'shopping-list', 'recipe-leftover']) ?? 'manual';
   }
   return ctx.random.pick(['manual', 'imported', 'system']) ?? 'manual';
@@ -490,24 +541,65 @@ function tableRefNames(fields: readonly PlaygroundControl[]): string[] {
 function inferEntityCategory(entity: PlaygroundEntity): EntityCategory {
   const identity = `${entity.typeName} ${entity.tableName}`.toLowerCase();
   const haystack = `${identity} ${entity.description ?? ''}`.toLowerCase();
+  const compactIdentity = identity.replace(/[^a-z0-9]/g, '');
+  const fieldNames = entity.fields.map((field) => field.fieldName.toLowerCase());
+
+  if (
+    matchesAny(compactIdentity, [
+      'shoppinglistitem',
+      'groceryitem',
+      'ingredientitem',
+      'pantryitem',
+      'fooditem',
+      'stockitem',
+      'produceitem',
+    ])
+  ) {
+    return 'food';
+  }
   if (matchesAny(identity, ['pantry', 'ingredient', 'grocery', 'food', 'stock', 'inventory'])) {
     return 'pantry';
   }
+  if (identity.includes('shopping') && entityLooksLikeFoodItem(fieldNames)) return 'food';
   if (matchesAny(identity, ['recipe', 'meal', 'dish', 'menu'])) return 'recipe';
   if (matchesAny(identity, ['todo', 'task', 'checklist', 'issue'])) return 'todo';
   if (matchesAny(identity, ['household', 'family', 'home'])) return 'household';
   if (matchesAny(identity, ['user', 'person', 'member', 'contact', 'assignee'])) return 'person';
-  if (matchesAny(identity, ['list', 'collection'])) return 'list';
+  if (matchesAny(identity, ['product', 'order', 'cart', 'catalogue', 'catalog', 'sku'])) {
+    return 'commerce';
+  }
   if (matchesAny(identity, ['company', 'organisation', 'organization', 'vendor', 'supplier'])) {
     return 'company';
   }
+  if (matchesAny(identity, ['invoice', 'payment', 'transaction', 'account', 'budget'])) {
+    return 'finance';
+  }
   if (matchesAny(identity, ['place', 'address', 'location', 'venue'])) return 'place';
+  if (matchesAny(identity, ['vehicle', 'car', 'bike', 'bicycle'])) return 'vehicle';
+  if (matchesAny(identity, ['book', 'author', 'publisher'])) return 'book';
+  if (matchesAny(identity, ['song', 'album', 'artist', 'playlist', 'track'])) return 'music';
+  if (matchesAny(identity, ['list', 'collection'])) return 'list';
   if (matchesAny(haystack, ['pantry', 'ingredient', 'grocery', 'food', 'stock', 'inventory'])) {
-    return 'pantry';
+    return 'food';
   }
   if (matchesAny(haystack, ['recipe', 'meal', 'dish', 'menu'])) return 'recipe';
   if (matchesAny(haystack, ['household', 'family', 'home'])) return 'household';
+  if (matchesAny(haystack, ['product', 'order', 'cart', 'catalogue', 'catalog'])) {
+    return 'commerce';
+  }
   return 'generic';
+}
+
+function entityLooksLikeFoodItem(fieldNames: readonly string[]): boolean {
+  const hasName = fieldNames.some((field) => field === 'name' || field.endsWith('name'));
+  const hasFoodShape = fieldNames.some((field) =>
+    matchesAny(field, ['quantity', 'unit', 'ingredient', 'pantry', 'purchased', 'checked']),
+  );
+  return hasName && hasFoodShape;
+}
+
+function entityCategoryUsesFood(category: EntityCategory): boolean {
+  return category === 'food' || category === 'pantry' || category === 'recipe';
 }
 
 function matchesAny(value: string, needles: readonly string[]): boolean {

--- a/packages/core/src/playground-fixtures.ts
+++ b/packages/core/src/playground-fixtures.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { z } from 'zod';
+import { generateFixtureValue } from './fixture-generators';
 import type { Schema } from './ir';
 import {
   buildPlaygroundContract,
@@ -142,30 +143,33 @@ type EntityCategory =
 function createFixtureRandom(seed: string): FixtureRandom {
   faker.seed(hashSeed(seed));
   return {
-    stringUuid: () => faker.string.uuid(),
-    personName: () => faker.person.fullName(),
-    email: () => faker.internet.email().toLowerCase(),
-    url: () => faker.internet.url(),
-    ingredient: () => faker.food.ingredient(),
-    dish: () => faker.food.dish(),
-    fruit: () => faker.food.fruit(),
-    vegetable: () => faker.food.vegetable(),
-    meat: () => faker.food.meat(),
-    product: () => faker.commerce.product(),
-    productName: () => faker.commerce.productName(),
-    productDescription: () => faker.commerce.productDescription(),
-    companyName: () => faker.company.name(),
-    jobTitle: () => faker.person.jobTitle(),
-    city: () => faker.location.city(),
-    country: () => faker.location.country(),
-    streetAddress: () => faker.location.streetAddress(),
-    phoneNumber: () => faker.phone.number(),
-    amount: () => faker.finance.amount({ min: 10, max: 250, dec: 2 }),
-    currencyCode: () => faker.finance.currencyCode(),
-    vehicle: () => faker.vehicle.vehicle(),
-    bookTitle: () => faker.book.title(),
-    musicSong: () => faker.music.songName(),
-    lastName: () => faker.person.lastName(),
+    stringUuid: () => stringFixture('string.uuid', () => faker.string.uuid()),
+    personName: () => stringFixture('person.fullName', () => faker.person.fullName()),
+    email: () => stringFixture('internet.email', () => faker.internet.email()).toLowerCase(),
+    url: () => stringFixture('internet.url', () => faker.internet.url()),
+    ingredient: () => stringFixture('food.ingredient', () => faker.food.ingredient()),
+    dish: () => stringFixture('food.dish', () => faker.food.dish()),
+    fruit: () => stringFixture('food.fruit', () => faker.food.fruit()),
+    vegetable: () => stringFixture('food.vegetable', () => faker.food.vegetable()),
+    meat: () => stringFixture('food.meat', () => faker.food.meat()),
+    product: () => stringFixture('commerce.product', () => faker.commerce.product()),
+    productName: () => stringFixture('commerce.productName', () => faker.commerce.productName()),
+    productDescription: () =>
+      stringFixture('commerce.productDescription', () => faker.commerce.productDescription()),
+    companyName: () => stringFixture('company.name', () => faker.company.name()),
+    jobTitle: () => stringFixture('person.jobTitle', () => faker.person.jobTitle()),
+    city: () => stringFixture('location.city', () => faker.location.city()),
+    country: () => stringFixture('location.country', () => faker.location.country()),
+    streetAddress: () =>
+      stringFixture('location.streetAddress', () => faker.location.streetAddress()),
+    phoneNumber: () => stringFixture('phone.number', () => faker.phone.number()),
+    amount: () =>
+      stringFixture('finance.amount', () => faker.finance.amount({ min: 10, max: 250, dec: 2 })),
+    currencyCode: () => stringFixture('finance.currencyCode', () => faker.finance.currencyCode()),
+    vehicle: () => stringFixture('vehicle.vehicle', () => faker.vehicle.vehicle()),
+    bookTitle: () => stringFixture('book.title', () => faker.book.title()),
+    musicSong: () => stringFixture('music.songName', () => faker.music.songName()),
+    lastName: () => stringFixture('person.lastName', () => faker.person.lastName()),
     words: (options) => faker.lorem.words({ min: options.min, max: options.max }),
     sentence: () => faker.lorem.sentence(),
     number: (options) =>
@@ -182,6 +186,11 @@ function createFixtureRandom(seed: string): FixtureRandom {
   };
 }
 
+function stringFixture(id: string, fallback: () => string): string {
+  const generated = generateFixtureValue(id);
+  return typeof generated === 'string' ? generated : fallback();
+}
+
 function generateEntityValue(ctx: GenerateValueContext): Record<string, unknown> {
   const value: Record<string, unknown> = {};
   for (const control of ctx.entity.fields) {
@@ -195,6 +204,8 @@ function generateEntityValue(ctx: GenerateValueContext): Record<string, unknown>
 
 function generateControlValue(control: PlaygroundControl, ctx: GenerateValueContext): unknown {
   if (control.defaultValue !== undefined) return control.defaultValue;
+  const hintedValue = generateHintedValue(control);
+  if (hintedValue !== undefined) return hintedValue;
 
   switch (control.kind) {
     case 'text':
@@ -242,6 +253,32 @@ function generateControlValue(control: PlaygroundControl, ctx: GenerateValueCont
     }
     case 'unsupported':
       return undefined;
+  }
+}
+
+function generateHintedValue(control: PlaygroundControl): unknown {
+  const generator = control.sampleData?.generator;
+  if (!generator) return undefined;
+  const generated = generateFixtureValue(generator);
+  if (generated === undefined) return undefined;
+  switch (control.kind) {
+    case 'text':
+    case 'ref':
+      return String(generated);
+    case 'number': {
+      const numeric = typeof generated === 'number' ? generated : Number(generated);
+      return Number.isFinite(numeric) ? numeric : undefined;
+    }
+    case 'boolean':
+      return typeof generated === 'boolean' ? generated : undefined;
+    case 'date':
+      return generated instanceof Date ? generated.toISOString().slice(0, 10) : String(generated);
+    case 'literal':
+    case 'enum':
+    case 'array':
+    case 'object':
+    case 'unsupported':
+      return generated;
   }
 }
 
@@ -539,6 +576,9 @@ function tableRefNames(fields: readonly PlaygroundControl[]): string[] {
 }
 
 function inferEntityCategory(entity: PlaygroundEntity): EntityCategory {
+  const hintedCategory = entityCategoryFromFixtureModule(entity.sampleData?.category);
+  if (hintedCategory) return hintedCategory;
+
   const identity = `${entity.typeName} ${entity.tableName}`.toLowerCase();
   const haystack = `${identity} ${entity.description ?? ''}`.toLowerCase();
   const compactIdentity = identity.replace(/[^a-z0-9]/g, '');
@@ -588,6 +628,31 @@ function inferEntityCategory(entity: PlaygroundEntity): EntityCategory {
     return 'commerce';
   }
   return 'generic';
+}
+
+function entityCategoryFromFixtureModule(moduleName: string | undefined): EntityCategory | null {
+  switch (moduleName) {
+    case 'person':
+      return 'person';
+    case 'food':
+      return 'food';
+    case 'commerce':
+      return 'commerce';
+    case 'company':
+      return 'company';
+    case 'finance':
+      return 'finance';
+    case 'location':
+      return 'place';
+    case 'vehicle':
+      return 'vehicle';
+    case 'book':
+      return 'book';
+    case 'music':
+      return 'music';
+    default:
+      return null;
+  }
 }
 
 function entityLooksLikeFoodItem(fieldNames: readonly string[]): boolean {

--- a/packages/core/src/playground-fixtures.ts
+++ b/packages/core/src/playground-fixtures.ts
@@ -168,6 +168,15 @@ function generateControlValue(control: PlaygroundControl, ctx: GenerateValueCont
     case 'text':
       return generateText(control as PlaygroundScalarControl & { kind: 'text' }, ctx);
     case 'number':
+      if (fieldLooksLike(control.fieldName, ['quantity', 'amount', 'count'])) {
+        return ctx.entityCategory === 'pantry' || ctx.entityCategory === 'recipe'
+          ? ctx.random.number({ min: 1, max: 12, int: true })
+          : ctx.random.number({
+              min: control.constraints.min ?? 1,
+              max: control.constraints.max ?? 20,
+              int: true,
+            });
+      }
       return ctx.random.number({
         min: control.constraints.min ?? 1,
         max: control.constraints.max ?? 100,
@@ -215,6 +224,11 @@ function generateText(
   if (control.constraints.format === 'url' || field.includes('url')) return ctx.random.url();
   if (control.constraints.format === 'uuid' || field === 'uuid') return ctx.random.stringUuid();
   if (field.includes('slug')) return ctx.random.slug(`${ctx.entity.typeName} ${ctx.index + 1}`);
+  if (field.includes('storagelocation') || field.includes('storage_location')) {
+    return storageLocationForEntity(ctx);
+  }
+  if (field.includes('sourcetype') || field.includes('source_type'))
+    return sourceTypeForEntity(ctx);
   if (isNameField(field, label)) return nameForEntity(ctx);
   if (field === 'title' || field.endsWith('title')) return titleForEntity(ctx.entity, ctx);
   if (field.includes('quantity') || field.includes('amount')) return quantityForEntity(ctx);
@@ -313,6 +327,22 @@ function unitForEntity(ctx: GenerateValueContext): string {
     return ctx.random.pick(['kg', 'g', 'ml', 'jar', 'tin', 'pack']) ?? 'pack';
   }
   return ctx.random.pick(['item', 'unit', 'pack']) ?? 'item';
+}
+
+function storageLocationForEntity(ctx: GenerateValueContext): string {
+  if (ctx.entityCategory === 'pantry') {
+    return (
+      ctx.random.pick(['Pantry', 'Fridge', 'Freezer', 'Cupboard', 'Allotment shed']) ?? 'Pantry'
+    );
+  }
+  return ctx.random.pick(['Main storage', 'Back room', 'Archive']) ?? 'Main storage';
+}
+
+function sourceTypeForEntity(ctx: GenerateValueContext): string {
+  if (ctx.entityCategory === 'pantry') {
+    return ctx.random.pick(['manual', 'shopping-list', 'recipe-leftover']) ?? 'manual';
+  }
+  return ctx.random.pick(['manual', 'imported', 'system']) ?? 'manual';
 }
 
 function generateRef(control: PlaygroundRefControl, ctx: GenerateValueContext): string | undefined {
@@ -458,20 +488,25 @@ function tableRefNames(fields: readonly PlaygroundControl[]): string[] {
 }
 
 function inferEntityCategory(entity: PlaygroundEntity): EntityCategory {
-  const haystack =
-    `${entity.typeName} ${entity.tableName} ${entity.description ?? ''}`.toLowerCase();
-  if (matchesAny(haystack, ['household', 'family', 'home'])) return 'household';
-  if (matchesAny(haystack, ['user', 'person', 'member', 'contact', 'assignee'])) return 'person';
+  const identity = `${entity.typeName} ${entity.tableName}`.toLowerCase();
+  const haystack = `${identity} ${entity.description ?? ''}`.toLowerCase();
+  if (matchesAny(identity, ['pantry', 'ingredient', 'grocery', 'food', 'stock', 'inventory'])) {
+    return 'pantry';
+  }
+  if (matchesAny(identity, ['recipe', 'meal', 'dish', 'menu'])) return 'recipe';
+  if (matchesAny(identity, ['todo', 'task', 'checklist', 'issue'])) return 'todo';
+  if (matchesAny(identity, ['household', 'family', 'home'])) return 'household';
+  if (matchesAny(identity, ['user', 'person', 'member', 'contact', 'assignee'])) return 'person';
+  if (matchesAny(identity, ['list', 'collection'])) return 'list';
+  if (matchesAny(identity, ['company', 'organisation', 'organization', 'vendor', 'supplier'])) {
+    return 'company';
+  }
+  if (matchesAny(identity, ['place', 'address', 'location', 'venue'])) return 'place';
   if (matchesAny(haystack, ['pantry', 'ingredient', 'grocery', 'food', 'stock', 'inventory'])) {
     return 'pantry';
   }
   if (matchesAny(haystack, ['recipe', 'meal', 'dish', 'menu'])) return 'recipe';
-  if (matchesAny(haystack, ['todo', 'task', 'checklist', 'issue'])) return 'todo';
-  if (matchesAny(haystack, ['list', 'collection'])) return 'list';
-  if (matchesAny(haystack, ['company', 'organisation', 'organization', 'vendor', 'supplier'])) {
-    return 'company';
-  }
-  if (matchesAny(haystack, ['place', 'address', 'location', 'venue'])) return 'place';
+  if (matchesAny(haystack, ['household', 'family', 'home'])) return 'household';
   return 'generic';
 }
 
@@ -481,6 +516,11 @@ function matchesAny(value: string, needles: readonly string[]): boolean {
 
 function isNameField(field: string, label: string): boolean {
   return field === 'name' || field.endsWith('name') || label.endsWith(' name');
+}
+
+function fieldLooksLike(fieldName: string, needles: readonly string[]): boolean {
+  const field = fieldName.toLowerCase();
+  return needles.some((needle) => field.includes(needle));
 }
 
 function fixtureId(typeName: string, index: number, random: FixtureRandom): string {

--- a/packages/core/tests/fixture-generators.test.ts
+++ b/packages/core/tests/fixture-generators.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fixtureGeneratorById,
+  generateFixtureValue,
+  listFixtureGenerators,
+  listFixtureModules,
+} from '../src/fixture-generators';
+import { IRSchema } from '../src/ir';
+
+describe('fixture generator catalog', () => {
+  it('discovers public Faker modules and generators from the installed package', () => {
+    const modules = listFixtureModules();
+    const moduleIds = modules.map((module) => module.id);
+
+    expect(moduleIds).toContain('person');
+    expect(moduleIds).toContain('internet');
+    expect(moduleIds).toContain('food');
+    expect(moduleIds).not.toContain('helpers');
+    expect(moduleIds).not.toContain('rawDefinitions');
+
+    expect(fixtureGeneratorById('person.fullName')).toMatchObject({
+      id: 'person.fullName',
+      label: 'Full name',
+      module: 'person',
+      valueType: 'string',
+    });
+    expect(fixtureGeneratorById('internet.email')).toMatchObject({
+      label: 'Email address',
+      valueType: 'string',
+    });
+  });
+
+  it('filters generators by compatible value type', () => {
+    const booleanGenerators = listFixtureGenerators({ valueType: 'boolean' });
+
+    expect(booleanGenerators.map((generator) => generator.id)).toContain('datatype.boolean');
+    expect(booleanGenerators.map((generator) => generator.id)).not.toContain('person.fullName');
+  });
+
+  it('can invoke a discovered generator', () => {
+    expect(generateFixtureValue('food.ingredient')).toEqual(expect.any(String));
+  });
+
+  it('keeps sample-data hints in the Contexture IR', () => {
+    const parsed = IRSchema.parse({
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'User',
+          fields: [
+            {
+              name: 'email',
+              type: { kind: 'string' },
+              sampleData: { generator: 'internet.email' },
+            },
+          ],
+          sampleData: { category: 'person' },
+        },
+      ],
+    });
+
+    const [type] = parsed.types;
+    expect(type?.kind).toBe('object');
+    if (type?.kind !== 'object') return;
+    expect(type.sampleData).toEqual({ category: 'person' });
+    expect(type.fields[0]?.sampleData).toEqual({ generator: 'internet.email' });
+  });
+});

--- a/packages/core/tests/playground-contract.test.ts
+++ b/packages/core/tests/playground-contract.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { Schema } from '../src/ir';
+import { buildPlaygroundContract, emptyEntityValue } from '../src/playground-contract';
+
+const schema: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Project',
+      table: true,
+      fields: [
+        { name: 'name', type: { kind: 'string', min: 2 } },
+        { name: 'status', type: { kind: 'ref', typeName: 'ProjectStatus' } },
+        { name: 'owner', type: { kind: 'ref', typeName: 'Person' }, optional: true },
+        { name: 'tasks', type: { kind: 'array', element: { kind: 'ref', typeName: 'Task' } } },
+        { name: 'createdAt', type: { kind: 'date' }, serverDerived: true },
+      ],
+      indexes: [{ name: 'by_status', fields: ['status'] }],
+    },
+    {
+      kind: 'object',
+      name: 'Person',
+      table: true,
+      fields: [{ name: 'email', type: { kind: 'string', format: 'email' } }],
+    },
+    {
+      kind: 'object',
+      name: 'Task',
+      fields: [
+        { name: 'title', type: { kind: 'string' } },
+        { name: 'done', type: { kind: 'boolean' }, default: false },
+      ],
+    },
+    {
+      kind: 'enum',
+      name: 'ProjectStatus',
+      values: [{ value: 'draft' }, { value: 'active' }],
+    },
+  ],
+};
+
+describe('buildPlaygroundContract', () => {
+  it('maps table objects into playground entities with form controls', () => {
+    const contract = buildPlaygroundContract(schema);
+
+    expect(contract.entities).toHaveLength(2);
+    expect(contract.entities[0]).toMatchObject({
+      typeName: 'Project',
+      tableName: 'project',
+      indexes: ['by_status'],
+      displayFieldName: 'name',
+    });
+    expect(contract.entities[0]?.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'text',
+          fieldName: 'name',
+          required: true,
+          constraints: expect.objectContaining({ min: 2 }),
+        }),
+        expect.objectContaining({
+          kind: 'enum',
+          fieldName: 'status',
+          options: [
+            { value: 'draft', label: 'Draft', description: undefined },
+            { value: 'active', label: 'Active', description: undefined },
+          ],
+        }),
+        expect.objectContaining({
+          kind: 'ref',
+          fieldName: 'owner',
+          required: false,
+          targetTypeName: 'Person',
+        }),
+        expect.objectContaining({
+          kind: 'array',
+          fieldName: 'tasks',
+          element: expect.objectContaining({ kind: 'object', typeName: 'Task' }),
+        }),
+      ]),
+    );
+  });
+
+  it('creates empty entity values without server-derived fields', () => {
+    const [project] = buildPlaygroundContract(schema).entities;
+
+    expect(project && emptyEntityValue(project)).toEqual({
+      name: '',
+      status: 'draft',
+      tasks: [],
+    });
+  });
+
+  it('does not recurse forever on embedded object cycles', () => {
+    const recursive: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Tree',
+          table: true,
+          fields: [{ name: 'root', type: { kind: 'ref', typeName: 'Branch' } }],
+        },
+        {
+          kind: 'object',
+          name: 'Branch',
+          fields: [{ name: 'child', type: { kind: 'ref', typeName: 'Branch' } }],
+        },
+      ],
+    };
+
+    const [tree] = buildPlaygroundContract(recursive).entities;
+    const root = tree?.fields[0];
+
+    expect(root).toMatchObject({
+      kind: 'object',
+      fieldName: 'root',
+      fields: [
+        expect.objectContaining({
+          kind: 'unsupported',
+          reason: 'Recursive embedded reference: Branch',
+        }),
+      ],
+    });
+  });
+});

--- a/packages/core/tests/playground-fixtures.test.ts
+++ b/packages/core/tests/playground-fixtures.test.ts
@@ -83,6 +83,29 @@ const pantrySchema: Schema = {
         { name: 'description', type: { kind: 'string' }, optional: true },
       ],
     },
+    {
+      kind: 'object',
+      name: 'ShoppingListItem',
+      description: 'A food item the household plans to buy.',
+      table: true,
+      fields: [
+        { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+        { name: 'name', type: { kind: 'string' } },
+        { name: 'quantity', type: { kind: 'number' } },
+        { name: 'unit', type: { kind: 'string' } },
+        { name: 'purchased', type: { kind: 'boolean' } },
+      ],
+    },
+    {
+      kind: 'object',
+      name: 'Product',
+      table: true,
+      fields: [
+        { name: 'name', type: { kind: 'string' } },
+        { name: 'description', type: { kind: 'string' } },
+        { name: 'price', type: { kind: 'string' } },
+      ],
+    },
   ],
 };
 
@@ -161,6 +184,8 @@ describe('generatePlaygroundFixtures', () => {
     const household = result.recordsByType.Household?.[0];
     const pantryItem = result.recordsByType.PantryItem?.[0];
     const recipe = result.recordsByType.Recipe?.[0];
+    const shoppingListItem = result.recordsByType.ShoppingListItem?.[0];
+    const product = result.recordsByType.Product?.[0];
 
     expect(result.warnings).toEqual([]);
     expect(household?.value.name).toMatch(/^The .+ Household$/);
@@ -175,5 +200,14 @@ describe('generatePlaygroundFixtures', () => {
     );
     expect(recipe?.value.name).toEqual(expect.any(String));
     expect(recipe?.value.name).not.toMatch(/^The .+ Household$/);
+    expect(shoppingListItem?.value.name).toEqual(expect.any(String));
+    expect(shoppingListItem?.value.name).not.toMatch(/Household$/);
+    expect(shoppingListItem?.value.quantity).toSatisfy(
+      (value: unknown) => typeof value === 'number' && value >= 1 && value <= 12,
+    );
+    expect(['kg', 'g', 'ml', 'jar', 'tin', 'pack']).toContain(shoppingListItem?.value.unit);
+    expect(product?.value.name).toEqual(expect.any(String));
+    expect(product?.value.description).toEqual(expect.any(String));
+    expect(product?.value.price).toEqual(expect.stringMatching(/^\d+\.\d{2}$/));
   });
 });

--- a/packages/core/tests/playground-fixtures.test.ts
+++ b/packages/core/tests/playground-fixtures.test.ts
@@ -63,11 +63,14 @@ const pantrySchema: Schema = {
     {
       kind: 'object',
       name: 'PantryItem',
+      description: 'A pantry item owned by a Household.',
       table: true,
       fields: [
         { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
         { name: 'name', type: { kind: 'string' } },
-        { name: 'quantity', type: { kind: 'string' } },
+        { name: 'quantity', type: { kind: 'number' } },
+        { name: 'unit', type: { kind: 'string' } },
+        { name: 'storageLocation', type: { kind: 'string' } },
         { name: 'notes', type: { kind: 'string' }, optional: true },
       ],
     },
@@ -162,8 +165,14 @@ describe('generatePlaygroundFixtures', () => {
     expect(result.warnings).toEqual([]);
     expect(household?.value.name).toMatch(/^The .+ Household$/);
     expect(pantryItem?.value.name).toEqual(expect.any(String));
-    expect(pantryItem?.value.name).not.toMatch(/\s[A-Z][a-z]+$/);
-    expect(pantryItem?.value.quantity).toMatch(/^(1|2|3|500|750) (kg|g|ml|jar|tin|pack)$/);
+    expect(pantryItem?.value.name).not.toMatch(/Household$/);
+    expect(pantryItem?.value.quantity).toSatisfy(
+      (value: unknown) => typeof value === 'number' && value >= 1 && value <= 12,
+    );
+    expect(['kg', 'g', 'ml', 'jar', 'tin', 'pack']).toContain(pantryItem?.value.unit);
+    expect(['Pantry', 'Fridge', 'Freezer', 'Cupboard', 'Allotment shed']).toContain(
+      pantryItem?.value.storageLocation,
+    );
     expect(recipe?.value.name).toEqual(expect.any(String));
     expect(recipe?.value.name).not.toMatch(/^The .+ Household$/);
   });

--- a/packages/core/tests/playground-fixtures.test.ts
+++ b/packages/core/tests/playground-fixtures.test.ts
@@ -106,6 +106,16 @@ const pantrySchema: Schema = {
         { name: 'price', type: { kind: 'string' } },
       ],
     },
+    {
+      kind: 'object',
+      name: 'Account',
+      table: true,
+      sampleData: { category: 'person' },
+      fields: [
+        { name: 'name', type: { kind: 'string' } },
+        { name: 'contact', type: { kind: 'string' }, sampleData: { generator: 'internet.email' } },
+      ],
+    },
   ],
 };
 
@@ -186,6 +196,7 @@ describe('generatePlaygroundFixtures', () => {
     const recipe = result.recordsByType.Recipe?.[0];
     const shoppingListItem = result.recordsByType.ShoppingListItem?.[0];
     const product = result.recordsByType.Product?.[0];
+    const account = result.recordsByType.Account?.[0];
 
     expect(result.warnings).toEqual([]);
     expect(household?.value.name).toMatch(/^The .+ Household$/);
@@ -209,5 +220,8 @@ describe('generatePlaygroundFixtures', () => {
     expect(product?.value.name).toEqual(expect.any(String));
     expect(product?.value.description).toEqual(expect.any(String));
     expect(product?.value.price).toEqual(expect.stringMatching(/^\d+\.\d{2}$/));
+    expect(account?.value.name).toEqual(expect.any(String));
+    expect(account?.value.name).not.toMatch(/Household$/);
+    expect(account?.value.contact).toEqual(expect.stringMatching(/@/));
   });
 });

--- a/packages/core/tests/playground-fixtures.test.ts
+++ b/packages/core/tests/playground-fixtures.test.ts
@@ -27,6 +27,17 @@ const todoSchema: Schema = {
       fields: [
         { name: 'name', type: { kind: 'string' } },
         { name: 'email', type: { kind: 'string', format: 'email' } },
+        { name: 'profile', type: { kind: 'ref', typeName: 'UserProfile' } },
+        { name: 'tags', type: { kind: 'array', element: { kind: 'string' } } },
+      ],
+    },
+    {
+      kind: 'object',
+      name: 'UserProfile',
+      fields: [
+        { name: 'bio', type: { kind: 'string' } },
+        { name: 'timezone', type: { kind: 'string' } },
+        { name: 'notificationsEnabled', type: { kind: 'boolean' } },
       ],
     },
     {
@@ -138,6 +149,14 @@ describe('generatePlaygroundFixtures', () => {
     const [item] = result.recordsByType.TodoItem ?? [];
 
     expect(user?.value.email).toEqual(expect.stringMatching(/@/));
+    expect(user?.value.profile).toMatchObject({
+      bio: expect.any(String),
+      timezone: expect.any(String),
+      notificationsEnabled: expect.any(Boolean),
+    });
+    expect(user?.value.tags).toSatisfy(
+      (value: unknown) => Array.isArray(value) && value.length === 3,
+    );
     expect(list?.value.ownerId).toSatisfy(
       (id: unknown) => typeof id === 'string' && userIds.has(id),
     );

--- a/packages/core/tests/playground-fixtures.test.ts
+++ b/packages/core/tests/playground-fixtures.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import type { Schema } from '../src/ir';
+import { generatePlaygroundFixtures } from '../src/playground-fixtures';
+
+const todoSchema: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'TodoItem',
+      table: true,
+      fields: [
+        { name: 'listId', type: { kind: 'ref', typeName: 'TodoList' } },
+        { name: 'assigneeId', type: { kind: 'ref', typeName: 'User' } },
+        { name: 'title', type: { kind: 'string', min: 3 } },
+        { name: 'notes', type: { kind: 'string' }, optional: true },
+        { name: 'status', type: { kind: 'ref', typeName: 'TodoStatus' } },
+        { name: 'priority', type: { kind: 'ref', typeName: 'Priority' } },
+        { name: 'dueAt', type: { kind: 'date' }, optional: true },
+        { name: 'createdAt', type: { kind: 'date' }, serverDerived: true },
+      ],
+    },
+    {
+      kind: 'object',
+      name: 'User',
+      table: true,
+      fields: [
+        { name: 'name', type: { kind: 'string' } },
+        { name: 'email', type: { kind: 'string', format: 'email' } },
+      ],
+    },
+    {
+      kind: 'object',
+      name: 'TodoList',
+      table: true,
+      fields: [
+        { name: 'title', type: { kind: 'string' } },
+        { name: 'ownerId', type: { kind: 'ref', typeName: 'User' } },
+      ],
+    },
+    {
+      kind: 'enum',
+      name: 'TodoStatus',
+      values: [{ value: 'todo' }, { value: 'doing' }, { value: 'done' }],
+    },
+    {
+      kind: 'enum',
+      name: 'Priority',
+      values: [{ value: 'low' }, { value: 'normal' }, { value: 'high' }],
+    },
+  ],
+};
+
+describe('generatePlaygroundFixtures', () => {
+  it('generates dependency-aware table records with valid refs and semantic values', () => {
+    const result = generatePlaygroundFixtures(todoSchema, {
+      seed: 'todo-demo',
+      countsByType: { User: 3, TodoList: 2, TodoItem: 5 },
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.recordsByType.User).toHaveLength(3);
+    expect(result.recordsByType.TodoList).toHaveLength(2);
+    expect(result.recordsByType.TodoItem).toHaveLength(5);
+
+    const userIds = new Set(result.recordsByType.User?.map((record) => record.id));
+    const listIds = new Set(result.recordsByType.TodoList?.map((record) => record.id));
+    const [user] = result.recordsByType.User ?? [];
+    const [list] = result.recordsByType.TodoList ?? [];
+    const [item] = result.recordsByType.TodoItem ?? [];
+
+    expect(user?.value.email).toEqual(expect.stringMatching(/@/));
+    expect(list?.value.ownerId).toSatisfy(
+      (id: unknown) => typeof id === 'string' && userIds.has(id),
+    );
+    expect(item?.value.listId).toSatisfy(
+      (id: unknown) => typeof id === 'string' && listIds.has(id),
+    );
+    expect(item?.value.assigneeId).toSatisfy(
+      (id: unknown) => typeof id === 'string' && userIds.has(id),
+    );
+    expect(item?.value.createdAt).toBeUndefined();
+    expect(['todo', 'doing', 'done']).toContain(item?.value.status);
+  });
+
+  it('supports scoped generation for the current entity using existing refs', () => {
+    const usersAndLists = generatePlaygroundFixtures(todoSchema, {
+      seed: 'base',
+      typeNames: ['User', 'TodoList'],
+      count: 2,
+    });
+    const items = generatePlaygroundFixtures(todoSchema, {
+      seed: 'items',
+      typeNames: ['TodoItem'],
+      count: 4,
+      existingRecordsByType: usersAndLists.recordsByType,
+    });
+
+    expect(items.warnings).toEqual([]);
+    expect(items.recordsByType.TodoItem).toHaveLength(4);
+  });
+
+  it('warns when required refs cannot be resolved', () => {
+    const result = generatePlaygroundFixtures(todoSchema, {
+      seed: 'items-only',
+      typeNames: ['TodoItem'],
+      count: 1,
+    });
+
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          typeName: 'TodoItem',
+          fieldName: 'listId',
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/core/tests/playground-fixtures.test.ts
+++ b/packages/core/tests/playground-fixtures.test.ts
@@ -51,6 +51,38 @@ const todoSchema: Schema = {
   ],
 };
 
+const pantrySchema: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Household',
+      table: true,
+      fields: [{ name: 'name', type: { kind: 'string' } }],
+    },
+    {
+      kind: 'object',
+      name: 'PantryItem',
+      table: true,
+      fields: [
+        { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+        { name: 'name', type: { kind: 'string' } },
+        { name: 'quantity', type: { kind: 'string' } },
+        { name: 'notes', type: { kind: 'string' }, optional: true },
+      ],
+    },
+    {
+      kind: 'object',
+      name: 'Recipe',
+      table: true,
+      fields: [
+        { name: 'name', type: { kind: 'string' } },
+        { name: 'description', type: { kind: 'string' }, optional: true },
+      ],
+    },
+  ],
+};
+
 describe('generatePlaygroundFixtures', () => {
   it('generates dependency-aware table records with valid refs and semantic values', () => {
     const result = generatePlaygroundFixtures(todoSchema, {
@@ -115,5 +147,24 @@ describe('generatePlaygroundFixtures', () => {
         }),
       ]),
     );
+  });
+
+  it('uses entity-aware semantics for pantry and household records', () => {
+    const result = generatePlaygroundFixtures(pantrySchema, {
+      seed: 'pantry-demo',
+      countsByType: { Household: 1, PantryItem: 3, Recipe: 2 },
+    });
+
+    const household = result.recordsByType.Household?.[0];
+    const pantryItem = result.recordsByType.PantryItem?.[0];
+    const recipe = result.recordsByType.Recipe?.[0];
+
+    expect(result.warnings).toEqual([]);
+    expect(household?.value.name).toMatch(/^The .+ Household$/);
+    expect(pantryItem?.value.name).toEqual(expect.any(String));
+    expect(pantryItem?.value.name).not.toMatch(/\s[A-Z][a-z]+$/);
+    expect(pantryItem?.value.quantity).toMatch(/^(1|2|3|500|750) (kg|g|ml|jar|tin|pack)$/);
+    expect(recipe?.value.name).toEqual(expect.any(String));
+    expect(recipe?.value.name).not.toMatch(/^The .+ Household$/);
   });
 });


### PR DESCRIPTION
## Summary
- add a pure Contexture playground contract for deriving entity controls from the IR
- add a desktop Playground tab with ephemeral records, RHF/Zod dynamic forms, and shadcn-style table/field UI
- support responsive compact layouts, table-first record browsing, and add/edit form overlays
- add Faker-backed semantic fixture generation orchestrated by Contexture and validated with Zod
- add seed actions for the current entity and the full model, inserting generated rows into the Playground store

## Checks
- bun run test -- playground-fixtures.test.ts playground-contract.test.ts
- bun run typecheck:web
- bun run typecheck (packages/core)
- bunx biome check targeted files
- pre-commit hook: turbo typecheck and turbo test