### PR TITLE
fix: support Claude Opus 4.8 model selection

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,7 +27,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.138",
+    "@anthropic-ai/claude-agent-sdk": "0.3.150",
     "@contexture/core": "workspace:*",
     "@contexture/runtime": "workspace:*",
     "@contexture/stdlib": "workspace:*",

--- a/apps/desktop/src/main/providers/claude/runtime.ts
+++ b/apps/desktop/src/main/providers/claude/runtime.ts
@@ -431,6 +431,7 @@ function claudeModelWithContext(
   model: string,
   options: Record<string, string | boolean> | undefined,
 ): string {
+  if (model === 'default') return model;
   const contextWindow = readStringOption(options, 'contextWindow');
   if (contextWindow === '1m' && !model.toLowerCase().includes('[1m]')) return `${model}[1m]`;
   if (contextWindow === '200k') return model.replace(/\[1m\]/gi, '');

--- a/apps/desktop/src/main/providers/model-registry.ts
+++ b/apps/desktop/src/main/providers/model-registry.ts
@@ -46,24 +46,24 @@ const THINKING: ModelOptionDescriptor = {
 
 export const CLAUDE_FALLBACK_MODELS: ModelInfo[] = [
   {
-    id: 'default',
-    label: 'Default',
+    id: 'claude-opus-4-8',
+    label: 'Claude Opus 4.8',
     optionDescriptors: [reasoning(LOW_MED_HIGH_MAX_ULTRA), FAST_MODE, contextWindow()],
   },
   {
-    id: 'haiku',
-    label: 'Haiku',
-    optionDescriptors: [THINKING],
-  },
-  {
-    id: 'sonnet',
-    label: 'Sonnet',
+    id: 'claude-sonnet-4-6',
+    label: 'Claude Sonnet 4.6',
     optionDescriptors: [reasoning(LOW_MED_HIGH_ULTRA), contextWindow()],
   },
   {
-    id: 'opus',
-    label: 'Opus',
-    optionDescriptors: [reasoning(LOW_MED_HIGH_MAX_ULTRA), FAST_MODE, contextWindow()],
+    id: 'claude-haiku-4-5',
+    label: 'Claude Haiku 4.5',
+    optionDescriptors: [THINKING],
+  },
+  {
+    id: 'default',
+    label: 'Default',
+    optionDescriptors: [reasoning(LOW_MED_HIGH_MAX_ULTRA), FAST_MODE],
   },
 ];
 
@@ -165,6 +165,9 @@ function knownClaudeModelOptions(
 ): ModelOptionDescriptor[] {
   const key = `${id} ${displayName} ${description}`.toLowerCase();
   const isOneMillion = key.includes('1m') || key.includes('1m context');
+  if (displayName === 'Default (recommended)') {
+    return [reasoning(LOW_MED_HIGH_MAX_ULTRA), FAST_MODE];
+  }
   if (key.includes('haiku')) return [THINKING];
   if (key.includes('sonnet')) {
     return [reasoning(LOW_MED_HIGH_ULTRA), contextWindow(isOneMillion ? '1m' : undefined)];
@@ -176,9 +179,6 @@ function knownClaudeModelOptions(
     const descriptors: ModelOptionDescriptor[] = [effort, FAST_MODE];
     if (!key.includes('4.5')) descriptors.push(contextWindow(isOneMillion ? '1m' : undefined));
     return descriptors;
-  }
-  if (displayName === 'Default (recommended)') {
-    return [reasoning(LOW_MED_HIGH_MAX_ULTRA), FAST_MODE, contextWindow()];
   }
   return [];
 }

--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -552,119 +552,121 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
               )}
             </div>
           )}
-          <div className="flex items-center gap-1.5 px-2 pb-2">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  disabled={!canCompose}
-                  className="size-7 rounded-lg flex items-center justify-center text-muted-foreground hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                  title="Add context"
-                  aria-label="Add context"
-                  data-testid="chat-add-context"
-                >
-                  <Plus className="size-4" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" side="top" className="w-48">
-                <DropdownMenuItem
-                  onSelect={() => void handleAttachFiles('photos')}
-                  data-testid="chat-add-photos"
-                >
-                  <Image className="size-4" />
-                  Add photos
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onSelect={() => void handleAttachFiles('files')}
-                  data-testid="chat-add-files"
-                >
-                  <File className="size-4" />
-                  Add files
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <Select value={modelSelectValue} onValueChange={setModel}>
-              <SelectTrigger className="w-24 h-7 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectLabel>Model</SelectLabel>
-                  {modelsLoading ? (
-                    <SelectItem value="models-loading" disabled>
-                      Loading models
-                    </SelectItem>
-                  ) : providerModels.length > 0 ? (
-                    providerModels.map((option) => (
-                      <SelectItem key={option.id} value={option.id}>
-                        {option.label}
-                      </SelectItem>
-                    ))
-                  ) : (
-                    <SelectItem value="models-unavailable" disabled>
-                      Models unavailable
-                    </SelectItem>
-                  )}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-            {modelOptionDescriptors.map((descriptor) =>
-              descriptor.type === 'select' ? (
-                <Select
-                  key={descriptor.id}
-                  value={resolveSelectValue(
-                    descriptor.options,
-                    readStringOption(modelOptionValues, descriptor.id),
-                  )}
-                  onValueChange={(value) => {
-                    chat.setModelOption(descriptor.id, value);
-                  }}
-                >
-                  <SelectTrigger
-                    aria-label={descriptor.label}
-                    title={descriptor.label}
-                    className={cn(
-                      'h-7 shrink-0 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5',
-                      descriptor.id === 'contextWindow' ? 'w-16' : 'w-20',
-                    )}
-                    data-testid={
-                      isEffortDescriptor(descriptor)
-                        ? 'chat-effort-select'
-                        : `chat-model-option-${descriptor.id}`
-                    }
+          <div className="flex items-end gap-1.5 px-2 pb-2">
+            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    disabled={!canCompose}
+                    className="size-7 rounded-lg flex items-center justify-center text-muted-foreground hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                    title="Add context"
+                    aria-label="Add context"
+                    data-testid="chat-add-context"
                   >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectLabel>{descriptor.label}</SelectLabel>
-                      {descriptor.options.map((option) => (
+                    <Plus className="size-4" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" side="top" className="w-48">
+                  <DropdownMenuItem
+                    onSelect={() => void handleAttachFiles('photos')}
+                    data-testid="chat-add-photos"
+                  >
+                    <Image className="size-4" />
+                    Add photos
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => void handleAttachFiles('files')}
+                    data-testid="chat-add-files"
+                  >
+                    <File className="size-4" />
+                    Add files
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <Select value={modelSelectValue} onValueChange={setModel}>
+                <SelectTrigger className="w-24 h-7 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>Model</SelectLabel>
+                    {modelsLoading ? (
+                      <SelectItem value="models-loading" disabled>
+                        Loading models
+                      </SelectItem>
+                    ) : providerModels.length > 0 ? (
+                      providerModels.map((option) => (
                         <SelectItem key={option.id} value={option.id}>
                           {option.label}
                         </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              ) : (
-                <div
-                  key={descriptor.id}
-                  className="flex h-7 shrink-0 items-center gap-1.5 px-1.5 text-xs text-muted-foreground"
-                  data-testid={`chat-model-option-${descriptor.id}`}
-                >
-                  <Checkbox
-                    aria-label={descriptor.label}
-                    className="size-3.5"
-                    checked={readBooleanOption(modelOptionValues, descriptor.id, descriptor)}
-                    onCheckedChange={(value) => {
-                      chat.setModelOption(descriptor.id, value === true);
+                      ))
+                    ) : (
+                      <SelectItem value="models-unavailable" disabled>
+                        Models unavailable
+                      </SelectItem>
+                    )}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              {modelOptionDescriptors.map((descriptor) =>
+                descriptor.type === 'select' ? (
+                  <Select
+                    key={descriptor.id}
+                    value={resolveSelectValue(
+                      descriptor.options,
+                      readStringOption(modelOptionValues, descriptor.id),
+                    )}
+                    onValueChange={(value) => {
+                      chat.setModelOption(descriptor.id, value);
                     }}
-                  />
-                  {descriptor.label}
-                </div>
-              ),
-            )}
-            <div className="ml-auto">
+                  >
+                    <SelectTrigger
+                      aria-label={descriptor.label}
+                      title={descriptor.label}
+                      className={cn(
+                        'h-7 shrink-0 text-xs border-0 bg-transparent shadow-none focus:ring-0 px-1.5',
+                        descriptor.id === 'contextWindow' ? 'w-16' : 'w-20',
+                      )}
+                      data-testid={
+                        isEffortDescriptor(descriptor)
+                          ? 'chat-effort-select'
+                          : `chat-model-option-${descriptor.id}`
+                      }
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectLabel>{descriptor.label}</SelectLabel>
+                        {descriptor.options.map((option) => (
+                          <SelectItem key={option.id} value={option.id}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <div
+                    key={descriptor.id}
+                    className="flex h-7 shrink-0 items-center gap-1.5 px-1.5 text-xs text-muted-foreground"
+                    data-testid={`chat-model-option-${descriptor.id}`}
+                  >
+                    <Checkbox
+                      aria-label={descriptor.label}
+                      className="size-3.5"
+                      checked={readBooleanOption(modelOptionValues, descriptor.id, descriptor)}
+                      onCheckedChange={(value) => {
+                        chat.setModelOption(descriptor.id, value === true);
+                      }}
+                    />
+                    {descriptor.label}
+                  </div>
+                ),
+              )}
+            </div>
+            <div className="shrink-0">
               {isStreaming ? (
                 <button
                   type="button"

--- a/apps/desktop/tests/main/claude-runtime.test.ts
+++ b/apps/desktop/tests/main/claude-runtime.test.ts
@@ -107,6 +107,89 @@ describe('ClaudeProviderRuntime', () => {
     );
   });
 
+  it('falls back to the current Claude model IDs when SDK discovery is unavailable', async () => {
+    const runtime = new ClaudeProviderRuntime({
+      execFile: supportedExec(),
+      queryFn: vi.fn(() => {
+        throw new Error('model discovery unavailable');
+      }) as unknown as NonNullable<ClaudeProviderRuntimeOptions['queryFn']>,
+      skillsPluginPath: null,
+    });
+
+    await expect(runtime.listModels()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'claude-opus-4-8',
+          label: 'Claude Opus 4.8',
+          optionDescriptors: expect.arrayContaining([
+            expect.objectContaining({ id: 'contextWindow', type: 'select' }),
+          ]),
+        }),
+        expect.objectContaining({ id: 'claude-sonnet-4-6' }),
+        expect.objectContaining({ id: 'claude-haiku-4-5' }),
+      ]),
+    );
+  });
+
+  it('keeps the 200K/1M context selector for discovered Opus 4.8 models', async () => {
+    const runtime = new ClaudeProviderRuntime({
+      execFile: supportedExec(),
+      queryFn: interruptibleQuery(
+        [],
+        [
+          {
+            value: 'claude-opus-4-8',
+            displayName: 'Claude Opus 4.8',
+            description: '1M context',
+            supportsEffort: true,
+            supportedEffortLevels: ['low', 'medium', 'high', 'max'],
+            supportsFastMode: true,
+          },
+        ],
+      ),
+      skillsPluginPath: null,
+    });
+
+    await expect(runtime.listModels()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'claude-opus-4-8',
+        optionDescriptors: expect.arrayContaining([
+          expect.objectContaining({ id: 'contextWindow', type: 'select' }),
+        ]),
+      }),
+    ]);
+  });
+
+  it('does not expose a context selector for Claude Code default aliases', async () => {
+    const runtime = new ClaudeProviderRuntime({
+      execFile: supportedExec(),
+      queryFn: interruptibleQuery(
+        [],
+        [
+          {
+            value: 'default',
+            displayName: 'Default (recommended)',
+            description: 'Opus 4.8 · Best for complex tasks',
+            supportsEffort: true,
+            supportedEffortLevels: ['low', 'medium', 'high', 'max'],
+            supportsFastMode: true,
+          },
+        ],
+      ),
+      skillsPluginPath: null,
+    });
+
+    await expect(runtime.listModels()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'default',
+        label: 'Default (Opus 4.8)',
+        optionDescriptors: expect.not.arrayContaining([
+          expect.objectContaining({ id: 'contextWindow' }),
+        ]),
+      }),
+    ]);
+  });
+
   it('maps Claude Agent SDK messages to provider events and persists session refs', async () => {
     const queryFn = interruptibleQuery([
       { type: 'system', subtype: 'init', session_id: 'session-1' },
@@ -197,6 +280,38 @@ describe('ClaudeProviderRuntime', () => {
           effort: 'xhigh',
           thinking: { type: 'disabled' },
           settings: { fastMode: true, fastModePerSessionOptIn: true },
+        }),
+      }),
+    );
+  });
+
+  it('does not append context suffixes to Claude Code default aliases', async () => {
+    const queryFn = interruptibleQuery([{ type: 'result', subtype: 'success', is_error: false }]);
+    const runtime = new ClaudeProviderRuntime({
+      execFile: supportedExec(),
+      queryFn,
+      skillsPluginPath: null,
+    });
+    const thread = await runtime.startThread({ schema: { version: '1', types: [] } });
+
+    for await (const _event of runtime.sendTurn({
+      thread,
+      schema: { version: '1', types: [] },
+      message: 'hello',
+      model: 'default',
+      options: {
+        contextWindow: '1m',
+        reasoningEffort: 'high',
+      },
+    })) {
+      // drain
+    }
+
+    expect(queryFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          model: 'default',
+          effort: 'high',
         }),
       }),
     );

--- a/bun.lock
+++ b/bun.lock
@@ -22,9 +22,9 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.28",
+      "version": "0.15.29",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.138",
+        "@anthropic-ai/claude-agent-sdk": "0.3.150",
         "@contexture/core": "workspace:*",
         "@contexture/runtime": "workspace:*",
         "@contexture/stdlib": "workspace:*",
@@ -221,23 +221,23 @@
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.138", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.138", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.138", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.138", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.138", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.138", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.138", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.138", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.138" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-rH6dFI3DBBsPBPcHTBdTZCHA14OCt2t4+6XYi2MJB/GlFrnZvlWmMIk2z9uxAiZ05Txg8YbftgSuE5A1qpAXwg=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.150", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.150", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.150", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.150", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.150", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.150", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.150", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.150", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.150" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-/RgkK5eTgIbzw5VRvH+T/hWeC5P7dCoYEO5ZWlwTSqvjfdVFOZhkiUKf4gz0ONpeLORAetqWU4rIfcVjQAH5fg=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.138", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aObxJ/GeJ5UxT9N8XypUHPYQKpwYsRT5THiJl5E2pKEUk/Xt42gT55N5GV0TOjtgxVAnDMWjxTAgGCGoDzjgpg=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.150", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YVWJ0MHdSy0tobHO2G5/+vd9iRGyosg3wM6sY4pirezsnwZJBkJv/9IeVIaKqdLv83OA6HUcxxOLGzKSBawq2Q=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.138", "", { "os": "darwin", "cpu": "x64" }, "sha512-ou3i1/gAf2PEgVl2WYJb7ZdE+KGwoB1I46JRhWHSC3uD6lb9HMZam233T/rlKCVX9e5dzfkujUOnmCkmXjgVGQ=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.150", "", { "os": "darwin", "cpu": "x64" }, "sha512-72M8mKCa7Tfy66G5hr5z9TirKynQa9sFj+4qDxkAp5LAYnyViUzHOqO6mEjVtwDr2aXnjqkhTdBtc5Hmn1m/nA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.138", "", { "os": "linux", "cpu": "arm64" }, "sha512-jp8lmAVe9uI9X5o+IYWFajLbN+Z80XogVX7NeyaenLHdpHkxg29Yf8pb6Os4OvHMjJOAdwDhPpXajf6RtBeEDA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.150", "", { "os": "linux", "cpu": "arm64" }, "sha512-1nhCXjfbxwhQPTgx2+q8lFYHx8DGJEOdaSd4wLvhGJifd/9QJwtnxaill1q+qdggZDroXHDJOTugttP0be6diA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.138", "", { "os": "linux", "cpu": "arm64" }, "sha512-uZaEFND1pl7KD9tdYqj2hd6ktjlYizVmkHRgU2Aj/P1CC6WMDsKG+rqPP7dsVXO77gMXhL4xjjwwqMjxx83HkA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.150", "", { "os": "linux", "cpu": "arm64" }, "sha512-KxkrUkGRhVcj4/2LkLrhVcEPl+6McDvtpZlgikHwAczVIf7aCvh01w2meEvuNjvex3dCv0d8CT+WYWxKJUhsbw=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.138", "", { "os": "linux", "cpu": "x64" }, "sha512-SLuUmu/nH1Wh0wnoXj/Bwh0nbDfEn9PgXqMsZHEUk3x1zxeR+6aRqFLjKZ8TawBey7xod7nfYUIjPnQx6IWDzg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.150", "", { "os": "linux", "cpu": "x64" }, "sha512-G7yOB9O6twOhQH3SvZWIvOcjehfA0HD5f/j49Z/yxZK5U72hOxtnbx7GCbcH/8AyB7JFyHjHpR9hxOxFoJNIhQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.138", "", { "os": "linux", "cpu": "x64" }, "sha512-T16F8Vkikb98E781ZM6Cx84yEBk+loSCqAObjaZ1hzQ1eKcpnxzSTF4rH2bz6N91dhFuCfIjFaBfNYg+oQA+yQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.150", "", { "os": "linux", "cpu": "x64" }, "sha512-cm+kWR077H4+ZaMPtqrHosjsVba9hjfn31gtK7D96ziz9Mzn/XhkAz68oObDOTBDqj4j+JbmAHSl5JvyGMHcAg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.138", "", { "os": "win32", "cpu": "arm64" }, "sha512-H/sD25fmMyEeJWamYmBKRS3E7jaIrg2S8KWxyR37P+xTZgkLe19sDTp7gYYywMXf1X9CJZJ8jJZ93qxINZoCeA=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.150", "", { "os": "win32", "cpu": "arm64" }, "sha512-z9vlm3JdOQ1Vqj9sG8kW+r9miunv4UFQOn0AqoI++J9AgoCBjKGCH2WWmZYhGOvezZqogunXaTciJvhtDhJiWQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.138", "", { "os": "win32", "cpu": "x64" }, "sha512-cSOdTH1OfIamVdJit9laWZiXne81ewgdP8MGh5HzLLLci0NGHkME7YxCWd0lYkCNkfiOEcToKU9axaZ+84jGiw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.150", "", { "os": "win32", "cpu": "x64" }, "sha512-lpAVi7tZdHi3BXRWmCVmOE2O8q7nzbvuMneYKS9rkpIbcjMjOBk6ud/rlp8Cuiqmp4LzZ8ylbbI7vFEiylK6Hg=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.95.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg=="],
 


### PR DESCRIPTION
## Summary
- update the Claude Agent SDK to the newest repo-policy-allowed release
- refresh Claude fallback model IDs for Opus 4.8, Sonnet 4.6, and Haiku 4.5
- prevent invalid `default[1m]` model strings while keeping 200K/1M controls for concrete Opus/Sonnet models
- wrap chat composer controls so the submit arrow stays inside narrow panels

## Verification
- turbo typecheck
- turbo test
- focused Claude runtime and ChatPanel suites also pass locally

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783001256&installation_id=136251083&pr_number=355&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F355&signature=4d9c5057a407270b644f79293d0f81a615bb442b46c8d16b4f6b9185c6a903e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->