### PR TITLE
Document occurrence-based identity for reused embedded relationships

### DIFF
--- a/packages/core/src/emit-convex-relationships.ts
+++ b/packages/core/src/emit-convex-relationships.ts
@@ -18,6 +18,11 @@ interface Relationship {
   targetOwnershipScopeField: string | null;
 }
 
+// Relationship identity is occurrence-based, not local-field-based.
+// Reused embedded object types can produce multiple relationships with the
+// same fromField. Consumers should key on relationship.name, or on
+// fromTable + fromPath + toTable.
+
 function banner(sourcePath?: string): string {
   const base = '// @contexture-generated — do not edit by hand. Regenerated on every IR save.';
   return sourcePath ? `${base} Source: ${sourcePath}` : base;

--- a/packages/core/tests/emit-convex-relationships.test.ts
+++ b/packages/core/tests/emit-convex-relationships.test.ts
@@ -7,6 +7,19 @@ function parses(source: string): boolean {
   return (sf as unknown as { parseDiagnostics: ts.Diagnostic[] }).parseDiagnostics.length === 0;
 }
 
+function emittedRelationships(source: string): Array<{
+  name: string;
+  fromTable: string;
+  fromField: string;
+  fromPath: string[];
+  toTable: string;
+}> {
+  const match = source.match(/export const relationships = (\[[\s\S]*?\]) as const/);
+  const json = match?.[1];
+  if (!json) return [];
+  return JSON.parse(json);
+}
+
 describe('emitConvexRelationships', () => {
   it('emits relationship metadata and generic app-layer helpers for table refs', () => {
     const schema: Schema = {
@@ -104,6 +117,70 @@ describe('emitConvexRelationships', () => {
     expect(out).toContain('"name": "PantryItem.ingredient.ingredientId"');
     expect(out).toContain('"fromPath": [\n      "ingredient",\n      "ingredientId"\n    ]');
     expect(out).toContain('collectContexturePathValues(input, relationship.fromPath)');
+    expect(parses(out)).toBe(true);
+  });
+
+  it('keeps reused embedded ref occurrences distinct by name and path', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Ingredient',
+          table: true,
+          fields: [],
+        },
+        {
+          kind: 'object',
+          name: 'FoodPreference',
+          fields: [{ name: 'ingredientId', type: { kind: 'ref', typeName: 'Ingredient' } }],
+        },
+        {
+          kind: 'object',
+          name: 'Household',
+          table: true,
+          fields: [
+            {
+              name: 'preferences',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'FoodPreference' } },
+            },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'HouseholdMember',
+          table: true,
+          fields: [
+            {
+              name: 'preferences',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'FoodPreference' } },
+            },
+          ],
+        },
+      ],
+    };
+
+    const out = emitConvexRelationships(schema);
+    const relationships = emittedRelationships(out);
+
+    expect(relationships).toEqual([
+      expect.objectContaining({
+        name: 'Household.preferences.[].ingredientId',
+        fromTable: 'household',
+        fromField: 'ingredientId',
+        fromPath: ['preferences', '[]', 'ingredientId'],
+        toTable: 'ingredient',
+      }),
+      expect.objectContaining({
+        name: 'HouseholdMember.preferences.[].ingredientId',
+        fromTable: 'householdMember',
+        fromField: 'ingredientId',
+        fromPath: ['preferences', '[]', 'ingredientId'],
+        toTable: 'ingredient',
+      }),
+    ]);
+    expect(new Set(relationships.map((relationship) => relationship.name)).size).toBe(2);
+    expect(new Set(relationships.map((relationship) => relationship.fromField)).size).toBe(1);
     expect(parses(out)).toBe(true);
   });
 


### PR DESCRIPTION
### Summary
- Clarify that generated relationship identity is occurrence-based, not just `fromType.fromField`.
- Add a regression test covering reused embedded refs so the same leaf field under different table roots stays distinct by `name`, `fromTable`, and `fromPath`.
- Leave emitter behavior unchanged, but document the contract for future canvas and edge consumers.

### Testing
- Added a focused core test for the reused embedded `FoodPreference` case.
- `bun run check` and `bun run typecheck` passed.
- Full repo test/typecheck validation passed via the commit hook.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783083675&installation_id=136251083&pr_number=368&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F368&signature=af7175557dea61ce8990c3937ffa8cdaec77ab6340479aefa00f9cb1df0c0d94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->