### PR TITLE
feat(desktop): add layered graph layout mode

### DIFF
--- a/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
@@ -19,6 +19,7 @@ import { Maximize2, RefreshCw, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Slider } from '@/components/ui/slider';
+import { cn } from '@/lib/utils';
 
 interface Props {
   onClose: () => void;
@@ -31,6 +32,11 @@ export function GraphControlsPanel({ onClose }: Props): React.JSX.Element {
 
   function handleRelayout(): void {
     document.dispatchEvent(new CustomEvent('graph:relayout'));
+  }
+
+  function handleLayoutModeChange(layoutMode: 'organic' | 'layered'): void {
+    setGraphLayout({ layoutMode });
+    setTimeout(() => document.dispatchEvent(new CustomEvent('graph:relayout')), 0);
   }
 
   function handleFit(): void {
@@ -57,6 +63,36 @@ export function GraphControlsPanel({ onClose }: Props): React.JSX.Element {
         <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
           Layout
         </p>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground w-16">Mode</span>
+          <fieldset
+            className="grid h-7 flex-1 grid-cols-2 overflow-hidden rounded-md border border-input bg-background shadow-sm"
+            aria-label="Layout mode"
+          >
+            {(['layered', 'organic'] as const).map((layoutMode) => (
+              <label
+                key={layoutMode}
+                htmlFor={`graph-layout-mode-${layoutMode}`}
+                className={cn(
+                  'flex cursor-pointer items-center justify-center px-2 text-xs font-medium text-muted-foreground transition-colors',
+                  'border-l border-border first:border-l-0 hover:bg-accent hover:text-foreground',
+                  'focus-within:z-10 focus-within:ring-1 focus-within:ring-ring',
+                  graphLayout.layoutMode === layoutMode && 'bg-muted text-foreground',
+                )}
+              >
+                <input
+                  id={`graph-layout-mode-${layoutMode}`}
+                  type="radio"
+                  name="graph-layout-mode"
+                  className="sr-only"
+                  checked={graphLayout.layoutMode === layoutMode}
+                  onChange={() => handleLayoutModeChange(layoutMode)}
+                />
+                {layoutMode === 'layered' ? 'Layered' : 'Organic'}
+              </label>
+            ))}
+          </fieldset>
+        </div>
         <div className="flex items-center gap-2">
           <span className="text-xs text-muted-foreground w-16">Spacing</span>
           <Slider

--- a/apps/desktop/src/renderer/src/hooks/useELKLayout.ts
+++ b/apps/desktop/src/renderer/src/hooks/useELKLayout.ts
@@ -12,22 +12,31 @@ export interface ELKLayoutResult {
 }
 
 /**
- * Build ELK layout options that scale with graph size.
- * Small graphs (≤100 nodes) use stress minimization for organic results.
- * Medium graphs (101-300) use stress with reduced iterations.
- * Large graphs (>300) switch to the much faster layered algorithm.
+ * Build ELK layout options that scale with graph size and user intent.
+ * Organic uses stress minimization for a loose map. Layered uses the
+ * Sugiyama pipeline, which is better for crossing reduction in directed
+ * schema relationships.
  */
-function buildLayoutOptions(nodeCount: number, nodeGap: number): Record<string, string> {
-  if (nodeCount > 300) {
-    // Layered (Sugiyama) — O(n log n), handles 1000+ nodes comfortably
+export function buildLayoutOptions(
+  nodeCount: number,
+  nodeGap: number,
+  layout?: Partial<GraphLayout>,
+): Record<string, string> {
+  const layoutMode = layout?.layoutMode ?? 'layered';
+
+  if (layoutMode === 'layered' || nodeCount > 300) {
+    const layerGap = Math.round(nodeGap * 1.6);
     return {
       'elk.algorithm': 'org.eclipse.elk.layered',
-      'elk.layered.spacing.nodeNodeBetweenLayers': String(nodeGap * 1.5),
+      'elk.direction': 'RIGHT',
+      'elk.padding': '[top=50, left=50, bottom=50, right=50]',
       'elk.spacing.nodeNode': String(nodeGap),
+      'elk.edgeRouting': 'SPLINES',
+      'elk.layered.spacing.nodeNodeBetweenLayers': String(layerGap),
+      'elk.layered.layering.strategy': 'NETWORK_SIMPLEX',
       'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
       'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
-      'elk.padding': '[top=50, left=50, bottom=50, right=50]',
-      'elk.edgeRouting': 'SPLINES',
+      'elk.layered.thoroughness': '20',
     };
   }
 
@@ -68,7 +77,7 @@ export function useELKLayout() {
 
       const elkGraph = {
         id: 'root',
-        layoutOptions: buildLayoutOptions(layoutChildren.length, nodeGap),
+        layoutOptions: buildLayoutOptions(layoutChildren.length, nodeGap, layout),
         children: layoutChildren,
         edges: edges.map((e) => ({
           id: e.id,

--- a/apps/desktop/src/renderer/src/store/layout-config.ts
+++ b/apps/desktop/src/renderer/src/store/layout-config.ts
@@ -8,12 +8,14 @@
 import { create } from 'zustand';
 
 export interface GraphLayout {
+  layoutMode: 'organic' | 'layered';
   nodeSpacing: number;
   showEnums: boolean;
   showEdgeLabels: boolean;
 }
 
 export const DEFAULT_LAYOUT: GraphLayout = {
+  layoutMode: 'layered',
   nodeSpacing: 180,
   showEnums: false,
   showEdgeLabels: true,

--- a/apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx
+++ b/apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx
@@ -30,14 +30,35 @@ describe('GraphControlsPanel', () => {
 
   it('resets visibility controls to defaults', () => {
     vi.useFakeTimers();
-    useGraphLayoutStore
-      .getState()
-      .setGraphLayout({ showEnums: false, showEdgeLabels: false, nodeSpacing: 240 });
+    useGraphLayoutStore.getState().setGraphLayout({
+      layoutMode: 'organic',
+      showEnums: false,
+      showEdgeLabels: false,
+      nodeSpacing: 240,
+    });
     render(<GraphControlsPanel onClose={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
     vi.runOnlyPendingTimers();
 
     expect(useGraphLayoutStore.getState().graphLayout).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it('switches layout mode and requests a re-layout', () => {
+    vi.useFakeTimers();
+    const relayoutListener = vi.fn();
+    document.addEventListener('graph:relayout', relayoutListener);
+    render(<GraphControlsPanel onClose={vi.fn()} />);
+
+    expect(screen.getByRole('radio', { name: 'Layered' })).toBeChecked();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Organic' }));
+    vi.runOnlyPendingTimers();
+
+    expect(useGraphLayoutStore.getState().graphLayout.layoutMode).toBe('organic');
+    expect(screen.getByRole('radio', { name: 'Organic' })).toBeChecked();
+    expect(relayoutListener).toHaveBeenCalledTimes(1);
+
+    document.removeEventListener('graph:relayout', relayoutListener);
   });
 });

--- a/apps/desktop/tests/hooks/useELKLayout.test.ts
+++ b/apps/desktop/tests/hooks/useELKLayout.test.ts
@@ -1,0 +1,27 @@
+import { buildLayoutOptions } from '@renderer/hooks/useELKLayout';
+import { describe, expect, it } from 'vitest';
+
+describe('buildLayoutOptions', () => {
+  it('uses a crossing-aware layered layout by default', () => {
+    expect(buildLayoutOptions(24, 180)).toMatchObject({
+      'elk.algorithm': 'org.eclipse.elk.layered',
+      'elk.direction': 'RIGHT',
+      'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
+      'elk.layered.layering.strategy': 'NETWORK_SIMPLEX',
+      'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
+    });
+  });
+
+  it('keeps the organic stress layout available for smaller graphs', () => {
+    expect(buildLayoutOptions(24, 180, { layoutMode: 'organic' })).toMatchObject({
+      'elk.algorithm': 'org.eclipse.elk.stress',
+      'elk.stress.desiredEdgeLength': '360',
+    });
+  });
+
+  it('uses layered layout for very large graphs even when organic is selected', () => {
+    expect(buildLayoutOptions(301, 180, { layoutMode: 'organic' })).toMatchObject({
+      'elk.algorithm': 'org.eclipse.elk.layered',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Layered / Organic mode selector to Graph Controls
- make Layered the default crossing-aware graph layout mode while preserving Organic stress layout
- tune ELK layered options for directed schema relationships and add layout option tests

## Verification
- bun run test -- tests/components/toolbar/GraphControlsPanel.test.tsx tests/hooks/useELKLayout.test.ts
- bun run lint
- bun run typecheck:web
- bun run test
- commit hook: turbo typecheck + turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782999407&installation_id=136251083&pr_number=354&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F354&signature=b1e2228e41e2e8cece39ddc2b5ad548f83a6480d62da0791912790ca31ecf163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->