### PR TITLE
Fix Playground QA follow-ups

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.28",
+  "version": "0.15.29",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
@@ -67,6 +67,20 @@ export function DetailPanel({
       useGraphSelectionStore.getState().click(op.typeName, 'replace');
       useGraphSelectionStore.getState().focus(op.typeName);
     }
+    if (
+      op.kind === 'update_field' &&
+      op.typeName === selection.typeName &&
+      op.fieldName === selection.fieldName &&
+      typeof op.patch.name === 'string' &&
+      op.patch.name.length > 0 &&
+      op.patch.name !== selection.fieldName
+    ) {
+      useGraphSelectionStore
+        .getState()
+        .selectField({ typeName: op.typeName, fieldName: op.patch.name });
+      useGraphSelectionStore.getState().focus({ nodeId: op.typeName, fieldName: op.patch.name });
+      onSelectField?.(op.typeName, op.patch.name);
+    }
   };
   const dispatchBatch = (ops: readonly Op[]): boolean => {
     const undo = useUndoStore.getState();

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -3,6 +3,7 @@ import {
   buildPlaygroundContract,
   emptyEntityValue,
   type PlaygroundArrayControl,
+  type PlaygroundArrayElementControl,
   type PlaygroundControl,
   type PlaygroundEntity,
   type PlaygroundRefControl,
@@ -59,15 +60,16 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
   const insertRecords = usePlaygroundStore((state) => state.insertRecords);
   const deleteRecord = usePlaygroundStore((state) => state.deleteRecord);
   const clearType = usePlaygroundStore((state) => state.clearType);
-  const pruneTypes = usePlaygroundStore((state) => state.pruneTypes);
+  const setScope = usePlaygroundStore((state) => state.setScope);
+  const scopeId = useMemo(() => schemaScopeId(schema), [schema]);
 
   useEffect(() => {
     const typeNames = contract.entities.map((entity) => entity.typeName);
-    pruneTypes(typeNames);
+    setScope(scopeId, typeNames);
     if (typeNames.length > 0 && (!selectedTypeName || !typeNames.includes(selectedTypeName))) {
       selectType(typeNames[0] ?? null);
     }
-  }, [contract.entities, pruneTypes, selectType, selectedTypeName]);
+  }, [contract.entities, scopeId, selectType, selectedTypeName, setScope]);
 
   const selectedEntity =
     contract.entities.find((entity) => entity.typeName === selectedTypeName) ??
@@ -270,11 +272,15 @@ export function ScopedPlaygroundWorkbench({
   const insertRecords = usePlaygroundStore((state) => state.insertRecords);
   const deleteRecord = usePlaygroundStore((state) => state.deleteRecord);
   const clearType = usePlaygroundStore((state) => state.clearType);
-  const pruneTypes = usePlaygroundStore((state) => state.pruneTypes);
+  const setScope = usePlaygroundStore((state) => state.setScope);
+  const scopeId = useMemo(() => schemaScopeId(schema), [schema]);
 
   useEffect(() => {
-    pruneTypes(contract.entities.map((entity) => entity.typeName));
-  }, [contract.entities, pruneTypes]);
+    setScope(
+      scopeId,
+      contract.entities.map((entity) => entity.typeName),
+    );
+  }, [contract.entities, scopeId, setScope]);
 
   const entity = contract.entities.find((candidate) => candidate.typeName === typeName) ?? null;
   if (!entity) return null;
@@ -1357,6 +1363,8 @@ function zodSchemaForControl(control: PlaygroundControl): z.ZodType {
   switch (control.kind) {
     case 'text': {
       let stringSchema = z.string();
+      if (control.required && !control.serverDerived && control.constraints.min === undefined)
+        stringSchema = stringSchema.min(1, 'Required.');
       if (control.constraints.min !== undefined)
         stringSchema = stringSchema.min(control.constraints.min);
       if (control.constraints.max !== undefined)
@@ -1387,7 +1395,7 @@ function zodSchemaForControl(control: PlaygroundControl): z.ZodType {
       schema = z.boolean();
       break;
     case 'date':
-      schema = z.string();
+      schema = requiredStringSchema(control);
       break;
     case 'literal':
       schema = z.literal(control.constraints.literalValue);
@@ -1399,20 +1407,40 @@ function zodSchemaForControl(control: PlaygroundControl): z.ZodType {
           : z.string();
       break;
     case 'ref':
-      schema = z.string();
+      schema = requiredStringSchema(control);
       break;
     case 'array':
-      schema = z.string().refine((value) => {
-        try {
-          const parsed = JSON.parse(value || '[]');
-          if (!Array.isArray(parsed)) return false;
-          if (control.min !== undefined && parsed.length < control.min) return false;
-          if (control.max !== undefined && parsed.length > control.max) return false;
-          return true;
-        } catch {
-          return false;
+      schema = z.string().superRefine((value, ctx) => {
+        const parsed = parseJsonArray(value);
+        if (!parsed.ok) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Enter a valid JSON array.' });
+          return;
         }
-      }, 'Enter a valid JSON array.');
+        if (control.min !== undefined && parsed.value.length < control.min) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Enter at least ${control.min} items.`,
+          });
+          return;
+        }
+        if (control.max !== undefined && parsed.value.length > control.max) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Enter at most ${control.max} items.`,
+          });
+          return;
+        }
+        const elementSchema = zodSchemaForArrayElement(control.element);
+        for (const [index, item] of parsed.value.entries()) {
+          if (!elementSchema.safeParse(item).success) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Item ${index + 1} does not match the array element type.`,
+            });
+            return;
+          }
+        }
+      });
       break;
     case 'object':
       schema = zodSchemaForControls(control.fields);
@@ -1428,8 +1456,70 @@ function zodSchemaForControl(control: PlaygroundControl): z.ZodType {
   return schema;
 }
 
+function requiredStringSchema(control: PlaygroundControl): z.ZodString {
+  return control.required && !control.serverDerived ? z.string().min(1, 'Required.') : z.string();
+}
+
+function zodSchemaForArrayElement(element: PlaygroundArrayElementControl): z.ZodType {
+  switch (element.kind) {
+    case 'text': {
+      let stringSchema = z.string();
+      if (element.constraints.min !== undefined)
+        stringSchema = stringSchema.min(element.constraints.min);
+      if (element.constraints.max !== undefined)
+        stringSchema = stringSchema.max(element.constraints.max);
+      if (element.constraints.regex)
+        stringSchema = stringSchema.regex(new RegExp(element.constraints.regex));
+      if (element.constraints.format === 'email') stringSchema = stringSchema.email();
+      if (element.constraints.format === 'url') stringSchema = stringSchema.url();
+      if (element.constraints.format === 'uuid') stringSchema = stringSchema.uuid();
+      if (element.constraints.format === 'datetime') stringSchema = stringSchema.datetime();
+      return stringSchema;
+    }
+    case 'number': {
+      let numberSchema = z.number();
+      if (element.constraints.int) numberSchema = numberSchema.int();
+      if (element.constraints.min !== undefined)
+        numberSchema = numberSchema.min(element.constraints.min);
+      if (element.constraints.max !== undefined)
+        numberSchema = numberSchema.max(element.constraints.max);
+      return numberSchema;
+    }
+    case 'boolean':
+      return z.boolean();
+    case 'date':
+    case 'ref':
+      return z.string().min(1);
+    case 'literal':
+      return z.literal(element.constraints.literalValue);
+    case 'enum':
+      return element.options.length > 0
+        ? z.enum(element.options.map((option) => option.value) as [string, ...string[]])
+        : z.string();
+    case 'array':
+      return z.array(zodSchemaForArrayElement(element.element));
+    case 'object':
+      return zodSchemaForControls(element.fields);
+    case 'unsupported':
+      return z.unknown();
+  }
+}
+
+function parseJsonArray(value: string): { ok: true; value: unknown[] } | { ok: false } {
+  try {
+    const parsed = JSON.parse(value || '[]');
+    return Array.isArray(parsed) ? { ok: true, value: parsed } : { ok: false };
+  } catch {
+    return { ok: false };
+  }
+}
+
 function emptyStringToUndefined(schema: z.ZodType): z.ZodType {
   return z.preprocess((value) => (value === '' ? undefined : value), schema);
+}
+
+function schemaScopeId(schema: Schema): string {
+  return `schema:${JSON.stringify(schema)}`;
 }
 
 function recordLabel(entity: PlaygroundEntity, record: PlaygroundRecord): string {

--- a/apps/desktop/src/renderer/src/store/playground.ts
+++ b/apps/desktop/src/renderer/src/store/playground.ts
@@ -12,7 +12,10 @@ interface PlaygroundStoreShape {
   selectedTypeName: string | null;
   selectedRecordId: string | null;
   recordsByType: Record<string, PlaygroundRecord[]>;
+  activeScopeId: string;
+  recordsByScope: Record<string, Record<string, PlaygroundRecord[]>>;
 
+  setScope(scopeId: string, typeNames?: readonly string[]): void;
   selectType(typeName: string | null): void;
   selectRecord(typeName: string, recordId: string | null): void;
   upsertRecord(typeName: string, recordId: string | null, value: Record<string, unknown>): string;
@@ -30,6 +33,36 @@ export const usePlaygroundStore = create<PlaygroundStoreShape>((set, get) => ({
   selectedTypeName: null,
   selectedRecordId: null,
   recordsByType: {},
+  activeScopeId: 'default',
+  recordsByScope: { default: {} },
+
+  setScope: (scopeId, typeNames) => {
+    const currentScopeId = get().activeScopeId;
+    set((state) => {
+      const recordsByScope = {
+        ...state.recordsByScope,
+        [currentScopeId]: state.recordsByType,
+      };
+      let recordsByType = recordsByScope[scopeId] ?? {};
+      if (typeNames) {
+        recordsByType = pruneRecordsByType(recordsByType, typeNames);
+      }
+      recordsByScope[scopeId] = recordsByType;
+      const selectedTypeName =
+        state.selectedTypeName && (!typeNames || typeNames.includes(state.selectedTypeName))
+          ? state.selectedTypeName
+          : null;
+      return {
+        activeScopeId: scopeId,
+        recordsByScope,
+        recordsByType,
+        selectedTypeName,
+        selectedRecordId: selectedTypeName
+          ? selectedRecordIdFor(recordsByType[selectedTypeName] ?? [], state.selectedRecordId)
+          : null,
+      };
+    });
+  },
 
   selectType: (typeName) => {
     const records = typeName ? (get().recordsByType[typeName] ?? []) : [];
@@ -61,6 +94,10 @@ export const usePlaygroundStore = create<PlaygroundStoreShape>((set, get) => ({
 
     set((state) => ({
       recordsByType: { ...state.recordsByType, [typeName]: nextRecords },
+      recordsByScope: {
+        ...state.recordsByScope,
+        [state.activeScopeId]: { ...state.recordsByType, [typeName]: nextRecords },
+      },
       selectedTypeName: typeName,
       selectedRecordId: id,
     }));
@@ -91,6 +128,7 @@ export const usePlaygroundStore = create<PlaygroundStoreShape>((set, get) => ({
       const selectedTypeName = state.selectedTypeName ?? Object.keys(nextRecordsByType)[0] ?? null;
       return {
         recordsByType,
+        recordsByScope: { ...state.recordsByScope, [state.activeScopeId]: recordsByType },
         selectedTypeName,
         selectedRecordId: selectedTypeName
           ? (recordsByType[selectedTypeName]?.[0]?.id ?? null)
@@ -104,6 +142,10 @@ export const usePlaygroundStore = create<PlaygroundStoreShape>((set, get) => ({
     const nextRecords = records.filter((record) => record.id !== recordId);
     set((state) => ({
       recordsByType: { ...state.recordsByType, [typeName]: nextRecords },
+      recordsByScope: {
+        ...state.recordsByScope,
+        [state.activeScopeId]: { ...state.recordsByType, [typeName]: nextRecords },
+      },
       selectedTypeName: typeName,
       selectedRecordId:
         state.selectedRecordId === recordId ? (nextRecords[0]?.id ?? null) : state.selectedRecordId,
@@ -113,28 +155,58 @@ export const usePlaygroundStore = create<PlaygroundStoreShape>((set, get) => ({
   clearType: (typeName) => {
     set((state) => ({
       recordsByType: { ...state.recordsByType, [typeName]: [] },
+      recordsByScope: {
+        ...state.recordsByScope,
+        [state.activeScopeId]: { ...state.recordsByType, [typeName]: [] },
+      },
       selectedRecordId: state.selectedTypeName === typeName ? null : state.selectedRecordId,
     }));
   },
 
-  clearAll: () => set({ recordsByType: {}, selectedRecordId: null }),
+  clearAll: () =>
+    set((state) => ({
+      recordsByType: {},
+      recordsByScope: { ...state.recordsByScope, [state.activeScopeId]: {} },
+      selectedRecordId: null,
+    })),
 
   pruneTypes: (typeNames) => {
-    const allowed = new Set(typeNames);
     set((state) => {
-      const recordsByType: Record<string, PlaygroundRecord[]> = {};
-      for (const [typeName, records] of Object.entries(state.recordsByType)) {
-        if (allowed.has(typeName)) recordsByType[typeName] = records;
-      }
+      const recordsByType = pruneRecordsByType(state.recordsByType, typeNames);
       const selectedTypeName =
-        state.selectedTypeName && allowed.has(state.selectedTypeName)
+        state.selectedTypeName && typeNames.includes(state.selectedTypeName)
           ? state.selectedTypeName
           : null;
       return {
         recordsByType,
+        recordsByScope: { ...state.recordsByScope, [state.activeScopeId]: recordsByType },
         selectedTypeName,
-        selectedRecordId: selectedTypeName ? state.selectedRecordId : null,
+        selectedRecordId: selectedTypeName
+          ? selectedRecordIdFor(recordsByType[selectedTypeName] ?? [], state.selectedRecordId)
+          : null,
       };
     });
   },
 }));
+
+function selectedRecordIdFor(
+  records: readonly PlaygroundRecord[],
+  currentRecordId: string | null,
+): string | null {
+  if (currentRecordId && records.some((record) => record.id === currentRecordId)) {
+    return currentRecordId;
+  }
+  return records[0]?.id ?? null;
+}
+
+function pruneRecordsByType(
+  recordsByType: Record<string, PlaygroundRecord[]>,
+  typeNames: readonly string[],
+): Record<string, PlaygroundRecord[]> {
+  const allowed = new Set(typeNames);
+  const next: Record<string, PlaygroundRecord[]> = {};
+  for (const [typeName, records] of Object.entries(recordsByType)) {
+    if (allowed.has(typeName)) next[typeName] = records;
+  }
+  return next;
+}

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -135,6 +135,35 @@ describe('DetailPanel', () => {
     expect(onClearSelectedField).toHaveBeenCalledOnce();
   });
 
+  it('keeps field detail focused on the field after it is renamed', async () => {
+    const user = userEvent.setup();
+    const onSelectField = vi.fn();
+    seed(plotSchema);
+    useGraphSelectionStore.getState().selectField({ typeName: 'Plot', fieldName: 'name' });
+
+    render(
+      <DetailPanel
+        selection={{ typeName: 'Plot', fieldName: 'name' }}
+        onSelectField={onSelectField}
+      />,
+    );
+
+    const input = screen.getByLabelText('Name');
+    await user.clear(input);
+    await user.type(input, 'title');
+    fireEvent.blur(input);
+
+    expect(useGraphSelectionStore.getState().state.selectedField).toEqual({
+      typeName: 'Plot',
+      fieldName: 'title',
+    });
+    expect(useGraphSelectionStore.getState().state.focusTarget).toEqual({
+      nodeId: 'Plot',
+      fieldName: 'title',
+    });
+    expect(onSelectField).toHaveBeenCalledWith('Plot', 'title');
+  });
+
   it('derives model shape guidance for the selected type from the schema', () => {
     seed(artworkSchema);
     render(<DetailPanel selection={{ typeName: 'ArtworkMedia' }} />);

--- a/apps/desktop/tests/components/playground/PlaygroundPanel.test.tsx
+++ b/apps/desktop/tests/components/playground/PlaygroundPanel.test.tsx
@@ -1,0 +1,73 @@
+import type { Schema } from '@contexture/core/ir';
+import { PlaygroundPanel } from '@renderer/components/playground/PlaygroundPanel';
+import { usePlaygroundStore } from '@renderer/store/playground';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const schema: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'User',
+      table: true,
+      fields: [
+        { name: 'name', type: { kind: 'string' } },
+        { name: 'bornOn', type: { kind: 'date' } },
+        { name: 'tagIds', type: { kind: 'array', element: { kind: 'string' } } },
+      ],
+    },
+  ],
+};
+
+describe('PlaygroundPanel', () => {
+  beforeEach(() => {
+    usePlaygroundStore.setState({
+      selectedTypeName: null,
+      selectedRecordId: null,
+      recordsByType: {},
+      activeScopeId: 'default',
+      recordsByScope: { default: {} },
+    });
+  });
+
+  afterEach(cleanup);
+
+  it('blocks required empty string and date values when saving manually', async () => {
+    const user = userEvent.setup();
+    render(<PlaygroundPanel schema={schema} />);
+
+    await user.click(screen.getByRole('button', { name: 'New record' }));
+    await user.clear(screen.getByLabelText('Name'));
+    await user.clear(screen.getByLabelText('Born On'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(usePlaygroundStore.getState().recordsByType.User).toBeUndefined();
+    expect(screen.getAllByText('Required.').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('validates JSON array item types before saving manually', async () => {
+    const user = userEvent.setup();
+    render(<PlaygroundPanel schema={schema} />);
+
+    await user.click(screen.getByRole('button', { name: 'New record' }));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Ada Lovelace' } });
+    fireEvent.change(screen.getByLabelText('Born On'), { target: { value: '1815-12-10' } });
+    fireEvent.change(screen.getByLabelText('Tag Ids'), { target: { value: '[1]' } });
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(usePlaygroundStore.getState().recordsByType.User).toBeUndefined();
+    expect(screen.getByText('Item 1 does not match the array element type.')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Tag Ids'), { target: { value: '["primary"]' } });
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(usePlaygroundStore.getState().recordsByType.User?.[0]?.value).toMatchObject({
+      name: 'Ada Lovelace',
+      bornOn: '1815-12-10',
+      tagIds: ['primary'],
+    });
+    expect(screen.getAllByText('Ada Lovelace').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/tests/store/playground.test.ts
+++ b/apps/desktop/tests/store/playground.test.ts
@@ -1,0 +1,41 @@
+import { usePlaygroundStore } from '@renderer/store/playground';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('playground store', () => {
+  beforeEach(() => {
+    usePlaygroundStore.setState({
+      selectedTypeName: null,
+      selectedRecordId: null,
+      recordsByType: {},
+      activeScopeId: 'default',
+      recordsByScope: { default: {} },
+    });
+  });
+
+  it('keeps records isolated by schema scope even when type names match', () => {
+    const store = usePlaygroundStore.getState();
+
+    store.setScope('schema:one', ['User']);
+    const firstId = usePlaygroundStore
+      .getState()
+      .upsertRecord('User', null, { name: 'Ada Lovelace' });
+
+    usePlaygroundStore.getState().setScope('schema:two', ['User']);
+    expect(usePlaygroundStore.getState().recordsByType.User).toBeUndefined();
+    expect(usePlaygroundStore.getState().selectedRecordId).toBeNull();
+
+    const secondId = usePlaygroundStore
+      .getState()
+      .upsertRecord('User', null, { name: 'Grace Hopper' });
+    expect(usePlaygroundStore.getState().recordsByType.User?.[0]).toMatchObject({
+      id: secondId,
+      value: { name: 'Grace Hopper' },
+    });
+
+    usePlaygroundStore.getState().setScope('schema:one', ['User']);
+    expect(usePlaygroundStore.getState().recordsByType.User?.[0]).toMatchObject({
+      id: firstId,
+      value: { name: 'Ada Lovelace' },
+    });
+  });
+});

--- a/packages/core/src/playground-fixtures.ts
+++ b/packages/core/src/playground-fixtures.ts
@@ -595,7 +595,7 @@ function zodSchemaForControl(control: PlaygroundControl): z.ZodType {
       schema = z.string();
       break;
     case 'array':
-      schema = z.array(z.unknown());
+      schema = z.array(zodSchemaForArrayElement(control.element));
       break;
     case 'object':
       schema = z.object(
@@ -614,6 +614,57 @@ function zodSchemaForControl(control: PlaygroundControl): z.ZodType {
   if (control.nullable) schema = schema.nullable();
   if (!control.required) schema = schema.optional();
   return schema;
+}
+
+function zodSchemaForArrayElement(element: PlaygroundArrayElementControl): z.ZodType {
+  switch (element.kind) {
+    case 'text': {
+      let stringSchema = z.string();
+      if (element.constraints.min !== undefined)
+        stringSchema = stringSchema.min(element.constraints.min);
+      if (element.constraints.max !== undefined)
+        stringSchema = stringSchema.max(element.constraints.max);
+      if (element.constraints.regex)
+        stringSchema = stringSchema.regex(new RegExp(element.constraints.regex));
+      if (element.constraints.format === 'email') stringSchema = stringSchema.email();
+      if (element.constraints.format === 'url') stringSchema = stringSchema.url();
+      if (element.constraints.format === 'uuid') stringSchema = stringSchema.uuid();
+      if (element.constraints.format === 'datetime') stringSchema = stringSchema.datetime();
+      return stringSchema;
+    }
+    case 'number': {
+      let numberSchema = z.number();
+      if (element.constraints.int) numberSchema = numberSchema.int();
+      if (element.constraints.min !== undefined)
+        numberSchema = numberSchema.min(element.constraints.min);
+      if (element.constraints.max !== undefined)
+        numberSchema = numberSchema.max(element.constraints.max);
+      return numberSchema;
+    }
+    case 'boolean':
+      return z.boolean();
+    case 'date':
+    case 'ref':
+      return z.string().min(1);
+    case 'literal':
+      return z.literal(element.constraints.literalValue);
+    case 'enum':
+      return element.options.length > 0
+        ? z.enum(element.options.map((option) => option.value) as [string, ...string[]])
+        : z.string();
+    case 'array':
+      return z.array(zodSchemaForArrayElement(element.element));
+    case 'object':
+      return z.object(
+        Object.fromEntries(
+          element.fields
+            .filter((field) => !field.serverDerived && field.kind !== 'unsupported')
+            .map((field) => [field.fieldName, zodSchemaForControl(field)]),
+        ),
+      );
+    case 'unsupported':
+      return z.unknown();
+  }
 }
 
 function orderEntitiesForRefs(entities: readonly PlaygroundEntity[]): PlaygroundEntity[] {


### PR DESCRIPTION
## Summary
- Scope Playground sample records per schema so matching table names do not leak data across models
- Tighten Playground form validation for required strings/dates/refs and typed JSON arrays
- Keep field detail focused after successful field renames
- Bump desktop app version to 0.15.29

## Verification
- cd apps/desktop && bun run test -- tests/store/playground.test.ts tests/components/playground/PlaygroundPanel.test.tsx tests/components/detail/DetailPanel.test.tsx
- cd packages/core && bun run test -- tests/playground-contract.test.ts tests/playground-fixtures.test.ts tests/fixture-generators.test.ts
- bun run ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782990108&installation_id=136251083&pr_number=350&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F350&signature=e442eb4199f3b9687b50a96ac06a97caf55e86506c89870b4c7e7f0db3cc2a01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->