### PR TITLE
fix: open hidden target properties from hover cards

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.31",
+  "version": "0.15.32",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -62,7 +62,11 @@ import {
   type KeyEvent as InteractionKeyEvent,
 } from './interactions';
 import { GroupNode } from './nodes/GroupNode';
-import { TYPE_NODE_ADD_FIELD_EVENT, TypeNode } from './nodes/TypeNode';
+import {
+  TYPE_NODE_ADD_FIELD_EVENT,
+  TYPE_NODE_TARGET_PROPERTIES_EVENT,
+  TypeNode,
+} from './nodes/TypeNode';
 import { type FieldRefPreview, TYPE_NODE_REF_PREVIEW_EVENT } from './ref-preview-event';
 import {
   type BuildGraphResult,
@@ -166,6 +170,8 @@ function GraphCanvasInner({
   const setAdjacencyResolver = useGraphSelectionStore((s) => s.setAdjacencyResolver);
   const focusTarget = useGraphSelectionStore((s) => s.state.focusTarget);
   const consumeFocus = useGraphSelectionStore((s) => s.consumeFocus);
+  const sidebarTab = useUIChromeStore((s) => s.sidebarTab);
+  const sidebarVisible = useUIChromeStore((s) => s.sidebarVisible);
   const setSidebarTab = useUIChromeStore((s) => s.setSidebarTab);
   const setSidebarVisible = useUIChromeStore((s) => s.setSidebarVisible);
 
@@ -278,6 +284,7 @@ function GraphCanvasInner({
 
   useEffect(() => {
     if ((showEnums && showStdlib) || !selectedNodeId) return;
+    if (sidebarVisible && sidebarTab === 'properties') return;
     const selectedNode = builtNodes.find((node) => node.id === selectedNodeId);
     if (
       selectedNode &&
@@ -286,7 +293,7 @@ function GraphCanvasInner({
     ) {
       clearNodes();
     }
-  }, [builtNodes, clearNodes, selectedNodeId, showEnums, showStdlib]);
+  }, [builtNodes, clearNodes, selectedNodeId, showEnums, showStdlib, sidebarTab, sidebarVisible]);
 
   // ELK once the nodes have measured DOM dimensions.
   const { runLayout } = useELKLayout();
@@ -530,6 +537,18 @@ function GraphCanvasInner({
     el.addEventListener(TYPE_NODE_ADD_FIELD_EVENT, handler);
     return () => el.removeEventListener(TYPE_NODE_ADD_FIELD_EVENT, handler);
   }, [addFieldFromNode]);
+
+  useEffect(() => {
+    const handler = (ev: Event): void => {
+      const detail = (ev as CustomEvent<{ typeName?: unknown }>).detail;
+      if (typeof detail?.typeName !== 'string') return;
+      click(detail.typeName, 'replace');
+      setSidebarVisible(true);
+      setSidebarTab('properties');
+    };
+    document.addEventListener(TYPE_NODE_TARGET_PROPERTIES_EVENT, handler);
+    return () => document.removeEventListener(TYPE_NODE_TARGET_PROPERTIES_EVENT, handler);
+  }, [click, setSidebarTab, setSidebarVisible]);
 
   useEffect(() => {
     const el = containerRef.current;

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -19,10 +19,11 @@
  * later slice.
  */
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
-import { CircleAlert, Table2 } from 'lucide-react';
+import { CircleAlert, Focus, Table2 } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { type FieldSelection, useGraphSelectionStore } from '../../../store/selection';
 import { type FieldRefPreview, TYPE_NODE_REF_PREVIEW_EVENT } from '../ref-preview-event';
@@ -31,6 +32,7 @@ import type { EnumTargetRow, StdlibTargetRow, TypeNodeData } from '../schema-to-
 export const TYPE_NODE_EVENT = 'contexture:field-select' as const;
 export const TYPE_NODE_OBJECT_EVENT = 'contexture:type-select' as const;
 export const TYPE_NODE_ADD_FIELD_EVENT = 'contexture:type-node-add-field' as const;
+export const TYPE_NODE_TARGET_PROPERTIES_EVENT = 'contexture:type-node-target-properties' as const;
 
 type TypeNodeKind = Node<TypeNodeData, 'type'>;
 
@@ -60,12 +62,20 @@ const enumValueBadgeStyle: CSSProperties = {
   color: 'var(--graph-node-header-text)',
 };
 
+const stdlibAccent = 'color-mix(in oklch, var(--chart-2) 85%, transparent)';
+
+const stdlibValueBadgeStyle: CSSProperties = {
+  background: stdlibAccent,
+  borderColor: stdlibAccent,
+  color: 'var(--graph-node-header-text)',
+};
+
 const enumHoverCardStyle: CSSProperties = {
   borderTop: '2px solid color-mix(in oklch, var(--chart-3) 85%, transparent)',
 };
 
 const stdlibHoverCardStyle: CSSProperties = {
-  borderTop: '2px solid color-mix(in oklch, var(--chart-2) 75%, var(--reference))',
+  borderTop: `2px solid ${stdlibAccent}`,
 };
 
 export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
@@ -448,11 +458,38 @@ function NodeKindLabel({
   );
 }
 
+function openTargetProperties(typeName: string, ev: React.MouseEvent<HTMLButtonElement>): void {
+  ev.preventDefault();
+  ev.stopPropagation();
+  document.dispatchEvent(
+    new CustomEvent(TYPE_NODE_TARGET_PROPERTIES_EVENT, { detail: { typeName } }),
+  );
+}
+
+function TargetPropertiesButton({ typeName }: { typeName: string }) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="size-6 shrink-0 text-muted-foreground hover:text-foreground"
+      aria-label={`Show ${typeName} properties`}
+      title={`Show ${typeName} properties`}
+      onClick={(ev) => openTargetProperties(typeName, ev)}
+    >
+      <Focus className="size-3.5" aria-hidden="true" />
+    </Button>
+  );
+}
+
 function EnumHoverCardContent({ enumTarget }: { enumTarget: EnumTargetRow }) {
   return (
     <div className="space-y-3">
       <div className="space-y-1">
-        <div className="text-sm font-semibold text-foreground">{enumTarget.name}</div>
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 text-sm font-semibold text-foreground">{enumTarget.name}</div>
+          <TargetPropertiesButton typeName={enumTarget.name} />
+        </div>
         <div
           className="text-[10px] font-medium uppercase tracking-wide"
           style={{ color: 'color-mix(in oklch, var(--chart-3) 85%, transparent)' }}
@@ -629,7 +666,7 @@ function FieldRowButton({
                   : field.enumTarget
                     ? 'var(--muted-foreground)'
                     : field.stdlibTarget
-                      ? 'color-mix(in oklch, var(--chart-2) 65%, var(--reference))'
+                      ? stdlibAccent
                       : field.refTarget
                         ? 'var(--graph-edge-ref)'
                         : 'var(--muted-foreground)',
@@ -699,6 +736,9 @@ function FieldRowButton({
         side="right"
         align="start"
         className="w-72 p-3 text-xs"
+        data-testid={
+          field.enumTarget ? 'type-node-field-enum-hover-card' : 'type-node-field-stdlib-hover-card'
+        }
         style={field.enumTarget ? enumHoverCardStyle : stdlibHoverCardStyle}
       >
         {field.enumTarget ? (
@@ -719,10 +759,14 @@ function StdlibHoverCardContent({ stdlibTarget }: { stdlibTarget: StdlibTargetRo
   return (
     <div className="space-y-3">
       <div className="space-y-1">
-        <div className="text-sm font-semibold text-foreground">{stdlibTarget.name}</div>
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 text-sm font-semibold text-foreground">{stdlibTarget.name}</div>
+          <TargetPropertiesButton typeName={stdlibTarget.name} />
+        </div>
         <div
+          data-testid="stdlib-kind-label"
           className="text-[10px] font-medium uppercase tracking-wide"
-          style={{ color: 'color-mix(in oklch, var(--chart-2) 75%, var(--reference))' }}
+          style={{ color: stdlibAccent }}
         >
           Stdlib {stdlibTarget.kind}
         </div>
@@ -740,9 +784,10 @@ function StdlibHoverCardContent({ stdlibTarget }: { stdlibTarget: StdlibTargetRo
               <Badge
                 key={value.value}
                 data-testid="stdlib-value-badge"
-                variant="secondary"
+                variant="default"
                 title={value.description}
-                className="max-w-full rounded border px-1.5 py-0 text-[10px] font-semibold shadow-sm"
+                className="max-w-full rounded border px-1.5 py-0 text-[10px] font-semibold shadow-sm hover:opacity-90"
+                style={stdlibValueBadgeStyle}
               >
                 <span className="truncate">{value.value}</span>
               </Badge>
@@ -750,8 +795,9 @@ function StdlibHoverCardContent({ stdlibTarget }: { stdlibTarget: StdlibTargetRo
             {hiddenValueCount > 0 ? (
               <Badge
                 data-testid="stdlib-value-more-badge"
-                variant="outline"
-                className="rounded px-1.5 py-0 text-[10px] font-semibold"
+                variant="default"
+                className="rounded border px-1.5 py-0 text-[10px] font-semibold shadow-sm hover:opacity-90"
+                style={stdlibValueBadgeStyle}
               >
                 +{hiddenValueCount} more
               </Badge>

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -748,7 +748,7 @@ function PlaygroundRecordForm({
       className="flex h-full min-h-0 flex-col"
       onSubmit={form.handleSubmit((value) => onSubmit(normalizeSubmitValue(entity.fields, value)))}
     >
-      <FieldGroup className="min-h-0 flex-1 overflow-y-auto p-3">
+      <FieldGroup className="min-h-0 flex-1 content-start overflow-y-auto p-3">
         {entity.fields.map((control) => (
           <PlaygroundControlField
             key={control.fieldName}

--- a/apps/desktop/tests/components/App.keyboard.test.tsx
+++ b/apps/desktop/tests/components/App.keyboard.test.tsx
@@ -8,6 +8,7 @@ import { TYPE_EDGE_SELECT_EVENT } from '@renderer/components/graph/edge-select-e
 import {
   TYPE_NODE_ADD_FIELD_EVENT,
   TYPE_NODE_EVENT,
+  TYPE_NODE_TARGET_PROPERTIES_EVENT,
 } from '@renderer/components/graph/nodes/TypeNode';
 import type { RefEdgeData } from '@renderer/components/graph/schema-to-graph';
 import { useGraphLayoutStore } from '@renderer/store/layout-config';
@@ -182,6 +183,61 @@ describe('App global keyboard', () => {
       nodeId: 'Plot',
       fieldName: 'field1',
     });
+  });
+
+  it('opens hidden enum target properties from a hover-card action', async () => {
+    useUndoStore.getState().apply({
+      kind: 'replace_schema',
+      schema: {
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'Recipe',
+            fields: [{ name: 'season', type: { kind: 'ref', typeName: 'Season' } }],
+          },
+          { kind: 'enum', name: 'Season', values: [{ value: 'spring' }] },
+        ],
+      },
+    });
+    useGraphLayoutStore.getState().setGraphLayout({ showEnums: false });
+    render(<App />);
+
+    document.dispatchEvent(
+      new CustomEvent(TYPE_NODE_TARGET_PROPERTIES_EVENT, { detail: { typeName: 'Season' } }),
+    );
+
+    expect(await screen.findByLabelText('Name')).toHaveValue('Season');
+    expect(screen.getByLabelText('Enum value spring')).toBeInTheDocument();
+    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('Season');
+  });
+
+  it('opens hidden stdlib target properties from a hover-card action', async () => {
+    useUndoStore.getState().apply({
+      kind: 'replace_schema',
+      schema: {
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'User',
+            fields: [{ name: 'email', type: { kind: 'ref', typeName: 'common.Email' } }],
+          },
+        ],
+      },
+    });
+    useGraphLayoutStore.getState().setGraphLayout({ showStdlib: false });
+    render(<App />);
+
+    document.dispatchEvent(
+      new CustomEvent(TYPE_NODE_TARGET_PROPERTIES_EVENT, {
+        detail: { typeName: 'common.Email' },
+      }),
+    );
+
+    expect(await screen.findByTestId('external-type-detail')).toHaveTextContent('common.Email');
+    expect(screen.getByRole('heading', { name: 'common.Email' })).toBeInTheDocument();
+    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('common.Email');
   });
 
   it('Cmd+Shift+F adds and opens a field on the selected object', async () => {

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -12,6 +12,7 @@ import {
   TYPE_NODE_ADD_FIELD_EVENT,
   TYPE_NODE_EVENT,
   TYPE_NODE_OBJECT_EVENT,
+  TYPE_NODE_TARGET_PROPERTIES_EVENT,
   TypeNode,
 } from '@renderer/components/graph/nodes/TypeNode';
 import { TYPE_NODE_REF_PREVIEW_EVENT } from '@renderer/components/graph/ref-preview-event';
@@ -501,7 +502,7 @@ describe('TypeNode', () => {
       'email, common.Email stdlib type',
     );
     expect(screen.getByTestId('type-node-field-stdlib-summary')).toHaveStyle({
-      color: 'color-mix(in oklch, var(--chart-2) 65%, var(--reference))',
+      color: 'color-mix(in oklch, var(--chart-2) 85%, transparent)',
       fontWeight: '400',
       fontFamily: 'var(--font-mono)',
     });
@@ -509,7 +510,89 @@ describe('TypeNode', () => {
     fireEvent.focus(screen.getByTestId('type-node-field'));
 
     expect(screen.getByText('Email address.')).toBeInTheDocument();
+    expect(screen.getByTestId('type-node-field-stdlib-hover-card').getAttribute('style')).toContain(
+      'border-top: 2px solid color-mix(in oklch, var(--chart-2) 85%, transparent)',
+    );
     expect(screen.getByText('Stdlib raw')).toBeInTheDocument();
+    expect(screen.getByTestId('stdlib-kind-label')).toHaveStyle({
+      color: 'color-mix(in oklch, var(--chart-2) 85%, transparent)',
+    });
+  });
+
+  it('opens stdlib target properties from the hover card action', () => {
+    const data: TypeNodeData = {
+      typeName: 'User',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'email',
+          summary: '→ common.Email',
+          optional: false,
+          nullable: false,
+          refTarget: 'common.Email',
+          stdlibTarget: {
+            name: 'common.Email',
+            description: 'Email address.',
+            kind: 'raw',
+          },
+        },
+      ],
+    };
+    const handler = vi.fn();
+    document.addEventListener(TYPE_NODE_TARGET_PROPERTIES_EVENT, handler as EventListener);
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    fireEvent.focus(screen.getByTestId('type-node-field'));
+    fireEvent.click(screen.getByRole('button', { name: 'Show common.Email properties' }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect((handler.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      typeName: 'common.Email',
+    });
+    document.removeEventListener(TYPE_NODE_TARGET_PROPERTIES_EVENT, handler as EventListener);
+  });
+
+  it('uses blue stdlib hover accents and value badges', () => {
+    vi.useFakeTimers();
+    const data: TypeNodeData = {
+      typeName: 'User',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'country',
+          summary: '→ place.CountryCode',
+          optional: false,
+          nullable: false,
+          refTarget: 'place.CountryCode',
+          stdlibTarget: {
+            name: 'place.CountryCode',
+            description: 'ISO 3166-1 alpha-2 country code.',
+            kind: 'enum',
+            values: [{ value: 'GB', description: 'United Kingdom' }, { value: 'US' }],
+          },
+        },
+      ],
+    };
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    fireEvent.pointerEnter(screen.getByTestId('type-node-field'));
+    act(() => vi.advanceTimersByTime(120));
+
+    expect(screen.getByTestId('stdlib-kind-label')).toHaveStyle({
+      color: 'color-mix(in oklch, var(--chart-2) 85%, transparent)',
+    });
+    expect(screen.getByText('GB')).toBeInTheDocument();
+    expect(screen.getByText('GB').closest('[title]')).toHaveAttribute('title', 'United Kingdom');
+    const badges = screen.getAllByTestId('stdlib-value-badge');
+    expect(badges[0]).toHaveStyle({
+      background: 'color-mix(in oklch, var(--chart-2) 85%, transparent)',
+      color: 'var(--graph-node-header-text)',
+    });
+    expect(badges[0].getAttribute('style')).toContain(
+      'border-color: color-mix(in oklch, var(--chart-2) 85%, transparent)',
+    );
   });
 
   it('renders discriminated union refs as relationship refs with a muted suffix', () => {
@@ -568,6 +651,37 @@ describe('TypeNode', () => {
 
     expect(screen.getByText('The growing season.')).toBeInTheDocument();
     expect(screen.getByText('spring')).toBeInTheDocument();
+  });
+
+  it('opens enum target properties from the hover card action', () => {
+    const data: TypeNodeData = {
+      typeName: 'Recipe',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'season',
+          summary: '→ Season',
+          optional: false,
+          nullable: false,
+          refTarget: 'Season',
+          enumTarget: {
+            name: 'Season',
+            values: [{ value: 'spring' }],
+          },
+        },
+      ],
+    };
+    const handler = vi.fn();
+    document.addEventListener(TYPE_NODE_TARGET_PROPERTIES_EVENT, handler as EventListener);
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    fireEvent.focus(screen.getByTestId('type-node-field'));
+    fireEvent.click(screen.getByRole('button', { name: 'Show Season properties' }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect((handler.mock.calls[0][0] as CustomEvent).detail).toEqual({ typeName: 'Season' });
+    document.removeEventListener(TYPE_NODE_TARGET_PROPERTIES_EVENT, handler as EventListener);
   });
 
   it('previews ref targets on hover and focus, including enum refs', () => {

--- a/apps/desktop/tests/components/playground/PlaygroundPanel.test.tsx
+++ b/apps/desktop/tests/components/playground/PlaygroundPanel.test.tsx
@@ -96,4 +96,14 @@ describe('PlaygroundPanel', () => {
     expect(screen.getByRole('combobox', { name: 'Country' })).toBeInTheDocument();
     expect(screen.queryByDisplayValue(/Unknown reference target/u)).not.toBeInTheDocument();
   });
+
+  it('packs record form fields at the top of the scroll area', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<PlaygroundPanel schema={schema} />);
+
+    await user.click(screen.getByRole('button', { name: 'New record' }));
+
+    expect(container.querySelector('[data-slot="field-group"].content-start')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add focus actions to enum and stdlib hover cards
- keep hidden enum/stdlib selections alive when Properties is explicitly opened
- use the blue stdlib hover-card treatment with defined graph tokens

## Verification
- bun run test -- tests/components/App.keyboard.test.tsx
- bun run test -- tests/components/graph/TypeNode.test.tsx
- bun run typecheck
- commit hook also ran turbo typecheck and turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783010401&installation_id=136251083&pr_number=359&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F359&signature=77af662371abae8dde3a3539aa1b9b547cd0c411b93b08131d777bcccd1b3ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->