### PR TITLE
feat: add stdlib canvas controls

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.30",
+  "version": "0.15.31",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/main/providers/codex/runtime.ts
+++ b/apps/desktop/src/main/providers/codex/runtime.ts
@@ -1,4 +1,6 @@
 import { tmpdir } from 'node:os';
+import { SYSTEM_PROMPT_STDLIB } from '@shared/stdlib-registry';
+import { buildSystemPromptAppend } from '@shared/system-prompt';
 import type { OpToolDescriptor } from '../../ops';
 import { overlayModelOptions } from '../model-registry';
 import type {
@@ -570,6 +572,8 @@ function buildSchemaOnlyInstructions(): string {
     'Do not read files, write files, run shell commands, browse, or mutate a repository.',
     'You may use file contents explicitly attached inside the user message as context.',
     'Treat the current Contexture IR in the user message as authoritative.',
+    '',
+    buildSystemPromptAppend({ stdlibRegistry: SYSTEM_PROMPT_STDLIB }),
   ].join('\n');
 }
 

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -291,7 +291,12 @@ export function ReconcileModal(): React.JSX.Element {
       return;
     }
     void window.contexture?.reconcile
-      .writeGeneratedTarget({ irPath: filePath, targetPath, contents: currentEmit.source })
+      .acceptGeneratedTarget({
+        irPath: filePath,
+        targetPath,
+        contents: currentEmit.source,
+        schema,
+      })
       .then(async () => {
         await window.contexture?.drift.check();
         close();
@@ -300,7 +305,7 @@ export function ReconcileModal(): React.JSX.Element {
         const message = err instanceof Error ? err.message : String(err);
         setError(`Failed to overwrite file: ${message}`);
       });
-  }, [filePath, targetPath, targetKind, currentEmit, close, setError]);
+  }, [filePath, targetPath, targetKind, currentEmit, schema, close, setError]);
 
   const handleOpenInChat = useCallback(() => {
     const irJson = JSON.stringify(schema, null, 2);

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -186,6 +186,7 @@ function GraphCanvasInner({
 
   const graphLayout = useGraphLayoutStore((s) => s.graphLayout);
   const showEnums = graphLayout.showEnums;
+  const showStdlib = graphLayout.showStdlib;
   const [refPreview, setRefPreview] = useState<RefPreview | null>(null);
   const refPreviewClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [focusedField, setFocusedField] = useState<{ nodeId: string; fieldName: string } | null>(
@@ -193,7 +194,10 @@ function GraphCanvasInner({
   );
   const focusedFieldClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { nodes: visibleBuiltNodes, edges: visibleBuiltEdges } = useMemo(() => {
-    const visible = filterGraphView({ nodes: builtNodes, edges: builtEdges }, { showEnums });
+    const visible = filterGraphView(
+      { nodes: builtNodes, edges: builtEdges },
+      { showEnums, showStdlib },
+    );
     const visibleWithFocusedField = focusedField
       ? {
           ...visible,
@@ -234,7 +238,7 @@ function GraphCanvasInner({
           : { ...edge, data: { ...edge.data, previewDimmed: true } };
       }),
     };
-  }, [builtNodes, builtEdges, showEnums, refPreview, focusedField]);
+  }, [builtNodes, builtEdges, showEnums, showStdlib, refPreview, focusedField]);
 
   const [nodes, setNodes] = useState<Node[]>(visibleBuiltNodes);
   const [edges, setEdges] = useState<Edge[]>(visibleBuiltEdges);
@@ -273,10 +277,16 @@ function GraphCanvasInner({
   }, [builtNodes, visibleBuiltNodes, visibleBuiltEdges]);
 
   useEffect(() => {
-    if (showEnums || !selectedNodeId) return;
+    if ((showEnums && showStdlib) || !selectedNodeId) return;
     const selectedNode = builtNodes.find((node) => node.id === selectedNodeId);
-    if (selectedNode?.data.kind === 'enum' && !selectedNode.data.imported) clearNodes();
-  }, [builtNodes, clearNodes, selectedNodeId, showEnums]);
+    if (
+      selectedNode &&
+      ((!showEnums && selectedNode.data.kind === 'enum' && !selectedNode.data.imported) ||
+        (!showStdlib && selectedNode.data.stdlib === true))
+    ) {
+      clearNodes();
+    }
+  }, [builtNodes, clearNodes, selectedNodeId, showEnums, showStdlib]);
 
   // ELK once the nodes have measured DOM dimensions.
   const { runLayout } = useELKLayout();
@@ -600,7 +610,7 @@ function GraphCanvasInner({
             pattern reads as texture not noise on both light and dark. */}
         <Background gap={28} size={0.8} color="var(--graph-dot)" />
         <Controls showInteractive={false} />
-        <GraphLegend showEnumNodes={showEnums} />
+        <GraphLegend showEnumNodes={showEnums} showStdlibNodes={showStdlib} />
       </ReactFlow>
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
@@ -67,6 +67,11 @@ const NODE_ITEMS: readonly NodeItem[] = [
     style: 'dashed',
   },
   {
+    label: 'Stdlib',
+    header: 'color-mix(in oklch, var(--chart-2) 72%, var(--graph-node-header-bg))',
+    style: 'dashed',
+  },
+  {
     label: 'Selected',
     header: 'var(--graph-node-selected)',
   },
@@ -74,20 +79,25 @@ const NODE_ITEMS: readonly NodeItem[] = [
 
 export const GraphLegend = memo(function GraphLegend({
   showEnumNodes = false,
+  showStdlibNodes = false,
 }: {
   showEnumNodes?: boolean;
+  showStdlibNodes?: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const visibleNodeItems = showStdlibNodes
+    ? NODE_ITEMS
+    : NODE_ITEMS.filter((item) => item.label !== 'Stdlib');
   const nodeItems = showEnumNodes
     ? [
-        ...NODE_ITEMS.slice(0, 2),
+        ...visibleNodeItems.slice(0, 2),
         {
           label: 'Enum',
           header: 'color-mix(in oklch, var(--chart-3) 85%, transparent)',
         },
-        ...NODE_ITEMS.slice(2),
+        ...visibleNodeItems.slice(2),
       ]
-    : NODE_ITEMS;
+    : visibleNodeItems;
 
   return (
     <div

--- a/apps/desktop/src/renderer/src/components/graph/graph-view.ts
+++ b/apps/desktop/src/renderer/src/components/graph/graph-view.ts
@@ -2,15 +2,22 @@ import type { BuildGraphResult } from './schema-to-graph';
 
 export interface GraphViewOptions {
   showEnums: boolean;
+  showStdlib: boolean;
 }
 
 export function filterGraphView(
   graph: BuildGraphResult,
   options: GraphViewOptions,
 ): BuildGraphResult {
-  if (options.showEnums) return graph;
+  if (options.showEnums && options.showStdlib) return graph;
   const hiddenNodeIds = new Set(
-    graph.nodes.filter((node) => node.data.kind === 'enum' && !node.data.imported).map((n) => n.id),
+    graph.nodes
+      .filter(
+        (node) =>
+          (!options.showEnums && node.data.kind === 'enum' && !node.data.imported) ||
+          (!options.showStdlib && node.data.stdlib === true),
+      )
+      .map((n) => n.id),
   );
   if (hiddenNodeIds.size === 0) return graph;
   return {

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -26,7 +26,7 @@ import { Badge } from '@/components/ui/badge';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { type FieldSelection, useGraphSelectionStore } from '../../../store/selection';
 import { type FieldRefPreview, TYPE_NODE_REF_PREVIEW_EVENT } from '../ref-preview-event';
-import type { EnumTargetRow, TypeNodeData } from '../schema-to-graph';
+import type { EnumTargetRow, StdlibTargetRow, TypeNodeData } from '../schema-to-graph';
 
 export const TYPE_NODE_EVENT = 'contexture:field-select' as const;
 export const TYPE_NODE_OBJECT_EVENT = 'contexture:type-select' as const;
@@ -64,6 +64,10 @@ const enumHoverCardStyle: CSSProperties = {
   borderTop: '2px solid color-mix(in oklch, var(--chart-3) 85%, transparent)',
 };
 
+const stdlibHoverCardStyle: CSSProperties = {
+  borderTop: '2px solid color-mix(in oklch, var(--chart-2) 75%, var(--reference))',
+};
+
 export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
   const { data, id } = props;
   const click = useGraphSelectionStore((s) => s.click);
@@ -92,7 +96,7 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
   const onFieldClick = useCallback(
     (field: TypeNodeData['fields'][number], ev: React.MouseEvent<HTMLElement>) => {
       ev.stopPropagation();
-      if (field.refTarget && !field.enumTarget) {
+      if (field.refTarget && !field.enumTarget && !field.stdlibTarget) {
         click(field.refTarget, 'replace');
         return;
       }
@@ -161,18 +165,25 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
   const borderWidth = isSelected || isAdjacent ? 2 : 1;
   const borderStyle = data.imported ? 'dashed' : 'solid';
   const headerColor = useMemo(
-    () => (data.table ? 'var(--graph-node-table-header-bg)' : headerColorFor(data.kind)),
-    [data.kind, data.table],
+    () =>
+      data.stdlib
+        ? 'color-mix(in oklch, var(--chart-2) 72%, var(--graph-node-header-bg))'
+        : data.table
+          ? 'var(--graph-node-table-header-bg)'
+          : headerColorFor(data.kind),
+    [data.kind, data.table, data.stdlib],
   );
   const selectionAccent = useMemo(
     () => (data.table ? 'var(--graph-node-selected)' : headerColorFor(data.kind)),
     [data.kind, data.table],
   );
-  const nodeKindLabel = data.table
-    ? 'table'
-    : data.kind === 'discriminatedUnion'
-      ? 'union'
-      : data.kind;
+  const nodeKindLabel = data.stdlib
+    ? 'stdlib'
+    : data.table
+      ? 'table'
+      : data.kind === 'discriminatedUnion'
+        ? 'union'
+        : data.kind;
   const baseNodeShadow = '0 2px 10px oklch(0 0 0 / 0.18), 0 0 1px oklch(0 0 0 / 0.15)';
   const node = (
     <div
@@ -502,10 +513,12 @@ function FieldRowButton({
 }) {
   const refTargetSelected = field.refTarget !== undefined && field.refTarget === selectedTarget;
   const hasValidationIssues = (field.validationIssueCount ?? 0) > 0;
-  const [enumCardOpen, setEnumCardOpen] = useState(false);
+  const [metadataCardOpen, setMetadataCardOpen] = useState(false);
   const [highlighted, setHighlighted] = useState(false);
   const enumSummary = field.enumTarget ? `${field.summary.replace(/^→\s*/, '')} enum` : undefined;
+  const stdlibSummary = field.stdlibTarget ? field.summary.replace(/^→\s*/, '') : undefined;
   const isUnionRef = field.refTargetKind === 'discriminatedUnion';
+  const hoverTarget = field.enumTarget ?? field.stdlibTarget;
   const button = (
     <button
       type="button"
@@ -516,11 +529,11 @@ function FieldRowButton({
       onClick={(ev) => onFieldClick(field, ev)}
       onFocus={() => {
         setHighlighted(true);
-        if (field.enumTarget) setEnumCardOpen(true);
+        if (hoverTarget) setMetadataCardOpen(true);
       }}
       onBlur={() => {
         setHighlighted(false);
-        if (field.enumTarget) setEnumCardOpen(false);
+        if (hoverTarget) setMetadataCardOpen(false);
       }}
       onMouseEnter={(ev) => {
         setHighlighted(true);
@@ -535,7 +548,9 @@ function FieldRowButton({
       aria-label={
         field.enumTarget
           ? `${field.name}, ${field.enumTarget.name} enum, ${field.enumTarget.values.length} values`
-          : undefined
+          : field.stdlibTarget
+            ? `${field.name}, ${field.stdlibTarget.name} stdlib type`
+            : undefined
       }
       data-search-focused={searchFocused ? 'true' : 'false'}
       className="contexture-type-node-field focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
@@ -596,9 +611,11 @@ function FieldRowButton({
         data-testid={
           field.enumTarget
             ? 'type-node-field-enum-summary'
-            : field.refTarget
-              ? 'type-node-field-ref-summary'
-              : undefined
+            : field.stdlibTarget
+              ? 'type-node-field-stdlib-summary'
+              : field.refTarget
+                ? 'type-node-field-ref-summary'
+                : undefined
         }
         style={{
           color: refTargetSelected
@@ -611,14 +628,18 @@ function FieldRowButton({
                   ? `color-mix(in oklch, ${selectionAccent} 42%, var(--foreground))`
                   : field.enumTarget
                     ? 'var(--muted-foreground)'
-                    : field.refTarget
-                      ? 'var(--graph-edge-ref)'
-                      : 'var(--muted-foreground)',
+                    : field.stdlibTarget
+                      ? 'color-mix(in oklch, var(--chart-2) 65%, var(--reference))'
+                      : field.refTarget
+                        ? 'var(--graph-edge-ref)'
+                        : 'var(--muted-foreground)',
           fontFamily: field.enumTarget
             ? 'var(--font-mono)'
-            : field.refTarget
-              ? 'inherit'
-              : 'var(--font-mono)',
+            : field.stdlibTarget
+              ? 'var(--font-mono)'
+              : field.refTarget
+                ? 'inherit'
+                : 'var(--font-mono)',
           fontSize: 9,
           fontWeight: refTargetSelected ? 700 : 400,
           overflow: 'hidden',
@@ -633,6 +654,13 @@ function FieldRowButton({
             style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
           >
             {enumSummary}
+          </span>
+        ) : field.stdlibTarget ? (
+          <span
+            data-testid="type-node-field-stdlib-affordance"
+            style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {stdlibSummary}
           </span>
         ) : isUnionRef ? (
           <span
@@ -657,19 +685,80 @@ function FieldRowButton({
     </button>
   );
 
-  if (!field.enumTarget) return button;
+  if (!hoverTarget) return button;
 
   return (
-    <HoverCard open={enumCardOpen} onOpenChange={setEnumCardOpen} openDelay={120} closeDelay={80}>
+    <HoverCard
+      open={metadataCardOpen}
+      onOpenChange={setMetadataCardOpen}
+      openDelay={120}
+      closeDelay={80}
+    >
       <HoverCardTrigger asChild>{button}</HoverCardTrigger>
       <HoverCardContent
         side="right"
         align="start"
         className="w-72 p-3 text-xs"
-        style={enumHoverCardStyle}
+        style={field.enumTarget ? enumHoverCardStyle : stdlibHoverCardStyle}
       >
-        <EnumHoverCardContent enumTarget={field.enumTarget} />
+        {field.enumTarget ? (
+          <EnumHoverCardContent enumTarget={field.enumTarget} />
+        ) : field.stdlibTarget ? (
+          <StdlibHoverCardContent stdlibTarget={field.stdlibTarget} />
+        ) : null}
       </HoverCardContent>
     </HoverCard>
+  );
+}
+
+function StdlibHoverCardContent({ stdlibTarget }: { stdlibTarget: StdlibTargetRow }) {
+  const values = stdlibTarget.values ?? [];
+  const visibleValues = values.slice(0, 18);
+  const hiddenValueCount = values.length - visibleValues.length;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <div className="text-sm font-semibold text-foreground">{stdlibTarget.name}</div>
+        <div
+          className="text-[10px] font-medium uppercase tracking-wide"
+          style={{ color: 'color-mix(in oklch, var(--chart-2) 75%, var(--reference))' }}
+        >
+          Stdlib {stdlibTarget.kind}
+        </div>
+        {stdlibTarget.description && (
+          <p className="text-xs leading-snug text-muted-foreground">{stdlibTarget.description}</p>
+        )}
+      </div>
+      {values.length > 0 ? (
+        <div className="space-y-1.5">
+          <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Values
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {visibleValues.map((value) => (
+              <Badge
+                key={value.value}
+                data-testid="stdlib-value-badge"
+                variant="secondary"
+                title={value.description}
+                className="max-w-full rounded border px-1.5 py-0 text-[10px] font-semibold shadow-sm"
+              >
+                <span className="truncate">{value.value}</span>
+              </Badge>
+            ))}
+            {hiddenValueCount > 0 ? (
+              <Badge
+                data-testid="stdlib-value-more-badge"
+                variant="outline"
+                className="rounded px-1.5 py-0 text-[10px] font-semibold"
+              >
+                +{hiddenValueCount} more
+              </Badge>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
+++ b/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
@@ -28,6 +28,7 @@
  */
 
 import type { FieldDef, FieldType, Schema, TypeDef } from '@contexture/core/ir';
+import { STDLIB_REGISTRY, STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registry';
 import type { Edge, Node } from '@xyflow/react';
 
 type TableTypeDef = Extract<TypeDef, { kind: 'object' }> & { table: true };
@@ -49,6 +50,8 @@ export interface TypeNodeData extends Record<string, unknown> {
   validationIssueCount?: number;
   /** True when the source `ObjectTypeDef` carries `table: true`. */
   table?: boolean;
+  /** True when this imported node represents a bundled stdlib type. */
+  stdlib?: boolean;
   /** Local object nodes can create fields directly from the canvas. */
   canAddFields?: boolean;
 }
@@ -71,6 +74,8 @@ export interface FieldRow {
   refTargetKind?: TypeDef['kind'];
   /** Local enum metadata when this field references an enum TypeDef. */
   enumTarget?: EnumTargetRow;
+  /** Bundled stdlib metadata when this field references `namespace.Type`. */
+  stdlibTarget?: StdlibTargetRow;
   validationIssueCount?: number;
 }
 
@@ -78,6 +83,13 @@ export interface EnumTargetRow {
   name: string;
   description?: string;
   values: ReadonlyArray<EnumValueRow>;
+}
+
+export interface StdlibTargetRow {
+  name: string;
+  description?: string;
+  kind: TypeDef['kind'];
+  values?: ReadonlyArray<EnumValueRow>;
 }
 
 export interface RefEdgeData extends Record<string, unknown> {
@@ -88,6 +100,8 @@ export interface RefEdgeData extends Record<string, unknown> {
   discriminator?: string;
   /** True when the target is an imported (out-of-file) type. */
   crossBoundary: boolean;
+  /** True when the target is a bundled stdlib type. */
+  stdlib?: boolean;
   previewHighlighted?: boolean;
   previewDimmed?: boolean;
 }
@@ -120,19 +134,20 @@ export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphRe
   const edges: Edge<RefEdgeData>[] = [];
   const externalNodeIds = new Set<string>();
 
-  const ensureExternalNode = (target: string): boolean => {
+  const ensureExternalNode = (target: string): { crossBoundary: boolean; stdlib: boolean } => {
     const crossBoundary = target.includes('.') || !localNames.has(target);
+    const stdlib = isStdlibRef(target);
     if (crossBoundary && !externalNodeIds.has(target)) {
       externalNodeIds.add(target);
-      nodes.push(externalNodeFor(target, positions?.[target] ?? DEFAULT_POSITION));
+      nodes.push(externalNodeFor(target, positions?.[target] ?? DEFAULT_POSITION, stdlib));
     }
-    return crossBoundary;
+    return { crossBoundary, stdlib };
   };
 
   for (const type of schema.types) {
     if (type.kind === 'discriminatedUnion') {
       for (const variant of type.variants) {
-        const crossBoundary = ensureExternalNode(variant);
+        const { crossBoundary, stdlib } = ensureExternalNode(variant);
         edges.push({
           id: `${type.name}.variant->${variant}`,
           source: type.name,
@@ -144,6 +159,7 @@ export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphRe
             targetType: variant,
             discriminator: type.discriminator,
             crossBoundary,
+            stdlib,
           },
         });
       }
@@ -154,7 +170,7 @@ export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphRe
     for (const field of type.fields) {
       const target = unwrapRefTarget(field.type);
       if (target) {
-        const crossBoundary = ensureExternalNode(target);
+        const { crossBoundary, stdlib } = ensureExternalNode(target);
 
         edges.push({
           id: `${type.name}.${field.name}->${target}`,
@@ -167,6 +183,7 @@ export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphRe
             sourceField: field.name,
             targetType: target,
             crossBoundary,
+            stdlib,
           },
         });
         continue;
@@ -218,7 +235,11 @@ function localNodeFor(
   };
 }
 
-function externalNodeFor(typeName: string, position: { x: number; y: number }): Node<TypeNodeData> {
+function externalNodeFor(
+  typeName: string,
+  position: { x: number; y: number },
+  stdlib: boolean,
+): Node<TypeNodeData> {
   return {
     id: typeName,
     type: 'type',
@@ -228,6 +249,7 @@ function externalNodeFor(typeName: string, position: { x: number; y: number }): 
       kind: 'object',
       fields: [],
       imported: true,
+      stdlib,
     },
   };
 }
@@ -280,6 +302,7 @@ function fieldRow(field: FieldDef, localTypes: ReadonlyMap<string, TypeDef>): Fi
   const target = unwrapRefTarget(field.type);
   const refTargetType = target ? localTypes.get(target) : undefined;
   const enumTarget = refTargetType?.kind === 'enum' ? refTargetType : undefined;
+  const stdlibTarget = target && !refTargetType ? stdlibTargetRow(target) : undefined;
   return {
     name: field.name,
     summary: summariseFieldType(field.type),
@@ -294,7 +317,30 @@ function fieldRow(field: FieldDef, localTypes: ReadonlyMap<string, TypeDef>): Fi
           values: enumTarget.values.map(enumValueRow),
         }
       : undefined,
+    stdlibTarget,
   };
+}
+
+function stdlibTargetRow(typeName: string): StdlibTargetRow | undefined {
+  if (!isStdlibRef(typeName)) return undefined;
+  const type = STDLIB_TYPE_DEFINITIONS.get(typeName);
+  if (!type) return undefined;
+  return {
+    name: typeName,
+    description: type.description,
+    kind: type.kind,
+    values: type.kind === 'enum' ? type.values.map(enumValueRow) : undefined,
+  };
+}
+
+function isStdlibRef(typeName: string): boolean {
+  const [namespace, name, ...rest] = typeName.split('.');
+  return (
+    rest.length === 0 &&
+    namespace !== undefined &&
+    name !== undefined &&
+    STDLIB_REGISTRY.hasType(namespace, name)
+  );
 }
 
 export function summariseFieldType(t: FieldType): string {

--- a/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
@@ -127,6 +127,17 @@ export function GraphControlsPanel({ onClose }: Props): React.JSX.Element {
         </label>
         <label
           className="flex items-center gap-2 text-xs text-foreground"
+          htmlFor="graph-control-show-stdlib"
+        >
+          <Checkbox
+            id="graph-control-show-stdlib"
+            checked={graphLayout.showStdlib}
+            onCheckedChange={(checked) => setGraphLayout({ showStdlib: checked === true })}
+          />
+          Show stdlib nodes
+        </label>
+        <label
+          className="flex items-center gap-2 text-xs text-foreground"
           htmlFor="graph-control-show-edge-labels"
         >
           <Checkbox

--- a/apps/desktop/src/renderer/src/store/layout-config.ts
+++ b/apps/desktop/src/renderer/src/store/layout-config.ts
@@ -11,6 +11,7 @@ export interface GraphLayout {
   layoutMode: 'organic' | 'layered';
   nodeSpacing: number;
   showEnums: boolean;
+  showStdlib: boolean;
   showEdgeLabels: boolean;
 }
 
@@ -18,6 +19,7 @@ export const DEFAULT_LAYOUT: GraphLayout = {
   layoutMode: 'layered',
   nodeSpacing: 180,
   showEnums: false,
+  showStdlib: false,
   showEdgeLabels: true,
 };
 

--- a/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
+++ b/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
@@ -97,11 +97,12 @@ describe('ReconcileModal', () => {
     fireEvent.click(screen.getByRole('button', { name: /regenerate from ir/i }));
 
     await waitFor(() =>
-      expect(window.contexture?.reconcile.writeGeneratedTarget).toHaveBeenCalledOnce(),
+      expect(window.contexture?.reconcile.acceptGeneratedTarget).toHaveBeenCalledOnce(),
     );
     const [payload] =
-      vi.mocked(window.contexture?.reconcile.writeGeneratedTarget).mock.calls[0] ?? [];
+      vi.mocked(window.contexture?.reconcile.acceptGeneratedTarget).mock.calls[0] ?? [];
     expect(payload).toMatchObject({ irPath: IR_PATH, targetPath: ZOD_PATH });
+    expect(payload?.schema).toEqual(SCHEMA);
     const contents = payload?.contents ?? '';
     expect(contents).toContain('@contexture-generated');
     expect(contents).toContain('Plot');
@@ -159,7 +160,7 @@ describe('ReconcileModal', () => {
     render(<ReconcileModal />);
     fireEvent.click(screen.getByRole('button', { name: /leave dirty/i }));
 
-    expect(window.contexture?.reconcile.writeGeneratedTarget).not.toHaveBeenCalled();
+    expect(window.contexture?.reconcile.acceptGeneratedTarget).not.toHaveBeenCalled();
     expect(useDriftStore.getState().driftedPaths).toEqual([ZOD_PATH]);
     expect(useReconcileStore.getState().isOpen).toBe(false);
   });

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -472,6 +472,46 @@ describe('TypeNode', () => {
     );
   });
 
+  it('renders stdlib refs as inline affordances with hover details', () => {
+    const data: TypeNodeData = {
+      typeName: 'User',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'email',
+          summary: '→ common.Email',
+          optional: false,
+          nullable: false,
+          refTarget: 'common.Email',
+          stdlibTarget: {
+            name: 'common.Email',
+            description: 'Email address.',
+            kind: 'raw',
+          },
+        },
+      ],
+    };
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId('type-node-field-stdlib-affordance')).toHaveTextContent(
+      'common.Email',
+    );
+    expect(screen.getByTestId('type-node-field')).toHaveAccessibleName(
+      'email, common.Email stdlib type',
+    );
+    expect(screen.getByTestId('type-node-field-stdlib-summary')).toHaveStyle({
+      color: 'color-mix(in oklch, var(--chart-2) 65%, var(--reference))',
+      fontWeight: '400',
+      fontFamily: 'var(--font-mono)',
+    });
+
+    fireEvent.focus(screen.getByTestId('type-node-field'));
+
+    expect(screen.getByText('Email address.')).toBeInTheDocument();
+    expect(screen.getByText('Stdlib raw')).toBeInTheDocument();
+  });
+
   it('renders discriminated union refs as relationship refs with a muted suffix', () => {
     const data: TypeNodeData = {
       typeName: 'Artwork',

--- a/apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx
+++ b/apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx
@@ -13,17 +13,20 @@ describe('GraphControlsPanel', () => {
     vi.useRealTimers();
   });
 
-  it('toggles expanded enum nodes and edge-label visibility', () => {
+  it('toggles expanded enum nodes, stdlib nodes, and edge-label visibility', () => {
     render(<GraphControlsPanel onClose={vi.fn()} />);
 
     expect(screen.getByRole('checkbox', { name: 'Show enum nodes' })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Show stdlib nodes' })).not.toBeChecked();
     expect(screen.getByRole('checkbox', { name: 'Edge labels' })).toBeChecked();
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Show enum nodes' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Show stdlib nodes' }));
     fireEvent.click(screen.getByRole('checkbox', { name: 'Edge labels' }));
 
     expect(useGraphLayoutStore.getState().graphLayout).toMatchObject({
       showEnums: true,
+      showStdlib: true,
       showEdgeLabels: false,
     });
   });
@@ -33,6 +36,7 @@ describe('GraphControlsPanel', () => {
     useGraphLayoutStore.getState().setGraphLayout({
       layoutMode: 'organic',
       showEnums: false,
+      showStdlib: true,
       showEdgeLabels: false,
       nodeSpacing: 240,
     });

--- a/apps/desktop/tests/graph/graph-view.test.ts
+++ b/apps/desktop/tests/graph/graph-view.test.ts
@@ -23,6 +23,18 @@ function graph(): BuildGraphResult {
         position: { x: 200, y: 0 },
         data: { typeName: 'common.ExternalEnum', kind: 'enum', imported: true, fields: [] },
       },
+      {
+        id: 'common.Email',
+        type: 'type',
+        position: { x: 300, y: 0 },
+        data: {
+          typeName: 'common.Email',
+          kind: 'object',
+          imported: true,
+          stdlib: true,
+          fields: [],
+        },
+      },
     ],
     edges: [
       {
@@ -51,13 +63,57 @@ function graph(): BuildGraphResult {
           crossBoundary: true,
         },
       },
+      {
+        id: 'Recipe.email->common.Email',
+        source: 'Recipe',
+        target: 'common.Email',
+        type: 'ref',
+        data: {
+          relation: 'fieldRef',
+          sourceType: 'Recipe',
+          sourceField: 'email',
+          targetType: 'common.Email',
+          crossBoundary: true,
+          stdlib: true,
+        },
+      },
     ],
   };
 }
 
 describe('filterGraphView', () => {
   it('keeps enum nodes and enum edges when enums are visible', () => {
-    const result = filterGraphView(graph(), { showEnums: true });
+    const result = filterGraphView(graph(), { showEnums: true, showStdlib: true });
+
+    expect(result.nodes.map((node) => node.id)).toEqual([
+      'Recipe',
+      'Difficulty',
+      'common.ExternalEnum',
+      'common.Email',
+    ]);
+    expect(result.edges.map((edge) => edge.id)).toEqual([
+      'Recipe.difficulty->Difficulty',
+      'Recipe.external->common.ExternalEnum',
+      'Recipe.email->common.Email',
+    ]);
+  });
+
+  it('hides local enum nodes and their incident edges', () => {
+    const result = filterGraphView(graph(), { showEnums: false, showStdlib: true });
+
+    expect(result.nodes.map((node) => node.id)).toEqual([
+      'Recipe',
+      'common.ExternalEnum',
+      'common.Email',
+    ]);
+    expect(result.edges.map((edge) => edge.id)).toEqual([
+      'Recipe.external->common.ExternalEnum',
+      'Recipe.email->common.Email',
+    ]);
+  });
+
+  it('hides stdlib nodes and their incident edges independently of other imports', () => {
+    const result = filterGraphView(graph(), { showEnums: true, showStdlib: false });
 
     expect(result.nodes.map((node) => node.id)).toEqual([
       'Recipe',
@@ -68,12 +124,5 @@ describe('filterGraphView', () => {
       'Recipe.difficulty->Difficulty',
       'Recipe.external->common.ExternalEnum',
     ]);
-  });
-
-  it('hides local enum nodes and their incident edges', () => {
-    const result = filterGraphView(graph(), { showEnums: false });
-
-    expect(result.nodes.map((node) => node.id)).toEqual(['Recipe', 'common.ExternalEnum']);
-    expect(result.edges.map((edge) => edge.id)).toEqual(['Recipe.external->common.ExternalEnum']);
   });
 });

--- a/apps/desktop/tests/graph/schema-to-graph.test.ts
+++ b/apps/desktop/tests/graph/schema-to-graph.test.ts
@@ -89,6 +89,46 @@ describe('buildGraph', () => {
     });
   });
 
+  it('marks stdlib refs as stdlib shadow nodes and field hover metadata', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'User',
+          fields: [{ name: 'email', type: { kind: 'ref', typeName: 'common.Email' } }],
+        },
+      ],
+    };
+
+    const { nodes, edges } = buildGraph({ schema });
+    const user = nodes.find((node) => node.id === 'User');
+    const email = nodes.find((node) => node.id === 'common.Email');
+
+    expect(email?.data).toMatchObject({
+      typeName: 'common.Email',
+      imported: true,
+      stdlib: true,
+    });
+    expect(user?.data.fields[0]).toMatchObject({
+      name: 'email',
+      summary: '→ common.Email',
+      refTarget: 'common.Email',
+      stdlibTarget: {
+        name: 'common.Email',
+        description: 'Email address.',
+        kind: 'raw',
+      },
+    });
+    expect(edges[0]).toMatchObject({
+      id: 'User.email->common.Email',
+      data: {
+        crossBoundary: true,
+        stdlib: true,
+      },
+    });
+  });
+
   it('passes local ref target kind into object field rows', () => {
     const schema: Schema = {
       version: '1',

--- a/apps/desktop/tests/main/codex-runtime.test.ts
+++ b/apps/desktop/tests/main/codex-runtime.test.ts
@@ -669,6 +669,7 @@ describe('CodexProviderRuntime', () => {
       sandbox: string;
       environments: unknown[];
       config: { web_search?: unknown; tools?: { view_image?: unknown } };
+      developerInstructions: string;
     };
     expect(params.cwd.length).toBeGreaterThan(0);
     expect(params.approvalPolicy).toEqual({
@@ -686,6 +687,12 @@ describe('CodexProviderRuntime', () => {
       web_search: 'disabled',
       tools: { view_image: false },
     });
+    expect(params.developerInstructions).toContain('## Stdlib-first modeling');
+    expect(params.developerInstructions).toContain('common.URL');
+    expect(params.developerInstructions).toContain('common.ISODate');
+    expect(params.developerInstructions).toContain(
+      '{ kind: "ref", typeName: "namespace.Type" }` with the namespace prefix',
+    );
     expect(params.dynamicTools).toEqual([
       expect.objectContaining({ namespace: 'contexture', name: 'add_type' }),
     ]);


### PR DESCRIPTION
## Summary
- add a graph control to show/hide stdlib shadow nodes separately from enum nodes
- keep stdlib refs visible inline with hovercard metadata on fields
- include stdlib type guidance in Codex schema-chat instructions
- bump desktop app version to 0.15.31

## Verification
- bun run test -- tests/graph/schema-to-graph.test.ts tests/graph/graph-view.test.ts tests/components/graph/TypeNode.test.tsx tests/components/toolbar/GraphControlsPanel.test.tsx tests/main/codex-runtime.test.ts
- bun run typecheck
- bun run lint
- pre-commit hook: turbo typecheck && turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783007176&installation_id=136251083&pr_number=358&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F358&signature=512cd64a1d84692675ec71c5ba35fc5e4c86daebc62bada9a1e5b7408dc0c228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->