### PR TITLE
feat: register embedded table refs

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.39",
+  "version": "0.15.40",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/components/detail/EdgeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/EdgeDetail.tsx
@@ -6,6 +6,7 @@
  * union-variant edges come from discriminated-union `variants`. There is
  * no edge entity to mutate directly.
  */
+import { GitBranch, Link2, type LucideIcon, Table2 } from 'lucide-react';
 import type { RefEdgeData } from '../graph/schema-to-graph';
 
 export interface EdgeDetailProps {
@@ -14,19 +15,16 @@ export interface EdgeDetailProps {
 }
 
 export function EdgeDetail({ data, onEditField }: EdgeDetailProps) {
-  const isUnionVariant = data.relation === 'unionVariant';
-  const isTableId = data.relation === 'tableId';
-  const editableSourceField = isUnionVariant ? undefined : data.sourceField;
+  const meta = edgeKindMeta(data);
+  const editableSourceField = data.relation === 'unionVariant' ? undefined : data.sourceField;
+  const Icon = meta.icon;
 
   return (
     <div className="space-y-2 p-3 text-xs">
       <div className="flex items-center justify-between">
-        <span className="text-sm font-semibold">
-          {isUnionVariant
-            ? 'Union variant edge'
-            : isTableId
-              ? 'Inferred table id edge'
-              : 'Ref edge'}
+        <span className="flex items-center gap-1.5 text-sm font-semibold">
+          <Icon aria-hidden="true" className="size-3.5 text-muted-foreground" />
+          {meta.label}
         </span>
         {data.crossBoundary && (
           <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
@@ -36,7 +34,7 @@ export function EdgeDetail({ data, onEditField }: EdgeDetailProps) {
       </div>
       <dl className="space-y-1">
         <Row term="Source type" detail={data.sourceType} />
-        {isUnionVariant ? (
+        {data.relation === 'unionVariant' ? (
           <Row term="Discriminator" detail={data.discriminator ?? ''} />
         ) : (
           <Row term="Source field" detail={data.sourceField ?? ''} />
@@ -54,6 +52,16 @@ export function EdgeDetail({ data, onEditField }: EdgeDetailProps) {
       )}
     </div>
   );
+}
+
+function edgeKindMeta(data: RefEdgeData): { icon: LucideIcon; label: string } {
+  if (data.relation === 'unionVariant') {
+    return { icon: GitBranch, label: 'Union variant edge' };
+  }
+  if (data.relation === 'tableId') {
+    return { icon: Table2, label: 'Inferred table id edge' };
+  }
+  return { icon: Link2, label: 'Modeled ref edge' };
 }
 
 function Row({ term, detail }: { term: string; detail: string }) {

--- a/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
@@ -21,12 +21,12 @@ interface EdgeItem {
 
 const EDGE_ITEMS: readonly EdgeItem[] = [
   {
-    label: 'Ref',
-    color: 'var(--graph-edge-ref)',
+    label: 'Modeled ref',
+    color: 'var(--graph-edge-fk)',
   },
   {
     label: 'Inferred table id',
-    color: 'var(--graph-edge-ref)',
+    color: 'var(--graph-edge-import)',
     dash: '6,4',
   },
   {
@@ -38,6 +38,10 @@ const EDGE_ITEMS: readonly EdgeItem[] = [
     label: 'Import (cross-boundary)',
     color: 'var(--graph-edge-import)',
     dash: '6,4',
+  },
+  {
+    label: 'Active selection',
+    color: 'var(--graph-edge-active)',
   },
 ];
 

--- a/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
@@ -5,8 +5,8 @@
  *
  * Styling:
  *   - Field refs rest as quiet structure and label the source field.
- *   - Inferred table id relationships are dashed because they are a
- *     diagram-only convention, not an IR ref.
+ *   - Inferred table id relationships are dashed and unlabeled because they
+ *     are diagram-only hints; the detail panel carries their field metadata.
  *   - Union variants use the discriminated-union accent and a dotted
  *     stroke so inheritance-like membership does not read as a field.
  *   - Cross-boundary refs are dashed and muted so imported namespaces read
@@ -28,6 +28,13 @@ import type { RefEdgeData } from '../schema-to-graph';
 import { getFloatingEdgeParams } from './floating-edge-utils';
 
 type RefEdgeKind = Edge<RefEdgeData, 'ref'>;
+
+export function labelForRefEdge(data: RefEdgeData | undefined): string | undefined {
+  if (!data) return undefined;
+  if (data.relation === 'tableId') return undefined;
+  if (data.relation === 'unionVariant') return 'variant';
+  return data.sourceField;
+}
 
 export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
   const { id, source, target, data, selected } = props;
@@ -78,7 +85,7 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
         : 'var(--graph-edge-fk, var(--muted-foreground))';
   const strokeWidth = selected || isAdjacent || isPreviewHighlighted ? 2 : 1.25;
   const strokeDasharray = isUnionVariant ? '2 4' : isTableId || crossBoundary ? '6 4' : undefined;
-  const label = isUnionVariant ? 'variant' : data?.sourceField;
+  const label = labelForRefEdge(data);
   const baseOpacity = isUnionVariant || isTableId || crossBoundary ? 0.72 : 0.68;
   const opacity = isDimmed ? 0.18 : isActive ? 0.95 : baseOpacity;
 

--- a/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/edges/RefEdge.tsx
@@ -4,13 +4,14 @@
  * clips the node body.
  *
  * Styling:
- *   - Field refs use the property accent and label the source field.
+ *   - Field refs rest as quiet structure and label the source field.
  *   - Inferred table id relationships are dashed because they are a
  *     diagram-only convention, not an IR ref.
  *   - Union variants use the discriminated-union accent and a dotted
  *     stroke so inheritance-like membership does not read as a field.
  *   - Cross-boundary refs are dashed and muted so imported namespaces read
  *     at a glance.
+ *   - Blue/lavender is reserved for selected, hovered, and adjacent edges.
  */
 import {
   BaseEdge,
@@ -67,17 +68,19 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
       target !== selectedNodeId) ||
     isPreviewDimmed;
 
-  const stroke =
-    selected || isAdjacent || isPreviewHighlighted
-      ? 'var(--graph-node-selected)'
-      : isUnionVariant
-        ? 'var(--graph-edge-union, var(--chart-4))'
-        : crossBoundary
-          ? 'var(--graph-edge-import, var(--muted-foreground))'
-          : 'var(--graph-edge-ref, var(--graph-edge-property))';
+  const isActive = selected || isAdjacent || isPreviewHighlighted;
+  const stroke = isActive
+    ? 'var(--graph-edge-active, var(--graph-node-selected))'
+    : isUnionVariant
+      ? 'var(--graph-edge-union, var(--chart-4))'
+      : crossBoundary || isTableId
+        ? 'var(--graph-edge-import, var(--muted-foreground))'
+        : 'var(--graph-edge-fk, var(--muted-foreground))';
   const strokeWidth = selected || isAdjacent || isPreviewHighlighted ? 2 : 1.25;
   const strokeDasharray = isUnionVariant ? '2 4' : isTableId || crossBoundary ? '6 4' : undefined;
   const label = isUnionVariant ? 'variant' : data?.sourceField;
+  const baseOpacity = isUnionVariant || isTableId || crossBoundary ? 0.72 : 0.68;
+  const opacity = isDimmed ? 0.18 : isActive ? 0.95 : baseOpacity;
 
   return (
     <>
@@ -88,7 +91,7 @@ export const RefEdge = memo(function RefEdge(props: EdgeProps<RefEdgeKind>) {
           stroke,
           strokeWidth,
           strokeDasharray,
-          opacity: isDimmed ? 0.2 : isPreviewHighlighted ? 0.95 : 1,
+          opacity,
           transition: 'opacity 0.15s ease, stroke 0.1s ease',
           fill: 'none',
         }}

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -91,7 +91,9 @@
   /* Zod-era edge tokens. `ref` is the default relationship edge;
      `union` is the discriminated-union variant edge; `import` is the
      dashed cross-boundary (stdlib / cross-project) edge. */
-  --graph-edge-ref: color-mix(in oklch, #7287fd 72%, #6c6f85);
+  --graph-edge-fk: color-mix(in oklch, #6c6f85 64%, #e6e9ef);
+  --graph-edge-ref: #1e66f5;
+  --graph-edge-active: #7287fd;
   --graph-edge-union: #40a02b;
   --graph-edge-import: #7c7f93;
   /* Background dot colour — deliberately subdued so the grid reads as
@@ -169,7 +171,9 @@
   --graph-edge-subclass: #9399b2;
   --graph-edge-restriction: #fab387;
   /* Zod-era edge tokens (dark). */
+  --graph-edge-fk: color-mix(in oklch, #9399b2 58%, #181825);
   --graph-edge-ref: #89b4fa;
+  --graph-edge-active: #89b4fa;
   --graph-edge-union: #a6e3a1;
   --graph-edge-import: #9399b2;
   /* Subdued dot grid on dark canvases too. */

--- a/apps/desktop/src/renderer/src/store/layout-config.ts
+++ b/apps/desktop/src/renderer/src/store/layout-config.ts
@@ -20,7 +20,7 @@ export const DEFAULT_LAYOUT: GraphLayout = {
   nodeSpacing: 180,
   showEnums: false,
   showStdlib: false,
-  showEdgeLabels: true,
+  showEdgeLabels: false,
 };
 
 interface GraphLayoutStoreShape {

--- a/apps/desktop/tests/components/App.keyboard.test.tsx
+++ b/apps/desktop/tests/components/App.keyboard.test.tsx
@@ -307,7 +307,7 @@ describe('App global keyboard', () => {
       }),
     );
 
-    expect(await screen.findByText('Ref edge')).toBeInTheDocument();
+    expect(await screen.findByText('Modeled ref edge')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit field' }));
 
     expect(await screen.findByTestId('field-detail')).toHaveTextContent('harvest');
@@ -347,7 +347,7 @@ describe('App global keyboard', () => {
       }),
     );
 
-    expect(await screen.findByText('Ref edge')).toBeInTheDocument();
+    expect(await screen.findByText('Modeled ref edge')).toBeInTheDocument();
     useUndoStore.getState().apply({
       kind: 'remove_field',
       typeName: 'Plot',
@@ -355,7 +355,7 @@ describe('App global keyboard', () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByText('Ref edge')).not.toBeInTheDocument();
+      expect(screen.queryByText('Modeled ref edge')).not.toBeInTheDocument();
       expect(useGraphSelectionStore.getState().state.edgeId).toBeNull();
     });
   });

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -374,7 +374,7 @@ describe('DetailPanel', () => {
       crossBoundary: false,
     };
     render(<DetailPanel selection={{ edge }} />);
-    expect(screen.getByText('Ref edge')).toBeInTheDocument();
+    expect(screen.getByText('Modeled ref edge')).toBeInTheDocument();
   });
 
   it('selects the source field from an editable edge detail', () => {

--- a/apps/desktop/tests/components/graph/GraphLegend.test.tsx
+++ b/apps/desktop/tests/components/graph/GraphLegend.test.tsx
@@ -13,6 +13,15 @@ describe('GraphLegend', () => {
     expect(screen.getByText('Table')).toBeInTheDocument();
   });
 
+  it('documents quiet modeled refs and active selection separately', () => {
+    render(<GraphLegend />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand legend' }));
+
+    expect(screen.getByText('Modeled ref')).toBeInTheDocument();
+    expect(screen.getByText('Active selection')).toBeInTheDocument();
+  });
+
   it('documents inline enums by default and only shows enum nodes when expanded in controls', () => {
     const { rerender } = render(<GraphLegend />);
 

--- a/apps/desktop/tests/components/graph/RefEdge.test.ts
+++ b/apps/desktop/tests/components/graph/RefEdge.test.ts
@@ -1,0 +1,33 @@
+import { labelForRefEdge } from '@renderer/components/graph/edges/RefEdge';
+import type { RefEdgeData } from '@renderer/components/graph/schema-to-graph';
+import { describe, expect, it } from 'vitest';
+
+describe('labelForRefEdge', () => {
+  it('labels modeled refs and union variants, but not inferred table-id hints', () => {
+    const modeled: RefEdgeData = {
+      relation: 'fieldRef',
+      sourceType: 'MealPlan',
+      sourceField: 'householdId',
+      targetType: 'Household',
+      crossBoundary: false,
+    };
+    const inferred: RefEdgeData = {
+      relation: 'tableId',
+      sourceType: 'Household',
+      sourceField: 'ownerUserId',
+      targetType: 'User',
+      crossBoundary: false,
+    };
+    const union: RefEdgeData = {
+      relation: 'unionVariant',
+      sourceType: 'MealTarget',
+      targetType: 'RecipeTarget',
+      discriminator: 'kind',
+      crossBoundary: false,
+    };
+
+    expect(labelForRefEdge(modeled)).toBe('householdId');
+    expect(labelForRefEdge(inferred)).toBeUndefined();
+    expect(labelForRefEdge(union)).toBe('variant');
+  });
+});

--- a/apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx
+++ b/apps/desktop/tests/components/toolbar/GraphControlsPanel.test.tsx
@@ -18,7 +18,7 @@ describe('GraphControlsPanel', () => {
 
     expect(screen.getByRole('checkbox', { name: 'Show enum nodes' })).not.toBeChecked();
     expect(screen.getByRole('checkbox', { name: 'Show stdlib nodes' })).not.toBeChecked();
-    expect(screen.getByRole('checkbox', { name: 'Edge labels' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Edge labels' })).not.toBeChecked();
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Show enum nodes' }));
     fireEvent.click(screen.getByRole('checkbox', { name: 'Show stdlib nodes' }));
@@ -27,7 +27,7 @@ describe('GraphControlsPanel', () => {
     expect(useGraphLayoutStore.getState().graphLayout).toMatchObject({
       showEnums: true,
       showStdlib: true,
-      showEdgeLabels: false,
+      showEdgeLabels: true,
     });
   });
 

--- a/packages/core/src/emit-convex-relationships.ts
+++ b/packages/core/src/emit-convex-relationships.ts
@@ -7,6 +7,7 @@ interface Relationship {
   fromType: string;
   fromTable: string;
   fromField: string;
+  fromPath: string[];
   toType: string;
   toTable: string;
   cardinality: 'one' | 'many';
@@ -46,6 +47,7 @@ function relationshipType(): string {
   fromType: string;
   fromTable: string;
   fromField: string;
+  fromPath: string[];
   toType: string;
   toTable: string;
   cardinality: 'one' | 'many';
@@ -65,30 +67,99 @@ function collectRelationships(schema: Schema): Relationship[] {
   for (const owner of objects) {
     if (owner.table !== true) continue;
     for (const field of owner.fields) {
-      const ref = unwrapRef(field.type);
-      if (!ref) continue;
-      const target = byName.get(ref.typeName);
-      if (!target || target.table !== true) continue;
-      const relationship = ref.relationship;
-      const ownership = relationship?.ownership;
-      relationships.push({
-        name: relationship?.name ?? `${owner.name}.${field.name}`,
-        fromType: owner.name,
-        fromTable: tableName(owner),
-        fromField: field.name,
-        toType: target.name,
-        toTable: tableName(target),
-        cardinality: ref.cardinality,
+      collectRelationshipsForType({
+        root: owner,
+        type: field.type,
+        byName,
+        relationships,
+        path: [field.name],
+        cardinality: 'one',
         optional: field.optional === true,
         nullable: field.nullable === true,
-        onDelete: relationship?.onDelete ?? 'none',
-        ownershipScopeField: ownership?.scopeField ?? null,
-        targetOwnershipScopeField: ownership?.targetScopeField ?? ownership?.scopeField ?? null,
+        visitedEmbeds: new Set([owner.name]),
       });
     }
   }
 
   return relationships.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function collectRelationshipsForType(args: {
+  root: ObjectType;
+  type: FieldType;
+  byName: ReadonlyMap<string, ObjectType>;
+  relationships: Relationship[];
+  path: string[];
+  cardinality: 'one' | 'many';
+  optional: boolean;
+  nullable: boolean;
+  visitedEmbeds: ReadonlySet<string>;
+}): void {
+  const {
+    root,
+    type,
+    byName,
+    relationships,
+    path,
+    cardinality,
+    optional,
+    nullable,
+    visitedEmbeds,
+  } = args;
+
+  if (type.kind === 'array') {
+    collectRelationshipsForType({
+      ...args,
+      type: type.element,
+      path: [...path, '[]'],
+      cardinality: 'many',
+    });
+    return;
+  }
+
+  if (type.kind !== 'ref') return;
+
+  const target = byName.get(type.typeName);
+  if (!target) return;
+
+  if (target.table === true) {
+    const relationship = type.relationship;
+    const ownership = relationship?.ownership;
+    const fromField = leafField(path);
+    relationships.push({
+      name: relationship?.name ?? `${root.name}.${formatPath(path)}`,
+      fromType: root.name,
+      fromTable: tableName(root),
+      fromField,
+      fromPath: path,
+      toType: target.name,
+      toTable: tableName(target),
+      cardinality,
+      optional,
+      nullable,
+      onDelete: relationship?.onDelete ?? 'none',
+      ownershipScopeField: ownership?.scopeField ?? null,
+      targetOwnershipScopeField: ownership?.targetScopeField ?? ownership?.scopeField ?? null,
+    });
+    return;
+  }
+
+  if (visitedEmbeds.has(target.name)) return;
+  const nextVisited = new Set(visitedEmbeds);
+  nextVisited.add(target.name);
+  for (const field of target.fields) {
+    collectRelationshipsForType({
+      root,
+      type: field.type,
+      byName,
+      relationships,
+      path: [...path, field.name],
+      cardinality,
+      optional: optional || field.optional === true,
+      nullable: nullable || field.nullable === true,
+      visitedEmbeds: nextVisited,
+    });
+  }
 }
 
 function assertionHelpers(relationships: Relationship[]): string[] {
@@ -111,10 +182,9 @@ function assertionHelpers(relationships: Relationship[]): string[] {
     `  relationship: ContextureRelationship,`,
     `  input: ContextureSource,`,
     `): Promise<void> {`,
-    `  const value = input[relationship.fromField];`,
-    `  if (value === undefined || value === null) return;`,
-    `  const ids = Array.isArray(value) ? value : [value];`,
+    `  const ids = collectContexturePathValues(input, relationship.fromPath);`,
     `  for (const id of ids) {`,
+    `    if (id === undefined || id === null) continue;`,
     `    if (typeof id !== 'string') {`,
     `      throw new Error(\`\${relationship.fromField} must be a Convex document id string.\`);`,
     `    }`,
@@ -129,6 +199,21 @@ function assertionHelpers(relationships: Relationship[]): string[] {
     `      throw new Error(\`\${relationship.fromField} must reference a \${relationship.toTable} document in the same \${relationship.ownershipScopeField} scope.\`);`,
     `    }`,
     `  }`,
+    `}`,
+    '',
+    `function collectContexturePathValues(value: unknown, path: readonly string[]): unknown[] {`,
+    `  if (path.length === 0) return [value];`,
+    `  const [segment, ...rest] = path;`,
+    `  if (segment === '[]') {`,
+    `    if (!Array.isArray(value)) return [];`,
+    `    return value.flatMap((item) => collectContexturePathValues(item, rest));`,
+    `  }`,
+    `  if (!isContextureRecord(value)) return [];`,
+    `  return collectContexturePathValues(value[segment], rest);`,
+    `}`,
+    '',
+    `function isContextureRecord(value: unknown): value is Record<string, unknown> {`,
+    `  return typeof value === 'object' && value !== null && !Array.isArray(value);`,
     `}`,
   ];
 
@@ -167,26 +252,16 @@ function deleteHelpers(relationships: Relationship[]): string[] {
   return lines;
 }
 
-function unwrapRef(type: FieldType): {
-  typeName: string;
-  relationship: Extract<FieldType, { kind: 'ref' }>['relationship'];
-  cardinality: 'one' | 'many';
-} | null {
-  if (type.kind === 'ref') {
-    return { typeName: type.typeName, relationship: type.relationship, cardinality: 'one' };
-  }
-  if (type.kind === 'array' && type.element.kind === 'ref') {
-    return {
-      typeName: type.element.typeName,
-      relationship: type.element.relationship,
-      cardinality: 'many',
-    };
-  }
-  return null;
-}
-
 function isObjectType(type: TypeDef): type is ObjectType {
   return type.kind === 'object';
+}
+
+function leafField(path: readonly string[]): string {
+  return [...path].reverse().find((segment) => segment !== '[]') ?? '';
+}
+
+function formatPath(path: readonly string[]): string {
+  return path.join('.');
 }
 
 function tableName(type: ObjectType): string {

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -212,9 +212,12 @@ function checkRefs(schema: Schema, catalog?: StdlibCatalog): SemanticIssueDraft[
     fieldName: string,
     fieldOptional: boolean,
     fieldNullable: boolean,
+    checkRefResolution: boolean,
+    validateRelationship: boolean,
+    visitedEmbeds: ReadonlySet<string>,
   ): void => {
     if (t.kind === 'ref') {
-      if (!resolves(t.typeName, localNames, aliases, catalog)) {
+      if (checkRefResolution && !resolves(t.typeName, localNames, aliases, catalog)) {
         issues.push({
           code: 'unresolved_ref',
           path,
@@ -222,19 +225,54 @@ function checkRefs(schema: Schema, catalog?: StdlibCatalog): SemanticIssueDraft[
           hint: hintForUnresolvedRef(t.typeName, catalog),
         });
       }
-      issues.push(
-        ...checkRelationshipMetadata(
-          t,
-          path,
-          owner,
-          fieldName,
-          fieldOptional,
-          fieldNullable,
-          localTypes,
-        ),
-      );
+      if (validateRelationship) {
+        issues.push(
+          ...checkRelationshipMetadata(
+            t,
+            path,
+            owner,
+            fieldName,
+            fieldOptional,
+            fieldNullable,
+            localTypes,
+          ),
+        );
+      }
+      const target = localTypes.get(t.typeName);
+      if (
+        validateRelationship &&
+        target?.kind === 'object' &&
+        target.table !== true &&
+        !visitedEmbeds.has(target.name)
+      ) {
+        const nextVisited = new Set(visitedEmbeds);
+        nextVisited.add(target.name);
+        target.fields.forEach((field, fieldIndex) => {
+          walk(
+            field.type,
+            `${path}.fields.${fieldIndex}.type`,
+            owner,
+            field.name,
+            fieldOptional || field.optional === true,
+            fieldNullable || field.nullable === true,
+            false,
+            true,
+            nextVisited,
+          );
+        });
+      }
     } else if (t.kind === 'array') {
-      walk(t.element, `${path}.element`, owner, fieldName, fieldOptional, fieldNullable);
+      walk(
+        t.element,
+        `${path}.element`,
+        owner,
+        fieldName,
+        fieldOptional,
+        fieldNullable,
+        checkRefResolution,
+        validateRelationship,
+        visitedEmbeds,
+      );
     }
   };
 
@@ -248,6 +286,9 @@ function checkRefs(schema: Schema, catalog?: StdlibCatalog): SemanticIssueDraft[
         f.name,
         f.optional === true,
         f.nullable === true,
+        true,
+        type.table === true,
+        new Set([type.name]),
       );
     });
   });

--- a/packages/core/tests/emit-convex-relationships.test.ts
+++ b/packages/core/tests/emit-convex-relationships.test.ts
@@ -46,10 +46,64 @@ describe('emitConvexRelationships', () => {
     expect(out).toContain('Source: plantry.contexture.json');
     expect(out).toContain('"fromTable": "mealPlanMeal"');
     expect(out).toContain('"fromField": "recipeId"');
+    expect(out).toContain('"fromPath": [\n      "recipeId"\n    ]');
     expect(out).toContain('"toTable": "recipe"');
     expect(out).toContain('"onDelete": "restrict"');
     expect(out).toContain('export async function assertContextureRefs');
     expect(out).toContain('export async function deleteWithContextureRelations');
+    expect(parses(out)).toBe(true);
+  });
+
+  it('registers refs inside embedded object paths from each root table', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Ingredient',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'string' } }],
+        },
+        {
+          kind: 'object',
+          name: 'RecipeIngredient',
+          fields: [{ name: 'ingredientId', type: { kind: 'ref', typeName: 'Ingredient' } }],
+        },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'string' } },
+            {
+              name: 'ingredients',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'RecipeIngredient' } },
+            },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'PantryItem',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'string' } },
+            { name: 'ingredient', type: { kind: 'ref', typeName: 'RecipeIngredient' } },
+          ],
+        },
+      ],
+    };
+
+    const out = emitConvexRelationships(schema);
+
+    expect(out).toContain('"name": "Recipe.ingredients.[].ingredientId"');
+    expect(out).toContain('"fromTable": "recipe"');
+    expect(out).toContain('"fromField": "ingredientId"');
+    expect(out).toContain(
+      '"fromPath": [\n      "ingredients",\n      "[]",\n      "ingredientId"\n    ]',
+    );
+    expect(out).toContain('"name": "PantryItem.ingredient.ingredientId"');
+    expect(out).toContain('"fromPath": [\n      "ingredient",\n      "ingredientId"\n    ]');
+    expect(out).toContain('collectContexturePathValues(input, relationship.fromPath)');
     expect(parses(out)).toBe(true);
   });
 

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Schema } from '../src/ir';
+import type { FieldType, Schema } from '../src/ir';
 import { checkSemantic, type StdlibCatalog } from '../src/semantic-validation';
 
 const STDLIB: StdlibCatalog = {
@@ -460,6 +460,65 @@ describe('checkSemantic — refs', () => {
     ]);
     expect(JSON.stringify(warnings)).not.toContain('createdAt');
     expect(JSON.stringify(warnings)).not.toContain('updatedAt');
+  });
+
+  it('warns for embedded table refs using the root table tenant axis', () => {
+    const schemaFor = (
+      relationship?: Extract<FieldType, { kind: 'ref' }>['relationship'],
+    ): Schema => ({
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Ingredient',
+          table: true,
+          fields: [{ name: 'householdId', type: { kind: 'string' } }],
+        },
+        {
+          kind: 'object',
+          name: 'RecipeIngredient',
+          fields: [
+            {
+              name: 'ingredientId',
+              type: { kind: 'ref', typeName: 'Ingredient', relationship },
+            },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'string' } },
+            {
+              name: 'ingredients',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'RecipeIngredient' } },
+            },
+          ],
+        },
+      ],
+    });
+
+    const warnings = checkSemantic(schemaFor(), STDLIB).filter(
+      (issue) => issue.code === 'relationship_ownership_scope_missing',
+    );
+
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        path: 'types.2.fields.1.type.element.fields.0.type.relationship.ownership',
+        message: expect.stringContaining('Recipe.ingredientId -> ingredient'),
+        hint: expect.stringContaining('scopeField: "householdId"'),
+      }),
+    ]);
+
+    for (const relationship of [
+      { ownership: { scopeField: 'householdId' } },
+      { crossScope: true },
+    ] as const) {
+      expect(
+        checkSemantic(schemaFor(relationship), STDLIB).map((issue) => issue.code),
+      ).not.toContain('relationship_ownership_scope_missing');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- walk table-root field trees when generating Convex relationships so refs inside embedded objects and arrays are registered
- add fromPath metadata while preserving fromField for existing callers/display
- teach assertContextureRefs to traverse fromPath, including array hops marked as []
- extend semantic validation so embedded table refs use the enclosing root table for ownership warnings and suppression
- bump desktop app version to 0.15.40

## Verification
- bun run test -- tests/semantic-validation.test.ts tests/emit-convex-relationships.test.ts (packages/core)
- Plantry emitted relationships smoke via source: embedded refs include Recipe.ingredients.[].ingredientId, MealPlan.meals.[].recipeId, ShoppingList.items.[].sourceRecipeIds.[]
- bun run build:mcp-cli (apps/desktop)
- compiled MCP emit smoke on temp Plantry IR reports mcp.version 0.15.40 and embedded relationship paths
- bun run check
- bun run typecheck
- commit hook: turbo typecheck and turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783080123&installation_id=136251083&pr_number=367&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F367&signature=35fb513d2e125223cd36cf2c0bbe70ac01d5a5709c9769a338206a8f4f7a8088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->