### PR TITLE
feat(desktop): dock agent turn details in chat composer

### DIFF
--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -12,8 +12,9 @@
  *   - Message list rendered as user bubbles (right-aligned primary),
  *     tool-use status lines (small monospace chips), and assistant
  *     markdown via `Streamdown`.
- *   - Prompt input as a single rounded card: textarea + Model select +
- *     Effort (thinking budget) select + Send / Stop button.
+ *   - Prompt input as a docked rounded surface: recent agent turn summary
+ *     (when present) + textarea + Model select + Effort (thinking budget)
+ *     select + Send / Stop button.
  *
  * File-backed threads live in localStorage (see `useChatThreads`). Each
  * can carry a provider-owned thread ref; switching threads pushes that
@@ -58,7 +59,7 @@ import {
   X,
   XCircle,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Streamdown } from 'streamdown';
 import { Badge } from '@/components/ui/badge';
 import { BorderBeam } from '@/components/ui/border-beam';
@@ -77,7 +78,6 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '@/components/ui/empty';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Select,
   SelectContent,
@@ -420,7 +420,7 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
           onDelete={handleDeleteThread}
         />
       ) : (
-        <div className="flex-1 overflow-y-auto p-3 space-y-3" data-testid="chat-transcript">
+        <div className="flex-1 overflow-y-auto p-3 pb-2 space-y-3" data-testid="chat-transcript">
           {messages.length === 0 && (
             <Empty className="border-0 p-4">
               <EmptyHeader>
@@ -482,20 +482,28 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
               </button>
             </div>
           )}
-          {recentAgentTurn && (
-            <AgentTurnSummaryCard
-              turn={recentAgentTurn}
-              isWaitingForFinalResponse={isWaitingForFinalResponse}
-            />
-          )}
           <div ref={messagesEndRef} />
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="p-3 border-t border-border">
+      <form
+        onSubmit={handleSubmit}
+        className="p-3 border-t border-border"
+        data-testid="chat-composer"
+      >
+        {recentAgentTurn && (
+          <div className="-mb-px px-2" data-testid="agent-turn-dock">
+            <AgentTurnSummaryCard
+              turn={recentAgentTurn}
+              isWaitingForFinalResponse={isWaitingForFinalResponse}
+              docked
+            />
+          </div>
+        )}
         <div
           className={cn(
-            'rounded-xl border border-input bg-card transition-shadow',
+            'relative rounded-xl border border-input bg-card transition-shadow',
+            recentAgentTurn && 'rounded-t-lg',
             'focus-within:ring-1 focus-within:ring-ring',
             (!isReady || isStreaming) && 'opacity-60',
           )}
@@ -692,9 +700,11 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
 function AgentTurnSummaryCard({
   turn,
   isWaitingForFinalResponse,
+  docked = false,
 }: {
   turn: AgentTurnRecord;
   isWaitingForFinalResponse: boolean;
+  docked?: boolean;
 }): React.JSX.Element {
   const applied = turn.ops.filter((op) => op.status === 'applied').length;
   const rejected = turn.ops.filter((op) => op.status === 'rejected').length;
@@ -719,100 +729,116 @@ function AgentTurnSummaryCard({
     markRolledBack(turn.id);
   }, [canUndoTurn, markRolledBack, turn.id, undo]);
 
+  const [expanded, setExpanded] = useState(false);
+  const detailId = useId();
+
   return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className={cn(
-            'group relative w-full overflow-hidden rounded-lg border border-border/70 bg-card px-3 py-3 text-left text-xs text-muted-foreground shadow-sm transition-colors',
-            'hover:border-primary/30 hover:bg-accent/35 focus:outline-none focus:ring-1 focus:ring-ring',
-          )}
-          data-testid="agent-turn-summary"
-        >
-          {isWaitingForFinalResponse && (
-            <span data-testid="agent-turn-pending-highlight">
-              <BorderBeam duration={6} size={100} />
-            </span>
-          )}
-          <div className="flex items-start gap-2.5">
-            <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border border-primary/15 bg-primary/10 text-primary">
-              <Wrench className="size-3.5" aria-hidden="true" />
+    <div className="w-full" data-testid="agent-turn-pane">
+      <button
+        type="button"
+        className={cn(
+          'relative w-full overflow-hidden border border-border/70 bg-card px-3 py-3 text-left text-xs text-muted-foreground shadow-sm transition-colors',
+          'hover:border-primary/30 hover:bg-accent/35 focus:outline-none focus:ring-1 focus:ring-ring',
+          docked && expanded && 'rounded-t-xl rounded-b-none border-b-border/70',
+          docked && !expanded && 'rounded-t-xl rounded-b-none border-b-input',
+          !docked && expanded && 'rounded-t-lg rounded-b-none',
+          !docked && !expanded && 'rounded-lg',
+        )}
+        data-testid="agent-turn-summary"
+        aria-expanded={expanded}
+        aria-controls={detailId}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        {isWaitingForFinalResponse && (
+          <span data-testid="agent-turn-pending-highlight">
+            <BorderBeam duration={6} size={100} />
+          </span>
+        )}
+        <div className="flex items-start gap-2.5">
+          <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border border-primary/15 bg-primary/10 text-primary">
+            <Wrench className="size-3.5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0 truncate text-sm font-semibold leading-5 text-foreground">
+                {turn.summary}
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                {turn.status === 'committed' && applied > 0 && (
+                  <CheckCircle2 className="size-4 text-success" aria-hidden="true" />
+                )}
+                {turn.status === 'rolled_back' && (
+                  <RotateCcw className="size-4 text-muted-foreground" aria-hidden="true" />
+                )}
+                <ChevronRight
+                  className={cn(
+                    'size-3.5 text-muted-foreground transition-transform',
+                    expanded && 'rotate-90',
+                  )}
+                  aria-hidden="true"
+                />
+              </div>
             </div>
-            <div className="min-w-0 flex-1">
-              <div className="flex items-start justify-between gap-2">
-                <div className="min-w-0 truncate text-sm font-semibold leading-5 text-foreground">
-                  {turn.summary}
-                </div>
-                <div className="flex shrink-0 items-center gap-1">
-                  {turn.status === 'committed' && applied > 0 && (
-                    <CheckCircle2 className="size-4 text-success" aria-hidden="true" />
-                  )}
-                  {turn.status === 'rolled_back' && (
-                    <RotateCcw className="size-4 text-muted-foreground" aria-hidden="true" />
-                  )}
-                  <ChevronRight
-                    className="size-3.5 text-muted-foreground transition-transform group-data-[state=open]:rotate-90"
-                    aria-hidden="true"
-                  />
-                </div>
-              </div>
-              <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-                <Badge variant="outline" className="h-5 px-1.5 py-0 text-[11px] font-medium">
-                  {turnStatusLabel(turn.status)}
+            <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+              <Badge variant="outline" className="h-5 px-1.5 py-0 text-[11px] font-medium">
+                {turnStatusLabel(turn.status)}
+              </Badge>
+              {toolCount > 0 && (
+                <Badge variant="secondary" className="h-5 px-1.5 py-0 text-[11px] font-medium">
+                  {toolCount} tool {toolCount === 1 ? 'call' : 'calls'}
                 </Badge>
-                {toolCount > 0 && (
-                  <Badge variant="secondary" className="h-5 px-1.5 py-0 text-[11px] font-medium">
-                    {toolCount} tool {toolCount === 1 ? 'call' : 'calls'}
-                  </Badge>
-                )}
-                <Badge variant="outline" className="h-5 px-1.5 py-0 text-[11px] font-medium">
-                  {applied} applied
+              )}
+              <Badge variant="outline" className="h-5 px-1.5 py-0 text-[11px] font-medium">
+                {applied} applied
+              </Badge>
+              {rejected > 0 && (
+                <Badge
+                  variant="outline"
+                  className="h-5 border-destructive/30 px-1.5 py-0 text-[11px] font-medium text-destructive"
+                >
+                  {rejected} rejected
                 </Badge>
-                {rejected > 0 && (
-                  <Badge
-                    variant="outline"
-                    className="h-5 border-destructive/30 px-1.5 py-0 text-[11px] font-medium text-destructive"
-                  >
-                    {rejected} rejected
-                  </Badge>
-                )}
-                {pending > 0 && (
-                  <Badge variant="outline" className="h-5 px-1.5 py-0 text-[11px] font-medium">
-                    {pending} pending
-                  </Badge>
-                )}
-              </div>
-              <div className="mt-2 grid gap-1.5">
-                {toolSummary && (
-                  <div
-                    className="flex min-w-0 items-center gap-1.5 rounded-md bg-muted/60 px-2 py-1 text-[11px] text-muted-foreground"
-                    data-testid="agent-turn-tool-summary"
-                  >
-                    <Wrench className="size-3 shrink-0" aria-hidden="true" />
-                    <span className="truncate font-mono">{toolSummary}</span>
-                  </div>
-                )}
-                {diffRows.length > 0 && (
-                  <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
-                    <CheckCircle2 className="size-3 shrink-0 text-success" aria-hidden="true" />
-                    <span className="truncate">{diffRows.slice(0, 2).join(', ')}</span>
-                  </div>
-                )}
-              </div>
+              )}
+              {pending > 0 && (
+                <Badge variant="outline" className="h-5 px-1.5 py-0 text-[11px] font-medium">
+                  {pending} pending
+                </Badge>
+              )}
+            </div>
+            <div className="mt-2 grid gap-1.5">
+              {toolSummary && (
+                <div
+                  className="flex min-w-0 items-center gap-1.5 rounded-md bg-muted/60 px-2 py-1 text-[11px] text-muted-foreground"
+                  data-testid="agent-turn-tool-summary"
+                >
+                  <Wrench className="size-3 shrink-0" aria-hidden="true" />
+                  <span className="truncate font-mono">{toolSummary}</span>
+                </div>
+              )}
+              {diffRows.length > 0 && (
+                <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+                  <CheckCircle2 className="size-3 shrink-0 text-success" aria-hidden="true" />
+                  <span className="truncate">{diffRows.slice(0, 2).join(', ')}</span>
+                </div>
+              )}
             </div>
           </div>
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        side="top"
-        sideOffset={8}
-        className="w-[min(24rem,calc(100vw-2rem))] p-0"
-      >
-        <AgentTurnDetail turn={turn} canUndo={canUndoTurn} onUndo={handleUndo} />
-      </PopoverContent>
-    </Popover>
+        </div>
+      </button>
+      {expanded && (
+        <section
+          id={detailId}
+          className={cn(
+            'max-h-96 overflow-y-auto border-x border-b border-border/70 bg-card',
+            docked ? 'rounded-b-none' : 'rounded-b-lg',
+          )}
+          aria-label="Agent turn details"
+          data-testid="agent-turn-detail"
+        >
+          <AgentTurnDetail turn={turn} canUndo={canUndoTurn} onUndo={handleUndo} />
+        </section>
+      )}
+    </div>
   );
 }
 

--- a/apps/desktop/tests/components/chat/ChatPanel.test.tsx
+++ b/apps/desktop/tests/components/chat/ChatPanel.test.tsx
@@ -9,7 +9,7 @@ import { ChatPanel } from '@renderer/components/chat/ChatPanel';
 import { useAgentTurnsStore } from '@renderer/store/agent-turns';
 import { useDocumentStore } from '@renderer/store/document';
 import { useUndoStore } from '@renderer/store/undo';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 function makeChat(overrides: Partial<SchemaAgentChatState> = {}): SchemaAgentChatState {
@@ -184,6 +184,38 @@ describe('ChatPanel', () => {
       ),
     );
     expect(screen.queryByText('Undo turn')).not.toBeInTheDocument();
+  });
+
+  it('docks the latest agent turn summary with the composer instead of the transcript', () => {
+    useUndoStore.getState().apply({
+      kind: 'add_type',
+      type: { kind: 'object', name: 'Plot', fields: [] },
+    });
+    useAgentTurnsStore.getState().begin({
+      before: { version: '1', types: [] },
+      userMessage: 'add a Plot type',
+      provider: 'codex',
+      model: 'gpt-5.4',
+    });
+    useAgentTurnsStore.getState().recordToolResult({
+      id: '1',
+      op: { kind: 'add_type', type: { kind: 'object', name: 'Plot', fields: [] } },
+      result: { schema: { version: '1', types: [{ kind: 'object', name: 'Plot', fields: [] }] } },
+    });
+    useAgentTurnsStore.getState().finish({
+      status: 'committed',
+      after: { version: '1', types: [{ kind: 'object', name: 'Plot', fields: [] }] },
+    });
+
+    render(<ChatPanel chat={makeChat()} />);
+
+    const composer = within(screen.getByTestId('chat-composer'));
+    expect(composer.getByTestId('agent-turn-summary')).toHaveTextContent(
+      'Agent applied 1 model change',
+    );
+    expect(
+      within(screen.getByTestId('chat-transcript')).queryByTestId('agent-turn-summary'),
+    ).not.toBeInTheDocument();
   });
 
   it('hides legacy inline tool-call messages from the transcript', () => {


### PR DESCRIPTION
## Summary
- dock the latest agent turn summary with the chat composer instead of the scrollable transcript
- replace the detached popover with an inline expandable detail pane
- add a regression test that keeps the agent turn summary attached to the composer

## Verification
- bun run test -- tests/components/chat/ChatPanel.test.tsx
- bun run lint
- bun run typecheck:web
- commit hook: turbo typecheck + turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782998803&installation_id=136251083&pr_number=353&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F353&signature=3515b7923f9984ae73e5a60da9970c0eed3c6e6ee66d956deec835bf87ccee20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->