### PR TITLE
fix: keep packaged MCP runtime fresh

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.37",
+  "version": "0.15.38",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",
@@ -10,7 +10,7 @@
     "postinstall": "bun run electron:install",
     "electron:install": "install-electron && node scripts/patch-electron-name.js",
     "dev": "bun run electron:install && electron-vite dev",
-    "build": "electron-vite build",
+    "build": "bun run build:mcp-cli && electron-vite build",
     "build:mcp-cli": "node scripts/build-mcp-cli.cjs",
     "start": "bun run electron:install && electron-vite preview",
     "typegen": "varlock typegen",

--- a/apps/desktop/scripts/build-mcp-cli.cjs
+++ b/apps/desktop/scripts/build-mcp-cli.cjs
@@ -1,10 +1,14 @@
 const { spawnSync } = require('node:child_process');
-const { mkdirSync } = require('node:fs');
+const { mkdirSync, readFileSync } = require('node:fs');
 const path = require('node:path');
 
 function buildMcpCli(options = {}) {
   const appDir = options.appDir ?? path.resolve(__dirname, '..');
   const workspaceRoot = options.workspaceRoot ?? path.resolve(appDir, '../..');
+  const version =
+    options.version ??
+    JSON.parse(readFileSync(path.join(appDir, 'package.json'), 'utf8')).version ??
+    '0.0.0';
   const outDir = path.join(appDir, 'build', 'bin');
   const executableName =
     (options.platform ?? process.platform) === 'win32' ? 'contexture-mcp.exe' : 'contexture-mcp';
@@ -15,10 +19,22 @@ function buildMcpCli(options = {}) {
 
   mkdir(outDir, { recursive: true });
 
-  const result = spawn('bun', ['build', '--compile', '--outfile', outFile, entrypoint], {
-    cwd: workspaceRoot,
-    stdio: 'inherit',
-  });
+  const result = spawn(
+    'bun',
+    [
+      'build',
+      '--compile',
+      '--define',
+      `CONTEXTURE_MCP_VERSION=${JSON.stringify(version)}`,
+      '--outfile',
+      outFile,
+      entrypoint,
+    ],
+    {
+      cwd: workspaceRoot,
+      stdio: 'inherit',
+    },
+  );
 
   if (result.error) {
     throw result.error;

--- a/apps/desktop/src/main/mcp-entrypoint.ts
+++ b/apps/desktop/src/main/mcp-entrypoint.ts
@@ -1,6 +1,7 @@
 import { createContextureMcpServer } from '@contexture/core/mcp-server';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { STDLIB_REGISTRY, STDLIB_RUNTIME_MODULES } from '@shared/stdlib-registry';
+import { app } from 'electron';
 
 export function isMcpMode(argv: readonly string[]): boolean {
   return argv.includes('--mcp');
@@ -8,6 +9,7 @@ export function isMcpMode(argv: readonly string[]): boolean {
 
 export async function startMcpServer(): Promise<void> {
   const server = createContextureMcpServer({
+    version: app.getVersion(),
     stdlib: STDLIB_REGISTRY,
     emitDeps: { stdlibRuntime: STDLIB_RUNTIME_MODULES },
   });

--- a/apps/desktop/tests/main/packaging-scripts.test.ts
+++ b/apps/desktop/tests/main/packaging-scripts.test.ts
@@ -27,6 +27,7 @@ describe('desktop packaging scripts', () => {
         calls.push(args);
         return { status: 0 };
       },
+      version: '0.15.38',
     });
 
     expect(mkdirCalls).toEqual([['/repo/apps/desktop/build/bin', { recursive: true }]]);
@@ -36,6 +37,8 @@ describe('desktop packaging scripts', () => {
         [
           'build',
           '--compile',
+          '--define',
+          'CONTEXTURE_MCP_VERSION="0.15.38"',
           '--outfile',
           '/repo/apps/desktop/build/bin/contexture-mcp',
           '/repo/packages/cli/src/mcp.ts',

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -4,9 +4,15 @@ import {
 } from '@contexture/core/mcp-server';
 import { STDLIB_REGISTRY, STDLIB_RUNTIME_MODULES } from './stdlib-runtime';
 
+declare const CONTEXTURE_MCP_VERSION: string | undefined;
+
+const DEFAULT_MCP_VERSION =
+  typeof CONTEXTURE_MCP_VERSION === 'string' ? CONTEXTURE_MCP_VERSION : '0.0.0';
+
 export function createContextureMcpServer(options: ContextureMcpServerOptions = {}) {
   return createCoreContextureMcpServer({
     ...options,
+    version: options.version ?? DEFAULT_MCP_VERSION,
     stdlib: options.stdlib ?? STDLIB_REGISTRY,
     emitDeps: {
       stdlibRuntime: STDLIB_RUNTIME_MODULES,

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -419,6 +419,7 @@ describe('Contexture MCP server', () => {
       expect(result.structuredContent).toMatchObject({
         path: irPath,
         valid: true,
+        mcp: { version: '0.0.0' },
         errors: [],
         warnings: [
           expect.objectContaining({
@@ -427,6 +428,71 @@ describe('Contexture MCP server', () => {
           }),
         ],
       });
+    });
+  });
+
+  it('uses tenant axes, not audit fields, for missing ownership warnings', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Ingredient',
+          table: true,
+          fields: [
+            { name: 'name', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'string' } },
+            { name: 'updatedAt', type: { kind: 'string' } },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'string' } },
+            { name: 'updatedAt', type: { kind: 'string' } },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'PantryItem',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'string' } },
+            { name: 'updatedAt', type: { kind: 'string' } },
+            { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
+            { name: 'ingredientId', type: { kind: 'ref', typeName: 'Ingredient' } },
+            { name: 'householdRefId', type: { kind: 'ref', typeName: 'Household' } },
+          ],
+        },
+      ],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'validate_contexture',
+        arguments: { irPath },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        path: irPath,
+        valid: true,
+        errors: [],
+        warnings: [
+          expect.objectContaining({
+            code: 'relationship_ownership_scope_missing',
+            path: 'types.3.fields.3.type.relationship.ownership',
+            message: expect.stringContaining('tenant axis "householdId"'),
+            hint: expect.stringContaining('scopeField: "householdId"'),
+          }),
+        ],
+      });
+      expect(JSON.stringify(result.structuredContent)).not.toContain('scopeField: "createdAt"');
+      expect(JSON.stringify(result.structuredContent)).not.toContain('scopeField: "updatedAt"');
     });
   });
 

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -12,11 +12,12 @@ import { assertContextureIrPath, bundlePathsFor } from './paths';
 import type { EmitPipelineDeps } from './pipeline';
 import { checkSemantic, type StdlibCatalog } from './semantic-validation';
 
-const VERSION = '0.0.0';
+const DEFAULT_VERSION = '0.0.0';
 
 export interface ContextureMcpServerOptions {
   stdlib?: StdlibCatalog;
   emitDeps?: EmitPipelineDeps;
+  version?: string;
 }
 
 const IrPathInput = {
@@ -94,6 +95,9 @@ const ValidationIssueSchema = z.object({
 const ValidateOutput = {
   path: z.string(),
   valid: z.boolean(),
+  mcp: z.object({
+    version: z.string(),
+  }),
   warnings: z.array(z.union([z.string(), ValidationIssueSchema])),
   errors: z.array(ValidationIssueSchema),
 };
@@ -150,7 +154,8 @@ const IntegrationGuidanceOutput = {
 };
 
 export function createContextureMcpServer(options: ContextureMcpServerOptions = {}): McpServer {
-  const server = new McpServer({ name: 'contexture-core', version: VERSION });
+  const version = options.version ?? DEFAULT_VERSION;
+  const server = new McpServer({ name: 'contexture-core', version });
 
   server.registerTool(
     'inspect_contexture',
@@ -187,7 +192,7 @@ export function createContextureMcpServer(options: ContextureMcpServerOptions = 
       },
     },
     async ({ irPath }) => {
-      const structuredContent = await validateContextureFile(irPath, options.stdlib);
+      const structuredContent = await validateContextureFile(irPath, options.stdlib, version);
       return jsonToolResult(structuredContent);
     },
   );
@@ -316,6 +321,7 @@ async function readContextureFile(irPath: string): Promise<{ schema: Schema; war
 async function validateContextureFile(
   irPath: string,
   catalog?: StdlibCatalog,
+  version = DEFAULT_VERSION,
 ): Promise<z.infer<z.ZodObject<typeof ValidateOutput>>> {
   try {
     const { schema, warnings } = await readContextureFile(irPath);
@@ -331,6 +337,7 @@ async function validateContextureFile(
     return {
       path: irPath,
       valid: errors.length === 0,
+      mcp: { version },
       warnings: [...warnings, ...semanticWarnings],
       errors,
     };
@@ -338,6 +345,7 @@ async function validateContextureFile(
     return {
       path: irPath,
       valid: false,
+      mcp: { version },
       warnings: [],
       errors: normalizeValidationError(err),
     };

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -406,6 +406,61 @@ describe('checkSemantic — refs', () => {
       }),
     ]);
   });
+
+  it('does not use audit fields as tenant axes for missing ownership warnings', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'Ingredient',
+          table: true,
+          fields: [
+            { name: 'name', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'string' } },
+            { name: 'updatedAt', type: { kind: 'string' } },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'string' } },
+            { name: 'updatedAt', type: { kind: 'string' } },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'PantryItem',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'string' } },
+            { name: 'updatedAt', type: { kind: 'string' } },
+            { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
+            { name: 'ingredientId', type: { kind: 'ref', typeName: 'Ingredient' } },
+            { name: 'householdRefId', type: { kind: 'ref', typeName: 'Household' } },
+          ],
+        },
+      ],
+    };
+
+    const warnings = checkSemantic(schema, STDLIB).filter(
+      (issue) => issue.code === 'relationship_ownership_scope_missing',
+    );
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        path: 'types.3.fields.3.type.relationship.ownership',
+        message: expect.stringContaining('tenant axis "householdId"'),
+        hint: expect.stringContaining('scopeField: "householdId"'),
+      }),
+    ]);
+    expect(JSON.stringify(warnings)).not.toContain('createdAt');
+    expect(JSON.stringify(warnings)).not.toContain('updatedAt');
+  });
 });
 
 describe('checkSemantic — imports', () => {


### PR DESCRIPTION
## Summary
- rebuild the standalone desktop MCP binary as part of the desktop build and bake the desktop version into the compiled command
- expose MCP runtime version metadata in validate_contexture output, including Electron --mcp launches
- add core and MCP regression coverage for tenant-axis ownership warnings so audit fields are never suggested
- bump desktop app version to 0.15.38

## Verification
- bun run test -- tests/semantic-validation.test.ts (packages/core)
- bun run test -- tests/mcp.test.ts (packages/cli)
- bun run test -- tests/main/packaging-scripts.test.ts tests/main/mcp-entrypoint.test.ts (apps/desktop)
- bun run build:mcp-cli (apps/desktop)
- compiled MCP stdio validation check reports mcp.version 0.15.38
- bun run check
- bun run typecheck
- commit hook: turbo typecheck and turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783074604&installation_id=136251083&pr_number=365&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F365&signature=a68c0d20a9d5d5938bd68d7937924b85c1757282e9d20bd574cba69621c320c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->