### PR TITLE
fix: ignore audit refs as tenant axes

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.38",
+  "version": "0.15.39",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -442,8 +442,8 @@ describe('Contexture MCP server', () => {
           table: true,
           fields: [
             { name: 'name', type: { kind: 'string' } },
-            { name: 'createdAt', type: { kind: 'string' } },
-            { name: 'updatedAt', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
+            { name: 'updatedAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
           ],
         },
         {
@@ -452,8 +452,8 @@ describe('Contexture MCP server', () => {
           table: true,
           fields: [
             { name: 'householdId', type: { kind: 'string' } },
-            { name: 'createdAt', type: { kind: 'string' } },
-            { name: 'updatedAt', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
+            { name: 'updatedAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
           ],
         },
         {
@@ -462,8 +462,8 @@ describe('Contexture MCP server', () => {
           table: true,
           fields: [
             { name: 'householdId', type: { kind: 'string' } },
-            { name: 'createdAt', type: { kind: 'string' } },
-            { name: 'updatedAt', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
+            { name: 'updatedAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
             { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
             { name: 'ingredientId', type: { kind: 'ref', typeName: 'Ingredient' } },
             { name: 'householdRefId', type: { kind: 'ref', typeName: 'Household' } },

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -329,7 +329,7 @@ function checkRelationshipMetadata(
     !ownership &&
     relationship?.crossScope !== true
   ) {
-    const axis = findSharedTenantAxis(owner, target, fieldName, ref.typeName);
+    const axis = findSharedTenantAxis(owner, target, fieldName, ref.typeName, localTypes);
     if (axis) {
       issues.push({
         code: 'relationship_ownership_scope_missing',
@@ -353,11 +353,24 @@ function findSharedTenantAxis(
   target: ObjectType,
   relationshipFieldName: string,
   relationshipTargetTypeName: string,
+  localTypes: ReadonlyMap<string, TypeDef>,
 ): { fieldName: string; targetFieldName: string } | null {
   const strong = owner.fields.find((sourceField) => {
-    if (!isRequiredField(sourceField) || sourceField.name === relationshipFieldName) return false;
+    if (
+      !isRequiredField(sourceField) ||
+      sourceField.name === relationshipFieldName ||
+      isExcludedTenantAxisFieldName(sourceField.name)
+    ) {
+      return false;
+    }
     const targetField = target.fields.find((field) => field.name === sourceField.name);
-    if (!targetField || !isRequiredField(targetField)) return false;
+    if (
+      !targetField ||
+      !isRequiredField(targetField) ||
+      isExcludedTenantAxisFieldName(targetField.name)
+    ) {
+      return false;
+    }
     if (
       sourceField.type.kind !== 'ref' ||
       targetField.type.kind !== 'ref' ||
@@ -365,22 +378,52 @@ function findSharedTenantAxis(
     ) {
       return false;
     }
+    const axisTarget = localTypes.get(sourceField.type.typeName);
+    if (axisTarget?.kind !== 'object' || axisTarget.table !== true) return false;
     return sourceField.type.typeName !== relationshipTargetTypeName;
   });
   if (strong) return { fieldName: strong.name, targetFieldName: strong.name };
 
   const fallback = owner.fields.find((sourceField) => {
-    if (!isRequiredField(sourceField) || sourceField.name === relationshipFieldName) return false;
+    if (
+      !isRequiredField(sourceField) ||
+      sourceField.name === relationshipFieldName ||
+      isExcludedTenantAxisFieldName(sourceField.name)
+    ) {
+      return false;
+    }
     if (!isLikelyTenantAxisName(sourceField.name) || sourceField.type.kind !== 'string') {
       return false;
     }
     const targetField = target.fields.find((field) => field.name === sourceField.name);
     return Boolean(
-      targetField && isRequiredField(targetField) && targetField.type.kind === 'string',
+      targetField &&
+        isRequiredField(targetField) &&
+        !isExcludedTenantAxisFieldName(targetField.name) &&
+        targetField.type.kind === 'string',
     );
   });
   return fallback ? { fieldName: fallback.name, targetFieldName: fallback.name } : null;
 }
+
+function isExcludedTenantAxisFieldName(name: string): boolean {
+  return COMMON_NON_TENANT_AXIS_FIELD_NAMES.has(name);
+}
+
+const COMMON_NON_TENANT_AXIS_FIELD_NAMES = new Set([
+  'createdAt',
+  'updatedAt',
+  'deletedAt',
+  'archivedAt',
+  'timestamp',
+  'name',
+  'title',
+  'description',
+  'notes',
+  'slug',
+  'status',
+  'type',
+]);
 
 function isRequiredField(field: ObjectType['fields'][number]): boolean {
   return field.optional !== true && field.nullable !== true;

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -6,7 +6,7 @@ const STDLIB: StdlibCatalog = {
   namespaces: ['common', 'place', 'money'],
   hasType: (ns, name) => {
     const types: Record<string, ReadonlySet<string>> = {
-      common: new Set(['Email', 'URL']),
+      common: new Set(['Email', 'URL', 'ISODateTime']),
       place: new Set(['CountryCode', 'Address']),
       money: new Set(['Money', 'CurrencyCode']),
     };
@@ -418,8 +418,8 @@ describe('checkSemantic — refs', () => {
           table: true,
           fields: [
             { name: 'name', type: { kind: 'string' } },
-            { name: 'createdAt', type: { kind: 'string' } },
-            { name: 'updatedAt', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
+            { name: 'updatedAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
           ],
         },
         {
@@ -428,8 +428,8 @@ describe('checkSemantic — refs', () => {
           table: true,
           fields: [
             { name: 'householdId', type: { kind: 'string' } },
-            { name: 'createdAt', type: { kind: 'string' } },
-            { name: 'updatedAt', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
+            { name: 'updatedAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
           ],
         },
         {
@@ -438,8 +438,8 @@ describe('checkSemantic — refs', () => {
           table: true,
           fields: [
             { name: 'householdId', type: { kind: 'string' } },
-            { name: 'createdAt', type: { kind: 'string' } },
-            { name: 'updatedAt', type: { kind: 'string' } },
+            { name: 'createdAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
+            { name: 'updatedAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
             { name: 'recipeId', type: { kind: 'ref', typeName: 'Recipe' } },
             { name: 'ingredientId', type: { kind: 'ref', typeName: 'Ingredient' } },
             { name: 'householdRefId', type: { kind: 'ref', typeName: 'Household' } },


### PR DESCRIPTION
## Summary
- exclude common non-tenant fields like createdAt/updatedAt from relationship ownership axis candidates
- require strong shared-ref tenant axes to point at local Contexture table types, so stdlib refs like common.ISODateTime cannot win
- keep the string migration fallback on tenant-looking required ids such as householdId
- update core and MCP regression tests to use the Plantry-real common.ISODateTime timestamp shape
- bump desktop app version to 0.15.39

## Verification
- bun run test -- tests/semantic-validation.test.ts (packages/core)
- bun run test -- tests/mcp.test.ts (packages/cli)
- Plantry-shaped source repro: only PantryItem -> Recipe warns, suggesting householdId; Ingredient and Household stay silent
- bun run build:mcp-cli (apps/desktop)
- Plantry-shaped compiled MCP stdio repro reports mcp.version 0.15.39 and only the householdId recipe warning
- bun run check
- bun run typecheck
- commit hook: turbo typecheck and turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783076071&installation_id=136251083&pr_number=366&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F366&signature=56218dab6f91a52c904e12115d56c48b4220db8dde3a8aff5771c34d80e0865a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->