### PR TITLE
feat: harden table ref relationships

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.35",
+  "version": "0.15.36",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/tests/main/op-tools.test.ts
+++ b/apps/desktop/tests/main/op-tools.test.ts
@@ -140,6 +140,43 @@ describe('createOpTools', () => {
     expect(result).toEqual({ ok: true });
   });
 
+  it('add_field forwards relationship metadata on ref field types', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const addField = toolNamed(tools, 'add_field');
+
+    await addField.handler({
+      typeName: 'MealPlanMeal',
+      field: {
+        name: 'recipeId',
+        type: {
+          kind: 'ref',
+          typeName: 'Recipe',
+          relationship: {
+            onDelete: 'cascade',
+            ownership: { scopeField: 'householdId' },
+          },
+        },
+      },
+    });
+
+    expect(forwardSpy.mock.calls[0][0]).toEqual({
+      kind: 'add_field',
+      typeName: 'MealPlanMeal',
+      field: {
+        name: 'recipeId',
+        type: {
+          kind: 'ref',
+          typeName: 'Recipe',
+          relationship: {
+            onDelete: 'cascade',
+            ownership: { scopeField: 'householdId' },
+          },
+        },
+      },
+    });
+  });
+
   it('add_field rejects malformed input before reaching the forwarder', async () => {
     const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
     const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
@@ -158,6 +195,43 @@ describe('createOpTools', () => {
       }),
     ).rejects.toThrow();
     expect(forwardSpy).not.toHaveBeenCalled();
+  });
+
+  it('update_field forwards relationship metadata inside type patches', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const updateField = toolNamed(tools, 'update_field');
+
+    await updateField.handler({
+      typeName: 'MealPlanMeal',
+      fieldName: 'recipeId',
+      patch: {
+        type: {
+          kind: 'ref',
+          typeName: 'Recipe',
+          relationship: {
+            onDelete: 'restrict',
+            ownership: { scopeField: 'householdId', targetScopeField: 'householdId' },
+          },
+        },
+      },
+    });
+
+    expect(forwardSpy.mock.calls[0][0]).toEqual({
+      kind: 'update_field',
+      typeName: 'MealPlanMeal',
+      fieldName: 'recipeId',
+      patch: {
+        type: {
+          kind: 'ref',
+          typeName: 'Recipe',
+          relationship: {
+            onDelete: 'restrict',
+            ownership: { scopeField: 'householdId', targetScopeField: 'householdId' },
+          },
+        },
+      },
+    });
   });
 
   it('add_type lenient tool accepts a valid TypeDef payload and forwards the op', async () => {

--- a/apps/desktop/tests/model/emit-json-schema.test.ts
+++ b/apps/desktop/tests/model/emit-json-schema.test.ts
@@ -207,6 +207,26 @@ describe('emit (JSON Schema)', () => {
     expect(out.$defs.Comment.properties.on).toEqual({ $ref: '#/$defs/Post' });
   });
 
+  it('emits a table ref as an id string instead of a $ref to the table object', () => {
+    const out = emit({
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+      ],
+    }) as { $defs: { Recipe: { properties: Record<string, unknown> } } };
+
+    expect(out.$defs.Recipe.properties.householdId).toEqual({
+      type: 'string',
+      description: 'Household id',
+    });
+  });
+
   it('emits a stdlib qualified ref as $ref to the runtime package URL', () => {
     const out = emit({
       version: '1',

--- a/apps/desktop/tests/model/emit-zod.test.ts
+++ b/apps/desktop/tests/model/emit-zod.test.ts
@@ -208,6 +208,32 @@ describe('emit (Zod)', () => {
     expect(src).toContain(`on: Post,`);
   });
 
+  it('emits a table ref as a branded id string instead of embedding the table object', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [
+            {
+              name: 'householdId',
+              optional: true,
+              type: { kind: 'ref', typeName: 'Household' },
+            },
+          ],
+        },
+      ],
+    };
+
+    const src = emit(schema, 'x.contexture.json');
+
+    expect(src).toContain(`householdId: z.string().brand<'HouseholdId'>().optional(),`);
+    expect(src).not.toContain(`householdId: Household`);
+  });
+
   it('emits local dependencies before consumers', () => {
     const schema: Schema = {
       version: '1',

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.35",
+      "version": "0.15.36",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.150",
         "@contexture/core": "workspace:*",

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -656,6 +656,69 @@ describe('Contexture MCP server', () => {
     });
   });
 
+  it('preserves relationship metadata through the typed add_field MCP tool', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+      ],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'add_field',
+        arguments: {
+          irPath,
+          typeName: 'MealPlanMeal',
+          field: {
+            name: 'recipeId',
+            type: {
+              kind: 'ref',
+              typeName: 'Recipe',
+              relationship: {
+                onDelete: 'restrict',
+                ownership: { scopeField: 'householdId' },
+              },
+            },
+          },
+        },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        applied: true,
+        opKind: 'add_field',
+      });
+      const updatedIr = JSON.parse(await readFile(irPath, 'utf8')) as {
+        types: Array<{ name: string; fields?: Array<{ name: string; type: unknown }> }>;
+      };
+      const mealPlanMeal = updatedIr.types.find((type) => type.name === 'MealPlanMeal');
+      expect(mealPlanMeal?.fields?.find((field) => field.name === 'recipeId')?.type).toEqual({
+        kind: 'ref',
+        typeName: 'Recipe',
+        relationship: {
+          onDelete: 'restrict',
+          ownership: { scopeField: 'householdId' },
+        },
+      });
+      await expect(
+        readFile(join(irPath, '..', 'convex', 'relationships.ts'), 'utf8'),
+      ).resolves.toContain('"onDelete": "restrict"');
+    });
+  });
+
   it('returns generated drift preflight failures as structured apply results', async () => {
     const irPath = await fixtureIr({
       version: '1',

--- a/packages/core/src/emit-convex-relationships.ts
+++ b/packages/core/src/emit-convex-relationships.ts
@@ -70,6 +70,7 @@ function collectRelationships(schema: Schema): Relationship[] {
       const target = byName.get(ref.typeName);
       if (!target || target.table !== true) continue;
       const relationship = ref.relationship;
+      const ownership = relationship?.ownership ?? deriveOwnership(owner, target, field.name);
       relationships.push({
         name: relationship?.name ?? `${owner.name}.${field.name}`,
         fromType: owner.name,
@@ -81,14 +82,41 @@ function collectRelationships(schema: Schema): Relationship[] {
         optional: field.optional === true,
         nullable: field.nullable === true,
         onDelete: relationship?.onDelete ?? 'none',
-        ownershipScopeField: relationship?.ownership?.scopeField ?? null,
-        targetOwnershipScopeField:
-          relationship?.ownership?.targetScopeField ?? relationship?.ownership?.scopeField ?? null,
+        ownershipScopeField: ownership?.scopeField ?? null,
+        targetOwnershipScopeField: ownership?.targetScopeField ?? ownership?.scopeField ?? null,
       });
     }
   }
 
   return relationships.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function deriveOwnership(
+  owner: ObjectType,
+  target: ObjectType,
+  relationshipFieldName: string,
+): { scopeField: string; targetScopeField?: string } | null {
+  const candidates = owner.fields.filter((sourceField) => {
+    if (sourceField.name === relationshipFieldName) return false;
+    if (sourceField.optional === true || sourceField.nullable === true) return false;
+    const targetField = target.fields.find((field) => field.name === sourceField.name);
+    if (!targetField || targetField.optional === true || targetField.nullable === true)
+      return false;
+    return fieldTypesMatch(sourceField.type, targetField.type);
+  });
+
+  const [candidate] = candidates;
+  if (!candidate || candidates.length !== 1) return null;
+  return { scopeField: candidate.name };
+}
+
+function fieldTypesMatch(left: FieldType, right: FieldType): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === 'ref' && right.kind === 'ref') return left.typeName === right.typeName;
+  if (left.kind === 'array' && right.kind === 'array') {
+    return fieldTypesMatch(left.element, right.element);
+  }
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function assertionHelpers(relationships: Relationship[]): string[] {

--- a/packages/core/src/emit-json-schema.ts
+++ b/packages/core/src/emit-json-schema.ts
@@ -12,7 +12,8 @@
  *     `emit_sample` tool takes a schema object directly).
  *
  * Ref handling mirrors the Zod emitter's uniform import mechanism:
- *   - Local refs → `{ $ref: '#/$defs/<Name>' }`
+ *   - Local refs to value-object types → `{ $ref: '#/$defs/<Name>' }`
+ *   - Local refs to table types → `{ type: 'string', description: '<Name> id' }`
  *   - Stdlib `alias.Name` with a matching import → points at the runtime's
  *     sibling schema: `{ $ref: '@contexture/runtime/<ns>#/$defs/<Name>' }`
  *   - Relative `alias.Name` → `{ $ref: './<alias>.schema.json#/$defs/<Name>' }`
@@ -40,6 +41,7 @@ export function emit(
   options: EmitOptions = {},
 ): object {
   const aliases = new Map<string, ImportDecl>();
+  const types = new Map(schema.types.map((type) => [type.name, type]));
   (schema.imports ?? []).forEach((imp) => {
     aliases.set(imp.alias, imp);
   });
@@ -63,7 +65,7 @@ export function emit(
   const defs: Record<string, object> = {};
   for (const type of schema.types) {
     if (type.name === rootTypeName) continue;
-    defs[type.name] = emitTypeDef(type, aliases);
+    defs[type.name] = emitTypeDef(type, { aliases, types });
   }
 
   if (rootTypeName) {
@@ -71,7 +73,7 @@ export function emit(
     if (!root) {
       throw new Error(`Root type "${rootTypeName}" not found in schema.`);
     }
-    const rootSchema = emitTypeDef(root, aliases) as Record<string, unknown>;
+    const rootSchema = emitTypeDef(root, { aliases, types }) as Record<string, unknown>;
     return {
       $schema: DRAFT,
       $contexture_generated: generatedMarker(sourcePath),
@@ -83,13 +85,18 @@ export function emit(
   return { $schema: DRAFT, $contexture_generated: generatedMarker(sourcePath), $defs: defs };
 }
 
-function emitTypeDef(type: TypeDef, aliases: Map<string, ImportDecl>): object {
+interface EmitContext {
+  aliases: Map<string, ImportDecl>;
+  types: Map<string, TypeDef>;
+}
+
+function emitTypeDef(type: TypeDef, ctx: EmitContext): object {
   switch (type.kind) {
     case 'object': {
       const properties: Record<string, object> = {};
       const required: string[] = [];
       for (const field of type.fields) {
-        properties[field.name] = emitField(field, aliases);
+        properties[field.name] = emitField(field, ctx);
         if (!field.optional) required.push(field.name);
       }
       return {
@@ -111,8 +118,8 @@ function emitTypeDef(type: TypeDef, aliases: Map<string, ImportDecl>): object {
   }
 }
 
-function emitField(field: FieldDef, aliases: Map<string, ImportDecl>): object {
-  let body = emitFieldType(field.type, aliases) as Record<string, unknown>;
+function emitField(field: FieldDef, ctx: EmitContext): object {
+  let body = emitFieldType(field.type, ctx) as Record<string, unknown>;
   if (field.nullable) {
     const current = body.type;
     if (typeof current === 'string') {
@@ -130,7 +137,7 @@ function emitField(field: FieldDef, aliases: Map<string, ImportDecl>): object {
   return body;
 }
 
-function emitFieldType(t: FieldType, aliases: Map<string, ImportDecl>): object {
+function emitFieldType(t: FieldType, ctx: EmitContext): object {
   switch (t.kind) {
     case 'string': {
       const out: Record<string, unknown> = { type: 'string' };
@@ -157,10 +164,16 @@ function emitFieldType(t: FieldType, aliases: Map<string, ImportDecl>): object {
       return { const: t.value };
     case 'ref': {
       const dot = t.typeName.indexOf('.');
-      if (dot === -1) return { $ref: `#/$defs/${t.typeName}` };
+      if (dot === -1) {
+        const target = ctx.types.get(t.typeName);
+        if (target?.kind === 'object' && target.table === true) {
+          return { type: 'string', description: `${target.name} id` };
+        }
+        return { $ref: `#/$defs/${t.typeName}` };
+      }
       const alias = t.typeName.slice(0, dot);
       const name = t.typeName.slice(dot + 1);
-      const imp = aliases.get(alias);
+      const imp = ctx.aliases.get(alias);
       if (!imp) {
         // Unresolved qualified ref — validator reports it; emit a best-effort
         // external $ref so the shape stays well-formed.
@@ -175,7 +188,7 @@ function emitFieldType(t: FieldType, aliases: Map<string, ImportDecl>): object {
     case 'array': {
       const out: Record<string, unknown> = {
         type: 'array',
-        items: emitFieldType(t.element, aliases),
+        items: emitFieldType(t.element, ctx),
       };
       if (t.min !== undefined) out.minItems = t.min;
       if (t.max !== undefined) out.maxItems = t.max;

--- a/packages/core/src/emit-zod.ts
+++ b/packages/core/src/emit-zod.ts
@@ -15,7 +15,9 @@
  *     validator, which treats stdlib namespaces as ambient.
  *   - Relative aliases map to `./<alias>.schema` (the emitted sibling of the
  *     referenced `.contexture.json`), importing only the names used.
- *   - Local refs emit as bare identifiers.
+ *   - Local refs to value-object types emit as bare identifiers.
+ *   - Local refs to table types emit as branded string ids, matching the
+ *     stored Convex document shape.
  *   - `raw` TypeDefs with an `import` hint emit an import from that module
  *     and re-export the name; otherwise the `zod` expression is inlined.
  *
@@ -221,7 +223,13 @@ function emitFieldType(t: FieldType, ctx: EmitContext): string {
       return `z.literal(${renderLiteral(t.value)})`;
     case 'ref': {
       const dot = t.typeName.indexOf('.');
-      if (dot === -1) return t.typeName;
+      if (dot === -1) {
+        const target = ctx.types.get(t.typeName);
+        if (target?.kind === 'object' && target.table === true) {
+          return `z.string().brand<'${target.name}Id'>()`;
+        }
+        return t.typeName;
+      }
       // Qualified: render as the bare imported name (import line already emitted).
       return t.typeName.slice(dot + 1);
     }
@@ -287,5 +295,7 @@ function collectLocalDependenciesForType(
     return;
   }
   if (t.kind !== 'ref') return;
+  const target = ctx.types.get(t.typeName);
+  if (target?.kind === 'object' && target.table === true) return;
   if (ctx.types.has(t.typeName)) dependencies.add(t.typeName);
 }

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -605,6 +605,7 @@ function buildIntegrationGuidance(
       'Do not hand-edit generated files with a @contexture-generated marker; change the IR and emit instead.',
       'Prefer typed op tools such as add_type, add_field, rename_type, set_table_flag, and add_index over apply_contexture_op when possible.',
       'Typed op tools take irPath plus their direct arguments. The generic apply_contexture_op takes { irPath, op } where op is the closed-world operation with a kind.',
+      'For Convex table refs, put relationship intent under field.type.relationship, for example { onDelete: "restrict", ownership: { scopeField: "householdId" } }.',
       'After any model mutation, validate, emit generated targets, and check drift before finishing.',
       'Wire generated outputs into the existing app architecture; Contexture does not own arbitrary application code.',
     ],

--- a/packages/core/src/op-tools.ts
+++ b/packages/core/src/op-tools.ts
@@ -44,6 +44,17 @@ export interface OpToolDescriptor {
 
 // ---- Field-type + field-def schemas (shared across strict ops) ---------
 
+const RelationshipSchema = z.object({
+  name: z.string().min(1).optional(),
+  onDelete: z.enum(['none', 'restrict', 'cascade', 'setNull']).optional(),
+  ownership: z
+    .object({
+      scopeField: z.string().min(1),
+      targetScopeField: z.string().min(1).optional(),
+    })
+    .optional(),
+});
+
 // Using z.lazy keeps the recursive `array.element` case honest (the
 // inner FieldType needs the outer FieldType's schema); but we cast the
 // whole expression to the hand-written `FieldType` so downstream
@@ -82,6 +93,9 @@ const FieldTypeSchema: z.ZodType<import('./ir').FieldType> = z.lazy(() =>
             'by the op layer — the namespace prefix is mandatory for ' +
             'stdlib refs.',
         ),
+      relationship: RelationshipSchema.describe(
+        'Relationship intent for refs to Convex table types. Use onDelete for delete policy and ownership.scopeField/targetScopeField for same-tenant checks.',
+      ).optional(),
     }),
     z.object({
       kind: z.literal('array'),

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -47,7 +47,8 @@ export type SemanticIssueCode =
   | 'convex_index_unknown_field'
   | 'relationship_target_not_table'
   | 'relationship_scope_field_missing'
-  | 'relationship_set_null_requires_nullable';
+  | 'relationship_set_null_requires_nullable'
+  | 'relationship_cleanup_index_missing';
 
 export interface SemanticIssue {
   code: SemanticIssueCode;
@@ -269,6 +270,18 @@ function checkRelationshipMetadata(
       message: `Relationship "${fieldName}" uses setNull but the field is required and non-nullable.`,
       hint: 'Mark the field nullable or optional, or use restrict/cascade/none.',
     });
+  }
+
+  if (ref.relationship.onDelete === 'cascade' || ref.relationship.onDelete === 'setNull') {
+    const hasCleanupIndex = (owner.indexes ?? []).some((index) => index.fields[0] === fieldName);
+    if (!hasCleanupIndex) {
+      issues.push({
+        code: 'relationship_cleanup_index_missing',
+        path: `${path}.relationship.onDelete`,
+        message: `Relationship "${fieldName}" uses ${ref.relationship.onDelete} but source table "${owner.name}" has no cleanup index starting with "${fieldName}".`,
+        hint: `Add an index on "${owner.name}" with "${fieldName}" as the first field before relying on generated cleanup plans.`,
+      });
+    }
   }
 
   const ownership = ref.relationship.ownership;

--- a/packages/core/tests/emit-ai-tool-schemas.test.ts
+++ b/packages/core/tests/emit-ai-tool-schemas.test.ts
@@ -69,4 +69,25 @@ describe('emitAiToolSchemas', () => {
       'AI tool schema name collision: "CustomerProfile" and "Customer_Profile" both emit "submit_customer_profile".',
     );
   });
+
+  it('emits table refs as id strings in tool parameters', () => {
+    const doc = emitAiToolSchemas({
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+      ],
+    });
+
+    expect(doc.tools.find((tool) => tool.name === 'submit_recipe')?.parameters).toMatchObject({
+      properties: {
+        householdId: { type: 'string', description: 'Household id' },
+      },
+    });
+  });
 });

--- a/packages/core/tests/emit-convex-relationships.test.ts
+++ b/packages/core/tests/emit-convex-relationships.test.ts
@@ -52,4 +52,76 @@ describe('emitConvexRelationships', () => {
     expect(out).toContain('export async function deleteWithContextureRelations');
     expect(parses(out)).toBe(true);
   });
+
+  it('auto-derives ownership scope when source and target share one required scope field', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
+          ],
+        },
+      ],
+    };
+
+    const out = emitConvexRelationships(schema);
+
+    expect(out).toContain('"name": "MealPlanMeal.recipeId"');
+    expect(out).toContain('"ownershipScopeField": "householdId"');
+    expect(out).toContain('"targetOwnershipScopeField": "householdId"');
+  });
+
+  it('keeps explicit ownership metadata over auto-derived scope', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Tenant', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [
+            { name: 'tenantId', type: { kind: 'ref', typeName: 'Tenant' } },
+            { name: 'regionId', type: { kind: 'string' } },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [
+            { name: 'tenantId', type: { kind: 'ref', typeName: 'Tenant' } },
+            { name: 'regionId', type: { kind: 'string' } },
+            {
+              name: 'recipeId',
+              type: {
+                kind: 'ref',
+                typeName: 'Recipe',
+                relationship: {
+                  ownership: { scopeField: 'regionId', targetScopeField: 'regionId' },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const out = emitConvexRelationships(schema);
+
+    expect(out).toContain('"ownershipScopeField": "regionId"');
+    expect(out).toContain('"targetOwnershipScopeField": "regionId"');
+  });
 });

--- a/packages/core/tests/emit-structured-output-schemas.test.ts
+++ b/packages/core/tests/emit-structured-output-schemas.test.ts
@@ -44,4 +44,25 @@ describe('emitStructuredOutputSchemas', () => {
       ],
     });
   });
+
+  it('emits table refs as id strings in structured output schemas', () => {
+    const doc = emitStructuredOutputSchemas({
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+      ],
+    });
+
+    expect(doc.schemas.find((entry) => entry.name === 'Recipe')?.schema).toMatchObject({
+      properties: {
+        householdId: { type: 'string', description: 'Household id' },
+      },
+    });
+  });
 });

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -192,9 +192,64 @@ describe('checkSemantic — refs', () => {
     expect(checkSemantic(schema, STDLIB).map((issue) => issue.code)).toEqual([
       'relationship_target_not_table',
       'relationship_set_null_requires_nullable',
+      'relationship_cleanup_index_missing',
       'relationship_scope_field_missing',
       'relationship_scope_field_missing',
     ]);
+  });
+
+  it('requires cleanup indexes for cascade and setNull delete policies', () => {
+    const baseTypes: Schema['types'] = [
+      { kind: 'object', name: 'Household', table: true, fields: [] },
+      {
+        kind: 'object',
+        name: 'Recipe',
+        table: true,
+        fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+      },
+    ];
+    const withoutIndex: Schema = {
+      version: '1',
+      types: [
+        ...baseTypes,
+        {
+          kind: 'object',
+          name: 'Leftover',
+          table: true,
+          fields: [
+            {
+              name: 'recipeId',
+              type: { kind: 'ref', typeName: 'Recipe', relationship: { onDelete: 'cascade' } },
+            },
+          ],
+        },
+      ],
+    };
+    const withIndex: Schema = {
+      version: '1',
+      types: [
+        ...baseTypes,
+        {
+          kind: 'object',
+          name: 'Leftover',
+          table: true,
+          fields: [
+            {
+              name: 'recipeId',
+              type: { kind: 'ref', typeName: 'Recipe', relationship: { onDelete: 'cascade' } },
+            },
+          ],
+          indexes: [{ name: 'by_recipe', fields: ['recipeId'] }],
+        },
+      ],
+    };
+
+    expect(checkSemantic(withoutIndex, STDLIB).map((issue) => issue.code)).toContain(
+      'relationship_cleanup_index_missing',
+    );
+    expect(checkSemantic(withIndex, STDLIB).map((issue) => issue.code)).not.toContain(
+      'relationship_cleanup_index_missing',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Emit refs to Convex table types as id strings across Zod, JSON Schema, AI tool schemas, and structured output schemas while preserving embedded value-object refs.
- Expose nested ref relationship metadata through typed op/MCP tools and document the field.type.relationship shape in MCP guidance.
- Auto-derive relationship ownership scope when source and target share one required scope field, and validate cleanup indexes for cascade/setNull delete policies.
- Bump desktop app version to 0.15.36.

## Verification
- bun run typecheck
- bun run test
- bun run check
- bun run test -- tests/mcp.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783070876&installation_id=136251083&pr_number=363&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F363&signature=db96e3d80e5fcfe7f85570d45e6af7fd4a7dd7075e980c49d4c6929a9b46d1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->