### PR TITLE
feat: warn on missing relationship ownership

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.36",
+  "version": "0.15.37",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/services/validation.ts
+++ b/apps/desktop/src/renderer/src/services/validation.ts
@@ -12,6 +12,7 @@ export interface ValidationError {
   code: SemanticIssueCode;
   path: string;
   message: string;
+  severity: SemanticIssue['severity'];
   hint?: string;
 }
 
@@ -35,6 +36,7 @@ function toValidationError(issue: SemanticIssue): ValidationError {
     code: issue.code,
     path: issue.path,
     message: issue.hint ? `${issue.message} ${issue.hint}` : issue.message,
+    severity: issue.severity,
     hint: issue.hint,
   };
 }

--- a/apps/desktop/tests/main/op-tools.test.ts
+++ b/apps/desktop/tests/main/op-tools.test.ts
@@ -177,6 +177,37 @@ describe('createOpTools', () => {
     });
   });
 
+  it('add_field forwards explicit cross-scope relationship opt-outs', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const addField = toolNamed(tools, 'add_field');
+
+    await addField.handler({
+      typeName: 'MealPlanMeal',
+      field: {
+        name: 'sharedRecipeId',
+        type: {
+          kind: 'ref',
+          typeName: 'Recipe',
+          relationship: { crossScope: true },
+        },
+      },
+    });
+
+    expect(forwardSpy.mock.calls[0][0]).toEqual({
+      kind: 'add_field',
+      typeName: 'MealPlanMeal',
+      field: {
+        name: 'sharedRecipeId',
+        type: {
+          kind: 'ref',
+          typeName: 'Recipe',
+          relationship: { crossScope: true },
+        },
+      },
+    });
+  });
+
   it('add_field rejects malformed input before reaching the forwarder', async () => {
     const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
     const { tools } = makeTools(forwardSpy as unknown as ForwardOp);

--- a/apps/desktop/tests/services/validation.test.ts
+++ b/apps/desktop/tests/services/validation.test.ts
@@ -21,6 +21,7 @@ describe('validate', () => {
     const dup = errs.find((e) => e.code === 'duplicate_type_name');
     expect(dup).toEqual({
       code: 'duplicate_type_name',
+      severity: 'error',
       path: 'types.1',
       message: 'Duplicate type name "User".',
     });
@@ -56,6 +57,7 @@ describe('validate', () => {
     const err = validate(schema).find((e) => e.code === 'unresolved_ref');
     expect(err).toEqual({
       code: 'unresolved_ref',
+      severity: 'error',
       path: 'types.0.fields.0.type',
       message: 'Unresolved ref "Post".',
     });
@@ -76,6 +78,37 @@ describe('validate', () => {
     expect(validate(schema).some((e) => e.code === 'unresolved_ref')).toBe(false);
   });
 
+  it('surfaces likely missing ownership scope as a warning', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
+          ],
+        },
+      ],
+    };
+
+    expect(validate(schema)).toEqual([
+      expect.objectContaining({
+        code: 'relationship_ownership_scope_missing',
+        severity: 'warning',
+      }),
+    ]);
+  });
+
   it('rule 2: qualified ref fails when no matching alias exists', () => {
     const schema: Schema = {
       version: '1',
@@ -90,6 +123,7 @@ describe('validate', () => {
     const err = validate(schema).find((e) => e.code === 'unresolved_ref');
     expect(err).toEqual({
       code: 'unresolved_ref',
+      severity: 'error',
       path: 'types.0.fields.0.type',
       message: 'Unresolved ref "common.Email".',
     });
@@ -163,6 +197,7 @@ describe('validate', () => {
     const err = validate(schema).find((e) => e.code === 'discriminator_variant_not_found');
     expect(err).toEqual({
       code: 'discriminator_variant_not_found',
+      severity: 'error',
       path: 'types.0.variants.0',
       message: 'Discriminated union variant "Click" is not defined.',
     });
@@ -184,6 +219,7 @@ describe('validate', () => {
     const err = validate(schema).find((e) => e.code === 'discriminator_variant_not_object');
     expect(err).toEqual({
       code: 'discriminator_variant_not_object',
+      severity: 'error',
       path: 'types.1.variants.0',
       message: 'Discriminated union variant "Color" must be an object type.',
     });
@@ -209,6 +245,7 @@ describe('validate', () => {
     const err = validate(schema).find((e) => e.code === 'discriminator_missing_on_variant');
     expect(err).toEqual({
       code: 'discriminator_missing_on_variant',
+      severity: 'error',
       path: 'types.1.variants.0',
       message: 'Variant "Click" is missing discriminator field "type".',
     });
@@ -223,6 +260,7 @@ describe('validate', () => {
     const err = validate(schema).find((e) => e.code === 'enum_empty');
     expect(err).toEqual({
       code: 'enum_empty',
+      severity: 'error',
       path: 'types.0.values',
       message: 'Enum "Role" must have at least one value.',
     });
@@ -242,6 +280,7 @@ describe('validate', () => {
     const err = validate(schema).find((e) => e.code === 'enum_duplicate_value');
     expect(err).toEqual({
       code: 'enum_duplicate_value',
+      severity: 'error',
       path: 'types.0.values.2',
       message: 'Duplicate enum value "admin" in "Role".',
     });
@@ -277,6 +316,7 @@ describe('validate', () => {
     const err = validate(schema).find((e) => e.code === 'convex_index_duplicate_field');
     expect(err).toEqual({
       code: 'convex_index_duplicate_field',
+      severity: 'error',
       path: 'types.0.indexes.0.fields.1',
       message:
         'Convex index "by_author" includes field "author" more than once. Remove the duplicate field from the index.',
@@ -297,6 +337,7 @@ describe('validate', () => {
     const err = validate(schema).find((e) => e.code === 'duplicate_alias');
     expect(err).toEqual({
       code: 'duplicate_alias',
+      severity: 'error',
       path: 'imports.1',
       message: 'Duplicate import alias "lib".',
     });
@@ -357,6 +398,7 @@ describe('validate', () => {
     const err = validate(schema).find((e) => e.code === 'duplicate_field_name');
     expect(err).toEqual({
       code: 'duplicate_field_name',
+      severity: 'error',
       path: 'types.0.fields.1.name',
       message:
         'Duplicate field name "title" in "Post". Rename one of the fields before editing indexes or generated outputs.',

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.36",
+      "version": "0.15.37",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.150",
         "@contexture/core": "workspace:*",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -612,16 +612,19 @@ async function run(argv: string[]): Promise<void> {
       });
       return;
     }
-    const errors = checkSemantic(parsed.data, STDLIB_REGISTRY).map((issue) => ({
+    const semanticIssues = checkSemantic(parsed.data, STDLIB_REGISTRY).map((issue) => ({
       code: issue.code,
       path: issue.path,
       message: issue.message,
+      severity: issue.severity,
       ...(issue.hint ? { hint: issue.hint } : {}),
     }));
+    const errors = semanticIssues.filter((issue) => issue.severity === 'error');
+    const warnings = semanticIssues.filter((issue) => issue.severity === 'warning');
     if (errors.length > 0) {
       process.exitCode = 1;
       if (options.json) {
-        writeJson({ ok: false, errors });
+        writeJson({ ok: false, errors, warnings });
       } else {
         process.stderr.write('Validation failed:\n');
         for (const error of errors) {
@@ -630,7 +633,7 @@ async function run(argv: string[]): Promise<void> {
       }
       return;
     }
-    writeResult({ valid: true, errors: [] }, options.json);
+    writeResult({ valid: true, errors: [], warnings }, options.json);
     return;
   }
 

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -196,6 +196,49 @@ describe('@contexture/cli', () => {
     });
   });
 
+  it('returns semantic warnings as structured JSON without failing validation', async () => {
+    const { dir, irPath } = await fixtureProject();
+    await writeFile(
+      irPath,
+      `${JSON.stringify({
+        version: '1',
+        types: [
+          { kind: 'object', name: 'Household', table: true, fields: [] },
+          {
+            kind: 'object',
+            name: 'Recipe',
+            table: true,
+            fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+          },
+          {
+            kind: 'object',
+            name: 'MealPlanMeal',
+            table: true,
+            fields: [
+              { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+              { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
+            ],
+          },
+        ],
+      })}\n`,
+    );
+
+    const result = await runCli(dir, ['validate', '--json']);
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      valid: true,
+      errors: [],
+      warnings: [
+        expect.objectContaining({
+          code: 'relationship_ownership_scope_missing',
+          severity: 'warning',
+        }),
+      ],
+    });
+  });
+
   it('adds a field and re-emits generated files', async () => {
     const { dir, irPath } = await fixtureProject();
     const result = await runCli(dir, ['add-field', 'Post', 'title', '{"kind":"string"}', '--json']);

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -387,6 +387,49 @@ describe('Contexture MCP server', () => {
     });
   });
 
+  it('reports semantic warnings without invalidating MCP validation', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
+          ],
+        },
+      ],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'validate_contexture',
+        arguments: { irPath },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        valid: true,
+        errors: [],
+        warnings: [
+          expect.objectContaining({
+            code: 'relationship_ownership_scope_missing',
+            severity: 'warning',
+          }),
+        ],
+      });
+    });
+  });
+
   it('applies typed per-op MCP tools without requiring generic op JSON', async () => {
     const irPath = await fixtureIr({
       version: '1',

--- a/packages/core/src/emit-convex-relationships.ts
+++ b/packages/core/src/emit-convex-relationships.ts
@@ -70,7 +70,7 @@ function collectRelationships(schema: Schema): Relationship[] {
       const target = byName.get(ref.typeName);
       if (!target || target.table !== true) continue;
       const relationship = ref.relationship;
-      const ownership = relationship?.ownership ?? deriveOwnership(owner, target, field.name);
+      const ownership = relationship?.ownership;
       relationships.push({
         name: relationship?.name ?? `${owner.name}.${field.name}`,
         fromType: owner.name,
@@ -89,34 +89,6 @@ function collectRelationships(schema: Schema): Relationship[] {
   }
 
   return relationships.sort((a, b) => a.name.localeCompare(b.name));
-}
-
-function deriveOwnership(
-  owner: ObjectType,
-  target: ObjectType,
-  relationshipFieldName: string,
-): { scopeField: string; targetScopeField?: string } | null {
-  const candidates = owner.fields.filter((sourceField) => {
-    if (sourceField.name === relationshipFieldName) return false;
-    if (sourceField.optional === true || sourceField.nullable === true) return false;
-    const targetField = target.fields.find((field) => field.name === sourceField.name);
-    if (!targetField || targetField.optional === true || targetField.nullable === true)
-      return false;
-    return fieldTypesMatch(sourceField.type, targetField.type);
-  });
-
-  const [candidate] = candidates;
-  if (!candidate || candidates.length !== 1) return null;
-  return { scopeField: candidate.name };
-}
-
-function fieldTypesMatch(left: FieldType, right: FieldType): boolean {
-  if (left.kind !== right.kind) return false;
-  if (left.kind === 'ref' && right.kind === 'ref') return left.typeName === right.typeName;
-  if (left.kind === 'array' && right.kind === 'array') {
-    return fieldTypesMatch(left.element, right.element);
-  }
-  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function assertionHelpers(relationships: Relationship[]): string[] {

--- a/packages/core/src/ir.ts
+++ b/packages/core/src/ir.ts
@@ -43,6 +43,7 @@ const RefFieldTypeSchema = z.object({
     .object({
       name: z.string().min(1).optional(),
       onDelete: z.enum(['none', 'restrict', 'cascade', 'setNull']).optional(),
+      crossScope: z.boolean().optional(),
       ownership: z
         .object({
           scopeField: z.string().min(1),

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -87,13 +87,14 @@ const ValidationIssueSchema = z.object({
   code: z.string(),
   path: z.string(),
   message: z.string(),
+  severity: z.enum(['error', 'warning']).optional(),
   hint: z.string().optional(),
 });
 
 const ValidateOutput = {
   path: z.string(),
   valid: z.boolean(),
-  warnings: z.array(z.string()),
+  warnings: z.array(z.union([z.string(), ValidationIssueSchema])),
   errors: z.array(ValidationIssueSchema),
 };
 
@@ -318,13 +319,21 @@ async function validateContextureFile(
 ): Promise<z.infer<z.ZodObject<typeof ValidateOutput>>> {
   try {
     const { schema, warnings } = await readContextureFile(irPath);
-    const errors = checkSemantic(schema, catalog).map((issue) => ({
+    const semanticIssues = checkSemantic(schema, catalog).map((issue) => ({
       code: issue.code,
       path: issue.path,
       message: issue.message,
+      severity: issue.severity,
       ...(issue.hint ? { hint: issue.hint } : {}),
     }));
-    return { path: irPath, valid: errors.length === 0, warnings, errors };
+    const errors = semanticIssues.filter((issue) => issue.severity === 'error');
+    const semanticWarnings = semanticIssues.filter((issue) => issue.severity === 'warning');
+    return {
+      path: irPath,
+      valid: errors.length === 0,
+      warnings: [...warnings, ...semanticWarnings],
+      errors,
+    };
   } catch (err) {
     return {
       path: irPath,
@@ -605,7 +614,7 @@ function buildIntegrationGuidance(
       'Do not hand-edit generated files with a @contexture-generated marker; change the IR and emit instead.',
       'Prefer typed op tools such as add_type, add_field, rename_type, set_table_flag, and add_index over apply_contexture_op when possible.',
       'Typed op tools take irPath plus their direct arguments. The generic apply_contexture_op takes { irPath, op } where op is the closed-world operation with a kind.',
-      'For Convex table refs, put relationship intent under field.type.relationship, for example { onDelete: "restrict", ownership: { scopeField: "householdId" } }.',
+      'For Convex table refs, put relationship intent under field.type.relationship, for example { onDelete: "restrict", ownership: { scopeField: "householdId" } }. Use relationship.crossScope: true for intentional cross-scope refs.',
       'After any model mutation, validate, emit generated targets, and check drift before finishing.',
       'Wire generated outputs into the existing app architecture; Contexture does not own arbitrary application code.',
     ],

--- a/packages/core/src/op-tools.ts
+++ b/packages/core/src/op-tools.ts
@@ -47,6 +47,10 @@ export interface OpToolDescriptor {
 const RelationshipSchema = z.object({
   name: z.string().min(1).optional(),
   onDelete: z.enum(['none', 'restrict', 'cascade', 'setNull']).optional(),
+  crossScope: z
+    .boolean()
+    .describe('Set true to mark this table ref as intentionally cross-scope.')
+    .optional(),
   ownership: z
     .object({
       scopeField: z.string().min(1),
@@ -94,7 +98,7 @@ const FieldTypeSchema: z.ZodType<import('./ir').FieldType> = z.lazy(() =>
             'stdlib refs.',
         ),
       relationship: RelationshipSchema.describe(
-        'Relationship intent for refs to Convex table types. Use onDelete for delete policy and ownership.scopeField/targetScopeField for same-tenant checks.',
+        'Relationship intent for refs to Convex table types. Use onDelete for delete policy, ownership.scopeField/targetScopeField for same-tenant checks, or crossScope: true for intentional cross-scope refs.',
       ).optional(),
     }),
     z.object({

--- a/packages/core/src/ops.ts
+++ b/packages/core/src/ops.ts
@@ -210,7 +210,7 @@ export function apply(schema: Schema, op: Op, catalog?: StdlibCatalog): ApplyRes
   const introduced = newIssues(
     checkSemantic(schema, catalog),
     checkSemantic(structural.data, catalog),
-  );
+  ).filter((issue) => issue.severity === 'error');
   if (introduced.length === 0) return { schema: structural.data };
   return { error: formatSemanticErrors(op.kind, introduced) };
 }

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -48,19 +48,23 @@ export type SemanticIssueCode =
   | 'relationship_target_not_table'
   | 'relationship_scope_field_missing'
   | 'relationship_set_null_requires_nullable'
-  | 'relationship_cleanup_index_missing';
+  | 'relationship_cleanup_index_missing'
+  | 'relationship_ownership_scope_missing';
+
+export type SemanticIssueSeverity = 'error' | 'warning';
 
 export interface SemanticIssue {
   code: SemanticIssueCode;
   path: string;
   message: string;
+  severity: SemanticIssueSeverity;
   /** Remediation suggestion the chat / UI should surface verbatim. */
   hint?: string;
 }
 
 export function checkSemantic(schema: Schema, catalog?: StdlibCatalog): SemanticIssue[] {
   if (!schema || schema.version !== '1') return [];
-  return [
+  return withDefaultSeverity([
     ...checkImports(schema, catalog),
     ...checkRefs(schema, catalog),
     ...checkDuplicateTypeNames(schema),
@@ -69,13 +73,21 @@ export function checkSemantic(schema: Schema, catalog?: StdlibCatalog): Semantic
     ...checkConvexTableShapes(schema),
     ...checkDiscriminatedUnions(schema),
     ...checkEnums(schema),
-  ];
+  ]);
 }
 
 type ObjectType = Extract<TypeDef, { kind: 'object' }>;
 
-function checkDuplicateConvexTableNames(schema: Schema): SemanticIssue[] {
-  const issues: SemanticIssue[] = [];
+type SemanticIssueDraft = Omit<SemanticIssue, 'severity'> & {
+  severity?: SemanticIssueSeverity;
+};
+
+function withDefaultSeverity(issues: SemanticIssueDraft[]): SemanticIssue[] {
+  return issues.map((issue) => ({ severity: 'error', ...issue }));
+}
+
+function checkDuplicateConvexTableNames(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
   const seen = new Map<string, number>();
 
   schema.types.forEach((type, i) => {
@@ -100,8 +112,8 @@ function convexTableName(type: ObjectType): string {
   return type.tableName ?? `${type.name.charAt(0).toLowerCase()}${type.name.slice(1)}`;
 }
 
-function checkConvexTableShapes(schema: Schema): SemanticIssue[] {
-  const issues: SemanticIssue[] = [];
+function checkConvexTableShapes(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
   schema.types.forEach((type, typeIndex) => {
     if (type.kind !== 'object' || type.table !== true) return;
     const tableName = convexTableName(type);
@@ -151,8 +163,8 @@ function checkConvexTableShapes(schema: Schema): SemanticIssue[] {
   return issues;
 }
 
-function checkImports(schema: Schema, catalog?: StdlibCatalog): SemanticIssue[] {
-  const issues: SemanticIssue[] = [];
+function checkImports(schema: Schema, catalog?: StdlibCatalog): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
   const seenAliases = new Set<string>();
   (schema.imports ?? []).forEach((imp, i) => {
     const path = `imports.${i}`;
@@ -187,8 +199,8 @@ function checkImports(schema: Schema, catalog?: StdlibCatalog): SemanticIssue[] 
   return issues;
 }
 
-function checkRefs(schema: Schema, catalog?: StdlibCatalog): SemanticIssue[] {
-  const issues: SemanticIssue[] = [];
+function checkRefs(schema: Schema, catalog?: StdlibCatalog): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
   const localTypes = new Map(schema.types.map((t) => [t.name, t]));
   const localNames = new Set(localTypes.keys());
   const aliases = new Set((schema.imports ?? []).map((i) => i.alias));
@@ -250,11 +262,11 @@ function checkRelationshipMetadata(
   fieldOptional: boolean,
   fieldNullable: boolean,
   localTypes: ReadonlyMap<string, TypeDef>,
-): SemanticIssue[] {
-  if (!ref.relationship) return [];
-  const issues: SemanticIssue[] = [];
+): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
   const target = localTypes.get(ref.typeName);
-  if (target?.kind !== 'object' || target.table !== true) {
+  const relationship = ref.relationship;
+  if (relationship && (target?.kind !== 'object' || target.table !== true)) {
     issues.push({
       code: 'relationship_target_not_table',
       path: `${path}.relationship`,
@@ -263,7 +275,7 @@ function checkRelationshipMetadata(
     });
   }
 
-  if (ref.relationship.onDelete === 'setNull' && !fieldOptional && !fieldNullable) {
+  if (relationship?.onDelete === 'setNull' && !fieldOptional && !fieldNullable) {
     issues.push({
       code: 'relationship_set_null_requires_nullable',
       path: `${path}.relationship.onDelete`,
@@ -272,19 +284,19 @@ function checkRelationshipMetadata(
     });
   }
 
-  if (ref.relationship.onDelete === 'cascade' || ref.relationship.onDelete === 'setNull') {
+  if (relationship?.onDelete === 'cascade' || relationship?.onDelete === 'setNull') {
     const hasCleanupIndex = (owner.indexes ?? []).some((index) => index.fields[0] === fieldName);
     if (!hasCleanupIndex) {
       issues.push({
         code: 'relationship_cleanup_index_missing',
         path: `${path}.relationship.onDelete`,
-        message: `Relationship "${fieldName}" uses ${ref.relationship.onDelete} but source table "${owner.name}" has no cleanup index starting with "${fieldName}".`,
+        message: `Relationship "${fieldName}" uses ${relationship.onDelete} but source table "${owner.name}" has no cleanup index starting with "${fieldName}".`,
         hint: `Add an index on "${owner.name}" with "${fieldName}" as the first field before relying on generated cleanup plans.`,
       });
     }
   }
 
-  const ownership = ref.relationship.ownership;
+  const ownership = relationship?.ownership;
   if (ownership && !owner.fields.some((field) => field.name === ownership.scopeField)) {
     issues.push({
       code: 'relationship_scope_field_missing',
@@ -310,7 +322,72 @@ function checkRelationshipMetadata(
     });
   }
 
+  if (
+    owner.table === true &&
+    target?.kind === 'object' &&
+    target.table === true &&
+    !ownership &&
+    relationship?.crossScope !== true
+  ) {
+    const axis = findSharedTenantAxis(owner, target, fieldName, ref.typeName);
+    if (axis) {
+      issues.push({
+        code: 'relationship_ownership_scope_missing',
+        severity: 'warning',
+        path: `${path}.relationship.ownership`,
+        message: `${owner.name}.${fieldName} -> ${convexTableName(target)}: source and target share tenant axis "${axis.fieldName}" but no ownership scope is set.`,
+        hint: `Add relationship.ownership.scopeField: "${axis.fieldName}"${
+          axis.targetFieldName === axis.fieldName
+            ? ''
+            : ` and targetScopeField: "${axis.targetFieldName}"`
+        }, or set relationship.crossScope: true to suppress this warning.`,
+      });
+    }
+  }
+
   return issues;
+}
+
+function findSharedTenantAxis(
+  owner: ObjectType,
+  target: ObjectType,
+  relationshipFieldName: string,
+  relationshipTargetTypeName: string,
+): { fieldName: string; targetFieldName: string } | null {
+  const strong = owner.fields.find((sourceField) => {
+    if (!isRequiredField(sourceField) || sourceField.name === relationshipFieldName) return false;
+    const targetField = target.fields.find((field) => field.name === sourceField.name);
+    if (!targetField || !isRequiredField(targetField)) return false;
+    if (
+      sourceField.type.kind !== 'ref' ||
+      targetField.type.kind !== 'ref' ||
+      sourceField.type.typeName !== targetField.type.typeName
+    ) {
+      return false;
+    }
+    return sourceField.type.typeName !== relationshipTargetTypeName;
+  });
+  if (strong) return { fieldName: strong.name, targetFieldName: strong.name };
+
+  const fallback = owner.fields.find((sourceField) => {
+    if (!isRequiredField(sourceField) || sourceField.name === relationshipFieldName) return false;
+    if (!isLikelyTenantAxisName(sourceField.name) || sourceField.type.kind !== 'string') {
+      return false;
+    }
+    const targetField = target.fields.find((field) => field.name === sourceField.name);
+    return Boolean(
+      targetField && isRequiredField(targetField) && targetField.type.kind === 'string',
+    );
+  });
+  return fallback ? { fieldName: fallback.name, targetFieldName: fallback.name } : null;
+}
+
+function isRequiredField(field: ObjectType['fields'][number]): boolean {
+  return field.optional !== true && field.nullable !== true;
+}
+
+function isLikelyTenantAxisName(name: string): boolean {
+  return /^(household|tenant|org|organization|workspace|account|team|project)Id$/.test(name);
 }
 
 function resolves(
@@ -339,8 +416,8 @@ function hintForUnresolvedRef(typeName: string, catalog?: StdlibCatalog): string
   return undefined;
 }
 
-function checkDuplicateTypeNames(schema: Schema): SemanticIssue[] {
-  const issues: SemanticIssue[] = [];
+function checkDuplicateTypeNames(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
   const seen = new Set<string>();
   schema.types.forEach((type, i) => {
     if (seen.has(type.name)) {
@@ -356,8 +433,8 @@ function checkDuplicateTypeNames(schema: Schema): SemanticIssue[] {
   return issues;
 }
 
-function checkDuplicateFieldNames(schema: Schema): SemanticIssue[] {
-  const issues: SemanticIssue[] = [];
+function checkDuplicateFieldNames(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
   schema.types.forEach((type, typeIndex) => {
     if (type.kind !== 'object') return;
     const seen = new Set<string>();
@@ -377,8 +454,8 @@ function checkDuplicateFieldNames(schema: Schema): SemanticIssue[] {
   return issues;
 }
 
-function checkDiscriminatedUnions(schema: Schema): SemanticIssue[] {
-  const issues: SemanticIssue[] = [];
+function checkDiscriminatedUnions(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
   const byName = new Map(schema.types.map((t) => [t.name, t]));
 
   schema.types.forEach((type, ti) => {
@@ -414,8 +491,8 @@ function checkDiscriminatedUnions(schema: Schema): SemanticIssue[] {
   return issues;
 }
 
-function checkEnums(schema: Schema): SemanticIssue[] {
-  const issues: SemanticIssue[] = [];
+function checkEnums(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
   schema.types.forEach((type, ti) => {
     if (type.kind !== 'enum') return;
     if (type.values.length === 0) {
@@ -460,7 +537,7 @@ function stdlibNamespaceFromPath(path: ImportDecl['path']): string | null {
  * pre-existing issues.
  */
 export function newIssues(pre: SemanticIssue[], post: SemanticIssue[]): SemanticIssue[] {
-  const key = (i: SemanticIssue) => `${i.code}|${i.path}|${i.message}`;
+  const key = (i: SemanticIssue) => `${i.severity}|${i.code}|${i.path}|${i.message}`;
   const seen = new Set(pre.map(key));
   return post.filter((i) => !seen.has(key(i)));
 }

--- a/packages/core/tests/apply-semantic-gate.test.ts
+++ b/packages/core/tests/apply-semantic-gate.test.ts
@@ -94,6 +94,34 @@ describe('apply() — delta semantic gate', () => {
     expect('schema' in result).toBe(true);
   });
 
+  it('accepts ops that introduce only semantic warnings', () => {
+    const start: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+      ],
+    };
+    const op: Op = {
+      kind: 'add_field',
+      typeName: 'MealPlanMeal',
+      field: { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
+    };
+
+    expect(apply(start, op, STDLIB)).toMatchObject({ schema: expect.any(Object) });
+  });
+
   it('accepts update_field that rewrites a ref to a primitive (not a new issue)', () => {
     const start: Schema = {
       version: '1',

--- a/packages/core/tests/emit-convex-relationships.test.ts
+++ b/packages/core/tests/emit-convex-relationships.test.ts
@@ -53,7 +53,7 @@ describe('emitConvexRelationships', () => {
     expect(parses(out)).toBe(true);
   });
 
-  it('auto-derives ownership scope when source and target share one required scope field', () => {
+  it('does not auto-derive ownership scope when source and target share a scope field', () => {
     const schema: Schema = {
       version: '1',
       types: [
@@ -79,11 +79,11 @@ describe('emitConvexRelationships', () => {
     const out = emitConvexRelationships(schema);
 
     expect(out).toContain('"name": "MealPlanMeal.recipeId"');
-    expect(out).toContain('"ownershipScopeField": "householdId"');
-    expect(out).toContain('"targetOwnershipScopeField": "householdId"');
+    expect(out).toContain('"ownershipScopeField": null');
+    expect(out).toContain('"targetOwnershipScopeField": null');
   });
 
-  it('keeps explicit ownership metadata over auto-derived scope', () => {
+  it('emits explicit ownership metadata', () => {
     const schema: Schema = {
       version: '1',
       types: [

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -251,6 +251,161 @@ describe('checkSemantic — refs', () => {
       'relationship_cleanup_index_missing',
     );
   });
+
+  it('warns when table refs share a tenant ref axis but ownership is missing', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+        },
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
+          ],
+        },
+      ],
+    };
+
+    const warnings = checkSemantic(schema, STDLIB).filter((issue) => issue.severity === 'warning');
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        code: 'relationship_ownership_scope_missing',
+        path: 'types.2.fields.1.type.relationship.ownership',
+        message: expect.stringContaining('MealPlanMeal.recipeId -> recipe'),
+        hint: expect.stringContaining('relationship.crossScope: true'),
+      }),
+    ]);
+  });
+
+  it('does not warn when ownership is explicit or cross-scope is explicit', () => {
+    const baseTypes: Schema['types'] = [
+      { kind: 'object', name: 'Household', table: true, fields: [] },
+      {
+        kind: 'object',
+        name: 'Recipe',
+        table: true,
+        fields: [{ name: 'householdId', type: { kind: 'ref', typeName: 'Household' } }],
+      },
+    ];
+    const scoped: Schema = {
+      version: '1',
+      types: [
+        ...baseTypes,
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            {
+              name: 'recipeId',
+              type: {
+                kind: 'ref',
+                typeName: 'Recipe',
+                relationship: { ownership: { scopeField: 'householdId' } },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const crossScope: Schema = {
+      version: '1',
+      types: [
+        ...baseTypes,
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            {
+              name: 'recipeId',
+              type: {
+                kind: 'ref',
+                typeName: 'Recipe',
+                relationship: { crossScope: true },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    for (const schema of [scoped, crossScope]) {
+      expect(checkSemantic(schema, STDLIB).map((issue) => issue.code)).not.toContain(
+        'relationship_ownership_scope_missing',
+      );
+    }
+  });
+
+  it('does not warn for refs to tenant roots or global tables without a shared axis', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Ingredient',
+          table: true,
+          fields: [{ name: 'name', type: { kind: 'string' } }],
+        },
+        {
+          kind: 'object',
+          name: 'PantryItem',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            { name: 'ingredientId', type: { kind: 'ref', typeName: 'Ingredient' } },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema, STDLIB).map((issue) => issue.code)).not.toContain(
+      'relationship_ownership_scope_missing',
+    );
+  });
+
+  it('warns from shared string tenant-axis fields during string-FK migrations', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'string' } }],
+        },
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'string' } },
+            { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema, STDLIB)).toEqual([
+      expect.objectContaining({
+        code: 'relationship_ownership_scope_missing',
+        severity: 'warning',
+        message: expect.stringContaining('tenant axis "householdId"'),
+      }),
+    ]);
+  });
 });
 
 describe('checkSemantic — imports', () => {


### PR DESCRIPTION
## Summary
- Remove auto-derived ownership from generated Convex relationship helpers so same-scope checks are explicit-only.
- Add relationship.crossScope as a greppable opt-out for intentional cross-scope table refs.
- Add warning severity to semantic diagnostics and warn when table refs likely share a tenant axis but lack ownership.
- Surface semantic warnings through CLI/MCP validation without failing validation or blocking op application.
- Bump desktop app version to 0.15.37.

## Verification
- bun run typecheck
- bun run test
- bun run check
- focused: core semantic/apply/relationships tests, desktop validation/op-tool tests, CLI/MCP tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783072727&installation_id=136251083&pr_number=364&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F364&signature=063e4eb06af4b92546f99bdb58974ecfe222aa48948dbc8d184775f3f784e326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->