### PR TITLE
fix: clarify Contexture MCP tool envelopes

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.32",
+  "version": "0.15.33",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/shared/system-prompt.ts
+++ b/apps/desktop/src/shared/system-prompt.ts
@@ -164,7 +164,7 @@ interface OpSpec {
 }
 
 const OP_CATALOGUE: OpSpec[] = [
-  { name: 'add_type', shape: '{ type: TypeDef }' },
+  { name: 'add_type', shape: '{ payload: TypeDef }' },
   { name: 'update_type', shape: "{ name: string; patch: Partial<Omit<TypeDef, 'kind'|'name'>> }" },
   { name: 'rename_type', shape: '{ from: string; to: string }' },
   { name: 'delete_type', shape: '{ name: string }' },
@@ -187,7 +187,7 @@ const OP_CATALOGUE: OpSpec[] = [
   { name: 'add_variant', shape: '{ typeName: string; variant: string }' },
   { name: 'remove_variant', shape: '{ typeName: string; variant: string }' },
   { name: 'set_discriminator', shape: '{ typeName: string; discriminator: string }' },
-  { name: 'add_import', shape: '{ import: ImportDecl }' },
+  { name: 'add_import', shape: '{ payload: ImportDecl }' },
   { name: 'remove_import', shape: '{ alias: string }' },
   { name: 'remove_import_at', shape: '{ index: number }' },
   { name: 'set_table_flag', shape: '{ typeName: string; table: boolean }' },

--- a/apps/desktop/tests/chat/__snapshots__/system-prompt.test.ts.snap
+++ b/apps/desktop/tests/chat/__snapshots__/system-prompt.test.ts.snap
@@ -31,7 +31,7 @@ Skills are available and auto-load on topic match:
 
 ## Op vocabulary
 
-- \`add_type\` { type: TypeDef }
+- \`add_type\` { payload: TypeDef }
 - \`update_type\` { name: string; patch: Partial<Omit<TypeDef, 'kind'|'name'>> }
 - \`rename_type\` { from: string; to: string }
 - \`delete_type\` { name: string }
@@ -45,7 +45,7 @@ Skills are available and auto-load on topic match:
 - \`add_variant\` { typeName: string; variant: string }
 - \`remove_variant\` { typeName: string; variant: string }
 - \`set_discriminator\` { typeName: string; discriminator: string }
-- \`add_import\` { import: ImportDecl }
+- \`add_import\` { payload: ImportDecl }
 - \`remove_import\` { alias: string }
 - \`remove_import_at\` { index: number }
 - \`set_table_flag\` { typeName: string; table: boolean }

--- a/apps/desktop/tests/main/op-tools.test.ts
+++ b/apps/desktop/tests/main/op-tools.test.ts
@@ -176,6 +176,32 @@ describe('createOpTools', () => {
     });
   });
 
+  it('add_type accepts bare and core-op-style TypeDef envelopes', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const addType = toolNamed(tools, 'add_type');
+    const typeDef = { kind: 'enum', name: 'Season', values: [{ value: 'spring' }] };
+
+    await addType.handler(typeDef);
+    await addType.handler({ type: typeDef });
+    await addType.handler({ payload: { type: typeDef } });
+
+    expect(forwardSpy.mock.calls.map((call) => call[0])).toEqual([
+      { kind: 'add_type', type: typeDef },
+      { kind: 'add_type', type: typeDef },
+      { kind: 'add_type', type: typeDef },
+    ]);
+  });
+
+  it('add_type description distinguishes typed input from apply_contexture_op input', () => {
+    const { tools } = makeTools();
+    const addType = toolNamed(tools, 'add_type');
+
+    expect(addType.description).toContain('{ payload: TypeDef }');
+    expect(addType.description).toContain('apply_contexture_op');
+    expect(addType.description).toContain('{ kind: "add_type", type: TypeDef }');
+  });
+
   it('add_type rejects a payload that fails the IR meta-schema', async () => {
     const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
     const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
@@ -185,6 +211,21 @@ describe('createOpTools', () => {
       /add_type/i,
     );
     expect(forwardSpy).not.toHaveBeenCalled();
+  });
+
+  it('add_import accepts payload and core-op-style import envelopes', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const addImport = toolNamed(tools, 'add_import');
+    const importDecl = { kind: 'stdlib', path: '@contexture/place', alias: 'place' };
+
+    await addImport.handler({ payload: importDecl });
+    await addImport.handler({ import: importDecl });
+
+    expect(forwardSpy.mock.calls.map((call) => call[0])).toEqual([
+      { kind: 'add_import', import: importDecl },
+      { kind: 'add_import', import: importDecl },
+    ]);
   });
 
   it('update_type rejects patches that try to change identity', async () => {

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -56,6 +56,7 @@ describe('Contexture MCP server', () => {
           }),
           expect.objectContaining({
             name: 'apply_contexture_op',
+            description: expect.stringContaining('{ irPath, op }'),
             annotations: expect.objectContaining({
               readOnlyHint: false,
               destructiveHint: true,
@@ -77,6 +78,7 @@ describe('Contexture MCP server', () => {
           }),
           expect.objectContaining({
             name: 'add_field',
+            description: expect.stringContaining('Include irPath with this typed tool call'),
             annotations: expect.objectContaining({
               readOnlyHint: false,
               destructiveHint: true,
@@ -84,6 +86,9 @@ describe('Contexture MCP server', () => {
           }),
           expect.objectContaining({
             name: 'rename_type',
+            description: expect.stringContaining(
+              'do not wrap it in the generic apply_contexture_op',
+            ),
             annotations: expect.objectContaining({
               readOnlyHint: false,
               destructiveHint: true,
@@ -158,6 +163,35 @@ describe('Contexture MCP server', () => {
           preferredMutationTools: expect.arrayContaining(['add_field', 'rename_type', 'add_index']),
         }),
       });
+    });
+  });
+
+  it('typed add_type accepts a core-op-style type envelope', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      metadata: { name: 'Garden' },
+      types: [],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'add_type',
+        arguments: {
+          irPath,
+          type: { kind: 'enum', name: 'Season', values: [{ value: 'spring' }] },
+        },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        applied: true,
+        opKind: 'add_type',
+      });
+
+      const updatedIr = JSON.parse(await readFile(irPath, 'utf8')) as {
+        types: Array<{ kind: string; name: string }>;
+      };
+      expect(updatedIr.types).toEqual([expect.objectContaining({ kind: 'enum', name: 'Season' })]);
     });
   });
 

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -194,7 +194,7 @@ export function createContextureMcpServer(options: ContextureMcpServerOptions = 
     {
       title: 'Apply Contexture Op',
       description:
-        'Mutate a .contexture.json file by applying one Contexture closed-world Op, then rewrite generated artifacts.',
+        'Mutate a .contexture.json file by applying one Contexture closed-world Op, then rewrite generated artifacts. Input is { irPath, op }; op must include its kind, for example { kind: "add_type", type: { kind: "enum", name: "Status", values: [{ value: "active" }] } }. For typed tools such as add_type, use their direct input shape instead.',
       inputSchema: ApplyContextureOpInput,
       outputSchema: ApplyContextureOpOutput,
       annotations: {
@@ -275,7 +275,7 @@ export function createContextureMcpServer(options: ContextureMcpServerOptions = 
       tool.name,
       {
         title: `Contexture ${tool.name}`,
-        description: `${tool.description} Mutates the .contexture.json file through the shared Contexture op applier and rewrites generated artifacts.`,
+        description: `${tool.description} Include irPath with this typed tool call. This typed tool receives its direct input shape; do not wrap it in the generic apply_contexture_op { op: ... } envelope. Mutates the .contexture.json file through the shared Contexture op applier and rewrites generated artifacts.`,
         inputSchema: { ...IrPathInput, ...tool.inputSchema },
         outputSchema: ApplyContextureOpOutput,
         annotations: {
@@ -584,7 +584,8 @@ function buildIntegrationGuidance(
     rules: [
       'Treat the .contexture.json IR as the source of truth for domain-model changes.',
       'Do not hand-edit generated files with a @contexture-generated marker; change the IR and emit instead.',
-      'Prefer typed op tools such as add_field, rename_type, set_table_flag, and add_index over apply_contexture_op when possible.',
+      'Prefer typed op tools such as add_type, add_field, rename_type, set_table_flag, and add_index over apply_contexture_op when possible.',
+      'Typed op tools take irPath plus their direct arguments. The generic apply_contexture_op takes { irPath, op } where op is the closed-world operation with a kind.',
       'After any model mutation, validate, emit generated targets, and check drift before finishing.',
       'Wire generated outputs into the existing app architecture; Contexture does not own arbitrary application code.',
     ],

--- a/packages/core/src/op-tools.ts
+++ b/packages/core/src/op-tools.ts
@@ -138,13 +138,14 @@ function lenientTool(
   toOp: (payload: unknown) => Op,
   validate: (op: Op) => void,
   forward: ForwardOp,
+  aliases: Record<string, ZodTypeAny> = {},
 ): OpToolDescriptor {
   return {
     name,
     description,
-    inputSchema: { payload: z.unknown() },
+    inputSchema: { payload: z.unknown().optional(), ...aliases },
     handler: async (args) => {
-      const op = toOp((args as { payload: unknown }).payload);
+      const op = toOp(unwrapFlexiblePayload(args));
       validate(op);
       return forward(op);
     },
@@ -186,6 +187,40 @@ function unwrapFlexiblePayload(args: Record<string, unknown>): unknown {
   }
   return raw;
 }
+
+function unwrapTypeDefPayload(payload: unknown): unknown {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return payload;
+  if ('type' in payload && !('kind' in payload)) {
+    return (payload as { type: unknown }).type;
+  }
+  return payload;
+}
+
+function unwrapImportDeclPayload(payload: unknown): unknown {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return payload;
+  if ('import' in payload && !('kind' in payload)) {
+    return (payload as { import: unknown }).import;
+  }
+  return payload;
+}
+
+const TypeDefAliasSchema = {
+  type: z.unknown().optional(),
+  kind: z.enum(['object', 'enum', 'discriminatedUnion', 'raw']).optional(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  fields: z.array(z.unknown()).optional(),
+  table: z.boolean().optional(),
+  tableName: z.string().optional(),
+  indexes: z.array(z.unknown()).optional(),
+  values: z.array(z.unknown()).optional(),
+  discriminator: z.string().optional(),
+  variants: z.array(z.unknown()).optional(),
+  zod: z.string().optional(),
+  jsonSchema: z.record(z.string(), z.unknown()).optional(),
+  import: z.unknown().optional(),
+  sampleData: z.unknown().optional(),
+};
 
 // ---- IR meta-schema checks for type-level payloads ---------------------
 
@@ -382,13 +417,18 @@ export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
     // --- Type-level (lenient with meta-schema validation) ---
     lenientTool(
       'add_type',
-      'Add a new TypeDef (object | enum | discriminatedUnion | raw).',
+      'Add a new TypeDef (object | enum | discriminatedUnion | raw). Preferred input: { payload: TypeDef }, for example { payload: { kind: "enum", name: "Status", values: [{ value: "active" }] } }. If you are using apply_contexture_op instead, pass the closed-world op as { kind: "add_type", type: TypeDef }.',
       (payload) => ({
         kind: 'add_type',
-        type: payload as Op & { kind: 'add_type' } extends { type: infer T } ? T : never,
+        type: unwrapTypeDefPayload(payload) as Op & { kind: 'add_type' } extends {
+          type: infer T;
+        }
+          ? T
+          : never,
       }),
       (op) => assertTypeDef((op as Extract<Op, { kind: 'add_type' }>).type, 'add_type'),
       forward,
+      TypeDefAliasSchema,
     ),
     flexiblePayloadTool(
       'update_type',
@@ -446,10 +486,11 @@ export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
         'a stdlib namespace listed in schema.imports[].',
       (payload) => ({
         kind: 'add_import',
-        import: payload as Extract<Op, { kind: 'add_import' }>['import'],
+        import: unwrapImportDeclPayload(payload) as Extract<Op, { kind: 'add_import' }>['import'],
       }),
       (op) => assertImportDecl((op as Extract<Op, { kind: 'add_import' }>).import, 'add_import'),
       forward,
+      { import: z.unknown().optional(), kind: z.enum(['stdlib', 'relative']).optional() },
     ),
     // --- Full IR escape hatch ---
     {


### PR DESCRIPTION
## Summary
- clarify typed Contexture MCP tool descriptions versus generic apply_contexture_op envelopes
- tolerate common add_type/add_import envelope mistakes at the shared op-tool boundary
- update embedded desktop prompt catalogue and bump desktop app to 0.15.33

## Checks
- turbo typecheck
- turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783018129&installation_id=136251083&pr_number=360&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F360&signature=e99f7d826fa1093af5fd4af6f440d4bbebb2f8a8bf6a0c01eb98527c3dc1ba8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->