### PR TITLE
feat: support monorepo output bundles

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.33",
+  "version": "0.15.34",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/main/documents/document-store.ts
+++ b/apps/desktop/src/main/documents/document-store.ts
@@ -28,6 +28,7 @@ import {
   detectDocumentMode,
   type FileEntry,
   GeneratedBundleDriftError,
+  type GeneratedTargetEmitOptions,
   type Layout,
   loadChatHistory,
   load as loadIR,
@@ -39,7 +40,7 @@ import {
   writeFilesAtomic,
   writeGeneratedBundle,
 } from '@contexture/core';
-import { STDLIB_NAMESPACES } from '@shared/stdlib-registry';
+import { STDLIB_NAMESPACES, STDLIB_RUNTIME_MODULES } from '@shared/stdlib-registry';
 
 /** Layout + chat now live inside `.contexture/` as implementation sidecars. */
 /** Hash manifest of every @contexture-generated artefact, used for drift detection. */
@@ -106,11 +107,15 @@ export interface DocumentStoreDeps {
   /** Absolute path to the recent-files ledger (typically under userData). */
   recentFilesPath: string;
   /** Override for tests — defaults to the real Zod emitter. */
-  emitZod?: (schema: Schema, sourcePath: string) => string;
+  emitZod?: (schema: Schema, sourcePath: string, options?: GeneratedTargetEmitOptions) => string;
   /** Override for tests — defaults to the real JSON-schema emitter. */
-  emitJsonSchema?: (schema: Schema, sourcePath?: string) => unknown;
+  emitJsonSchema?: (
+    schema: Schema,
+    sourcePath?: string,
+    options?: GeneratedTargetEmitOptions,
+  ) => unknown;
   /** Override for tests — defaults to the real schema-index emitter. */
-  emitSchemaIndex?: (baseName: string, sourcePath?: string) => string;
+  emitSchemaIndex?: (baseName: string, sourcePath?: string, schemaModule?: string) => string;
   /** Override for tests — defaults to the real Convex emitter. */
   emitConvex?: (schema: Schema, sourcePath?: string) => string;
   /** Optional hook for main-process integration (e.g. `app.addRecentDocument`). */
@@ -123,10 +128,16 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
   const {
     fs,
     recentFilesPath,
-    emitZod = (s: Schema, sp: string) =>
-      defaultEmitZod(s, sp, { stdlibNamespaces: STDLIB_NAMESPACES }),
-    emitJsonSchema = (s: Schema, sp?: string) =>
-      defaultEmitJsonSchema(s, undefined, sp, { stdlibNamespaces: STDLIB_NAMESPACES }),
+    emitZod = (s: Schema, sp: string, options?: GeneratedTargetEmitOptions) =>
+      defaultEmitZod(s, sp, {
+        ...options,
+        stdlibNamespaces: options?.stdlibNamespaces ?? STDLIB_NAMESPACES,
+      }),
+    emitJsonSchema = (s: Schema, sp?: string, options?: GeneratedTargetEmitOptions) =>
+      defaultEmitJsonSchema(s, undefined, sp, {
+        ...options,
+        stdlibNamespaces: options?.stdlibNamespaces ?? STDLIB_NAMESPACES,
+      }),
     emitSchemaIndex = defaultEmitSchemaIndex,
     emitConvex,
     onRecentFileAdded,
@@ -214,6 +225,7 @@ export function createDocumentStore(deps: DocumentStoreDeps): DocumentStore {
           emitJsonSchema,
           emitSchemaIndex,
           emitConvex,
+          stdlibRuntime: STDLIB_RUNTIME_MODULES,
         },
       });
     } catch (err) {

--- a/apps/desktop/src/main/documents/drift-watcher.ts
+++ b/apps/desktop/src/main/documents/drift-watcher.ts
@@ -21,8 +21,8 @@ import { type FSWatcher, promises as fsPromises, watch } from 'node:fs';
 import {
   bundlePathsFor,
   classifyGeneratedBundleDrift,
+  type EmitPipelineDeps,
   type GeneratedDriftClassification,
-  generatedTargetsFor,
   load,
 } from '@contexture/core';
 
@@ -95,6 +95,7 @@ export interface DriftWatcherOptions {
   onResolved: () => void;
   debounceMs?: number;
   readFile?: (path: string) => Promise<string>;
+  emitDeps?: EmitPipelineDeps;
 }
 
 export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
@@ -105,9 +106,9 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
     onResolved,
     debounceMs = 300,
     readFile = (p) => fsPromises.readFile(p, 'utf-8'),
+    emitDeps,
   } = opts;
   const emittedJsonPath = bundlePathsFor(irPath).emitted;
-  const allowedPaths = generatedTargetsFor(irPath).map((entry) => entry.path);
 
   let watchers: FSWatcher[] = [];
   let watchedPaths: string[] = [];
@@ -116,7 +117,7 @@ export function createDriftWatcher(opts: DriftWatcherOptions): DriftWatcher {
   let stopped = false;
 
   async function doCheck(): Promise<void> {
-    const results = await detectCurrentDrift(irPath, emittedJsonPath, readFile, allowedPaths);
+    const results = await detectCurrentDrift(irPath, emittedJsonPath, readFile, emitDeps);
     if (stopped || results.length === 0) return;
 
     const problems = results.flatMap((result): DriftProblem[] => {
@@ -247,15 +248,12 @@ async function detectCurrentDrift(
   irPath: string,
   emittedJsonPath: string,
   readFile: (path: string) => Promise<string>,
-  allowedPaths: readonly string[],
+  emitDeps?: EmitPipelineDeps,
 ): Promise<Array<{ path: string; status: DriftResult['status'] | GeneratedDriftClassification }>> {
   try {
     const { schema } = load(await readFile(irPath));
-    const allowed = new Set(allowedPaths);
-    return (await classifyGeneratedBundleDrift(schema, irPath, { readFile })).filter((result) =>
-      allowed.has(result.path),
-    );
+    return classifyGeneratedBundleDrift(schema, irPath, { readFile }, emitDeps);
   } catch {
-    return detectDrift(emittedJsonPath, readFile, { allowedPaths });
+    return detectDrift(emittedJsonPath, readFile);
   }
 }

--- a/apps/desktop/src/main/ipc/drift.ts
+++ b/apps/desktop/src/main/ipc/drift.ts
@@ -10,6 +10,7 @@
  * `drift:check` is a one-shot manual re-check (window focus trigger).
  */
 
+import { STDLIB_RUNTIME_MODULES } from '@shared/stdlib-registry';
 import type { BrowserWindow } from 'electron';
 import { ipcMain } from 'electron';
 import { z } from 'zod';
@@ -39,6 +40,7 @@ export function registerDriftIpc(mainWindow: BrowserWindow): void {
           files: problems,
         }),
       onResolved: () => mainWindow.webContents.send('drift:resolved'),
+      emitDeps: { stdlibRuntime: STDLIB_RUNTIME_MODULES },
     });
     activeWatcher.start();
     return { ok: true };

--- a/apps/desktop/src/main/ipc/reconcile.ts
+++ b/apps/desktop/src/main/ipc/reconcile.ts
@@ -5,11 +5,13 @@ import {
   type EmittedManifest,
   hashContent,
   IRSchema,
+  load as loadIR,
   manifestKeyForGeneratedPath,
   type Schema,
   save as saveIR,
   writeGeneratedBundle,
 } from '@contexture/core';
+import { STDLIB_RUNTIME_MODULES } from '@shared/stdlib-registry';
 import { ipcMain } from 'electron';
 import { z } from 'zod';
 import { nodeFsAdapter } from '../documents/node-fs-adapter';
@@ -61,7 +63,11 @@ export async function readGeneratedTarget(input: unknown): Promise<string | null
     GeneratedTargetInputSchema,
     input,
   );
-  const target = assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath);
+  const target = assertGeneratedTargetForIr(
+    parsed.irPath,
+    parsed.targetPath,
+    await readOptionalSchema(parsed.irPath),
+  );
   try {
     return await readFile(target, 'utf8');
   } catch {
@@ -75,7 +81,11 @@ export async function writeGeneratedTarget(input: unknown): Promise<void> {
     WriteGeneratedTargetInputSchema,
     input,
   );
-  const target = assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath);
+  const target = assertGeneratedTargetForIr(
+    parsed.irPath,
+    parsed.targetPath,
+    await readOptionalSchema(parsed.irPath),
+  );
   const manifestPath = bundlePathsFor(parsed.irPath).emitted;
   await writeGeneratedTargetContents(parsed.irPath, target, manifestPath, parsed.contents);
 }
@@ -86,7 +96,7 @@ export async function acceptGeneratedTarget(input: unknown): Promise<void> {
     AcceptGeneratedTargetInputSchema,
     input,
   );
-  const target = assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath);
+  const target = assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath, parsed.schema);
   const manifestPath = bundlePathsFor(parsed.irPath).emitted;
   const previousTarget = await readOptionalFile(target);
   const previousManifest = await readOptionalFile(manifestPath);
@@ -98,6 +108,7 @@ export async function acceptGeneratedTarget(input: unknown): Promise<void> {
       irPath: parsed.irPath,
       schema: parsed.schema,
       fs: nodeFsAdapter,
+      emitDeps: { stdlibRuntime: STDLIB_RUNTIME_MODULES },
     });
   } catch (err) {
     await restoreOptionalFile(target, previousTarget);
@@ -115,11 +126,24 @@ export async function validateConvexGeneratedTarget(
     GeneratedTargetInputSchema,
     input,
   );
-  assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath);
+  const schema = await readSchema(parsed.irPath);
+  assertGeneratedTargetForIr(parsed.irPath, parsed.targetPath, schema);
   return validateReconciledConvexProject(
-    { irPath: parsed.irPath, targetPath: parsed.targetPath },
+    { irPath: parsed.irPath, targetPath: parsed.targetPath, schema },
     deps,
   );
+}
+
+async function readSchema(irPath: string): Promise<Schema> {
+  return loadIR(await readFile(irPath, 'utf8')).schema;
+}
+
+async function readOptionalSchema(irPath: string): Promise<Schema | undefined> {
+  try {
+    return await readSchema(irPath);
+  } catch {
+    return undefined;
+  }
 }
 
 async function writeGeneratedTargetContents(

--- a/apps/desktop/src/main/mcp-entrypoint.ts
+++ b/apps/desktop/src/main/mcp-entrypoint.ts
@@ -1,13 +1,16 @@
 import { createContextureMcpServer } from '@contexture/core/mcp-server';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { STDLIB_REGISTRY } from '@shared/stdlib-registry';
+import { STDLIB_REGISTRY, STDLIB_RUNTIME_MODULES } from '@shared/stdlib-registry';
 
 export function isMcpMode(argv: readonly string[]): boolean {
   return argv.includes('--mcp');
 }
 
 export async function startMcpServer(): Promise<void> {
-  const server = createContextureMcpServer({ stdlib: STDLIB_REGISTRY });
+  const server = createContextureMcpServer({
+    stdlib: STDLIB_REGISTRY,
+    emitDeps: { stdlibRuntime: STDLIB_RUNTIME_MODULES },
+  });
   const transport = new StdioServerTransport();
 
   let shuttingDown = false;

--- a/apps/desktop/src/main/reconcile/convex-cli-validation.ts
+++ b/apps/desktop/src/main/reconcile/convex-cli-validation.ts
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
+import type { Schema } from '@contexture/core';
 import { bundlePathsFor, generatedTargetForPath } from '@contexture/core/paths';
 
 const execFileAsync = promisify(execFile);
@@ -37,6 +38,7 @@ export type ExecFileLike = (
 interface ValidateConvexCliInput {
   irPath: string;
   targetPath: string;
+  schema?: Schema;
 }
 
 interface ValidateConvexCliDeps {
@@ -50,12 +52,12 @@ export async function validateReconciledConvexProject(
   input: ValidateConvexCliInput,
   deps: ValidateConvexCliDeps = {},
 ): Promise<ConvexCliValidationResult> {
-  const target = generatedTargetForPath(input.irPath, input.targetPath);
+  const target = generatedTargetForPath(input.irPath, input.targetPath, input.schema);
   if (target?.kind !== 'convex' && target?.kind !== 'convex-validators') {
     return { status: 'skipped', reason: 'Target is not a Convex generated file.' };
   }
 
-  const projectDir = dirname(dirname(bundlePathsFor(input.irPath).convex));
+  const projectDir = dirname(dirname(bundlePathsFor(input.irPath, input.schema).convex));
   const configured = await hasConvexCliValidationConfig(projectDir, deps.env ?? process.env);
   if (!configured.ok) return { status: 'skipped', reason: configured.reason };
 

--- a/apps/desktop/src/main/security.ts
+++ b/apps/desktop/src/main/security.ts
@@ -1,5 +1,6 @@
 import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, parse, resolve } from 'node:path';
+import type { Schema } from '@contexture/core';
 import { assertContextureIrPath, generatedTargetsFor } from '@contexture/core/paths';
 
 const SAFE_EXTERNAL_PROTOCOLS = new Set(['https:', 'http:', 'mailto:']);
@@ -13,13 +14,19 @@ export function isSafeExternalUrl(rawUrl: string): boolean {
   }
 }
 
-export function assertGeneratedTargetForIr(irPath: string, targetPath: string): string {
+export function assertGeneratedTargetForIr(
+  irPath: string,
+  targetPath: string,
+  schema?: Schema,
+): string {
   if (!isAbsolute(irPath) || !isAbsolute(targetPath)) {
     throw new Error('Contexture generated target paths must be absolute.');
   }
 
   const target = resolve(targetPath);
-  const allowed = new Set(generatedTargetsFor(resolve(irPath)).map((entry) => resolve(entry.path)));
+  const allowed = new Set(
+    generatedTargetsFor(resolve(irPath), schema).map((entry) => resolve(entry.path)),
+  );
 
   if (!allowed.has(target)) {
     throw new Error('Target is not a generated Contexture artifact for this IR.');

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -24,6 +24,7 @@ import {
   enableGeneratedTarget,
   isGeneratedTargetEnabled,
   previewableGeneratedTargets,
+  setGeneratedTargetOutputDir,
 } from '@contexture/core/generated-targets';
 import type { Schema } from '@contexture/core/ir';
 import { STDLIB_REGISTRY, STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registry';
@@ -59,7 +60,11 @@ import { TYPE_NODE_EVENT, TYPE_NODE_OBJECT_EVENT } from './components/graph/node
 import { DriftBanner } from './components/hud/DriftBanner';
 import { ModelSyncBanner } from './components/hud/ModelSyncBanner';
 import { PlaygroundPanel } from './components/playground/PlaygroundPanel';
-import { SchemaPanel, type SchemaPanelSource } from './components/schema/SchemaPanel';
+import {
+  type SchemaOutputType,
+  SchemaPanel,
+  type SchemaPanelSource,
+} from './components/schema/SchemaPanel';
 import { StatusBar } from './components/status-bar/StatusBar';
 import { StdlibPanel } from './components/stdlib/StdlibPanel';
 import { GraphControlsPanel } from './components/toolbar/GraphControlsPanel';
@@ -433,6 +438,32 @@ export default function App(): React.JSX.Element {
     [schema],
   );
 
+  const updateSchemaOutputDir = useCallback(
+    (type: SchemaOutputType, dir: string | null): void => {
+      if (type === 'stdlib-runtime') {
+        const nextConfig = { ...(schema.outputs?.stdlibRuntime ?? {}) };
+        if (dir === null) delete nextConfig.dir;
+        else nextConfig.dir = dir;
+        useUndoStore.getState().apply({
+          kind: 'replace_schema',
+          schema: {
+            ...schema,
+            outputs: {
+              ...(schema.outputs ?? {}),
+              stdlibRuntime: nextConfig,
+            },
+          },
+        });
+        return;
+      }
+      useUndoStore.getState().apply({
+        kind: 'replace_schema',
+        schema: setGeneratedTargetOutputDir(schema, type, dir),
+      });
+    },
+    [schema],
+  );
+
   const openGeneratedFile = useCallback((path: string): void => {
     void window.contexture?.shell.openInEditor(path);
   }, []);
@@ -570,10 +601,12 @@ export default function App(): React.JSX.Element {
                   error={schemaEmissions.error}
                   onCopy={copyToClipboard}
                   onEnableOutput={enableSchemaOutput}
+                  onOutputDirChange={updateSchemaOutputDir}
                   documentFilePath={filePath}
                   onOpenGeneratedFile={openGeneratedFile}
                   onRequestSave={() => void fileMenu.handleSave()}
                   schemaFileName={schemaFileName}
+                  schema={schema}
                 />
               </div>
               <div

--- a/apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/schema/SchemaPanel.tsx
@@ -29,10 +29,16 @@ import {
   type GeneratedTargetLanguage,
   generatedTargetDisplayPath,
   generatedTargetMetadata,
+  generatedTargetOutputDir,
   generatedTargetPath,
   previewableGeneratedTargets,
 } from '@contexture/core/generated-targets';
-import type { GeneratedTargetKind } from '@contexture/core/paths';
+import type { Schema } from '@contexture/core/ir';
+import {
+  bundlePathsFor,
+  type GeneratedTargetKind,
+  manifestKeyForGeneratedPath,
+} from '@contexture/core/paths';
 import {
   AArrowDown,
   AArrowUp,
@@ -42,11 +48,14 @@ import {
   FileBracesCorner,
   FileCode,
   PlugZap,
+  RotateCcw,
   Settings2,
 } from 'lucide-react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '../ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../ui/empty';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import {
   Select,
@@ -62,16 +71,16 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import { getHighlighter, SHIKI_THEMES } from './shiki-highlighter';
 
-export type SchemaOutputType = GeneratedTargetKind;
+export type SchemaOutputType = GeneratedTargetKind | 'stdlib-runtime';
 
 export interface SchemaPanelAdditionalSource {
-  type: Exclude<SchemaOutputType, 'zod' | 'json-schema' | 'schema-index' | 'convex'>;
+  type: Exclude<GeneratedTargetKind, 'zod' | 'json-schema' | 'schema-index' | 'convex'>;
   source: string;
   enabled?: boolean;
 }
 
 export interface SchemaPanelSource {
-  type: SchemaOutputType;
+  type: GeneratedTargetKind;
   source: string;
   enabled?: boolean;
 }
@@ -104,9 +113,13 @@ export interface SchemaPanelProps {
    */
   additionalSources?: SchemaPanelAdditionalSource[];
   /** Enable an optional output target from the output configuration popover. */
-  onEnableOutput?: (type: SchemaOutputType) => void;
+  onEnableOutput?: (type: GeneratedTargetKind) => void;
+  /** Configure a generated target's IR-relative output directory. */
+  onOutputDirChange?: (type: SchemaOutputType, dir: string | null) => void;
   /** Absolute path of the active `.contexture.json`; absent for unsaved documents. */
   documentFilePath?: string | null;
+  /** Current IR schema, used to resolve configured generated output paths. */
+  schema?: Schema;
   /** Open the selected generated file in an external editor. */
   onOpenGeneratedFile?: (path: string) => void;
   /** Prompt the app save flow when agent setup needs a stable IR path. */
@@ -173,6 +186,7 @@ interface OutputOption {
   help: string;
   language: GeneratedTargetLanguage;
   fileName: string;
+  dir: string | null;
   enabled: boolean;
 }
 
@@ -193,11 +207,13 @@ export function SchemaPanel({
   schemaFileName = 'schema.ts',
   additionalSources = [],
   onEnableOutput,
+  onOutputDirChange,
   documentFilePath = null,
+  schema,
   onOpenGeneratedFile,
   onRequestSave,
 }: SchemaPanelProps): React.JSX.Element {
-  const [activeOutput, setActiveOutput] = useState<SchemaOutputType>('convex');
+  const [activeOutput, setActiveOutput] = useState<GeneratedTargetKind>('convex');
   const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null);
   const [fontSizeIndex, setFontSizeIndex] = useState<number>(DEFAULT_FONT_SIZE_INDEX);
   const [copied, setCopied] = useState(false);
@@ -251,17 +267,36 @@ export function SchemaPanel({
           help: metadata.help,
           language: metadata.language,
           fileName: generatedTargetDisplayPath(type, baseName),
+          dir: schema ? generatedTargetOutputDir(schema, type) : null,
           enabled,
         };
       });
-  }, [additionalSources, convexSource, jsonSource, schemaFileName, sources, zodSource]);
+  }, [additionalSources, convexSource, jsonSource, schema, schemaFileName, sources, zodSource]);
+
+  const configOptions = useMemo<OutputOption[]>(
+    () => [
+      ...outputOptions,
+      {
+        type: 'stdlib-runtime',
+        source: '',
+        group: 'supporting',
+        label: 'Stdlib runtime',
+        help: 'Generated runtime modules for stdlib types referenced by this schema.',
+        language: 'typescript',
+        fileName: 'contexture-runtime/*.ts',
+        dir: schema?.outputs?.stdlibRuntime?.dir ?? null,
+        enabled: true,
+      },
+    ],
+    [outputOptions, schema?.outputs?.stdlibRuntime?.dir],
+  );
 
   const enabledOutputOptions = useMemo(
-    () => outputOptions.filter((output) => output.enabled),
-    [outputOptions],
-  );
-  const disabledOutputOptions = useMemo(
-    () => outputOptions.filter((output) => !output.enabled),
+    () =>
+      outputOptions.filter(
+        (output): output is OutputOption & { type: GeneratedTargetKind } =>
+          output.enabled && output.type !== 'stdlib-runtime',
+      ),
     [outputOptions],
   );
 
@@ -278,8 +313,12 @@ export function SchemaPanel({
   const activeSource = selectedOutput?.source ?? '';
   const selectedOutputPath =
     selectedOutput && documentFilePath
-      ? generatedTargetPath(selectedOutput.type, documentFilePath)
+      ? safePreviewTargetPath(selectedOutput, documentFilePath, schema)
       : null;
+  const selectedOutputDisplayPath =
+    selectedOutput && documentFilePath && selectedOutputPath
+      ? manifestKeyForGeneratedPath(documentFilePath, selectedOutputPath)
+      : (selectedOutput?.fileName ?? 'schema.ts');
 
   // Re-highlight whenever the active source or output type changes.
   useEffect(() => {
@@ -413,16 +452,17 @@ export function SchemaPanel({
                     setHighlightedHtml(null);
                   }}
                 />
-                {disabledOutputOptions.length > 0 ? (
-                  <OutputConfigPopover
-                    disabledOptions={disabledOutputOptions}
-                    onEnableOutput={(type) => {
-                      setActiveOutput(type);
-                      setHighlightedHtml(null);
-                      onEnableOutput?.(type);
-                    }}
-                  />
-                ) : null}
+                <OutputConfigPopover
+                  options={configOptions}
+                  documentFilePath={documentFilePath}
+                  schema={schema}
+                  onEnableOutput={(type) => {
+                    setActiveOutput(type);
+                    setHighlightedHtml(null);
+                    onEnableOutput?.(type);
+                  }}
+                  onOutputDirChange={onOutputDirChange}
+                />
                 <AgentSetupPopover
                   documentFilePath={documentFilePath}
                   copied={agentCopied}
@@ -432,7 +472,7 @@ export function SchemaPanel({
                 />
               </div>
               <div className="truncate font-mono text-[10px]" data-testid="schema-filename">
-                {selectedOutput?.fileName ?? 'schema.ts'}
+                {selectedOutputDisplayPath}
               </div>
               <div
                 className="mt-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/80"
@@ -513,19 +553,40 @@ export function SchemaPanel({
   );
 }
 
+function safeGeneratedTargetPath(
+  type: GeneratedTargetKind,
+  documentFilePath: string,
+  schema?: Schema,
+): string | null {
+  try {
+    return generatedTargetPath(type, documentFilePath, schema);
+  } catch {
+    return null;
+  }
+}
+
+function safePreviewTargetPath(
+  output: OutputOption,
+  documentFilePath: string,
+  schema?: Schema,
+): string | null {
+  if (output.type === 'stdlib-runtime') return null;
+  return safeGeneratedTargetPath(output.type, documentFilePath, schema);
+}
+
 function OutputSelect({
   activeOutput,
   enabledOptions,
   onValueChange,
 }: {
-  activeOutput: SchemaOutputType;
+  activeOutput: GeneratedTargetKind;
   enabledOptions: OutputOption[];
-  onValueChange: (type: SchemaOutputType) => void;
+  onValueChange: (type: GeneratedTargetKind) => void;
 }): React.JSX.Element {
   return (
     <Select
       value={activeOutput}
-      onValueChange={(value) => onValueChange(value as SchemaOutputType)}
+      onValueChange={(value) => onValueChange(value as GeneratedTargetKind)}
     >
       <SelectTrigger
         className="h-7 min-w-0 flex-1 border-border/70 bg-background/80 px-2 py-1 text-xs"
@@ -563,11 +624,17 @@ function OutputSelect({
 }
 
 function OutputConfigPopover({
-  disabledOptions,
+  options,
+  documentFilePath,
+  schema,
   onEnableOutput,
+  onOutputDirChange,
 }: {
-  disabledOptions: OutputOption[];
-  onEnableOutput?: (type: SchemaOutputType) => void;
+  options: OutputOption[];
+  documentFilePath: string | null;
+  schema?: Schema;
+  onEnableOutput?: (type: GeneratedTargetKind) => void;
+  onOutputDirChange?: (type: SchemaOutputType, dir: string | null) => void;
 }): React.JSX.Element {
   return (
     <Popover>
@@ -593,16 +660,17 @@ function OutputConfigPopover({
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <PopoverContent className="w-72 p-2" align="end">
+      <PopoverContent className="w-[420px] p-2" align="end">
         <div className="mb-2 px-1">
           <div className="text-xs font-semibold text-foreground">Generated outputs</div>
           <p className="text-[11px] leading-snug text-muted-foreground">
-            Convex files are primary generated outputs. Enable supporting targets as needed.
+            Set IR-relative folders for each generated target. Empty folders use Contexture's
+            default layout.
           </p>
         </div>
-        <div className="space-y-1">
+        <div className="max-h-[60vh] space-y-2 overflow-y-auto pr-1">
           {OUTPUT_GROUPS.map(({ group, label }) => {
-            const groupOutputs = disabledOptions.filter((output) => output.group === group);
+            const groupOutputs = options.filter((output) => output.group === group);
             if (groupOutputs.length === 0) return null;
             return (
               <div key={group} data-testid={`schema-group-${group}`}>
@@ -610,23 +678,14 @@ function OutputConfigPopover({
                   {label}
                 </div>
                 {groupOutputs.map((output) => (
-                  <button
+                  <OutputConfigRow
                     key={output.type}
-                    type="button"
-                    className="flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    onClick={() => onEnableOutput?.(output.type)}
-                    data-testid={`schema-output-${output.type}`}
-                  >
-                    <span className="mt-0.5 text-muted-foreground">+</span>
-                    <span className="min-w-0">
-                      <span className="block font-medium text-foreground">
-                        Enable {output.label}
-                      </span>
-                      <span className="block text-[11px] leading-snug text-muted-foreground">
-                        {output.help}
-                      </span>
-                    </span>
-                  </button>
+                    output={output}
+                    documentFilePath={documentFilePath}
+                    schema={schema}
+                    onEnableOutput={onEnableOutput}
+                    onOutputDirChange={onOutputDirChange}
+                  />
                 ))}
               </div>
             );
@@ -635,6 +694,168 @@ function OutputConfigPopover({
       </PopoverContent>
     </Popover>
   );
+}
+
+function OutputConfigRow({
+  output,
+  documentFilePath,
+  schema,
+  onEnableOutput,
+  onOutputDirChange,
+}: {
+  output: OutputOption;
+  documentFilePath: string | null;
+  schema?: Schema;
+  onEnableOutput?: (type: GeneratedTargetKind) => void;
+  onOutputDirChange?: (type: SchemaOutputType, dir: string | null) => void;
+}): React.JSX.Element {
+  const inputId = `output-dir-${output.type}`;
+  const defaultDir = defaultOutputDirFor(output.type, documentFilePath, output.fileName, schema);
+  const [draft, setDraft] = useState(output.dir ?? '');
+
+  useEffect(() => {
+    setDraft(output.dir ?? '');
+  }, [output.dir]);
+
+  const validation = validateOutputDirDraft(draft);
+  const canApply = validation === null && draft.trim() !== (output.dir ?? '');
+
+  const applyDraft = (): void => {
+    if (!canApply) return;
+    const normalized = normalizeOutputDirDraft(draft);
+    onOutputDirChange?.(output.type, normalized === '' ? null : normalized);
+  };
+
+  return (
+    <div
+      className="rounded-md border border-border/70 bg-background/80 px-2 py-2"
+      data-testid={`schema-output-${output.type}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate text-xs font-medium text-foreground">{output.label}</span>
+            {!output.enabled ? (
+              <span className="rounded border border-border px-1 py-0.5 text-[10px] text-muted-foreground">
+                Off
+              </span>
+            ) : null}
+          </div>
+          <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">{output.help}</p>
+        </div>
+        {!output.enabled ? (
+          <Button
+            type="button"
+            variant="secondary"
+            className="h-7 shrink-0 px-2 text-xs"
+            onClick={() => {
+              if (output.type !== 'stdlib-runtime') onEnableOutput?.(output.type);
+            }}
+            data-testid={`schema-enable-${output.type}`}
+          >
+            Enable
+          </Button>
+        ) : null}
+      </div>
+      <div className="mt-2 grid gap-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <Label htmlFor={inputId} className="text-[11px] text-muted-foreground">
+            Output folder
+          </Label>
+          {output.dir ? (
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="size-6"
+              onClick={() => onOutputDirChange?.(output.type, null)}
+              aria-label={`Reset ${output.label} output folder`}
+              title={`Reset ${output.label} output folder`}
+              data-testid={`schema-output-dir-reset-${output.type}`}
+            >
+              <RotateCcw className="size-3" />
+            </Button>
+          ) : null}
+        </div>
+        <div className="flex gap-1.5">
+          <Input
+            id={inputId}
+            value={draft}
+            placeholder={defaultDir}
+            onChange={(event) => setDraft(event.target.value)}
+            onBlur={applyDraft}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') applyDraft();
+            }}
+            className="h-8 font-mono text-xs"
+            aria-invalid={validation !== null}
+            data-testid={`schema-output-dir-${output.type}`}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            className="h-8 px-2 text-xs"
+            disabled={!canApply}
+            onClick={applyDraft}
+            data-testid={`schema-output-dir-apply-${output.type}`}
+          >
+            Apply
+          </Button>
+        </div>
+        <p
+          className={`text-[10px] leading-snug ${
+            validation ? 'text-destructive' : 'text-muted-foreground'
+          }`}
+          data-testid={`schema-output-dir-help-${output.type}`}
+        >
+          {validation ?? `Default: ${defaultDir}`}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function defaultOutputDirFor(
+  type: SchemaOutputType,
+  documentFilePath: string | null,
+  fallbackPath: string,
+  schema?: Schema,
+): string {
+  if (documentFilePath) {
+    if (type === 'stdlib-runtime') {
+      return dirname(
+        manifestKeyForGeneratedPath(
+          documentFilePath,
+          bundlePathsFor(documentFilePath, schema).stdlibRuntimeDir,
+        ),
+      );
+    }
+    const path = safeGeneratedTargetPath(type, documentFilePath, schema);
+    if (path) return dirname(manifestKeyForGeneratedPath(documentFilePath, path));
+  }
+  return dirname(fallbackPath);
+}
+
+function validateOutputDirDraft(value: string): string | null {
+  const normalized = normalizeOutputDirDraft(value);
+  if (normalized === '') return null;
+  if (normalized.startsWith('/') || /^[A-Za-z]:\//.test(normalized)) {
+    return 'Use a relative folder path.';
+  }
+  if (normalized === '..' || normalized.startsWith('../')) {
+    return 'Folder must stay within the directory containing the IR.';
+  }
+  return null;
+}
+
+function normalizeOutputDirDraft(value: string): string {
+  return value.trim().replaceAll('\\', '/').replace(/\/+/g, '/').replace(/^\.\//, '');
+}
+
+function dirname(path: string): string {
+  const slash = path.lastIndexOf('/');
+  if (slash <= 0) return slash === 0 ? '/' : '.';
+  return path.slice(0, slash);
 }
 
 function AgentSetupPopover({

--- a/apps/desktop/src/shared/stdlib-registry.ts
+++ b/apps/desktop/src/shared/stdlib-registry.ts
@@ -6,7 +6,8 @@
  * used by core validation, emitters, and chat prompts.
  */
 
-import type { TypeDef } from '@contexture/core/ir';
+import type { StdlibRuntimeModule } from '@contexture/core/generated-targets';
+import type { Schema, TypeDef } from '@contexture/core/ir';
 import type { StdlibCatalog } from '@contexture/core/semantic-validation';
 import { IR_BY_NAMESPACE, NAMESPACES, type Namespace } from '@contexture/stdlib/registry';
 import type { StdlibRegistry as SystemPromptStdlibRegistry } from './system-prompt';
@@ -41,6 +42,13 @@ export function buildStdlibRegistry(): StdlibRegistry {
 
 /** Singleton for app runtime; tests build their own via `buildStdlibRegistry`. */
 export const STDLIB_REGISTRY: StdlibRegistry = buildStdlibRegistry();
+
+export const STDLIB_RUNTIME_MODULES: readonly StdlibRuntimeModule[] = NAMESPACES.map(
+  (namespace) => ({
+    namespace,
+    schema: IR_BY_NAMESPACE[namespace] as Schema,
+  }),
+);
 
 export function buildStdlibTypeDefinitions(): ReadonlyMap<string, TypeDef> {
   const types = new Map<string, TypeDef>();

--- a/apps/desktop/tests/components/App.schema-outputs.test.tsx
+++ b/apps/desktop/tests/components/App.schema-outputs.test.tsx
@@ -70,7 +70,7 @@ describe('App schema outputs', () => {
       expect(screen.getByTestId('schema-output-config')).toBeInTheDocument();
     });
     fireEvent.click(screen.getByTestId('schema-output-config'));
-    fireEvent.click(screen.getByTestId('schema-output-ai-tool-schemas'));
+    fireEvent.click(screen.getByTestId('schema-enable-ai-tool-schemas'));
 
     await waitFor(() => {
       expect(useUndoStore.getState().schema.outputs?.aiPipeline?.toolSchemas?.enabled).toBe(true);
@@ -100,5 +100,34 @@ describe('App schema outputs', () => {
       );
     });
     expect(screen.getByTestId('schema-code').textContent ?? '').not.toContain('<unsaved>');
+  });
+
+  it('lets users set a generated output folder from the Schema panel', async () => {
+    useDocumentStore.getState().setFilePath('/repo/garden.contexture.json');
+    useUndoStore.getState().apply({
+      kind: 'replace_schema',
+      schema: {
+        version: '1',
+        types: [{ kind: 'object', name: 'Lead', fields: [] }],
+      },
+    });
+
+    render(<App />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId('schema-output-config'));
+    await user.type(screen.getByTestId('schema-output-dir-zod'), 'packages/domain/src/generated');
+    fireEvent.click(screen.getByTestId('schema-output-dir-apply-zod'));
+
+    await waitFor(() => {
+      expect(useUndoStore.getState().schema.outputs?.zod?.dir).toBe(
+        'packages/domain/src/generated',
+      );
+    });
+    await user.click(screen.getByTestId('schema-output-selector'));
+    fireEvent.click(await screen.findByTestId('schema-output-zod'));
+    expect(screen.getByTestId('schema-filename')).toHaveTextContent(
+      'packages/domain/src/generated/garden.schema.ts',
+    );
   });
 });

--- a/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
+++ b/apps/desktop/tests/components/schema/SchemaPanel.test.tsx
@@ -329,8 +329,72 @@ describe('SchemaPanel', () => {
       fireEvent.click(screen.getByTestId('schema-output-config'));
       expect(screen.getByTestId('schema-group-agent')).toHaveTextContent('Tool schemas');
       expect(screen.getByTestId('schema-group-agent')).toHaveTextContent('Form validators');
-      fireEvent.click(screen.getByTestId('schema-output-ai-tool-schemas'));
+      fireEvent.click(screen.getByTestId('schema-enable-ai-tool-schemas'));
       expect(onEnableOutput).toHaveBeenCalledWith('ai-tool-schemas');
+    });
+
+    it('lets users configure a relative output folder for a target', async () => {
+      const user = userEvent.setup();
+      const onOutputDirChange = vi.fn();
+      render(
+        <SchemaPanel
+          {...DEFAULT_PROPS}
+          zodSource="zod"
+          documentFilePath="/repo/garden.contexture.json"
+          onOutputDirChange={onOutputDirChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('schema-output-config'));
+      await user.clear(screen.getByTestId('schema-output-dir-zod'));
+      await user.type(screen.getByTestId('schema-output-dir-zod'), 'packages/domain/src/generated');
+      fireEvent.click(screen.getByTestId('schema-output-dir-apply-zod'));
+
+      expect(onOutputDirChange).toHaveBeenCalledWith('zod', 'packages/domain/src/generated');
+    });
+
+    it('lets users configure the stdlib runtime output folder', async () => {
+      const user = userEvent.setup();
+      const onOutputDirChange = vi.fn();
+      render(
+        <SchemaPanel
+          {...DEFAULT_PROPS}
+          zodSource="zod"
+          documentFilePath="/repo/garden.contexture.json"
+          onOutputDirChange={onOutputDirChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('schema-output-config'));
+      expect(screen.getByTestId('schema-output-stdlib-runtime')).toHaveTextContent(
+        'Stdlib runtime',
+      );
+      await user.clear(screen.getByTestId('schema-output-dir-stdlib-runtime'));
+      await user.type(screen.getByTestId('schema-output-dir-stdlib-runtime'), 'src/runtime');
+      fireEvent.click(screen.getByTestId('schema-output-dir-apply-stdlib-runtime'));
+
+      expect(onOutputDirChange).toHaveBeenCalledWith('stdlib-runtime', 'src/runtime');
+    });
+
+    it('rejects output folders that escape the IR directory', async () => {
+      const user = userEvent.setup();
+      const onOutputDirChange = vi.fn();
+      render(
+        <SchemaPanel
+          {...DEFAULT_PROPS}
+          zodSource="zod"
+          documentFilePath="/repo/garden.contexture.json"
+          onOutputDirChange={onOutputDirChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('schema-output-config'));
+      await user.type(screen.getByTestId('schema-output-dir-zod'), '../outside');
+
+      expect(screen.getByTestId('schema-output-dir-help-zod')).toHaveTextContent(
+        /must stay within/i,
+      );
+      expect(screen.getByTestId('schema-output-dir-apply-zod')).toBeDisabled();
     });
 
     it('describes disabled optional outputs in the configuration popover', () => {
@@ -393,11 +457,18 @@ describe('SchemaPanel', () => {
           additionalSources={[{ type: 'mcp-definitions', source: '{\n  "servers": []\n}\n' }]}
           documentFilePath="/repo/garden.contexture.json"
           onOpenGeneratedFile={onOpenGeneratedFile}
+          schema={{
+            version: '1',
+            outputs: { zod: { dir: 'packages/domain/src/generated' } },
+            types: [{ kind: 'object', name: 'Garden', fields: [] }],
+          }}
         />,
       );
 
       fireEvent.click(screen.getByTestId('schema-open-generated'));
-      expect(onOpenGeneratedFile).toHaveBeenLastCalledWith('/repo/schema/garden.schema.ts');
+      expect(onOpenGeneratedFile).toHaveBeenLastCalledWith(
+        '/repo/packages/domain/src/generated/garden.schema.ts',
+      );
       screen.getByTestId('schema-copy').focus();
       await user.tab();
       expect(screen.getByTestId('schema-open-generated')).toHaveFocus();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,9 @@ import {
   type TypeDef,
   writeGeneratedBundle,
 } from '@contexture/core';
+import { STDLIB_REGISTRY, STDLIB_RUNTIME_MODULES } from './stdlib-runtime';
+
+const STDLIB_EMIT_DEPS = { stdlibRuntime: STDLIB_RUNTIME_MODULES } as const;
 
 interface CliOptions {
   json: boolean;
@@ -547,7 +550,7 @@ async function run(argv: string[]): Promise<void> {
       });
       return;
     }
-    const errors = checkSemantic(parsed.data).map((issue) => ({
+    const errors = checkSemantic(parsed.data, STDLIB_REGISTRY).map((issue) => ({
       code: issue.code,
       path: issue.path,
       message: issue.message,
@@ -576,6 +579,7 @@ async function run(argv: string[]): Promise<void> {
       irPath: writableIrPath,
       schema,
       fs: nodeFileBackedFs,
+      emitDeps: STDLIB_EMIT_DEPS,
       driftPreflight: false,
     });
     writeResult({ message: `Emitted ${emitted.length} files.`, manifest }, options.json);
@@ -585,7 +589,12 @@ async function run(argv: string[]): Promise<void> {
   if (command === 'check-generated') {
     const writableIrPath = assertContextureIrPath(irPath);
     const schema = await readSchema(writableIrPath);
-    const files = await checkGeneratedBundle(schema, writableIrPath, nodeFileBackedFs);
+    const files = await checkGeneratedBundle(
+      schema,
+      writableIrPath,
+      nodeFileBackedFs,
+      STDLIB_EMIT_DEPS,
+    );
     const drift = files.filter((file) => file.status !== 'clean');
     if (drift.length > 0) {
       process.exitCode = 1;
@@ -636,7 +645,11 @@ async function run(argv: string[]): Promise<void> {
       else process.stderr.write(`${error.error.message}\n`);
       return;
     }
-    const forward = createFileBackedForward(writableIrPath, { changeSource: 'cli' });
+    const forward = createFileBackedForward(writableIrPath, {
+      stdlib: STDLIB_REGISTRY,
+      emitDeps: STDLIB_EMIT_DEPS,
+      changeSource: 'cli',
+    });
     type ForwardResult = Awaited<ReturnType<typeof forward>>;
     let result: ForwardResult;
     try {
@@ -660,7 +673,11 @@ async function run(argv: string[]): Promise<void> {
   }
 
   const writableIrPath = assertContextureIrPath(irPath);
-  const forward = createFileBackedForward(writableIrPath, { changeSource: 'cli' });
+  const forward = createFileBackedForward(writableIrPath, {
+    stdlib: STDLIB_REGISTRY,
+    emitDeps: STDLIB_EMIT_DEPS,
+    changeSource: 'cli',
+  });
   const tools = new Map(createOpTools(forward).map((tool) => [tool.name, tool]));
   const { tool: toolName, input } = commandToToolInput(command, args);
   const tool = tools.get(toolName);

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -2,25 +2,16 @@ import {
   type ContextureMcpServerOptions,
   createContextureMcpServer as createCoreContextureMcpServer,
 } from '@contexture/core/mcp-server';
-import { IR_BY_NAMESPACE, NAMESPACES } from '@contexture/stdlib/registry';
-
-const typeNamesByNamespace: Record<string, ReadonlySet<string>> = Object.fromEntries(
-  NAMESPACES.map((namespace) => [
-    namespace,
-    new Set(IR_BY_NAMESPACE[namespace].types.map((type) => type.name)),
-  ]),
-);
-
-const STDLIB_REGISTRY = {
-  namespaces: NAMESPACES,
-  hasType: (namespace: string, typeName: string) =>
-    typeNamesByNamespace[namespace]?.has(typeName) ?? false,
-};
+import { STDLIB_REGISTRY, STDLIB_RUNTIME_MODULES } from './stdlib-runtime';
 
 export function createContextureMcpServer(options: ContextureMcpServerOptions = {}) {
   return createCoreContextureMcpServer({
     ...options,
     stdlib: options.stdlib ?? STDLIB_REGISTRY,
+    emitDeps: {
+      stdlibRuntime: STDLIB_RUNTIME_MODULES,
+      ...(options.emitDeps ?? {}),
+    },
   });
 }
 

--- a/packages/cli/src/stdlib-runtime.ts
+++ b/packages/cli/src/stdlib-runtime.ts
@@ -1,0 +1,22 @@
+import type { Schema, StdlibRuntimeModule } from '@contexture/core';
+import { IR_BY_NAMESPACE, NAMESPACES } from '@contexture/stdlib/registry';
+
+const typeNamesByNamespace: Record<string, ReadonlySet<string>> = Object.fromEntries(
+  NAMESPACES.map((namespace) => [
+    namespace,
+    new Set(IR_BY_NAMESPACE[namespace].types.map((type) => type.name)),
+  ]),
+);
+
+export const STDLIB_REGISTRY = {
+  namespaces: NAMESPACES,
+  hasType: (namespace: string, typeName: string) =>
+    typeNamesByNamespace[namespace]?.has(typeName) ?? false,
+};
+
+export const STDLIB_RUNTIME_MODULES: readonly StdlibRuntimeModule[] = NAMESPACES.map(
+  (namespace) => ({
+    namespace,
+    schema: IR_BY_NAMESPACE[namespace] as Schema,
+  }),
+);

--- a/packages/core/src/emit-form-validators.ts
+++ b/packages/core/src/emit-form-validators.ts
@@ -13,10 +13,15 @@ function header(sourcePath?: string): string {
   return sourcePath ? `${base} Source: ${sourcePath}\n` : `${base}\n`;
 }
 
-export function emitFormValidators(schema: Schema, baseName: string, sourcePath?: string): string {
+export function emitFormValidators(
+  schema: Schema,
+  baseName: string,
+  sourcePath?: string,
+  schemaModule = `./${baseName}.schema`,
+): string {
   const names = schema.types.map((type) => type.name).sort();
   const imports =
-    names.length > 0 ? `import { ${names.join(', ')} } from './${baseName}.schema';\n` : '';
+    names.length > 0 ? `import { ${names.join(', ')} } from '${schemaModule}';\n` : '';
   const validators = names
     .map((name) => `export const ${name}Validator = createFormValidator(${name});\n`)
     .join('');

--- a/packages/core/src/emit-schema-index.ts
+++ b/packages/core/src/emit-schema-index.ts
@@ -13,6 +13,10 @@ function header(sourcePath?: string): string {
   return sourcePath ? `${base} Source: ${sourcePath}\n` : `${base}\n`;
 }
 
-export function emit(baseName: string, sourcePath?: string): string {
-  return `${header(sourcePath)}export * from './${baseName}.schema';\n`;
+export function emit(
+  baseName: string,
+  sourcePath?: string,
+  schemaModule = `./${baseName}.schema`,
+): string {
+  return `${header(sourcePath)}export * from '${schemaModule}';\n`;
 }

--- a/packages/core/src/emit-zod.ts
+++ b/packages/core/src/emit-zod.ts
@@ -27,6 +27,8 @@ import type { FieldDef, FieldType, ImportDecl, Schema, TypeDef } from './ir';
 export interface EmitOptions {
   /** Namespaces (e.g. `'place'`, `'money'`) treated as ambient stdlib. */
   stdlibNamespaces?: readonly string[];
+  /** Override module specifiers for stdlib namespace imports. */
+  stdlibModuleForNamespace?: (namespace: string) => string | null | undefined;
 }
 
 export function emit(schema: Schema, sourcePath: string, options: EmitOptions = {}): string {
@@ -55,6 +57,7 @@ interface EmitContext {
   rawExternal: Map<string, { from: string; name: string }>;
   /** Local types by name, used to order declarations before consumers. */
   types: Map<string, TypeDef>;
+  stdlibModuleForNamespace?: (namespace: string) => string | null | undefined;
 }
 
 function buildContext(schema: Schema, options: EmitOptions): EmitContext {
@@ -106,7 +109,14 @@ function buildContext(schema: Schema, options: EmitOptions): EmitContext {
     }
   });
 
-  return { aliases, imports, usedByAlias, rawExternal, types };
+  return {
+    aliases,
+    imports,
+    usedByAlias,
+    rawExternal,
+    types,
+    stdlibModuleForNamespace: options.stdlibModuleForNamespace,
+  };
 }
 
 function renderExternalImports(ctx: EmitContext): string {
@@ -116,7 +126,7 @@ function renderExternalImports(ctx: EmitContext): string {
     const used = ctx.usedByAlias.get(imp.alias);
     if (!used || used.size === 0) return;
     const names = [...used].sort().join(', ');
-    const module = moduleForImport(imp);
+    const module = moduleForImport(imp, ctx);
     lines.push(`import { ${names} } from '${module}';`);
   });
 
@@ -127,10 +137,12 @@ function renderExternalImports(ctx: EmitContext): string {
   return lines.length ? `${lines.join('\n')}\n` : '';
 }
 
-function moduleForImport(imp: ImportDecl): string {
+function moduleForImport(imp: ImportDecl, ctx: EmitContext): string {
   if (imp.kind === 'stdlib') {
     // `@contexture/common` → `@contexture/runtime/common`
     const ns = imp.path.slice('@contexture/'.length);
+    const localModule = ctx.stdlibModuleForNamespace?.(ns);
+    if (localModule) return localModule;
     return `@contexture/runtime/${ns}`;
   }
   // Relative: emit as `./<alias>.schema` (sibling of the original file).

--- a/packages/core/src/file-forward.ts
+++ b/packages/core/src/file-forward.ts
@@ -9,6 +9,7 @@ import { type GeneratedBundleFs, writeGeneratedBundle } from './generated-bundle
 import { load } from './load';
 import { type ApplyResult, apply, type Op } from './ops';
 import { assertContextureIrPath } from './paths';
+import type { EmitPipelineDeps } from './pipeline';
 import type { StdlibCatalog } from './semantic-validation';
 
 export interface FileBackedFs extends GeneratedBundleFs {
@@ -46,6 +47,7 @@ export const nodeFileBackedFs: FileBackedFs = {
 export interface FileBackedForwardOptions {
   fs?: FileBackedFs;
   stdlib?: StdlibCatalog;
+  emitDeps?: EmitPipelineDeps;
   changeSource?: ModelChangeSource;
   actor?: string;
 }
@@ -64,7 +66,12 @@ export function createFileBackedForward(
     const result = apply(schema, op, options.stdlib);
     if ('error' in result) return result;
 
-    await writeGeneratedBundle({ irPath: resolvedIrPath, schema: result.schema, fs });
+    await writeGeneratedBundle({
+      irPath: resolvedIrPath,
+      schema: result.schema,
+      fs,
+      emitDeps: options.emitDeps,
+    });
     if (options.changeSource) {
       await appendModelChangeLogEntry({
         irPath: resolvedIrPath,

--- a/packages/core/src/generated-bundle-writer.ts
+++ b/packages/core/src/generated-bundle-writer.ts
@@ -78,7 +78,7 @@ export function buildGeneratedBundle(
   irPath: string,
   emitDeps?: EmitPipelineDeps,
 ): GeneratedBundleBuild {
-  const paths = bundlePathsFor(irPath);
+  const paths = bundlePathsFor(irPath, schema);
   const { emitted, manifest } = runEmitPipeline(schema, irPath, emitDeps);
   return {
     paths,
@@ -117,6 +117,7 @@ export async function checkGeneratedBundle(
 export async function checkGeneratedManifestDrift(
   irPath: string,
   fs: Pick<GeneratedBundleFs, 'readFile'>,
+  schema?: Schema,
 ): Promise<GeneratedFileCheck[]> {
   const paths = bundlePathsFor(irPath);
   const manifest = await readGeneratedManifest(paths.emitted, fs);
@@ -126,7 +127,7 @@ export async function checkGeneratedManifestDrift(
 
   const checks: GeneratedFileCheck[] = [];
   for (const [manifestKey, expectedHash] of Object.entries(manifest.files ?? {})) {
-    const path = resolveManifestGeneratedPath(irPath, manifestKey);
+    const path = resolveManifestGeneratedPath(irPath, manifestKey, schema);
     let content: string | undefined;
     try {
       content = await fs.readFile(path);
@@ -152,7 +153,7 @@ export async function classifyGeneratedBundleDrift(
   const manifest = await readGeneratedManifest(bundle.paths.emitted, fs);
   const manifestFiles = Object.fromEntries(
     Object.entries(manifest?.files ?? {}).map(([manifestKey, hash]) => [
-      resolveManifestGeneratedPath(irPath, manifestKey),
+      resolveManifestGeneratedPath(irPath, manifestKey, schema),
       hash,
     ]),
   );
@@ -233,7 +234,7 @@ export async function writeGeneratedBundle(
   } = input;
 
   if (driftPreflight) {
-    const drift = (await checkGeneratedManifestDrift(irPath, fs)).filter(
+    const drift = (await checkGeneratedManifestDrift(irPath, fs, schema)).filter(
       (check) => check.status !== 'clean' && check.status !== 'missing',
     );
     if (drift.length > 0) throw new GeneratedBundleDriftError(drift);

--- a/packages/core/src/generated-targets.ts
+++ b/packages/core/src/generated-targets.ts
@@ -7,7 +7,13 @@ import { emit as emitSchemaIndex } from './emit-schema-index';
 import { emitStructuredOutputSchemas } from './emit-structured-output-schemas';
 import { emit as emitZod } from './emit-zod';
 import type { Schema } from './ir';
-import { type BundlePaths, baseNameFor, bundlePathsFor, type GeneratedTargetKind } from './paths';
+import {
+  type BundlePaths,
+  baseNameFor,
+  bundlePathsFor,
+  type GeneratedTargetKind,
+  moduleSpecifierBetween,
+} from './paths';
 
 export type GeneratedTargetGroup = 'convex' | 'supporting' | 'agent';
 export type GeneratedTargetLanguage = 'typescript' | 'json';
@@ -24,6 +30,12 @@ export interface GeneratedTargetMetadata {
 
 export interface GeneratedTargetEmitOptions {
   stdlibNamespaces?: readonly string[];
+  stdlibModuleForNamespace?: (namespace: string) => string | null | undefined;
+}
+
+export interface StdlibRuntimeModule {
+  namespace: string;
+  schema: Schema;
 }
 
 export interface EmitPipelineDeps {
@@ -33,13 +45,19 @@ export interface EmitPipelineDeps {
     sourcePath?: string,
     options?: GeneratedTargetEmitOptions,
   ) => unknown;
-  emitSchemaIndex?: (baseName: string, sourcePath?: string) => string;
+  emitSchemaIndex?: (baseName: string, sourcePath?: string, schemaModule?: string) => string;
   emitConvex?: (schema: Schema, sourcePath?: string) => string;
   emitConvexValidators?: (schema: Schema, sourcePath?: string) => string;
   emitAiToolSchemas?: (schema: Schema, sourcePath?: string) => unknown;
   emitStructuredOutputSchemas?: (schema: Schema, sourcePath?: string) => unknown;
   emitMcpDefinitions?: (schema: Schema, sourcePath?: string) => unknown;
-  emitFormValidators?: (schema: Schema, baseName: string, sourcePath?: string) => string;
+  emitFormValidators?: (
+    schema: Schema,
+    baseName: string,
+    sourcePath?: string,
+    schemaModule?: string,
+  ) => string;
+  stdlibRuntime?: readonly StdlibRuntimeModule[];
 }
 
 interface GeneratedTargetDescriptor extends GeneratedTargetMetadata {
@@ -49,6 +67,7 @@ interface GeneratedTargetDescriptor extends GeneratedTargetMetadata {
   emit: (
     schema: Schema,
     irPath: string,
+    paths: BundlePaths,
     deps: EmitPipelineDeps,
     options?: GeneratedTargetEmitOptions,
   ) => string;
@@ -114,7 +133,7 @@ export const GENERATED_TARGETS: readonly GeneratedTargetDescriptor[] = [
     path: (paths) => paths.convex,
     enabled: (schema) => coreOutputEnabled(schema, 'convex'),
     enable: (schema) => enableCoreOutput(schema, 'convex'),
-    emit: (schema, irPath, deps) => (deps.emitConvex ?? emitConvexSchema)(schema, irPath),
+    emit: (schema, irPath, _paths, deps) => (deps.emitConvex ?? emitConvexSchema)(schema, irPath),
   },
   {
     kind: 'convex-validators',
@@ -127,7 +146,7 @@ export const GENERATED_TARGETS: readonly GeneratedTargetDescriptor[] = [
     path: (paths) => paths.convexValidators,
     enabled: (schema) => coreOutputEnabled(schema, 'convex'),
     enable: (schema) => enableCoreOutput(schema, 'convex'),
-    emit: (schema, irPath, deps) =>
+    emit: (schema, irPath, _paths, deps) =>
       (deps.emitConvexValidators ?? emitConvexValidators)(schema, irPath),
   },
   {
@@ -141,7 +160,8 @@ export const GENERATED_TARGETS: readonly GeneratedTargetDescriptor[] = [
     path: (paths) => paths.schemaTs,
     enabled: (schema) => coreOutputEnabled(schema, 'zod'),
     enable: (schema) => enableCoreOutput(schema, 'zod'),
-    emit: (schema, irPath, deps, options) => (deps.emitZod ?? emitZod)(schema, irPath, options),
+    emit: (schema, irPath, _paths, deps, options) =>
+      (deps.emitZod ?? emitZod)(schema, irPath, options),
   },
   {
     kind: 'json-schema',
@@ -154,7 +174,7 @@ export const GENERATED_TARGETS: readonly GeneratedTargetDescriptor[] = [
     path: (paths) => paths.schemaJson,
     enabled: (schema) => coreOutputEnabled(schema, 'jsonSchema'),
     enable: (schema) => enableCoreOutput(schema, 'jsonSchema'),
-    emit: (schema, irPath, deps, options) =>
+    emit: (schema, irPath, _paths, deps, options) =>
       json((deps.emitJsonSchema ?? defaultEmitJsonSchema)(schema, irPath, options)),
   },
   {
@@ -168,8 +188,12 @@ export const GENERATED_TARGETS: readonly GeneratedTargetDescriptor[] = [
     path: (paths) => paths.schemaIndex,
     enabled: (schema) => coreOutputEnabled(schema, 'schemaIndex'),
     enable: (schema) => enableCoreOutput(schema, 'schemaIndex'),
-    emit: (_schema, irPath, deps) =>
-      (deps.emitSchemaIndex ?? emitSchemaIndex)(baseNameFor(irPath), irPath),
+    emit: (_schema, irPath, paths, deps) =>
+      (deps.emitSchemaIndex ?? emitSchemaIndex)(
+        baseNameFor(irPath),
+        irPath,
+        moduleSpecifierBetween(paths.schemaIndex, paths.schemaTs),
+      ),
   },
   {
     kind: 'ai-tool-schemas',
@@ -182,7 +206,7 @@ export const GENERATED_TARGETS: readonly GeneratedTargetDescriptor[] = [
     path: (paths) => paths.aiToolSchemas,
     enabled: (schema) => aiOutputEnabled(schema, 'toolSchemas'),
     enable: (schema) => enableAiOutput(schema, 'toolSchemas'),
-    emit: (schema, irPath, deps) =>
+    emit: (schema, irPath, _paths, deps) =>
       json((deps.emitAiToolSchemas ?? emitAiToolSchemas)(schema, irPath)),
   },
   {
@@ -196,7 +220,7 @@ export const GENERATED_TARGETS: readonly GeneratedTargetDescriptor[] = [
     path: (paths) => paths.structuredOutputSchemas,
     enabled: (schema) => aiOutputEnabled(schema, 'structuredOutputs'),
     enable: (schema) => enableAiOutput(schema, 'structuredOutputs'),
-    emit: (schema, irPath, deps) =>
+    emit: (schema, irPath, _paths, deps) =>
       json((deps.emitStructuredOutputSchemas ?? emitStructuredOutputSchemas)(schema, irPath)),
   },
   {
@@ -210,7 +234,7 @@ export const GENERATED_TARGETS: readonly GeneratedTargetDescriptor[] = [
     path: (paths) => paths.mcpDefinitions,
     enabled: (schema) => aiOutputEnabled(schema, 'mcpDefinitions'),
     enable: (schema) => enableAiOutput(schema, 'mcpDefinitions'),
-    emit: (schema, irPath, deps) =>
+    emit: (schema, irPath, _paths, deps) =>
       json((deps.emitMcpDefinitions ?? emitMcpDefinitions)(schema, irPath)),
   },
   {
@@ -224,8 +248,13 @@ export const GENERATED_TARGETS: readonly GeneratedTargetDescriptor[] = [
     path: (paths) => paths.formValidators,
     enabled: (schema) => aiOutputEnabled(schema, 'formValidators'),
     enable: (schema) => enableAiOutput(schema, 'formValidators'),
-    emit: (schema, irPath, deps) =>
-      (deps.emitFormValidators ?? emitFormValidators)(schema, baseNameFor(irPath), irPath),
+    emit: (schema, irPath, paths, deps) =>
+      (deps.emitFormValidators ?? emitFormValidators)(
+        schema,
+        baseNameFor(irPath),
+        irPath,
+        moduleSpecifierBetween(paths.formValidators, paths.schemaTs),
+      ),
   },
 ] as const;
 
@@ -241,9 +270,13 @@ export function generatedTargetMetadata(kind: GeneratedTargetKind): GeneratedTar
   return target;
 }
 
-export function generatedTargetPath(kind: GeneratedTargetKind, irPath: string): string {
+export function generatedTargetPath(
+  kind: GeneratedTargetKind,
+  irPath: string,
+  schema?: Schema,
+): string {
   const target = requireGeneratedTargetDescriptor(kind);
-  return target.path(bundlePathsFor(irPath));
+  return target.path(bundlePathsFor(irPath, schema));
 }
 
 export function generatedTargetDisplayPath(kind: GeneratedTargetKind, baseName = 'schema'): string {
@@ -258,6 +291,112 @@ export function enableGeneratedTarget(schema: Schema, kind: GeneratedTargetKind)
   return requireGeneratedTargetDescriptor(kind).enable(schema);
 }
 
+export function generatedTargetOutputDir(schema: Schema, kind: GeneratedTargetKind): string | null {
+  switch (kind) {
+    case 'zod':
+      return schema.outputs?.zod?.dir ?? null;
+    case 'json-schema':
+      return schema.outputs?.jsonSchema?.dir ?? null;
+    case 'schema-index':
+      return schema.outputs?.schemaIndex?.dir ?? null;
+    case 'convex':
+    case 'convex-validators':
+      return schema.outputs?.convex?.dir ?? null;
+    case 'ai-tool-schemas':
+      return schema.outputs?.aiPipeline?.toolSchemas?.dir ?? null;
+    case 'structured-output-schemas':
+      return schema.outputs?.aiPipeline?.structuredOutputs?.dir ?? null;
+    case 'mcp-definitions':
+      return schema.outputs?.aiPipeline?.mcpDefinitions?.dir ?? null;
+    case 'form-validators':
+      return schema.outputs?.aiPipeline?.formValidators?.dir ?? null;
+  }
+}
+
+export function setGeneratedTargetOutputDir(
+  schema: Schema,
+  kind: GeneratedTargetKind,
+  dir: string | null,
+): Schema {
+  const nextConfig = (config: { enabled?: boolean; dir?: string } | undefined) => {
+    const next = { ...(config ?? {}) };
+    if (dir === null) delete next.dir;
+    else next.dir = dir;
+    return next;
+  };
+
+  switch (kind) {
+    case 'zod':
+      return {
+        ...schema,
+        outputs: { ...(schema.outputs ?? {}), zod: nextConfig(schema.outputs?.zod) },
+      };
+    case 'json-schema':
+      return {
+        ...schema,
+        outputs: { ...(schema.outputs ?? {}), jsonSchema: nextConfig(schema.outputs?.jsonSchema) },
+      };
+    case 'schema-index':
+      return {
+        ...schema,
+        outputs: {
+          ...(schema.outputs ?? {}),
+          schemaIndex: nextConfig(schema.outputs?.schemaIndex),
+        },
+      };
+    case 'convex':
+    case 'convex-validators':
+      return {
+        ...schema,
+        outputs: { ...(schema.outputs ?? {}), convex: nextConfig(schema.outputs?.convex) },
+      };
+    case 'ai-tool-schemas':
+      return {
+        ...schema,
+        outputs: {
+          ...(schema.outputs ?? {}),
+          aiPipeline: {
+            ...(schema.outputs?.aiPipeline ?? {}),
+            toolSchemas: nextConfig(schema.outputs?.aiPipeline?.toolSchemas),
+          },
+        },
+      };
+    case 'structured-output-schemas':
+      return {
+        ...schema,
+        outputs: {
+          ...(schema.outputs ?? {}),
+          aiPipeline: {
+            ...(schema.outputs?.aiPipeline ?? {}),
+            structuredOutputs: nextConfig(schema.outputs?.aiPipeline?.structuredOutputs),
+          },
+        },
+      };
+    case 'mcp-definitions':
+      return {
+        ...schema,
+        outputs: {
+          ...(schema.outputs ?? {}),
+          aiPipeline: {
+            ...(schema.outputs?.aiPipeline ?? {}),
+            mcpDefinitions: nextConfig(schema.outputs?.aiPipeline?.mcpDefinitions),
+          },
+        },
+      };
+    case 'form-validators':
+      return {
+        ...schema,
+        outputs: {
+          ...(schema.outputs ?? {}),
+          aiPipeline: {
+            ...(schema.outputs?.aiPipeline ?? {}),
+            formValidators: nextConfig(schema.outputs?.aiPipeline?.formValidators),
+          },
+        },
+      };
+  }
+}
+
 export function emitGeneratedTarget(
   schema: Schema,
   kind: GeneratedTargetKind,
@@ -265,7 +404,13 @@ export function emitGeneratedTarget(
   deps: EmitPipelineDeps = {},
   options: GeneratedTargetEmitOptions = {},
 ): string {
-  return requireGeneratedTargetDescriptor(kind).emit(schema, irPath, deps, options);
+  return requireGeneratedTargetDescriptor(kind).emit(
+    schema,
+    irPath,
+    bundlePathsFor(irPath, schema),
+    deps,
+    options,
+  );
 }
 
 export function previewableGeneratedTargets(): GeneratedTargetMetadata[] {
@@ -273,7 +418,7 @@ export function previewableGeneratedTargets(): GeneratedTargetMetadata[] {
 }
 
 export function enabledGeneratedTargets(schema: Schema, irPath: string) {
-  const paths = bundlePathsFor(irPath);
+  const paths = bundlePathsFor(irPath, schema);
   return GENERATED_TARGETS.filter((target) => target.enabled(schema)).map((target) => ({
     kind: target.kind,
     path: target.path(paths),

--- a/packages/core/src/ir.ts
+++ b/packages/core/src/ir.ts
@@ -189,6 +189,7 @@ const MetadataSchema = z.object({
 
 const OutputTargetConfigSchema = z.object({
   enabled: z.boolean().optional(),
+  dir: z.string().min(1).optional(),
 });
 
 export type OutputTargetConfig = z.infer<typeof OutputTargetConfigSchema>;
@@ -207,6 +208,7 @@ const OutputsConfigSchema = z.object({
   jsonSchema: OutputTargetConfigSchema.optional(),
   schemaIndex: OutputTargetConfigSchema.optional(),
   convex: OutputTargetConfigSchema.optional(),
+  stdlibRuntime: OutputTargetConfigSchema.optional(),
   aiPipeline: AiPipelineOutputsSchema.optional(),
 });
 

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -9,12 +9,14 @@ import { load } from './load';
 import { createOpTools } from './op-tools';
 import { OpSchema } from './ops';
 import { assertContextureIrPath, bundlePathsFor } from './paths';
+import type { EmitPipelineDeps } from './pipeline';
 import { checkSemantic, type StdlibCatalog } from './semantic-validation';
 
 const VERSION = '0.0.0';
 
 export interface ContextureMcpServerOptions {
   stdlib?: StdlibCatalog;
+  emitDeps?: EmitPipelineDeps;
 }
 
 const IrPathInput = {
@@ -204,7 +206,12 @@ export function createContextureMcpServer(options: ContextureMcpServerOptions = 
       },
     },
     async ({ irPath, op }) => {
-      const structuredContent = await applyContextureOp(irPath, op, options.stdlib);
+      const structuredContent = await applyContextureOp(
+        irPath,
+        op,
+        options.stdlib,
+        options.emitDeps,
+      );
       return jsonToolResult(structuredContent);
     },
   );
@@ -224,7 +231,7 @@ export function createContextureMcpServer(options: ContextureMcpServerOptions = 
       },
     },
     async ({ irPath }) => {
-      const structuredContent = await emitContextureBundle(irPath);
+      const structuredContent = await emitContextureBundle(irPath, options.emitDeps);
       return jsonToolResult(structuredContent);
     },
   );
@@ -244,7 +251,7 @@ export function createContextureMcpServer(options: ContextureMcpServerOptions = 
       },
     },
     async ({ irPath }) => {
-      const structuredContent = await checkContextureDrift(irPath);
+      const structuredContent = await checkContextureDrift(irPath, options.emitDeps);
       return jsonToolResult(structuredContent);
     },
   );
@@ -285,7 +292,12 @@ export function createContextureMcpServer(options: ContextureMcpServerOptions = 
         },
       },
       async (args) => {
-        const structuredContent = await applyTypedContextureOp(tool.name, args, options.stdlib);
+        const structuredContent = await applyTypedContextureOp(
+          tool.name,
+          args,
+          options.stdlib,
+          options.emitDeps,
+        );
         return jsonToolResult(structuredContent);
       },
     );
@@ -327,6 +339,7 @@ async function applyContextureOp(
   irPath: string,
   op: Record<string, unknown>,
   catalog?: StdlibCatalog,
+  emitDeps?: EmitPipelineDeps,
 ): Promise<z.infer<z.ZodObject<typeof ApplyContextureOpOutput>>> {
   const opKind = typeof op.kind === 'string' ? op.kind : 'unknown';
   const path = assertContextureIrPath(irPath);
@@ -342,9 +355,11 @@ async function applyContextureOp(
 
   let result: Awaited<ReturnType<ReturnType<typeof createFileBackedForward>>>;
   try {
-    result = await createFileBackedForward(path, { stdlib: catalog, changeSource: 'mcp' })(
-      parsed.data,
-    );
+    result = await createFileBackedForward(path, {
+      stdlib: catalog,
+      emitDeps,
+      changeSource: 'mcp',
+    })(parsed.data);
   } catch (err) {
     return {
       path,
@@ -375,6 +390,7 @@ function formatZodIssues(error: ZodError): string {
 
 async function emitContextureBundle(
   irPath: string,
+  emitDeps?: EmitPipelineDeps,
 ): Promise<z.infer<z.ZodObject<typeof EmitContextureOutput>>> {
   const path = assertContextureIrPath(irPath);
   const { schema } = await readContextureFile(path);
@@ -382,6 +398,7 @@ async function emitContextureBundle(
     irPath: path,
     schema,
     fs: nodeFileBackedFs,
+    emitDeps,
     driftPreflight: false,
   });
   return {
@@ -393,10 +410,11 @@ async function emitContextureBundle(
 
 async function checkContextureDrift(
   irPath: string,
+  emitDeps?: EmitPipelineDeps,
 ): Promise<z.infer<z.ZodObject<typeof CheckContextureDriftOutput>>> {
   const path = assertContextureIrPath(irPath);
   const { schema } = await readContextureFile(path);
-  const files = await checkGeneratedBundle(schema, path, nodeFileBackedFs);
+  const files = await checkGeneratedBundle(schema, path, nodeFileBackedFs, emitDeps);
 
   const drift = files.filter((file) => file.status !== 'clean');
   return {
@@ -429,7 +447,7 @@ function buildInspectSummary(
   schema: Schema,
   irPath: string,
 ): z.infer<z.ZodObject<typeof InspectOutput>> {
-  const paths = bundlePathsFor(irPath);
+  const paths = bundlePathsFor(irPath, schema);
   const preferredMutationTools = createOpTools(async () => ({ error: 'inspect only' })).map(
     (tool) => tool.name,
   );
@@ -522,6 +540,7 @@ async function applyTypedContextureOp(
   opKind: string,
   args: Record<string, unknown>,
   catalog?: StdlibCatalog,
+  emitDeps?: EmitPipelineDeps,
 ): Promise<z.infer<z.ZodObject<typeof ApplyContextureOpOutput>>> {
   const irPath = typeof args.irPath === 'string' ? args.irPath : '';
   let path: string;
@@ -538,9 +557,9 @@ async function applyTypedContextureOp(
 
   const { irPath: _irPath, ...toolArgs } = args;
   const tools = new Map(
-    createOpTools(createFileBackedForward(path, { stdlib: catalog, changeSource: 'mcp' })).map(
-      (tool) => [tool.name, tool],
-    ),
+    createOpTools(
+      createFileBackedForward(path, { stdlib: catalog, emitDeps, changeSource: 'mcp' }),
+    ).map((tool) => [tool.name, tool]),
   );
   const tool = tools.get(opKind);
   if (!tool) return { path, applied: false, opKind, error: `unknown op tool: ${opKind}` };

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,3 +1,5 @@
+import type { Schema } from './ir';
+
 export const IR_SUFFIX = '.contexture.json';
 export const SCHEMA_TS_SUFFIX = '.schema.ts';
 export const SCHEMA_JSON_SUFFIX = '.schema.json';
@@ -11,6 +13,7 @@ export const MCP_DEFINITIONS_FILE = 'mcp-definitions.json';
 export const FORM_VALIDATORS_FILE = 'form-validators.ts';
 export const CONVEX_VALIDATORS_FILE = 'validators.ts';
 export const SCHEMA_DIR = 'schema';
+export const STDLIB_RUNTIME_DIR = 'contexture-runtime';
 
 export interface BundlePaths {
   ir: string;
@@ -27,6 +30,7 @@ export interface BundlePaths {
   structuredOutputSchemas: string;
   mcpDefinitions: string;
   formValidators: string;
+  stdlibRuntimeDir: string;
 }
 
 export type GeneratedTargetKind =
@@ -39,6 +43,8 @@ export type GeneratedTargetKind =
   | 'structured-output-schemas'
   | 'mcp-definitions'
   | 'form-validators';
+
+type OutputDirTargetKind = GeneratedTargetKind | 'stdlib-runtime';
 
 export interface GeneratedTarget {
   kind: GeneratedTargetKind;
@@ -70,33 +76,52 @@ export function assertContextureIrPath(path: string): string {
   return normalized;
 }
 
-export function bundlePathsFor(irPath: string): BundlePaths {
+export function bundlePathsFor(irPath: string, schema?: Schema): BundlePaths {
   const resolvedIrPath = assertContextureIrPath(irPath);
   const baseName = baseNameFor(resolvedIrPath);
   const ctxDir = contextureDirFor(resolvedIrPath);
   const irDir = dirname(resolvedIrPath);
   const layout = bundleLayoutFor(irDir);
-  const schemaBase = `${layout.schemaDir}/${baseName}`;
+  const schemaDir = outputDirFor(schema, 'zod', layout.schemaDir, irDir);
+  const jsonSchemaDir = outputDirFor(schema, 'json-schema', layout.schemaDir, irDir);
+  const schemaIndexDir = outputDirFor(schema, 'schema-index', layout.schemaDir, irDir);
+  const convexDir = outputDirFor(schema, 'convex', `${layout.projectDir}/convex`, irDir);
+  const aiToolSchemasDir = outputDirFor(schema, 'ai-tool-schemas', ctxDir, irDir);
+  const structuredOutputSchemasDir = outputDirFor(
+    schema,
+    'structured-output-schemas',
+    ctxDir,
+    irDir,
+  );
+  const mcpDefinitionsDir = outputDirFor(schema, 'mcp-definitions', ctxDir, irDir);
+  const formValidatorsDir = outputDirFor(schema, 'form-validators', layout.schemaDir, irDir);
+  const stdlibRuntimeDir = outputDirFor(
+    schema,
+    'stdlib-runtime',
+    `${schemaDir}/${STDLIB_RUNTIME_DIR}`,
+    irDir,
+  );
   return {
     ir: resolvedIrPath,
     layout: `${ctxDir}/${LAYOUT_FILE}`,
     chat: `${ctxDir}/${CHAT_FILE}`,
     emitted: `${ctxDir}/${EMITTED_FILE}`,
     changeLog: `${ctxDir}/${CHANGE_LOG_FILE}`,
-    schemaTs: `${schemaBase}${SCHEMA_TS_SUFFIX}`,
-    schemaJson: `${schemaBase}${SCHEMA_JSON_SUFFIX}`,
-    schemaIndex: `${layout.schemaDir}/index.ts`,
-    convex: `${layout.projectDir}/convex/schema.ts`,
-    convexValidators: `${layout.projectDir}/convex/${CONVEX_VALIDATORS_FILE}`,
-    aiToolSchemas: `${ctxDir}/${AI_TOOL_SCHEMAS_FILE}`,
-    structuredOutputSchemas: `${ctxDir}/${STRUCTURED_OUTPUT_SCHEMAS_FILE}`,
-    mcpDefinitions: `${ctxDir}/${MCP_DEFINITIONS_FILE}`,
-    formValidators: `${layout.schemaDir}/${FORM_VALIDATORS_FILE}`,
+    schemaTs: `${schemaDir}/${baseName}${SCHEMA_TS_SUFFIX}`,
+    schemaJson: `${jsonSchemaDir}/${baseName}${SCHEMA_JSON_SUFFIX}`,
+    schemaIndex: `${schemaIndexDir}/index.ts`,
+    convex: `${convexDir}/schema.ts`,
+    convexValidators: `${convexDir}/${CONVEX_VALIDATORS_FILE}`,
+    aiToolSchemas: `${aiToolSchemasDir}/${AI_TOOL_SCHEMAS_FILE}`,
+    structuredOutputSchemas: `${structuredOutputSchemasDir}/${STRUCTURED_OUTPUT_SCHEMAS_FILE}`,
+    mcpDefinitions: `${mcpDefinitionsDir}/${MCP_DEFINITIONS_FILE}`,
+    formValidators: `${formValidatorsDir}/${FORM_VALIDATORS_FILE}`,
+    stdlibRuntimeDir,
   };
 }
 
-export function generatedTargetsFor(irPath: string): GeneratedTarget[] {
-  const paths = bundlePathsFor(irPath);
+export function generatedTargetsFor(irPath: string, schema?: Schema): GeneratedTarget[] {
+  const paths = bundlePathsFor(irPath, schema);
   return [
     { kind: 'zod', path: paths.schemaTs },
     { kind: 'json-schema', path: paths.schemaJson },
@@ -118,9 +143,13 @@ export function manifestKeyForGeneratedPath(irPath: string, generatedPath: strin
   return relativePath(projectDirFor(irPath), normalizeContexturePath(generatedPath));
 }
 
-export function resolveManifestGeneratedPath(irPath: string, manifestKey: string): string {
+export function resolveManifestGeneratedPath(
+  irPath: string,
+  manifestKey: string,
+  schema?: Schema,
+): string {
   const normalizedKey = normalizeContexturePath(manifestKey);
-  const targets = generatedTargetsFor(irPath);
+  const targets = generatedTargetsFor(irPath, schema);
   const byCurrentKey = new Map(
     targets.map((target) => [manifestKeyForGeneratedPath(irPath, target.path), target.path]),
   );
@@ -142,9 +171,20 @@ export function resolveManifestGeneratedPath(irPath: string, manifestKey: string
   return joinPath(projectDirFor(irPath), normalizedKey);
 }
 
-export function generatedTargetForPath(irPath: string, targetPath: string): GeneratedTarget | null {
+export function generatedTargetForPath(
+  irPath: string,
+  targetPath: string,
+  schema?: Schema,
+): GeneratedTarget | null {
   const target = normalizeContexturePath(targetPath);
-  return generatedTargetsFor(irPath).find((candidate) => candidate.path === target) ?? null;
+  return generatedTargetsFor(irPath, schema).find((candidate) => candidate.path === target) ?? null;
+}
+
+export function moduleSpecifierBetween(fromFile: string, toFile: string): string {
+  const fromDir = dirname(normalizeContexturePath(fromFile));
+  const target = stripTypescriptExtension(normalizeContexturePath(toFile));
+  const relative = relativePath(fromDir, target);
+  return relative.startsWith('.') ? relative : `./${relative}`;
 }
 
 function normalizeContexturePath(path: string): string {
@@ -226,4 +266,53 @@ function dirname(path: string): string {
 function leafName(path: string): string {
   const slash = path.lastIndexOf('/');
   return slash === -1 ? path : path.slice(slash + 1);
+}
+
+function outputDirFor(
+  schema: Schema | undefined,
+  kind: OutputDirTargetKind,
+  defaultDir: string,
+  irDir: string,
+): string {
+  const configured = outputDirConfigFor(schema, kind);
+  if (!configured) return defaultDir;
+  if (isAbsolutePath(configured)) {
+    throw new Error(`Contexture output dir for ${kind} must be relative to the IR file.`);
+  }
+
+  const normalized = normalizeContexturePath(configured);
+  if (normalized === '..' || normalized.startsWith('../')) {
+    throw new Error(`Contexture output dir for ${kind} must stay within the IR directory.`);
+  }
+
+  return joinPath(irDir, normalized);
+}
+
+function outputDirConfigFor(schema: Schema | undefined, kind: OutputDirTargetKind): string | null {
+  if (!schema?.outputs) return null;
+  switch (kind) {
+    case 'zod':
+      return schema.outputs.zod?.dir ?? null;
+    case 'json-schema':
+      return schema.outputs.jsonSchema?.dir ?? null;
+    case 'schema-index':
+      return schema.outputs.schemaIndex?.dir ?? null;
+    case 'convex':
+    case 'convex-validators':
+      return schema.outputs.convex?.dir ?? null;
+    case 'stdlib-runtime':
+      return schema.outputs.stdlibRuntime?.dir ?? null;
+    case 'ai-tool-schemas':
+      return schema.outputs.aiPipeline?.toolSchemas?.dir ?? null;
+    case 'structured-output-schemas':
+      return schema.outputs.aiPipeline?.structuredOutputs?.dir ?? null;
+    case 'mcp-definitions':
+      return schema.outputs.aiPipeline?.mcpDefinitions?.dir ?? null;
+    case 'form-validators':
+      return schema.outputs.aiPipeline?.formValidators?.dir ?? null;
+  }
+}
+
+function stripTypescriptExtension(path: string): string {
+  return path.endsWith('.ts') ? path.slice(0, -'.ts'.length) : path;
 }

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -1,12 +1,19 @@
 import { createHash } from 'node:crypto';
+import { emit as emitZod } from './emit-zod';
 import {
   type EmitPipelineDeps,
-  emitGeneratedTarget,
   GENERATED_TARGETS,
+  type GeneratedTargetEmitOptions,
   isGeneratedTargetEnabled,
+  type StdlibRuntimeModule,
 } from './generated-targets';
-import type { Schema } from './ir';
-import { bundlePathsFor, manifestKeyForGeneratedPath, sourceLabelForIrPath } from './paths';
+import type { FieldType, ImportDecl, Schema } from './ir';
+import {
+  bundlePathsFor,
+  manifestKeyForGeneratedPath,
+  moduleSpecifierBetween,
+  sourceLabelForIrPath,
+} from './paths';
 
 export type { EmitPipelineDeps } from './generated-targets';
 export type { BundlePaths } from './paths';
@@ -26,11 +33,13 @@ export {
   IR_SUFFIX,
   LAYOUT_FILE,
   manifestKeyForGeneratedPath,
+  moduleSpecifierBetween,
   projectDirFor,
   resolveManifestGeneratedPath,
   SCHEMA_DIR,
   SCHEMA_JSON_SUFFIX,
   SCHEMA_TS_SUFFIX,
+  STDLIB_RUNTIME_DIR,
   sourceLabelForIrPath,
 } from './paths';
 
@@ -67,12 +76,103 @@ export function runEmitPipeline(
   deps: EmitPipelineDeps = {},
 ): EmitPipelineResult {
   const sourceLabel = sourceLabelForIrPath(irPath);
+  const paths = bundlePathsFor(irPath, schema);
+  const stdlibRuntimePlan = planStdlibRuntime(schema, paths.schemaTs, paths.stdlibRuntimeDir, deps);
+  const targetOptions: GeneratedTargetEmitOptions = {
+    stdlibNamespaces: stdlibRuntimePlan.availableNamespaces,
+    stdlibModuleForNamespace: stdlibRuntimePlan.moduleForNamespace,
+  };
   const emitted = GENERATED_TARGETS.filter((target) =>
     isGeneratedTargetEnabled(schema, target.kind),
   ).map((target) => ({
-    path: target.path(bundlePathsFor(irPath)),
-    content: emitGeneratedTarget(schema, target.kind, sourceLabel, deps),
+    path: target.path(paths),
+    content: target.emit(schema, sourceLabel, paths, deps, targetOptions),
   }));
+  const stdlibRuntimeEntries = stdlibRuntimePlan.modules.map((module) => {
+    const path = `${paths.stdlibRuntimeDir}/${module.namespace}.ts`;
+    return {
+      path,
+      content: emitZod(module.schema, `@contexture/runtime/${module.namespace}`, {
+        stdlibNamespaces: stdlibRuntimePlan.availableNamespaces,
+        stdlibModuleForNamespace: (namespace) =>
+          moduleSpecifierBetween(path, `${paths.stdlibRuntimeDir}/${namespace}.ts`),
+      }),
+    };
+  });
+  const allEmitted = [...emitted, ...stdlibRuntimeEntries];
 
-  return { emitted, manifest: buildManifest(irPath, emitted) };
+  return { emitted: allEmitted, manifest: buildManifest(irPath, allEmitted) };
+}
+
+interface StdlibRuntimePlan {
+  availableNamespaces: readonly string[];
+  modules: readonly StdlibRuntimeModule[];
+  moduleForNamespace: (namespace: string) => string | null;
+}
+
+function planStdlibRuntime(
+  schema: Schema,
+  schemaTsPath: string,
+  stdlibRuntimeDir: string,
+  deps: EmitPipelineDeps,
+): StdlibRuntimePlan {
+  const modulesByNamespace = new Map(
+    (deps.stdlibRuntime ?? []).map((module) => [module.namespace, module]),
+  );
+  const availableNamespaces = [...modulesByNamespace.keys()].sort();
+  const usedNamespaces = usedStdlibNamespaces(schema, modulesByNamespace);
+  const modules = [...usedNamespaces]
+    .sort()
+    .map((namespace) => modulesByNamespace.get(namespace))
+    .filter((module): module is StdlibRuntimeModule => module !== undefined);
+
+  return {
+    availableNamespaces,
+    modules,
+    moduleForNamespace(namespace) {
+      if (!modulesByNamespace.has(namespace)) return null;
+      return moduleSpecifierBetween(schemaTsPath, `${stdlibRuntimeDir}/${namespace}.ts`);
+    },
+  };
+}
+
+function usedStdlibNamespaces(
+  schema: Schema,
+  modulesByNamespace: ReadonlyMap<string, StdlibRuntimeModule>,
+): Set<string> {
+  const importNamespacesByAlias = new Map<string, string>();
+  for (const imp of schema.imports ?? []) {
+    const namespace = namespaceForImport(imp);
+    if (namespace && modulesByNamespace.has(namespace)) {
+      importNamespacesByAlias.set(imp.alias, namespace);
+    }
+  }
+
+  const namespaces = new Set<string>();
+  const visit = (fieldType: FieldType): void => {
+    if (fieldType.kind === 'array') {
+      visit(fieldType.element);
+      return;
+    }
+    if (fieldType.kind !== 'ref') return;
+
+    const dot = fieldType.typeName.indexOf('.');
+    if (dot === -1) return;
+    const alias = fieldType.typeName.slice(0, dot);
+    const namespace =
+      importNamespacesByAlias.get(alias) ?? (modulesByNamespace.has(alias) ? alias : null);
+    if (namespace) namespaces.add(namespace);
+  };
+
+  for (const type of schema.types) {
+    if (type.kind !== 'object') continue;
+    for (const field of type.fields) visit(field.type);
+  }
+
+  return namespaces;
+}
+
+function namespaceForImport(imp: ImportDecl): string | null {
+  if (imp.kind !== 'stdlib') return null;
+  return imp.path.slice('@contexture/'.length);
 }

--- a/packages/core/tests/paths.test.ts
+++ b/packages/core/tests/paths.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import type { Schema } from '../src';
 import {
   assertContextureIrPath,
   bundlePathsFor,
   generatedTargetForPath,
   generatedTargetsFor,
   manifestKeyForGeneratedPath,
+  moduleSpecifierBetween,
   resolveManifestGeneratedPath,
   sourceLabelForIrPath,
 } from '../src';
@@ -25,6 +27,7 @@ describe('Contexture path policy', () => {
     expect(paths.schemaJson).toBe('/repo/apps/misprint/schema/misprint.schema.json');
     expect(paths.schemaIndex).toBe('/repo/apps/misprint/schema/index.ts');
     expect(paths.formValidators).toBe('/repo/apps/misprint/schema/form-validators.ts');
+    expect(paths.stdlibRuntimeDir).toBe('/repo/apps/misprint/schema/contexture-runtime');
     expect(paths.convex).toBe('/repo/apps/misprint/convex/schema.ts');
     expect(paths.convexValidators).toBe('/repo/apps/misprint/convex/validators.ts');
     expect(paths.emitted).toBe('/repo/apps/misprint/.contexture/emitted.json');
@@ -65,6 +68,62 @@ describe('Contexture path policy', () => {
       )?.kind,
     ).toBe('mcp-definitions');
     expect(generatedTargetForPath(irPath, '/repo/packages/contexture/src/index.ts')).toBeNull();
+  });
+
+  it('derives generated target paths from configured output directories', () => {
+    const irPath = '/repo/app.contexture.json';
+    const schema: Schema = {
+      version: '1',
+      types: [],
+      outputs: {
+        zod: { dir: 'packages/domain/src/generated' },
+        stdlibRuntime: { dir: 'packages/domain/src/runtime' },
+        schemaIndex: { dir: 'packages/domain/src' },
+        convex: { dir: 'apps/api/convex' },
+      },
+    };
+
+    expect(generatedTargetsFor(irPath, schema)).toContainEqual({
+      kind: 'zod',
+      path: '/repo/packages/domain/src/generated/app.schema.ts',
+    });
+    expect(generatedTargetsFor(irPath, schema)).toContainEqual({
+      kind: 'convex-validators',
+      path: '/repo/apps/api/convex/validators.ts',
+    });
+    expect(bundlePathsFor(irPath, schema).stdlibRuntimeDir).toBe(
+      '/repo/packages/domain/src/runtime',
+    );
+    expect(
+      generatedTargetForPath(irPath, '/repo/packages/domain/src/generated/app.schema.ts', schema)
+        ?.kind,
+    ).toBe('zod');
+    expect(resolveManifestGeneratedPath(irPath, 'apps/api/convex/schema.ts', schema)).toBe(
+      '/repo/apps/api/convex/schema.ts',
+    );
+  });
+
+  it('rejects output directories that escape the IR directory', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [],
+      outputs: {
+        zod: { dir: '../outside' },
+      },
+    };
+
+    expect(() => bundlePathsFor('/repo/app.contexture.json', schema)).toThrow(
+      /must stay within the IR directory/,
+    );
+  });
+
+  it('derives TypeScript module specifiers between generated files', () => {
+    expect(
+      moduleSpecifierBetween(
+        '/repo/packages/domain/src/index.ts',
+        '/repo/packages/domain/src/generated/app.schema.ts',
+      ),
+    ).toBe('./generated/app.schema');
   });
 
   it('derives checkout-stable source labels and manifest keys', () => {

--- a/packages/core/tests/pipeline.test.ts
+++ b/packages/core/tests/pipeline.test.ts
@@ -6,6 +6,19 @@ const baseSchema: Schema = {
   types: [{ kind: 'object', name: 'Post', fields: [] }],
 };
 
+const commonRuntimeSchema: Schema = {
+  version: '1',
+  metadata: { name: 'Common stdlib runtime' },
+  types: [
+    {
+      kind: 'raw',
+      name: 'Email',
+      zod: 'z.string().email()',
+      jsonSchema: { type: 'string', format: 'email' },
+    },
+  ],
+};
+
 describe('runEmitPipeline output config', () => {
   it('keeps existing generated outputs enabled when outputs config is omitted', () => {
     const { emitted } = runEmitPipeline(
@@ -53,6 +66,43 @@ describe('runEmitPipeline output config', () => {
       '/repo/packages/contexture/index.ts',
     ]);
     expect(Object.keys(manifest.files)).toEqual(['app.schema.ts', 'index.ts']);
+  });
+
+  it('emits configured targets into monorepo output directories', () => {
+    const schema: Schema = {
+      ...baseSchema,
+      outputs: {
+        zod: { dir: 'packages/domain/src/generated' },
+        jsonSchema: { dir: 'packages/domain/schema' },
+        schemaIndex: { dir: 'packages/domain/src/indexes' },
+        convex: { dir: 'apps/api/convex' },
+        aiPipeline: {
+          formValidators: { enabled: true, dir: 'apps/web/src/forms' },
+          mcpDefinitions: { enabled: true, dir: 'packages/domain/mcp' },
+        },
+      },
+    };
+
+    const { emitted, manifest } = runEmitPipeline(schema, '/repo/app.contexture.json');
+    const byPath = new Map(emitted.map((file) => [file.path, file.content]));
+
+    expect(emitted.map((file) => file.path)).toEqual([
+      '/repo/apps/api/convex/schema.ts',
+      '/repo/apps/api/convex/validators.ts',
+      '/repo/packages/domain/src/generated/app.schema.ts',
+      '/repo/packages/domain/schema/app.schema.json',
+      '/repo/packages/domain/src/indexes/index.ts',
+      '/repo/packages/domain/mcp/mcp-definitions.json',
+      '/repo/apps/web/src/forms/form-validators.ts',
+    ]);
+    expect(byPath.get('/repo/packages/domain/src/indexes/index.ts')).toContain(
+      "export * from '../generated/app.schema';",
+    );
+    expect(byPath.get('/repo/apps/web/src/forms/form-validators.ts')).toContain(
+      "import { Post } from '../../../../packages/domain/src/generated/app.schema';",
+    );
+    expect(manifest.files).toHaveProperty('apps/api/convex/schema.ts');
+    expect(manifest.files).toHaveProperty('packages/domain/src/generated/app.schema.ts');
   });
 
   it('uses stable source labels and manifest keys across checkout roots', () => {
@@ -150,5 +200,64 @@ describe('runEmitPipeline output config', () => {
     expect(manifest.files).toHaveProperty('.contexture/structured-output-schemas.json');
     expect(manifest.files).toHaveProperty('.contexture/mcp-definitions.json');
     expect(manifest.files).toHaveProperty('form-validators.ts');
+  });
+
+  it('vendors only referenced stdlib runtime modules into the generated bundle', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'User',
+          fields: [{ name: 'email', type: { kind: 'ref', typeName: 'common.Email' } }],
+        },
+      ],
+    };
+
+    const { emitted, manifest } = runEmitPipeline(schema, '/repo/app.contexture.json', {
+      stdlibRuntime: [
+        { namespace: 'common', schema: commonRuntimeSchema },
+        { namespace: 'money', schema: { version: '1', types: [] } },
+      ],
+    });
+    const byPath = new Map(emitted.map((file) => [file.path, file.content]));
+
+    expect(byPath.get('/repo/schema/app.schema.ts')).toContain(
+      "import { Email } from './contexture-runtime/common';",
+    );
+    expect(byPath.get('/repo/schema/contexture-runtime/common.ts')).toContain(
+      'export const Email = z.string().email();',
+    );
+    expect(byPath.has('/repo/schema/contexture-runtime/money.ts')).toBe(false);
+    expect(manifest.files).toHaveProperty('schema/contexture-runtime/common.ts');
+    expect(manifest.files).not.toHaveProperty('schema/contexture-runtime/money.ts');
+  });
+
+  it('respects a configured stdlib runtime output directory', () => {
+    const schema: Schema = {
+      version: '1',
+      outputs: {
+        zod: { dir: 'packages/domain/src/generated' },
+        stdlibRuntime: { dir: 'packages/domain/src/runtime' },
+      },
+      types: [
+        {
+          kind: 'object',
+          name: 'User',
+          fields: [{ name: 'email', type: { kind: 'ref', typeName: 'common.Email' } }],
+        },
+      ],
+    };
+
+    const { emitted, manifest } = runEmitPipeline(schema, '/repo/app.contexture.json', {
+      stdlibRuntime: [{ namespace: 'common', schema: commonRuntimeSchema }],
+    });
+    const byPath = new Map(emitted.map((file) => [file.path, file.content]));
+
+    expect(byPath.get('/repo/packages/domain/src/generated/app.schema.ts')).toContain(
+      "import { Email } from '../runtime/common';",
+    );
+    expect(byPath.has('/repo/packages/domain/src/runtime/common.ts')).toBe(true);
+    expect(manifest.files).toHaveProperty('packages/domain/src/runtime/common.ts');
   });
 });

--- a/scripts/check-no-suppressions.ts
+++ b/scripts/check-no-suppressions.ts
@@ -12,6 +12,7 @@ const ignoredDirectories = new Set([
   'dist',
   'node_modules',
   'out',
+  'storybook-static',
 ]);
 const ignoredFiles = new Set(['env.d.ts']);
 


### PR DESCRIPTION
## Summary
- add IR output directory config for generated targets, including stdlib runtime modules
- emit referenced stdlib runtime modules into the generated document bundle with relative Zod imports
- wire output dirs and runtime emit deps through desktop, CLI, MCP, drift checks, and tests
- expose output folder configuration in the desktop Schema panel and bump desktop to 0.15.34

## Verification
- bun run test -- tests/pipeline.test.ts tests/paths.test.ts (packages/core)
- bun run test -- tests/components/schema/SchemaPanel.test.tsx (apps/desktop)
- bun run ci
- pre-commit turbo typecheck + turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783028812&installation_id=136251083&pr_number=361&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F361&signature=b1e9ef0a04e4e5585b833b1f23d55be7f0e599ecc3eb6e926405e54a321781fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->