### PR TITLE
Improve stdlib UX integration

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.29",
+  "version": "0.15.30",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -26,7 +26,7 @@ import {
   previewableGeneratedTargets,
 } from '@contexture/core/generated-targets';
 import type { Schema } from '@contexture/core/ir';
-import { STDLIB_REGISTRY } from '@shared/stdlib-registry';
+import { STDLIB_REGISTRY, STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registry';
 import {
   Bot,
   Boxes,
@@ -61,6 +61,7 @@ import { ModelSyncBanner } from './components/hud/ModelSyncBanner';
 import { PlaygroundPanel } from './components/playground/PlaygroundPanel';
 import { SchemaPanel, type SchemaPanelSource } from './components/schema/SchemaPanel';
 import { StatusBar } from './components/status-bar/StatusBar';
+import { StdlibPanel } from './components/stdlib/StdlibPanel';
 import { GraphControlsPanel } from './components/toolbar/GraphControlsPanel';
 import { Toolbar } from './components/toolbar/Toolbar';
 import { UpdateBanner } from './components/UpdateBanner';
@@ -361,6 +362,10 @@ export default function App(): React.JSX.Element {
   }, []);
 
   const detailTypeName = selectedField?.typeName ?? selectedEdge?.data.sourceType ?? selectedNodeId;
+  const selectedStdlibTypeName =
+    typeof selectedNodeId === 'string' && STDLIB_TYPE_DEFINITIONS.has(selectedNodeId)
+      ? selectedNodeId
+      : undefined;
   const hasSelection = detailTypeName !== null && detailTypeName !== undefined;
   const onboardingState = useMemo(
     () => buildOnboardingState(schema, activeTab, filePath, isDirty, driftedPaths.length),
@@ -575,6 +580,9 @@ export default function App(): React.JSX.Element {
                 className={activeTab !== 'playground' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}
               >
                 <PlaygroundPanel schema={schema} />
+              </div>
+              <div className={activeTab !== 'stdlib' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
+                <StdlibPanel schema={schema} focusedTypeName={selectedStdlibTypeName} />
               </div>
               <div className={activeTab !== 'changes' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
                 <ChangesPanel />

--- a/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
+++ b/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
@@ -1,5 +1,6 @@
 import type { SidebarTab } from '@renderer/store/ui-chrome';
 import {
+  BookOpen,
   FileBracesCorner,
   FlaskConical,
   History,
@@ -18,6 +19,7 @@ const TABS: Array<{ id: SidebarTab; icon: React.ReactNode; label: string }> = [
   { id: 'chat', icon: <MessageSquare className="size-4" />, label: 'Chat' },
   { id: 'schema', icon: <FileBracesCorner className="size-4" />, label: 'Schema' },
   { id: 'playground', icon: <FlaskConical className="size-4" />, label: 'Playground' },
+  { id: 'stdlib', icon: <BookOpen className="size-4" />, label: 'Stdlib' },
   { id: 'changes', icon: <History className="size-4" />, label: 'Changes' },
 ];
 

--- a/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
+++ b/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
@@ -17,10 +17,10 @@ interface ActivityBarProps {
 const TABS: Array<{ id: SidebarTab; icon: React.ReactNode; label: string }> = [
   { id: 'properties', icon: <MousePointer2 className="size-4" />, label: 'Properties' },
   { id: 'chat', icon: <MessageSquare className="size-4" />, label: 'Chat' },
+  { id: 'changes', icon: <History className="size-4" />, label: 'Changes' },
   { id: 'schema', icon: <FileBracesCorner className="size-4" />, label: 'Schema' },
   { id: 'playground', icon: <FlaskConical className="size-4" />, label: 'Playground' },
   { id: 'stdlib', icon: <BookOpen className="size-4" />, label: 'Stdlib' },
-  { id: 'changes', icon: <History className="size-4" />, label: 'Changes' },
 ];
 
 export function ActivityBar({ activeTab, onTabChange }: ActivityBarProps): React.JSX.Element {

--- a/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
@@ -15,11 +15,15 @@
  * concern. Splitting them like this keeps the panel test-only on the
  * selection prop surface.
  */
+
+import type { TypeDef } from '@contexture/core/ir';
 import { analyzeModelingHints } from '@contexture/core/modeling-hints';
 import { type ValidationError, validate } from '@renderer/services/validation';
 import { repairForValidationError } from '@renderer/services/validation-repairs';
-import { STDLIB_REGISTRY } from '@shared/stdlib-registry';
+import { STDLIB_REGISTRY, STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registry';
 import { useMemo, useSyncExternalStore } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import type { Op } from '../../store/ops';
 import { useGraphSelectionStore } from '../../store/selection';
 import { useUIChromeStore } from '../../store/ui-chrome';
@@ -129,6 +133,10 @@ export function DetailPanel({
   const typeIndex = schema.types.findIndex((t) => t.name === selection.typeName);
   const type = schema.types[typeIndex];
   if (!type) {
+    const externalType = STDLIB_TYPE_DEFINITIONS.get(selection.typeName);
+    if (externalType) {
+      return <ExternalTypeDetail qualifiedName={selection.typeName} type={externalType} />;
+    }
     return <EmptyState message={`No type named "${selection.typeName}" in the current schema.`} />;
   }
   const typeValidationErrors = validationErrorsForType(validationErrors, typeIndex);
@@ -248,6 +256,95 @@ export function DetailPanel({
 
 function EmptyState({ message }: { message: string }) {
   return <p className="p-4 text-xs text-muted-foreground">{message}</p>;
+}
+
+function ExternalTypeDetail({
+  qualifiedName,
+  type,
+}: {
+  qualifiedName: string;
+  type: TypeDef;
+}): React.JSX.Element {
+  const openStdlib = (): void => {
+    useUIChromeStore.getState().setSidebarVisible(true);
+    useUIChromeStore.getState().setSidebarTab('stdlib');
+  };
+
+  return (
+    <div className="space-y-4 p-3 pt-0" data-testid="external-type-detail">
+      <header className="-mx-3 flex min-h-20 items-center justify-between border-b bg-muted/20 px-3 py-3">
+        <div className="min-w-0">
+          <div className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            stdlib {type.kind}
+          </div>
+          <h2 className="truncate text-lg font-semibold leading-tight text-foreground">
+            {qualifiedName}
+          </h2>
+          <div className="mt-1">
+            <Badge variant="secondary">Read-only library type</Badge>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="ml-3 shrink-0"
+          onClick={openStdlib}
+        >
+          View in Stdlib
+        </Button>
+      </header>
+
+      {type.description && (
+        <section className="space-y-1">
+          <h3 className="text-xs font-medium text-muted-foreground">Description</h3>
+          <p className="text-sm text-foreground">{type.description}</p>
+        </section>
+      )}
+
+      {type.kind === 'raw' && (
+        <section className="space-y-2">
+          <h3 className="text-xs font-medium text-muted-foreground">Raw schema</h3>
+          <pre className="max-h-56 overflow-auto rounded-md border bg-muted/30 p-2 text-xs">
+            {JSON.stringify(type.jsonSchema, null, 2)}
+          </pre>
+        </section>
+      )}
+
+      {type.kind === 'enum' && (
+        <section className="space-y-2">
+          <h3 className="text-xs font-medium text-muted-foreground">Values</h3>
+          <div className="flex flex-wrap gap-1.5">
+            {type.values.slice(0, 80).map((value) => (
+              <Badge key={value.value} variant="outline">
+                {value.value}
+              </Badge>
+            ))}
+            {type.values.length > 80 && (
+              <Badge variant="secondary">+{type.values.length - 80}</Badge>
+            )}
+          </div>
+        </section>
+      )}
+
+      {type.kind === 'object' && (
+        <section className="space-y-2">
+          <h3 className="text-xs font-medium text-muted-foreground">Fields</h3>
+          <div className="space-y-1">
+            {type.fields.map((field) => (
+              <div
+                key={field.name}
+                className="flex items-center justify-between gap-2 rounded-md border bg-muted/20 px-2 py-1.5 text-xs"
+              >
+                <span className="font-medium">{field.name}</span>
+                <span className="text-muted-foreground">{field.type.kind}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
 }
 
 function validationErrorsForType(

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -247,7 +247,12 @@ export function FieldDetail({
             />
           )}
           <SampleDataRow field={field} update={update} />
-          <ModelAdviceRow hints={modelingHints} />
+          <ModelAdviceRow
+            hints={modelingHints}
+            onUseStdlibType={(stdlibTypeName) =>
+              update({ type: { kind: 'ref', typeName: stdlibTypeName } })
+            }
+          />
         </div>
       </div>
     </div>
@@ -457,7 +462,13 @@ function SampleDataRow({
   );
 }
 
-function ModelAdviceRow({ hints }: { hints: readonly ModelingHint[] }) {
+function ModelAdviceRow({
+  hints,
+  onUseStdlibType,
+}: {
+  hints: readonly ModelingHint[];
+  onUseStdlibType: (typeName: string) => void;
+}) {
   if (hints.length === 0) return null;
   const [primary, ...secondary] = hints;
   if (!primary) return null;
@@ -484,10 +495,14 @@ function ModelAdviceRow({ hints }: { hints: readonly ModelingHint[] }) {
         <PopoverContent align="end" side="left" className="w-80 p-3 text-xs">
           <div className="space-y-3">
             <HintBody hint={primary} />
+            <HintAction hint={primary} onUseStdlibType={onUseStdlibType} />
             {secondary.length > 0 && (
               <div className="space-y-2 border-t border-border/70 pt-2">
                 {secondary.map((hint) => (
-                  <HintBody key={hint.id} hint={hint} compact />
+                  <div key={hint.id} className="space-y-2">
+                    <HintBody hint={hint} compact />
+                    <HintAction hint={hint} onUseStdlibType={onUseStdlibType} />
+                  </div>
                 ))}
               </div>
             )}
@@ -495,6 +510,28 @@ function ModelAdviceRow({ hints }: { hints: readonly ModelingHint[] }) {
         </PopoverContent>
       </Popover>
     </InspectorRow>
+  );
+}
+
+function HintAction({
+  hint,
+  onUseStdlibType,
+}: {
+  hint: ModelingHint;
+  onUseStdlibType: (typeName: string) => void;
+}) {
+  const action = hint.action;
+  if (action?.kind !== 'use_stdlib_type') return null;
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="h-7 px-2 text-xs"
+      onClick={() => onUseStdlibType(action.typeName)}
+    >
+      Use {action.typeName}
+    </Button>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/detail/ModelShapeHints.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/ModelShapeHints.tsx
@@ -86,6 +86,12 @@ const fieldBadgeStyle: CSSProperties = {
 
 function toneForHint(kind: ModelingHint['kind']): CSSProperties {
   switch (kind) {
+    case 'stdlib_type':
+      return {
+        background: 'color-mix(in oklch, var(--reference) 14%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--reference) 46%, transparent)',
+        color: 'var(--reference-text)',
+      };
     case 'possible_entity':
       return {
         background: 'color-mix(in oklch, var(--inspector-advisory) 16%, transparent)',
@@ -119,13 +125,15 @@ function compareHints(a: ModelingHint, b: ModelingHint): number {
 
 function hintRank(hint: ModelingHint): number {
   switch (hint.kind) {
-    case 'possible_entity':
+    case 'stdlib_type':
       return 0;
-    case 'query_handle':
+    case 'possible_entity':
       return 1;
-    case 'embedded_collection':
+    case 'query_handle':
       return 2;
-    case 'owned_value_object':
+    case 'embedded_collection':
       return 3;
+    case 'owned_value_object':
+      return 4;
   }
 }

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -242,14 +242,14 @@ function TableTypeDetail({
               <ButtonGroup aria-label="Table inspector mode">
                 <TabsTrigger
                   value="shape"
-                  className="h-8 rounded-none border-0 px-3 text-xs first:rounded-l-md last:rounded-r-md data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                  className="h-8 gap-1.5 rounded-none border-0 px-3 text-xs first:rounded-l-md last:rounded-r-md data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=active]:shadow-none"
                 >
                   <SlidersHorizontal aria-hidden="true" className="size-3.5" />
                   Shape
                 </TabsTrigger>
                 <TabsTrigger
                   value="try"
-                  className="h-8 rounded-none border-0 px-3 text-xs first:rounded-l-md last:rounded-r-md data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                  className="h-8 gap-1.5 rounded-none border-0 px-3 text-xs first:rounded-l-md last:rounded-r-md data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=active]:shadow-none"
                 >
                   <Play aria-hidden="true" className="size-3.5" />
                   Try

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from '@contexture/core/playground-contract';
 import { generatePlaygroundFixtures } from '@contexture/core/playground-fixtures';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registry';
 import {
   Check,
   Database,
@@ -50,7 +51,10 @@ interface PlaygroundPanelProps {
 export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Element {
   const [panelRef, isCompact] = useCompactPanel();
   const [formOpen, setFormOpen] = useState(false);
-  const contract = useMemo(() => buildPlaygroundContract(schema), [schema]);
+  const contract = useMemo(
+    () => buildPlaygroundContract(schema, { externalTypes: STDLIB_TYPE_DEFINITIONS }),
+    [schema],
+  );
   const selectedTypeName = usePlaygroundStore((state) => state.selectedTypeName);
   const selectedRecordId = usePlaygroundStore((state) => state.selectedRecordId);
   const recordsByType = usePlaygroundStore((state) => state.recordsByType);
@@ -102,6 +106,7 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
       count: 5,
       typeNames: scope === 'current' && selectedEntity ? [selectedEntity.typeName] : undefined,
       existingRecordsByType: recordsByType,
+      externalTypes: STDLIB_TYPE_DEFINITIONS,
     });
     insertRecords(result.recordsByType);
     const generatedCount = Object.values(result.recordsByType).reduce(
@@ -264,7 +269,10 @@ export function ScopedPlaygroundWorkbench({
   const [panelRef, isCompact] = useCompactPanel(680);
   const [formOpen, setFormOpen] = useState(false);
   const [seedNotice, setSeedNotice] = useState<string | null>(null);
-  const contract = useMemo(() => buildPlaygroundContract(schema), [schema]);
+  const contract = useMemo(
+    () => buildPlaygroundContract(schema, { externalTypes: STDLIB_TYPE_DEFINITIONS }),
+    [schema],
+  );
   const selectedRecordId = usePlaygroundStore((state) => state.selectedRecordId);
   const recordsByType = usePlaygroundStore((state) => state.recordsByType);
   const selectRecord = usePlaygroundStore((state) => state.selectRecord);
@@ -305,6 +313,7 @@ export function ScopedPlaygroundWorkbench({
       count: 5,
       typeNames: [entity.typeName],
       existingRecordsByType: recordsByType,
+      externalTypes: STDLIB_TYPE_DEFINITIONS,
     });
     insertRecords(result.recordsByType);
     const generatedCount = Object.values(result.recordsByType).reduce(

--- a/apps/desktop/src/renderer/src/components/stdlib/StdlibPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/stdlib/StdlibPanel.tsx
@@ -1,0 +1,254 @@
+import type { FieldType, Schema } from '@contexture/core/ir';
+import { STDLIB_TYPE_OPTIONS } from '@shared/stdlib-registry';
+import { BookOpen, Search, X } from 'lucide-react';
+import type { KeyboardEvent } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface StdlibPanelProps {
+  schema: Schema;
+  focusedTypeName?: string;
+}
+
+export function StdlibPanel({ schema, focusedTypeName }: StdlibPanelProps): React.JSX.Element {
+  const searchId = useId();
+  const [query, setQuery] = useState('');
+  const focusedRef = useRef<HTMLElement | null>(null);
+  const usageByType = useMemo(() => stdlibUsageByType(schema), [schema]);
+  const groups = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const byNamespace = new Map<string, typeof STDLIB_TYPE_OPTIONS>();
+    for (const option of STDLIB_TYPE_OPTIONS) {
+      const searchable =
+        `${option.qualifiedName} ${option.description} ${option.example}`.toLowerCase();
+      if (q && !searchable.includes(q)) continue;
+      byNamespace.set(option.namespace, [...(byNamespace.get(option.namespace) ?? []), option]);
+    }
+    return [...byNamespace.entries()];
+  }, [query]);
+
+  useEffect(() => {
+    if (!focusedTypeName) return;
+    setQuery(focusedTypeName);
+  }, [focusedTypeName]);
+
+  useEffect(() => {
+    if (!focusedTypeName) return;
+    if (query.trim() !== focusedTypeName) return;
+    focusedRef.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [focusedTypeName, query]);
+
+  const clearSearch = (): void => setQuery('');
+  const onSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key !== 'Escape') return;
+    if (!query) return;
+    event.preventDefault();
+    event.stopPropagation();
+    clearSearch();
+  };
+
+  return (
+    <section className="flex h-full min-h-0 flex-col" aria-label="Stdlib">
+      <header className="border-b px-3 py-3">
+        <div className="flex items-center gap-2">
+          <div className="flex size-7 items-center justify-center rounded-md border bg-primary/10 text-primary">
+            <BookOpen className="size-3.5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold">Stdlib</h2>
+            <p className="text-xs text-muted-foreground">Reusable value types for fields.</p>
+          </div>
+        </div>
+        <label htmlFor={searchId} className="relative mt-3 block">
+          <Search className="absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            id={searchId}
+            type="search"
+            aria-label="Search stdlib"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={onSearchKeyDown}
+            placeholder="Search Email, ISODate, CountryCode..."
+            className="h-8 pl-7 pr-8 text-xs [&::-webkit-search-cancel-button]:hidden"
+          />
+          {query && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Clear stdlib search"
+              className="absolute right-1 top-1/2 size-6 -translate-y-1/2 rounded-sm text-muted-foreground hover:text-foreground"
+              onClick={clearSearch}
+            >
+              <X className="size-3.5" aria-hidden="true" />
+            </Button>
+          )}
+        </label>
+      </header>
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-3">
+        {groups.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No stdlib types match this search.</p>
+        ) : (
+          groups.map(([namespace, options]) => (
+            <section key={namespace} className="space-y-2">
+              <div className="flex items-center justify-between">
+                <h3 className="text-xs font-medium uppercase text-muted-foreground">{namespace}</h3>
+                <Badge variant="outline">{options.length}</Badge>
+              </div>
+              <div className="space-y-1.5">
+                {options.map((option) => {
+                  const usages = usageByType.get(option.qualifiedName) ?? [];
+                  const jsonExample = parseJsonExample(option.example);
+                  return (
+                    <article
+                      key={option.qualifiedName}
+                      ref={option.qualifiedName === focusedTypeName ? focusedRef : undefined}
+                      className={
+                        option.qualifiedName === focusedTypeName
+                          ? 'rounded-md border border-primary/70 bg-primary/10 p-2 text-xs'
+                          : 'rounded-md border bg-muted/15 p-2 text-xs'
+                      }
+                    >
+                      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+                        <div className="min-w-0">
+                          <div className="truncate font-mono text-[11px] text-foreground">
+                            {option.qualifiedName}
+                          </div>
+                          <p className="mt-1 leading-5 text-muted-foreground">
+                            {option.description}
+                          </p>
+                        </div>
+                        {option.example && !jsonExample && (
+                          <Badge
+                            variant="secondary"
+                            className="min-w-0 max-w-[min(24rem,52vw)] overflow-hidden px-2"
+                          >
+                            <span className="block min-w-0 truncate">{option.example}</span>
+                          </Badge>
+                        )}
+                        {jsonExample && <JsonExample value={jsonExample} />}
+                      </div>
+                      {usages.length > 0 && (
+                        <div className="mt-2 flex flex-wrap gap-1">
+                          {usages.map((usage) => (
+                            <Badge
+                              key={usage}
+                              variant="outline"
+                              className="min-w-0 max-w-full px-2 font-mono text-[10px]"
+                            >
+                              <span className="min-w-0 truncate">{usage}</span>
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function stdlibUsageByType(schema: Schema): Map<string, string[]> {
+  const usages = new Map<string, string[]>();
+  for (const type of schema.types) {
+    if (type.kind !== 'object') continue;
+    for (const field of type.fields) {
+      const target = unwrapRefTarget(field.type);
+      if (!target?.includes('.')) continue;
+      const entries = usages.get(target) ?? [];
+      entries.push(`${type.name}.${field.name}`);
+      usages.set(target, entries);
+    }
+  }
+  return usages;
+}
+
+function unwrapRefTarget(type: FieldType): string | undefined {
+  let current = type;
+  while (current.kind === 'array') current = current.element;
+  return current.kind === 'ref' ? current.typeName : undefined;
+}
+
+function parseJsonExample(example: string): string | null {
+  const trimmed = example.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null;
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2);
+  } catch {
+    return null;
+  }
+}
+
+function JsonExample({ value }: { value: string }): React.JSX.Element {
+  return (
+    <pre className="max-h-24 max-w-[min(20rem,45vw)] overflow-auto rounded-lg border border-border/80 bg-secondary/45 px-2.5 py-1.5 font-mono text-[10px] leading-4 shadow-inner">
+      {jsonLines(value).map(({ key, line }) => (
+        <span key={key} className="block">
+          {renderJsonLine(line)}
+        </span>
+      ))}
+    </pre>
+  );
+}
+
+function renderJsonLine(line: string): React.ReactNode[] {
+  return jsonTokens(line).map(({ key, token }) => {
+    if (/^"(?:[^"\\]|\\.)*"\s*:$/u.test(token)) {
+      return (
+        <span key={key} className="text-primary">
+          {token}
+        </span>
+      );
+    }
+    if (/^"(?:[^"\\]|\\.)*"$/u.test(token)) {
+      return (
+        <span key={key} className="text-foreground">
+          {token}
+        </span>
+      );
+    }
+    if (/^[{}[\],:]$/u.test(token)) {
+      return (
+        <span key={key} className="text-muted-foreground/70">
+          {token}
+        </span>
+      );
+    }
+    return (
+      <span key={key} className="text-muted-foreground">
+        {token}
+      </span>
+    );
+  });
+}
+
+function jsonLines(value: string): { key: string; line: string }[] {
+  const lines: { key: string; line: string }[] = [];
+  let offset = 0;
+  for (const line of value.split('\n')) {
+    lines.push({ key: `line-${offset}`, line });
+    offset += line.length + 1;
+  }
+  return lines;
+}
+
+function jsonTokens(line: string): { key: string; token: string }[] {
+  const pieces = line
+    .split(/("(?:[^"\\]|\\.)*"\s*:|"(?:[^"\\]|\\.)*"|[{}[\],:])/gu)
+    .filter(Boolean);
+  const tokens: { key: string; token: string }[] = [];
+  let offset = 0;
+  for (const token of pieces) {
+    const start = line.indexOf(token, offset);
+    tokens.push({ key: `token-${start}`, token });
+    offset = start + token.length;
+  }
+  return tokens;
+}

--- a/apps/desktop/src/renderer/src/store/ui-chrome.ts
+++ b/apps/desktop/src/renderer/src/store/ui-chrome.ts
@@ -9,7 +9,7 @@ import { create } from 'zustand';
 
 export type Theme = 'dark' | 'light';
 export type ThemePreference = Theme | 'system';
-export type SidebarTab = 'properties' | 'chat' | 'schema' | 'playground' | 'changes';
+export type SidebarTab = 'properties' | 'chat' | 'schema' | 'playground' | 'stdlib' | 'changes';
 
 const THEME_STORAGE_KEY = 'theme';
 

--- a/apps/desktop/src/shared/stdlib-registry.ts
+++ b/apps/desktop/src/shared/stdlib-registry.ts
@@ -5,6 +5,8 @@
  * converts those namespace-indexed IR sidecars into the small lookup surfaces
  * used by core validation, emitters, and chat prompts.
  */
+
+import type { TypeDef } from '@contexture/core/ir';
 import type { StdlibCatalog } from '@contexture/core/semantic-validation';
 import { IR_BY_NAMESPACE, NAMESPACES, type Namespace } from '@contexture/stdlib/registry';
 import type { StdlibRegistry as SystemPromptStdlibRegistry } from './system-prompt';
@@ -39,6 +41,18 @@ export function buildStdlibRegistry(): StdlibRegistry {
 
 /** Singleton for app runtime; tests build their own via `buildStdlibRegistry`. */
 export const STDLIB_REGISTRY: StdlibRegistry = buildStdlibRegistry();
+
+export function buildStdlibTypeDefinitions(): ReadonlyMap<string, TypeDef> {
+  const types = new Map<string, TypeDef>();
+  for (const ns of NAMESPACES) {
+    for (const type of IR_BY_NAMESPACE[ns].types) {
+      types.set(`${ns}.${type.name}`, type as TypeDef);
+    }
+  }
+  return types;
+}
+
+export const STDLIB_TYPE_DEFINITIONS = buildStdlibTypeDefinitions();
 
 /**
  * Adapter for the system-prompt builder's registry shape, which expects a flat
@@ -97,11 +111,13 @@ function stdlibExample(type: StdlibExampleType): string {
   if (namedExample) return namedExample;
 
   if (type.kind === 'object' && type.fields) {
-    const fields = type.fields
-      .filter((field) => field.optional !== true)
-      .slice(0, 3)
-      .map((field) => `${field.name}: ${exampleForFieldType(field.type.kind)}`);
-    return `{ ${fields.join(', ')} }`;
+    const fields = Object.fromEntries(
+      type.fields
+        .filter((field) => field.optional !== true)
+        .slice(0, 3)
+        .map((field) => [field.name, exampleForFieldType(field.type.kind)]),
+    );
+    return JSON.stringify(fields, null, 2);
   }
   if (type.kind === 'enum') return type.values?.[0]?.value ?? 'value';
   if (type.kind !== 'raw') return type.name;
@@ -138,8 +154,8 @@ function stdlibNamedExample(typeName: string): string | undefined {
   }
 }
 
-function exampleForFieldType(kind: string): string {
-  if (kind === 'number') return '1';
-  if (kind === 'boolean') return 'true';
-  return '"value"';
+function exampleForFieldType(kind: string): string | number | boolean {
+  if (kind === 'number') return 1;
+  if (kind === 'boolean') return true;
+  return 'value';
 }

--- a/apps/desktop/src/shared/system-prompt.ts
+++ b/apps/desktop/src/shared/system-prompt.ts
@@ -49,6 +49,10 @@ export function buildSystemPromptAppend(input: BuildSystemPromptAppendInput): st
     '',
     renderOpCatalogue(),
     '',
+    '## Stdlib-first modeling',
+    '',
+    STDLIB_RULES.trim(),
+    '',
     '## Stdlib types',
     '',
     renderStdlib(input.stdlibRegistry),
@@ -127,9 +131,31 @@ Skills are available and auto-load on topic match:
 - \`model-domain\` — use when the user asks to model a new domain from
   scratch. Walks entities, relationships, enums, constraints, stdlib.
 - \`use-stdlib\` — use when a field could reuse a curated stdlib type
-  (Email, URL, UUID, Address, Money, PhoneE164, …).
+  (Email, URL, UUID, ISODate, Money, CountryCode, PhoneNumber, …).
 - \`generate-sample\` — use when the user asks for sample / fixture /
   example data for a type.
+`;
+
+const STDLIB_RULES = `
+Before creating or leaving a primitive field for a common value format, check
+the stdlib list below and prefer a qualified ref when it fits. Use
+\`{ kind: "ref", typeName: "namespace.Type" }\` with the namespace prefix.
+
+Common mappings:
+- email -> \`common.Email\`
+- url, website, link, image URL -> \`common.URL\`
+- uuid -> \`common.UUID\`
+- date, releaseDate, bornOn -> \`common.ISODate\`
+- timestamp, createdAt, updatedAt -> \`common.ISODateTime\`
+- slug -> \`common.Slug\`
+- country, countryCode -> \`place.CountryCode\`
+- amount, price, cost, currency amount -> \`money.Money\`
+- currency, currencyCode -> \`money.CurrencyCode\`
+- phone, telephone, mobile -> \`contact.PhoneNumber\`
+
+Only create a custom raw/object shape when the user needs semantics that the
+stdlib type does not cover. If you intentionally choose a primitive instead of
+a matching stdlib type, explain the reason briefly.
 `;
 
 interface OpSpec {

--- a/apps/desktop/tests/chat/__snapshots__/system-prompt.test.ts.snap
+++ b/apps/desktop/tests/chat/__snapshots__/system-prompt.test.ts.snap
@@ -25,7 +25,7 @@ Skills are available and auto-load on topic match:
 - \`model-domain\` — use when the user asks to model a new domain from
   scratch. Walks entities, relationships, enums, constraints, stdlib.
 - \`use-stdlib\` — use when a field could reuse a curated stdlib type
-  (Email, URL, UUID, Address, Money, PhoneE164, …).
+  (Email, URL, UUID, ISODate, Money, CountryCode, PhoneNumber, …).
 - \`generate-sample\` — use when the user asks for sample / fixture /
   example data for a type.
 
@@ -53,6 +53,28 @@ Skills are available and auto-load on topic match:
 - \`update_index\` { typeName: string; name: string; patch: Partial<IndexDef> }
 - \`remove_index\` { typeName: string; name: string }
 - \`replace_schema\` { schema: Schema }   # escape hatch; full IR
+
+## Stdlib-first modeling
+
+Before creating or leaving a primitive field for a common value format, check
+the stdlib list below and prefer a qualified ref when it fits. Use
+\`{ kind: "ref", typeName: "namespace.Type" }\` with the namespace prefix.
+
+Common mappings:
+- email -> \`common.Email\`
+- url, website, link, image URL -> \`common.URL\`
+- uuid -> \`common.UUID\`
+- date, releaseDate, bornOn -> \`common.ISODate\`
+- timestamp, createdAt, updatedAt -> \`common.ISODateTime\`
+- slug -> \`common.Slug\`
+- country, countryCode -> \`place.CountryCode\`
+- amount, price, cost, currency amount -> \`money.Money\`
+- currency, currencyCode -> \`money.CurrencyCode\`
+- phone, telephone, mobile -> \`contact.PhoneNumber\`
+
+Only create a custom raw/object shape when the user needs semantics that the
+stdlib type does not cover. If you intentionally choose a primitive instead of
+a matching stdlib type, explain the reason briefly.
 
 ## Stdlib types
 

--- a/apps/desktop/tests/chat/system-prompt.test.ts
+++ b/apps/desktop/tests/chat/system-prompt.test.ts
@@ -80,6 +80,16 @@ describe('buildSystemPromptAppend', () => {
     expect(prompt).toContain('Currency + minor-units amount');
   });
 
+  it('instructs agents to prefer stdlib refs for common value formats', () => {
+    const prompt = buildSystemPromptAppend({ stdlibRegistry: EMPTY_STDLIB });
+    expect(prompt).toContain('## Stdlib-first modeling');
+    expect(prompt).toContain('date, releaseDate, bornOn');
+    expect(prompt).toContain('common.ISODate');
+    expect(prompt).toContain('country, countryCode');
+    expect(prompt).toContain('place.CountryCode');
+    expect(prompt).toContain('{ kind: "ref", typeName: "namespace.Type" }');
+  });
+
   it('is deterministic across stdlib-entry orderings', () => {
     const a: StdlibRegistry = {
       entries: [

--- a/apps/desktop/tests/components/activity-bar/ActivityBar.test.tsx
+++ b/apps/desktop/tests/components/activity-bar/ActivityBar.test.tsx
@@ -1,0 +1,13 @@
+import { ActivityBar } from '@renderer/components/activity-bar/ActivityBar';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('ActivityBar', () => {
+  it('orders tabs by the model-building workflow', () => {
+    render(<ActivityBar activeTab="properties" onTabChange={vi.fn()} />);
+
+    expect(
+      screen.getAllByRole('button').map((button) => button.getAttribute('aria-label')),
+    ).toEqual(['Properties', 'Chat', 'Changes', 'Schema', 'Playground', 'Stdlib']);
+  });
+});

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -12,6 +12,7 @@ import type { Schema } from '@contexture/core/ir';
 import { DetailPanel } from '@renderer/components/detail/DetailPanel';
 import type { RefEdgeData } from '@renderer/components/graph/schema-to-graph';
 import { useGraphSelectionStore } from '@renderer/store/selection';
+import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import { useUndoStore } from '@renderer/store/undo';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -78,6 +79,8 @@ describe('DetailPanel', () => {
   beforeEach(() => {
     seed({ version: '1', types: [] });
     useGraphSelectionStore.getState().clear();
+    useUIChromeStore.getState().setSidebarVisible(true);
+    useUIChromeStore.getState().setSidebarTab('properties');
   });
   afterEach(cleanup);
 
@@ -398,5 +401,35 @@ describe('DetailPanel', () => {
   it('shows an empty state when the selected type no longer exists', () => {
     render(<DetailPanel selection={{ typeName: 'Missing' }} />);
     expect(screen.getByText(/No type named "Missing"/i)).toBeInTheDocument();
+  });
+
+  it('renders read-only details for selected stdlib raw nodes', () => {
+    render(<DetailPanel selection={{ typeName: 'common.URL' }} />);
+
+    expect(screen.getByTestId('external-type-detail')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'common.URL' })).toBeInTheDocument();
+    expect(screen.getByText('Read-only library type')).toBeInTheDocument();
+    expect(screen.getByText(/Absolute URL/i)).toBeInTheDocument();
+    expect(screen.getByText(/"format": "uri"/i)).toBeInTheDocument();
+    expect(screen.queryByText(/No type named/i)).not.toBeInTheDocument();
+  });
+
+  it('links selected stdlib nodes through to the stdlib sidebar', () => {
+    render(<DetailPanel selection={{ typeName: 'common.URL' }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'View in Stdlib' }));
+
+    expect(useUIChromeStore.getState().sidebarVisible).toBe(true);
+    expect(useUIChromeStore.getState().sidebarTab).toBe('stdlib');
+  });
+
+  it('renders read-only details for selected stdlib enum nodes', () => {
+    render(<DetailPanel selection={{ typeName: 'place.CountryCode' }} />);
+
+    expect(screen.getByTestId('external-type-detail')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'place.CountryCode' })).toBeInTheDocument();
+    expect(screen.getByText(/ISO 3166-1/i)).toBeInTheDocument();
+    expect(screen.getByText('GB')).toBeInTheDocument();
+    expect(screen.queryByText(/No type named/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/tests/components/detail/FieldDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/FieldDetail.test.tsx
@@ -536,4 +536,34 @@ describe('FieldDetail', () => {
     expect(screen.getAllByText('Query handle').length).toBeGreaterThan(0);
     expect(screen.getByText(/stay denormalized/i)).toBeInTheDocument();
   });
+
+  it('applies a stdlib model advice action to the selected field', () => {
+    const { dispatch } = setup({ name: 'releaseDate', type: { kind: 'string' } }, [
+      {
+        id: 'v1:stdlib_type:Plot:releaseDate:common.ISODate',
+        kind: 'stdlib_type',
+        signals: ['identity_pressure'],
+        path: 'types.0.fields.0',
+        typeName: 'Plot',
+        fieldName: 'releaseDate',
+        title: 'Stdlib type available',
+        message:
+          'releaseDate looks like an ISO date. Use common.ISODate to reuse the shared validator and generated type.',
+        rationale:
+          'Stdlib refs keep common value formats consistent across the model, generated validators, and agent-created changes.',
+        fieldNames: ['releaseDate'],
+        action: { kind: 'use_stdlib_type', typeName: 'common.ISODate' },
+      },
+    ]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Model advice' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Use common.ISODate' }));
+
+    expect(dispatch).toHaveBeenCalledWith({
+      kind: 'update_field',
+      typeName: 'Plot',
+      fieldName: 'releaseDate',
+      patch: { type: { kind: 'ref', typeName: 'common.ISODate' } },
+    });
+  });
 });

--- a/apps/desktop/tests/components/playground/PlaygroundPanel.test.tsx
+++ b/apps/desktop/tests/components/playground/PlaygroundPanel.test.tsx
@@ -21,6 +21,21 @@ const schema: Schema = {
   ],
 };
 
+const stdlibRefSchema: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'RecordLabel',
+      table: true,
+      fields: [
+        { name: 'name', type: { kind: 'ref', typeName: 'common.NonEmptyString' } },
+        { name: 'country', type: { kind: 'ref', typeName: 'place.CountryCode' } },
+      ],
+    },
+  ],
+};
+
 describe('PlaygroundPanel', () => {
   beforeEach(() => {
     usePlaygroundStore.setState({
@@ -69,5 +84,16 @@ describe('PlaygroundPanel', () => {
       tagIds: ['primary'],
     });
     expect(screen.getAllByText('Ada Lovelace').length).toBeGreaterThan(0);
+  });
+
+  it('renders stdlib value refs as editable fields instead of unknown reference targets', async () => {
+    const user = userEvent.setup();
+    render(<PlaygroundPanel schema={stdlibRefSchema} />);
+
+    await user.click(screen.getByRole('button', { name: 'New record' }));
+
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Country' })).toBeInTheDocument();
+    expect(screen.queryByDisplayValue(/Unknown reference target/u)).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/tests/components/stdlib/StdlibPanel.test.tsx
+++ b/apps/desktop/tests/components/stdlib/StdlibPanel.test.tsx
@@ -1,0 +1,77 @@
+import type { Schema } from '@contexture/core/ir';
+import { StdlibPanel } from '@renderer/components/stdlib/StdlibPanel';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const schema: Schema = {
+  version: '1',
+  types: [
+    {
+      kind: 'object',
+      name: 'Artist',
+      fields: [
+        { name: 'website', type: { kind: 'ref', typeName: 'common.URL' } },
+        { name: 'country', type: { kind: 'ref', typeName: 'place.CountryCode' } },
+      ],
+    },
+  ],
+};
+
+describe('StdlibPanel', () => {
+  afterEach(cleanup);
+
+  it('lists stdlib types with examples and current schema usage', () => {
+    render(<StdlibPanel schema={schema} />);
+
+    expect(screen.getByRole('heading', { name: 'Stdlib' })).toBeInTheDocument();
+    expect(screen.getByText('common.URL')).toBeInTheDocument();
+    expect(screen.getByText('Artist.website')).toBeInTheDocument();
+    expect(screen.getByText('place.CountryCode')).toBeInTheDocument();
+    expect(screen.getByText('Artist.country')).toBeInTheDocument();
+  });
+
+  it('renders structured examples as formatted JSON', () => {
+    render(<StdlibPanel schema={schema} />);
+
+    const personName = screen.getByText('identity.PersonName').closest('article');
+    expect(personName).not.toBeNull();
+    expect(personName?.querySelector('pre')).toHaveTextContent('"given": "value"');
+  });
+
+  it('filters stdlib types by search text', () => {
+    render(<StdlibPanel schema={schema} />);
+
+    const search = screen.getByLabelText('Search stdlib');
+    expect(search).toHaveAttribute('type', 'search');
+
+    fireEvent.change(search, { target: { value: 'ISODate' } });
+
+    expect(screen.getByText('common.ISODate')).toBeInTheDocument();
+    expect(screen.queryByText('common.URL')).not.toBeInTheDocument();
+  });
+
+  it('clears the search with Escape and the clear button', () => {
+    render(<StdlibPanel schema={schema} />);
+
+    const search = screen.getByLabelText('Search stdlib');
+    fireEvent.change(search, { target: { value: 'ISODate' } });
+
+    fireEvent.keyDown(search, { key: 'Escape' });
+    expect(search).toHaveValue('');
+    expect(screen.getByText('common.URL')).toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: 'CountryCode' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Clear stdlib search' }));
+
+    expect(search).toHaveValue('');
+    expect(screen.getByText('common.URL')).toBeInTheDocument();
+  });
+
+  it('focuses the selected stdlib type from the canvas', () => {
+    render(<StdlibPanel schema={schema} focusedTypeName="common.URL" />);
+
+    expect(screen.getByLabelText('Search stdlib')).toHaveValue('common.URL');
+    expect(screen.getByText('common.URL').closest('article')).toHaveClass('border-primary/70');
+    expect(screen.queryByText('common.Email')).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/src/modeling-hints.ts
+++ b/packages/core/src/modeling-hints.ts
@@ -6,7 +6,8 @@ export type ModelingHintKind =
   | 'owned_value_object'
   | 'possible_entity'
   | 'query_handle'
-  | 'embedded_collection';
+  | 'embedded_collection'
+  | 'stdlib_type';
 
 export type ModelingSignal =
   | 'identity_pressure'
@@ -26,7 +27,13 @@ export interface ModelingHint {
   message: string;
   rationale: string;
   fieldNames: string[];
+  action?: ModelingHintAction;
 }
+
+export type ModelingHintAction = {
+  kind: 'use_stdlib_type';
+  typeName: string;
+};
 
 type ObjectType = Extract<TypeDef, { kind: 'object' }>;
 
@@ -90,6 +97,9 @@ export function analyzeModelingHints(schema: Schema): ModelingHint[] {
       if (isTable && isQueryHandleField(field, type)) {
         hints.push(queryHandleHint(type, field, fieldPath));
       }
+
+      const stdlibHint = stdlibTypeHint(type, field, fieldPath);
+      if (stdlibHint) hints.push(stdlibHint);
     });
   });
 
@@ -183,6 +193,29 @@ function queryHandleHint(type: ObjectType, field: FieldDef, path: string): Model
   };
 }
 
+function stdlibTypeHint(type: ObjectType, field: FieldDef, path: string): ModelingHint | null {
+  if (unwrapRefTarget(field.type)) return null;
+  if (field.type.kind !== 'string' && field.type.kind !== 'number') return null;
+
+  const target = stdlibTargetForField(field);
+  if (!target) return null;
+
+  return {
+    id: hintId('stdlib_type', type.name, field.name, [target.typeName]),
+    kind: 'stdlib_type',
+    signals: ['identity_pressure'],
+    path,
+    typeName: type.name,
+    fieldName: field.name,
+    title: 'Stdlib type available',
+    message: `${field.name} looks like ${target.label}. Use ${target.typeName} to reuse the shared validator and generated type.`,
+    rationale:
+      'Stdlib refs keep common value formats consistent across the model, generated validators, and agent-created changes.',
+    fieldNames: [field.name],
+    action: { kind: 'use_stdlib_type', typeName: target.typeName },
+  };
+}
+
 function collectTypeUsages(objects: ObjectType[]): Map<string, TypeUsage[]> {
   const usages = new Map<string, TypeUsage[]>();
   for (const owner of objects) {
@@ -233,6 +266,66 @@ function isIdentityLikeField(field: FieldDef): boolean {
     );
   }
   return false;
+}
+
+function stdlibTargetForField(field: FieldDef): { typeName: string; label: string } | null {
+  const name = field.name.toLowerCase();
+  const description = field.description?.toLowerCase() ?? '';
+  const haystack = `${name} ${description}`;
+
+  if (field.type.kind === 'string') {
+    if (field.type.format === 'email' || /\bemail\b/u.test(haystack)) {
+      return { typeName: 'common.Email', label: 'an email address' };
+    }
+    if (
+      field.type.format === 'url' ||
+      /\b(url|uri|website|webpage|link|imageurl|avatarurl|coverimage)\b/u.test(haystack)
+    ) {
+      return { typeName: 'common.URL', label: 'a URL' };
+    }
+    if (field.type.format === 'uuid' || /\buuid\b/u.test(haystack)) {
+      return { typeName: 'common.UUID', label: 'a UUID' };
+    }
+    if (/\b(datetime|timestamp|instant|occurredat|createdat|updatedat)\b/u.test(haystack)) {
+      return { typeName: 'common.ISODateTime', label: 'an ISO timestamp' };
+    }
+    if (
+      name.includes('date') ||
+      /\b(iso)?date\b/u.test(haystack) ||
+      /(bornon|releasedon)$/u.test(name)
+    ) {
+      return { typeName: 'common.ISODate', label: 'an ISO date' };
+    }
+    if (/\bslug\b/u.test(haystack)) {
+      return { typeName: 'common.Slug', label: 'a slug' };
+    }
+    if (/\bcountry(code)?\b/u.test(haystack)) {
+      return { typeName: 'place.CountryCode', label: 'a country code' };
+    }
+    if (/\bcurrency(code)?\b/u.test(haystack)) {
+      return { typeName: 'money.CurrencyCode', label: 'a currency code' };
+    }
+    if (/\b(phone|telephone|mobile)\b/u.test(haystack)) {
+      return { typeName: 'contact.PhoneNumber', label: 'a phone number' };
+    }
+    if (/\b(name|title|label)\b/u.test(haystack) && field.type.min === 1) {
+      return { typeName: 'common.NonEmptyString', label: 'non-empty text' };
+    }
+  }
+
+  if (field.type.kind === 'number') {
+    if (/\b(price|amount|cost|total|subtotal|balance|money)\b/u.test(haystack)) {
+      return { typeName: 'money.Money', label: 'a money amount' };
+    }
+    if (field.type.int === true && field.type.min !== undefined && field.type.min >= 1) {
+      return { typeName: 'common.PositiveInt', label: 'a positive integer' };
+    }
+    if (field.type.min !== undefined && field.type.min > 0) {
+      return { typeName: 'common.PositiveNumber', label: 'a positive number' };
+    }
+  }
+
+  return null;
 }
 
 function unwrapRefTarget(type: FieldType): string | undefined {

--- a/packages/core/src/playground-contract.ts
+++ b/packages/core/src/playground-contract.ts
@@ -107,13 +107,24 @@ export interface PlaygroundContract {
   enums: Array<{ typeName: string; options: PlaygroundEnumOption[] }>;
 }
 
+export interface PlaygroundContractOptions {
+  externalTypes?: ReadonlyMap<string, TypeDef> | Record<string, TypeDef>;
+}
+
 type ObjectType = Extract<TypeDef, { kind: 'object' }>;
 type EnumType = Extract<TypeDef, { kind: 'enum' }>;
+type RawType = Extract<TypeDef, { kind: 'raw' }>;
 
 const DISPLAY_FIELD_CANDIDATES = ['name', 'title', 'label', 'slug', 'email', 'key'];
 
-export function buildPlaygroundContract(schema: Schema): PlaygroundContract {
-  const typeByName = new Map(schema.types.map((type) => [type.name, type]));
+export function buildPlaygroundContract(
+  schema: Schema,
+  options: PlaygroundContractOptions = {},
+): PlaygroundContract {
+  const typeByName = new Map([
+    ...externalTypeEntries(options.externalTypes),
+    ...schema.types.map((type) => [type.name, type] as const),
+  ]);
   const entities = schema.types
     .filter((type): type is ObjectType => type.kind === 'object' && type.table === true)
     .map((type) => buildEntity(type, typeByName, [type.name]));
@@ -259,6 +270,7 @@ function refControlShape(
 ): PlaygroundControlShape {
   const target = typeByName.get(typeName);
   if (target?.kind === 'enum') return { kind: 'enum', options: enumOptions(target) };
+  if (target?.kind === 'raw') return rawControlShape(target);
   if (target?.kind === 'object' && target.table === true) {
     return {
       kind: 'ref',
@@ -273,6 +285,56 @@ function refControlShape(
     return buildObjectShape(target, typeByName, [...stack, target.name]);
   }
   return { kind: 'unsupported', reason: `Unknown reference target: ${typeName}` };
+}
+
+function rawControlShape(type: RawType): PlaygroundControlShape {
+  const jsonSchema = type.jsonSchema;
+  const jsonType = typeof jsonSchema.type === 'string' ? jsonSchema.type : null;
+  if (jsonType === 'number' || jsonType === 'integer') {
+    return {
+      kind: 'number',
+      constraints: {
+        min: numericConstraint(jsonSchema.minimum ?? jsonSchema.exclusiveMinimum),
+        max: numericConstraint(jsonSchema.maximum ?? jsonSchema.exclusiveMaximum),
+        int: jsonType === 'integer',
+      },
+    };
+  }
+  if (jsonType === 'boolean') return { kind: 'boolean', constraints: {} };
+  if (jsonType === 'string') {
+    const format = stringFormat(jsonSchema.format);
+    return {
+      kind: format === 'date' ? 'date' : 'text',
+      constraints: {
+        min: numericConstraint(jsonSchema.minLength),
+        max: numericConstraint(jsonSchema.maxLength),
+        regex: typeof jsonSchema.pattern === 'string' ? jsonSchema.pattern : undefined,
+        ...(format && format !== 'date' ? { format } : {}),
+      },
+    };
+  }
+  return { kind: 'unsupported', reason: `Unsupported raw reference target: ${type.name}` };
+}
+
+function externalTypeEntries(
+  externalTypes: PlaygroundContractOptions['externalTypes'],
+): Array<readonly [string, TypeDef]> {
+  if (!externalTypes) return [];
+  return externalTypes instanceof Map
+    ? [...externalTypes.entries()]
+    : Object.entries(externalTypes);
+}
+
+function numericConstraint(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function stringFormat(value: unknown): PlaygroundFieldConstraints['format'] | 'date' | undefined {
+  if (value === 'email' || value === 'uuid' || value === 'datetime' || value === 'date') {
+    return value;
+  }
+  if (value === 'uri') return 'url';
+  return undefined;
 }
 
 function buildObjectControl(

--- a/packages/core/src/playground-fixtures.ts
+++ b/packages/core/src/playground-fixtures.ts
@@ -5,6 +5,7 @@ import type { Schema } from './ir';
 import {
   buildPlaygroundContract,
   type PlaygroundArrayElementControl,
+  type PlaygroundContractOptions,
   type PlaygroundControl,
   type PlaygroundEntity,
   type PlaygroundFieldConstraints,
@@ -24,6 +25,7 @@ export interface PlaygroundFixtureOptions {
   countsByType?: Record<string, number>;
   typeNames?: readonly string[];
   existingRecordsByType?: Record<string, Array<{ id: string; value: Record<string, unknown> }>>;
+  externalTypes?: PlaygroundContractOptions['externalTypes'];
 }
 
 export interface PlaygroundFixtureResult {
@@ -43,7 +45,7 @@ export function generatePlaygroundFixtures(
   schema: Schema,
   options: PlaygroundFixtureOptions = {},
 ): PlaygroundFixtureResult {
-  const contract = buildPlaygroundContract(schema);
+  const contract = buildPlaygroundContract(schema, { externalTypes: options.externalTypes });
   const requestedTypeNames = new Set(
     options.typeNames ?? contract.entities.map((entity) => entity.typeName),
   );

--- a/packages/core/tests/modeling-hints.test.ts
+++ b/packages/core/tests/modeling-hints.test.ts
@@ -113,4 +113,42 @@ describe('analyzeModelingHints', () => {
       ]),
     );
   });
+
+  it('suggests stdlib refs for primitive fields that match shared value types', () => {
+    const hints = analyzeModelingHints({
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Album',
+          table: true,
+          fields: [
+            { name: 'releaseDate', type: { kind: 'string' } },
+            { name: 'website', type: { kind: 'string' } },
+            { name: 'country', type: { kind: 'string' } },
+          ],
+        },
+      ],
+    });
+
+    expect(hints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'stdlib_type',
+          fieldName: 'releaseDate',
+          action: { kind: 'use_stdlib_type', typeName: 'common.ISODate' },
+        }),
+        expect.objectContaining({
+          kind: 'stdlib_type',
+          fieldName: 'website',
+          action: { kind: 'use_stdlib_type', typeName: 'common.URL' },
+        }),
+        expect.objectContaining({
+          kind: 'stdlib_type',
+          fieldName: 'country',
+          action: { kind: 'use_stdlib_type', typeName: 'place.CountryCode' },
+        }),
+      ]),
+    );
+  });
 });

--- a/packages/core/tests/playground-contract.test.ts
+++ b/packages/core/tests/playground-contract.test.ts
@@ -124,4 +124,60 @@ describe('buildPlaygroundContract', () => {
       ],
     });
   });
+
+  it('resolves qualified external raw and enum references into editable controls', () => {
+    const externalTypes = new Map([
+      [
+        'common.NonEmptyString',
+        {
+          kind: 'raw' as const,
+          name: 'NonEmptyString',
+          zod: 'z.string().min(1)',
+          jsonSchema: { type: 'string', minLength: 1 },
+        },
+      ],
+      [
+        'place.CountryCode',
+        {
+          kind: 'enum' as const,
+          name: 'CountryCode',
+          values: [{ value: 'GB' }, { value: 'US' }],
+        },
+      ],
+    ]);
+    const recordLabelSchema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'RecordLabel',
+          table: true,
+          fields: [
+            { name: 'name', type: { kind: 'ref', typeName: 'common.NonEmptyString' } },
+            { name: 'country', type: { kind: 'ref', typeName: 'place.CountryCode' } },
+          ],
+        },
+      ],
+    };
+
+    const [recordLabel] = buildPlaygroundContract(recordLabelSchema, { externalTypes }).entities;
+
+    expect(recordLabel?.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'text',
+          fieldName: 'name',
+          constraints: expect.objectContaining({ min: 1 }),
+        }),
+        expect.objectContaining({
+          kind: 'enum',
+          fieldName: 'country',
+          options: [
+            { value: 'GB', label: 'GB', description: undefined },
+            { value: 'US', label: 'US', description: undefined },
+          ],
+        }),
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- resolve external stdlib refs in playground contracts/fixtures and selected node details
- add stdlib-aware modeling hints with one-click field actions
- add a Stdlib sidebar with search, usage indicators, selected-type focus, and polished examples
- strengthen agent prompt guidance to prefer shared stdlib refs for common value formats

## Verification
- pre-commit hook: biome check --write --no-errors-on-unmatched
- pre-commit hook: turbo typecheck
- pre-commit hook: turbo test
- focused during development: StdlibPanel, DetailPanel, FieldDetail, PlaygroundPanel, system prompt, modeling hints, playground contract tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783003641&installation_id=136251083&pr_number=356&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F356&signature=2e4a775680ec4eb8880796546ff4c93ade52ea4e48683aaf573abc42f34c7d15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->