### PR TITLE
feat: add field derivation policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ apps/desktop/build/bin/
 
 # Sensitive docs migrated to Paperclip issue documents (ONT-49)
 Marketing/
+
+# Scratch files for testing
+scratch/

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,3 @@ apps/desktop/build/bin/
 
 # Sensitive docs migrated to Paperclip issue documents (ONT-49)
 Marketing/
-
-# Scatch files for testing
-Scratch

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ apps/desktop/build/bin/
 
 # Sensitive docs migrated to Paperclip issue documents (ONT-49)
 Marketing/
+
+# Scatch files for testing
+Scratch

--- a/apps/desktop/src/renderer/src/components/detail/DetailPanel.stories.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/DetailPanel.stories.tsx
@@ -18,6 +18,16 @@ const tableType: Extract<TypeDef, { kind: 'object' }> = {
     { name: 'status', type: { kind: 'string' } },
     { name: 'partySize', type: { kind: 'number', int: true } },
     { name: 'requestedDates', type: { kind: 'array', element: { kind: 'date' } }, optional: true },
+    {
+      name: 'nutrition',
+      type: { kind: 'string' },
+      serverDerived: true,
+      derivation: {
+        kind: 'computed',
+        sources: ['menuItems[].grams', 'Ingredient.nutrition'],
+        owner: 'backend',
+      },
+    },
   ],
   indexes: [
     { name: 'by_customerId', fields: ['customerId'] },
@@ -64,8 +74,14 @@ const hints: ModelingHint[] = [
 ];
 
 const selectedField: FieldDef = {
-  name: 'customerId',
-  type: { kind: 'ref', typeName: 'Customer' },
+  name: 'nutrition',
+  type: { kind: 'string' },
+  serverDerived: true,
+  derivation: {
+    kind: 'computed',
+    sources: ['menuItems[].grams', 'Ingredient.nutrition'],
+    owner: 'backend',
+  },
 };
 
 function StoryFrame({ children }: { children: React.ReactNode }) {

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -11,12 +11,13 @@
  * nothing here mutates the store directly.
  */
 
+import { derivationKindLabel } from '@contexture/core/derivation';
 import {
   type FixtureValueType,
   listFixtureGenerators,
   listFixtureModules,
 } from '@contexture/core/fixture-generators';
-import type { FieldDef, FieldType, IndexDef } from '@contexture/core/ir';
+import type { DerivationPolicy, FieldDef, FieldType, IndexDef } from '@contexture/core/ir';
 import type { ModelingHint } from '@contexture/core/modeling-hints';
 import { TYPE_NODE_REF_PREVIEW_EVENT } from '@renderer/components/graph/ref-preview-event';
 import type { ValidationError } from '@renderer/services/validation';
@@ -159,9 +160,18 @@ export function FieldDetail({
                 nullable
               </Badge>
             )}
-            {field.serverDerived && (
+            {field.serverDerived && !field.derivation && (
               <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
                 server derived
+              </Badge>
+            )}
+            {field.derivation && (
+              <Badge
+                variant="outline"
+                className="h-5 rounded-md px-1.5 text-[11px]"
+                style={toneSurfaceStyle(derivationTone(field.derivation), 14, 50)}
+              >
+                {derivationKindLabel(field.derivation.kind)}
               </Badge>
             )}
             {primaryIndex && (
@@ -233,6 +243,7 @@ export function FieldDetail({
           <Separator />
 
           <PresenceRow field={field} update={update} />
+          <DerivationRow field={field} update={update} />
           <DescriptionRow field={field} update={update} />
           <DefaultValueRow field={field} update={update} />
 
@@ -283,13 +294,193 @@ function PresenceRow({
           checked={field.nullable === true}
           onCheckedChange={(v) => update({ nullable: v === true })}
         />
-        <CheckboxOption
-          id="field-server-derived"
-          label="Server derived"
-          description="Computed by backend"
-          checked={field.serverDerived === true}
-          onCheckedChange={(v) => update({ serverDerived: v === true ? true : undefined })}
-        />
+      </div>
+    </InspectorRow>
+  );
+}
+
+function DerivationRow({
+  field,
+  update,
+}: {
+  field: FieldDef;
+  update: (patch: Partial<FieldDef>) => void;
+}) {
+  const derivation = field.derivation;
+  const mode = derivation?.kind ?? 'stored';
+  const summary = derivationSummary(derivation);
+  return (
+    <InspectorRow label="Derivation">
+      <div className="min-w-0 flex-1 space-y-2">
+        <div className="grid gap-2 sm:grid-cols-2">
+          <Field>
+            <FieldLabel htmlFor="field-derivation-kind">Mode</FieldLabel>
+            <Select
+              value={mode}
+              onValueChange={(value) => {
+                if (value === 'stored') {
+                  update({ derivation: undefined, serverDerived: undefined });
+                  return;
+                }
+                const kind = value as DerivationPolicy['kind'];
+                update({
+                  derivation: {
+                    ...defaultDerivation(kind),
+                    ...derivation,
+                    kind,
+                  },
+                  serverDerived:
+                    (derivation?.owner ?? defaultDerivation(kind).owner) === 'backend'
+                      ? true
+                      : undefined,
+                });
+              }}
+            >
+              <SelectTrigger id="field-derivation-kind" className="h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="stored">Stored input</SelectItem>
+                <SelectItem value="computed">Computed</SelectItem>
+                <SelectItem value="cachedHandle">Cached handle</SelectItem>
+                <SelectItem value="snapshot">Snapshot</SelectItem>
+                <SelectItem value="rollup">Rollup</SelectItem>
+                <SelectItem value="estimate">Estimate</SelectItem>
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="field-derivation-owner">Owner</FieldLabel>
+            <Select
+              value={derivation?.owner ?? (field.serverDerived ? 'backend' : 'client')}
+              disabled={!derivation}
+              onValueChange={(value) => {
+                if (!derivation) return;
+                const owner = value as NonNullable<DerivationPolicy['owner']>;
+                update({
+                  derivation: { ...derivation, owner },
+                  serverDerived: owner === 'backend' ? true : undefined,
+                });
+              }}
+            >
+              <SelectTrigger id="field-derivation-owner" className="h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="backend">Backend only</SelectItem>
+                <SelectItem value="client">Client writable</SelectItem>
+                <SelectItem value="external">External system</SelectItem>
+              </SelectContent>
+            </Select>
+          </Field>
+        </div>
+        <p className="text-xs leading-5 text-muted-foreground">{summary}</p>
+        {derivation && (
+          <div className="grid gap-2 sm:grid-cols-2">
+            <Field className="sm:col-span-2">
+              <FieldLabel htmlFor="field-derivation-sources">Sources</FieldLabel>
+              <Input
+                id="field-derivation-sources"
+                className="h-8 text-xs"
+                placeholder="ingredients[].grams, Ingredient.allergens"
+                defaultValue={(derivation.sources ?? []).join(', ')}
+                onBlur={(ev) =>
+                  update({
+                    derivation: {
+                      ...derivation,
+                      sources: parseSourceList(ev.target.value),
+                    },
+                  })
+                }
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="field-derivation-refresh">Refresh</FieldLabel>
+              <Select
+                value={derivation.refresh ?? 'none'}
+                onValueChange={(value) =>
+                  update({
+                    derivation: {
+                      ...derivation,
+                      refresh:
+                        value === 'none' ? undefined : (value as DerivationPolicy['refresh']),
+                    },
+                  })
+                }
+              >
+                <SelectTrigger id="field-derivation-refresh" className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Not declared</SelectItem>
+                  <SelectItem value="onWrite">On write</SelectItem>
+                  <SelectItem value="asyncJob">Async job</SelectItem>
+                  <SelectItem value="onRead">On read</SelectItem>
+                  <SelectItem value="manual">Manual</SelectItem>
+                  <SelectItem value="frozen">Frozen</SelectItem>
+                  <SelectItem value="external">External</SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="field-derivation-drift">Drift policy</FieldLabel>
+              <Select
+                value={derivation.driftPolicy ?? 'none'}
+                onValueChange={(value) =>
+                  update({
+                    derivation: {
+                      ...derivation,
+                      driftPolicy:
+                        value === 'none' ? undefined : (value as DerivationPolicy['driftPolicy']),
+                    },
+                  })
+                }
+              >
+                <SelectTrigger id="field-derivation-drift" className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Not declared</SelectItem>
+                  <SelectItem value="mustMatch">Must match</SelectItem>
+                  <SelectItem value="eventual">Eventually consistent</SelectItem>
+                  <SelectItem value="allowed">Allowed</SelectItem>
+                  <SelectItem value="warnWhenStale">Warn when stale</SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="field-derivation-stale">Stale field</FieldLabel>
+              <Input
+                id="field-derivation-stale"
+                className="h-8 text-xs"
+                placeholder="isStale"
+                defaultValue={derivation.staleField ?? ''}
+                onBlur={(ev) =>
+                  update({
+                    derivation: { ...derivation, staleField: ev.target.value.trim() || undefined },
+                  })
+                }
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="field-derivation-confidence">Confidence field</FieldLabel>
+              <Input
+                id="field-derivation-confidence"
+                className="h-8 text-xs"
+                placeholder="confidence"
+                defaultValue={derivation.confidenceField ?? ''}
+                onBlur={(ev) =>
+                  update({
+                    derivation: {
+                      ...derivation,
+                      confidenceField: ev.target.value.trim() || undefined,
+                    },
+                  })
+                }
+              />
+            </Field>
+          </div>
+        )}
       </div>
     </InspectorRow>
   );
@@ -1326,6 +1517,54 @@ function parseDefaultInput(value: string, fieldType: FieldType): unknown {
     case 'ref':
       return value;
   }
+}
+
+function defaultDerivation(kind: DerivationPolicy['kind']): DerivationPolicy {
+  switch (kind) {
+    case 'computed':
+    case 'cachedHandle':
+    case 'rollup':
+    case 'estimate':
+      return { kind, owner: 'backend' };
+    case 'snapshot':
+      return { kind, owner: 'backend', refresh: 'frozen', driftPolicy: 'allowed' };
+  }
+}
+
+function derivationSummary(derivation: DerivationPolicy | undefined): string {
+  if (!derivation) return 'Stored directly. No derivation policy.';
+  switch (derivation.kind) {
+    case 'computed':
+      return 'Computed from source fields. Recompute when sources change.';
+    case 'cachedHandle':
+      return 'Stored for querying over embedded or resolved data.';
+    case 'snapshot':
+      return 'Copied at write time. Does not update automatically.';
+    case 'rollup':
+      return 'Aggregated from related records. Needs a refresh policy.';
+    case 'estimate':
+      return 'Derived with uncertainty. Track confidence or coverage.';
+  }
+}
+
+function parseSourceList(value: string): string[] | undefined {
+  const sources = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return sources.length > 0 ? sources : undefined;
+}
+
+function derivationTone(derivation: DerivationPolicy): string {
+  if (
+    derivation.kind !== 'snapshot' &&
+    (derivation.sources?.length ?? 0) > 0 &&
+    !derivation.refresh &&
+    !derivation.driftPolicy
+  ) {
+    return 'var(--warning)';
+  }
+  return derivation.kind === 'snapshot' ? 'var(--success)' : 'var(--inspector-advisory)';
 }
 
 function fieldKindColor(fieldType: FieldType): string {

--- a/apps/desktop/src/renderer/src/components/detail/ModelShapeHints.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/ModelShapeHints.tsx
@@ -100,6 +100,7 @@ function toneForHint(kind: ModelingHint['kind']): CSSProperties {
         color: 'var(--inspector-advisory)',
       };
     case 'query_handle':
+    case 'derivation_policy':
       return {
         background: 'color-mix(in oklch, var(--graph-node-selected) 14%, transparent)',
         borderColor: 'color-mix(in oklch, var(--graph-node-selected) 55%, var(--foreground))',
@@ -132,6 +133,7 @@ function hintRank(hint: ModelingHint): number {
     case 'possible_entity':
       return 1;
     case 'query_handle':
+    case 'derivation_policy':
       return 2;
     case 'embedded_collection':
       return 3;

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -13,6 +13,7 @@
  * `blur` (not `change`) to avoid a history entry per keystroke.
  */
 
+import { derivationKindLabel } from '@contexture/core/derivation';
 import { listFixtureModules } from '@contexture/core/fixture-generators';
 import type { FieldDef, FieldType, IndexDef, Schema, TypeDef } from '@contexture/core/ir';
 import type { ModelingHint } from '@contexture/core/modeling-hints';
@@ -637,7 +638,10 @@ function ObjectBody({
                   />
                 </TableCell>
                 <TableCell className="px-2 py-1.5 text-right">
-                  <FieldKindPill fieldType={f.type} />
+                  <div className="inline-flex items-center justify-end gap-1">
+                    {f.derivation && <FieldDerivationPill field={f} />}
+                    <FieldKindPill fieldType={f.type} />
+                  </div>
                 </TableCell>
                 {showAdviceColumn && (
                   <TableCell className="w-14 px-1 py-1.5 text-center">
@@ -1427,6 +1431,7 @@ function suggestionReason(suggestion: SuggestedIndex): string {
 
 function isIndexSuggestionField(field: FieldDef): boolean {
   if (hasRef(field.type)) return true;
+  if (field.derivation?.kind === 'cachedHandle') return true;
   if (/(^|_)(kind|state|status|slug|key)$|name$|searchtext$|date$|at$|year$/iu.test(field.name)) {
     return true;
   }
@@ -1873,6 +1878,36 @@ function FieldKindPill({ fieldType }: { fieldType: FieldType }): React.JSX.Eleme
       {summariseKind(fieldType.kind)}
     </span>
   );
+}
+
+function FieldDerivationPill({ field }: { field: FieldDef }): React.JSX.Element | null {
+  if (!field.derivation) return null;
+  const color =
+    field.derivation.kind !== 'snapshot' &&
+    (field.derivation.sources?.length ?? 0) > 0 &&
+    !field.derivation.refresh &&
+    !field.derivation.driftPolicy
+      ? 'var(--warning)'
+      : 'var(--inspector-advisory)';
+  return (
+    <span
+      className="inline-flex items-center rounded border px-1.5 py-0.5 text-[11px] font-medium leading-none"
+      title={derivationPillTitle(field)}
+      style={toneSurfaceStyle(color, 13, 46)}
+    >
+      {derivationKindLabel(field.derivation.kind)}
+    </span>
+  );
+}
+
+function derivationPillTitle(field: FieldDef): string {
+  const derivation = field.derivation;
+  if (!derivation) return '';
+  if (derivation.kind === 'snapshot') return 'Copied at write time and intentionally frozen.';
+  if ((derivation.sources?.length ?? 0) > 0 && !derivation.refresh && !derivation.driftPolicy) {
+    return 'Drift risk: source data can change without a refresh or drift policy.';
+  }
+  return 'Derivation policy declared.';
 }
 
 function inspectorTypeColor(type: TypeDef): string {

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -310,6 +310,7 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         <span
           style={{
             flex: 1,
+            minWidth: 0,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
@@ -317,48 +318,58 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         >
           {data.typeName}
         </span>
-        {hasValidationIssues && (
-          <span
-            data-testid="type-node-validation-label"
-            role="img"
-            aria-label={`${data.validationIssueCount} validation ${
-              data.validationIssueCount === 1 ? 'issue' : 'issues'
-            }`}
-            title={`${data.validationIssueCount} validation ${
-              data.validationIssueCount === 1 ? 'issue' : 'issues'
-            }`}
-            style={{
-              flex: '0 0 auto',
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 2,
-              minWidth: 18,
-              height: 18,
-              borderRadius: 999,
-              background: 'color-mix(in oklch, var(--destructive) 24%, var(--background))',
-              color: 'var(--destructive-foreground)',
-              border: '1px solid color-mix(in oklch, var(--destructive) 60%, transparent)',
-              fontSize: 10,
-              fontWeight: 700,
-            }}
-          >
-            <CircleAlert aria-hidden="true" size={11} strokeWidth={2.4} />
-            {data.validationIssueCount && data.validationIssueCount > 1
-              ? data.validationIssueCount
-              : null}
-          </span>
-        )}
-        {data.table ? (
-          <NodeKindLabel
-            data-testid="type-node-table-label"
-            style={{ color: 'var(--graph-node-table-accent)', opacity: 1 }}
-          >
-            table
-          </NodeKindLabel>
-        ) : (
-          <NodeKindLabel>{nodeKindLabel}</NodeKindLabel>
-        )}
+        <span
+          style={{
+            flex: '0 0 auto',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            minWidth: 0,
+          }}
+        >
+          {hasValidationIssues && (
+            <span
+              data-testid="type-node-validation-label"
+              role="img"
+              aria-label={`${data.validationIssueCount} validation ${
+                data.validationIssueCount === 1 ? 'issue' : 'issues'
+              }`}
+              title={`${data.validationIssueCount} validation ${
+                data.validationIssueCount === 1 ? 'issue' : 'issues'
+              }`}
+              style={{
+                flex: '0 0 auto',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 2,
+                minWidth: 18,
+                height: 18,
+                borderRadius: 999,
+                background: 'color-mix(in oklch, var(--destructive) 24%, var(--background))',
+                color: 'var(--destructive-foreground)',
+                border: '1px solid color-mix(in oklch, var(--destructive) 60%, transparent)',
+                fontSize: 10,
+                fontWeight: 700,
+              }}
+            >
+              <CircleAlert aria-hidden="true" size={11} strokeWidth={2.4} />
+              {data.validationIssueCount && data.validationIssueCount > 1
+                ? data.validationIssueCount
+                : null}
+            </span>
+          )}
+          {data.table ? (
+            <NodeKindLabel
+              data-testid="type-node-table-label"
+              style={{ color: 'var(--graph-node-table-accent)', opacity: 1 }}
+            >
+              table
+            </NodeKindLabel>
+          ) : (
+            <NodeKindLabel>{nodeKindLabel}</NodeKindLabel>
+          )}
+        </span>
       </button>
 
       {data.fields.length > 0 && (

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -19,7 +19,7 @@
  * later slice.
  */
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
-import { CircleAlert, Focus, Table2 } from 'lucide-react';
+import { Focus, Table2 } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
@@ -318,58 +318,16 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
         >
           {data.typeName}
         </span>
-        <span
-          style={{
-            flex: '0 0 auto',
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 6,
-            minWidth: 0,
-          }}
-        >
-          {hasValidationIssues && (
-            <span
-              data-testid="type-node-validation-label"
-              role="img"
-              aria-label={`${data.validationIssueCount} validation ${
-                data.validationIssueCount === 1 ? 'issue' : 'issues'
-              }`}
-              title={`${data.validationIssueCount} validation ${
-                data.validationIssueCount === 1 ? 'issue' : 'issues'
-              }`}
-              style={{
-                flex: '0 0 auto',
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 2,
-                minWidth: 18,
-                height: 18,
-                borderRadius: 999,
-                background: 'color-mix(in oklch, var(--destructive) 24%, var(--background))',
-                color: 'var(--destructive-foreground)',
-                border: '1px solid color-mix(in oklch, var(--destructive) 60%, transparent)',
-                fontSize: 10,
-                fontWeight: 700,
-              }}
-            >
-              <CircleAlert aria-hidden="true" size={11} strokeWidth={2.4} />
-              {data.validationIssueCount && data.validationIssueCount > 1
-                ? data.validationIssueCount
-                : null}
-            </span>
-          )}
-          {data.table ? (
-            <NodeKindLabel
-              data-testid="type-node-table-label"
-              style={{ color: 'var(--graph-node-table-accent)', opacity: 1 }}
-            >
-              table
-            </NodeKindLabel>
-          ) : (
-            <NodeKindLabel>{nodeKindLabel}</NodeKindLabel>
-          )}
-        </span>
+        {data.table ? (
+          <NodeKindLabel
+            data-testid="type-node-table-label"
+            style={{ flex: '0 0 auto', color: 'var(--graph-node-table-accent)', opacity: 1 }}
+          >
+            table
+          </NodeKindLabel>
+        ) : (
+          <NodeKindLabel style={{ flex: '0 0 auto' }}>{nodeKindLabel}</NodeKindLabel>
+        )}
       </button>
 
       {data.fields.length > 0 && (

--- a/apps/desktop/tests/components/detail/FieldDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/FieldDetail.test.tsx
@@ -486,31 +486,64 @@ describe('FieldDetail', () => {
     });
   });
 
-  it('server-derived checkbox dispatches update_field', () => {
+  it('derivation mode marks computed fields as backend-owned', async () => {
     const { dispatch } = setup({ name: 'createdAt', type: { kind: 'date' } });
-    const serverDerived = screen.getByRole('checkbox', { name: 'Server derived' });
-    expect(serverDerived).toHaveAccessibleDescription('Computed by backend');
-    fireEvent.click(serverDerived);
+    expect(screen.getByText('Derivation')).toBeInTheDocument();
+    expect(screen.getByText('Stored directly. No derivation policy.')).toBeInTheDocument();
+
+    await chooseSelectOption('Mode', 'Computed');
+
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',
       fieldName: 'createdAt',
-      patch: { serverDerived: true },
+      patch: {
+        derivation: { kind: 'computed', owner: 'backend' },
+        serverDerived: true,
+      },
     });
   });
 
-  it('server-derived checkbox clears the marker when unchecked', () => {
+  it('stored input mode clears derivation and legacy server-derived marker', async () => {
     const { dispatch } = setup({
       name: 'createdAt',
       type: { kind: 'date' },
       serverDerived: true,
+      derivation: { kind: 'computed', owner: 'backend' },
     });
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Server derived' }));
+
+    await chooseSelectOption('Mode', 'Stored input');
+
     expect(dispatch).toHaveBeenCalledWith({
       kind: 'update_field',
       typeName: 'Plot',
       fieldName: 'createdAt',
-      patch: { serverDerived: undefined },
+      patch: { derivation: undefined, serverDerived: undefined },
+    });
+  });
+
+  it('edits derivation source paths', () => {
+    const { dispatch } = setup({
+      name: 'nutrition',
+      type: { kind: 'string' },
+      derivation: { kind: 'computed', owner: 'backend' },
+    });
+
+    const sources = screen.getByLabelText('Sources');
+    fireEvent.change(sources, { target: { value: 'ingredients[].grams, Ingredient.calories' } });
+    fireEvent.blur(sources);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      kind: 'update_field',
+      typeName: 'Plot',
+      fieldName: 'nutrition',
+      patch: {
+        derivation: {
+          kind: 'computed',
+          owner: 'backend',
+          sources: ['ingredients[].grams', 'Ingredient.calories'],
+        },
+      },
     });
   });
 

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -113,9 +113,7 @@ describe('TypeNode', () => {
     const field = screen.getByTestId('type-node-field');
 
     expect(node.dataset.validationIssues).toBe('true');
-    expect(screen.getByTestId('type-node-validation-label')).toHaveAccessibleName(
-      '1 validation issue',
-    );
+    expect(node).toHaveAttribute('title', '1 validation issue');
     expect(screen.getByTestId('type-node-validation-rail')).toBeInTheDocument();
     expect(field.dataset.validationIssues).toBe('true');
     expect(field.getAttribute('style')).toContain('inset 3px 0 0 var(--destructive)');

--- a/apps/desktop/tests/main/op-tools.test.ts
+++ b/apps/desktop/tests/main/op-tools.test.ts
@@ -265,6 +265,43 @@ describe('createOpTools', () => {
     });
   });
 
+  it('update_field forwards derivation policy patches', async () => {
+    const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
+    const { tools } = makeTools(forwardSpy as unknown as ForwardOp);
+    const updateField = toolNamed(tools, 'update_field');
+
+    await updateField.handler({
+      typeName: 'Recipe',
+      fieldName: 'nutrition',
+      patch: {
+        derivation: {
+          kind: 'computed',
+          sources: ['ingredients[].grams', 'Ingredient.calories'],
+          refresh: 'onWrite',
+          driftPolicy: 'mustMatch',
+          owner: 'backend',
+        },
+        serverDerived: true,
+      },
+    });
+
+    expect(forwardSpy.mock.calls[0][0]).toEqual({
+      kind: 'update_field',
+      typeName: 'Recipe',
+      fieldName: 'nutrition',
+      patch: {
+        derivation: {
+          kind: 'computed',
+          sources: ['ingredients[].grams', 'Ingredient.calories'],
+          refresh: 'onWrite',
+          driftPolicy: 'mustMatch',
+          owner: 'backend',
+        },
+        serverDerived: true,
+      },
+    });
+  });
+
   it('add_type lenient tool accepts a valid TypeDef payload and forwards the op', async () => {
     const forwardSpy = vi.fn(async (_op: Op) => ({ ok: true }) as const);
     const { tools } = makeTools(forwardSpy as unknown as ForwardOp);

--- a/apps/desktop/tests/model/ir.test.ts
+++ b/apps/desktop/tests/model/ir.test.ts
@@ -115,7 +115,7 @@ describe('IRSchema', () => {
     expect(nested.element.kind).toBe('array');
   });
 
-  it('accepts FieldDef optional/nullable/default/description/serverDerived', () => {
+  it('accepts FieldDef optional/nullable/default/description/serverDerived/derivation', () => {
     const input = {
       version: '1',
       types: [
@@ -131,6 +131,13 @@ describe('IRSchema', () => {
               nullable: true,
               default: 'anon',
               serverDerived: true,
+              derivation: {
+                kind: 'cachedHandle',
+                sources: ['displayName'],
+                refresh: 'onWrite',
+                driftPolicy: 'mustMatch',
+                owner: 'backend',
+              },
             },
           ],
         },
@@ -146,6 +153,13 @@ describe('IRSchema', () => {
       nullable: true,
       default: 'anon',
       serverDerived: true,
+      derivation: {
+        kind: 'cachedHandle',
+        sources: ['displayName'],
+        refresh: 'onWrite',
+        driftPolicy: 'mustMatch',
+        owner: 'backend',
+      },
     });
   });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
     ".": "./src/index.ts",
     "./agent-turn-ledger": "./src/agent-turn-ledger.ts",
     "./change-log": "./src/change-log.ts",
+    "./derivation": "./src/derivation.ts",
     "./emit-ai-tool-schemas": "./src/emit-ai-tool-schemas.ts",
     "./emit-convex": "./src/emit-convex.ts",
     "./emit-form-validators": "./src/emit-form-validators.ts",

--- a/packages/core/src/derivation.ts
+++ b/packages/core/src/derivation.ts
@@ -1,0 +1,20 @@
+import type { FieldDef } from './ir';
+
+export function fieldIsRuntimeDerived(field: FieldDef): boolean {
+  return field.serverDerived === true || field.derivation?.owner === 'backend';
+}
+
+export function derivationKindLabel(kind: NonNullable<FieldDef['derivation']>['kind']): string {
+  switch (kind) {
+    case 'computed':
+      return 'computed';
+    case 'cachedHandle':
+      return 'cache';
+    case 'snapshot':
+      return 'snapshot';
+    case 'rollup':
+      return 'rollup';
+    case 'estimate':
+      return 'estimate';
+  }
+}

--- a/packages/core/src/emit-form-validators.ts
+++ b/packages/core/src/emit-form-validators.ts
@@ -6,6 +6,8 @@
  * dependencies while still giving React Hook Form, TanStack Form, and custom
  * form code a stable `validate(value)` contract.
  */
+
+import { fieldIsRuntimeDerived } from './derivation';
 import type { Schema, TypeDef } from './ir';
 
 function header(sourcePath?: string): string {
@@ -30,7 +32,7 @@ export function emitFormValidators(
     .sort((a, b) => a.name.localeCompare(b.name))
     .map((type) => {
       const omitted = type.fields
-        .filter((field) => field.serverDerived === true)
+        .filter(fieldIsRuntimeDerived)
         .map((field) => `${field.name}: true`)
         .join(', ');
       return `export const ${type.name}CreateValidator = createFormValidator(${type.name}.omit({ ${omitted} }));\n`;
@@ -88,5 +90,5 @@ ${validators}${createValidators}`;
 type ObjectType = Extract<TypeDef, { kind: 'object' }>;
 
 function hasServerDerivedFields(type: TypeDef): type is ObjectType {
-  return type.kind === 'object' && type.fields.some((field) => field.serverDerived === true);
+  return type.kind === 'object' && type.fields.some(fieldIsRuntimeDerived);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from './agent-turn-ledger';
 export * from './change-log';
 export * from './chat-history';
 export * from './convex-capabilities';
+export * from './derivation';
 export * from './document-bundle';
 export { emitAiToolSchemas } from './emit-ai-tool-schemas';
 export { emitConvexSchema, emitConvexValidators } from './emit-convex';

--- a/packages/core/src/ir.ts
+++ b/packages/core/src/ir.ts
@@ -61,6 +61,18 @@ const SampleDataHintSchema = z.object({
 
 export type SampleDataHint = z.infer<typeof SampleDataHintSchema>;
 
+const DerivationPolicySchema = z.object({
+  kind: z.enum(['computed', 'cachedHandle', 'snapshot', 'rollup', 'estimate']),
+  sources: z.array(z.string().min(1)).optional(),
+  refresh: z.enum(['onWrite', 'asyncJob', 'onRead', 'manual', 'frozen', 'external']).optional(),
+  driftPolicy: z.enum(['mustMatch', 'eventual', 'allowed', 'warnWhenStale']).optional(),
+  owner: z.enum(['backend', 'client', 'external']).optional(),
+  staleField: z.string().min(1).optional(),
+  confidenceField: z.string().min(1).optional(),
+});
+
+export type DerivationPolicy = z.infer<typeof DerivationPolicySchema>;
+
 // Recursive discriminated union: `array.element` refers back to `FieldType`.
 // The explicit `z.ZodType<FieldType>` annotation breaks the circularity for
 // TypeScript; the `FieldType` itself is inferred further down.
@@ -105,6 +117,7 @@ export const FieldDefSchema = z.object({
   nullable: z.boolean().optional(),
   default: z.unknown().optional(),
   serverDerived: z.boolean().optional(),
+  derivation: DerivationPolicySchema.optional(),
   sampleData: SampleDataHintSchema.optional(),
 });
 

--- a/packages/core/src/modeling-hints.ts
+++ b/packages/core/src/modeling-hints.ts
@@ -1,3 +1,4 @@
+import { derivationKindLabel } from './derivation';
 import type { FieldDef, FieldType, Schema, TypeDef } from './ir';
 
 export const MODELING_HINT_ANALYZER_VERSION = 1;
@@ -6,6 +7,7 @@ export type ModelingHintKind =
   | 'owned_value_object'
   | 'possible_entity'
   | 'query_handle'
+  | 'derivation_policy'
   | 'embedded_collection'
   | 'stdlib_type'
   | 'stringly_ref';
@@ -13,6 +15,7 @@ export type ModelingHintKind =
 export type ModelingSignal =
   | 'identity_pressure'
   | 'query_pressure'
+  | 'derivation_pressure'
   | 'embedded_collection_pressure'
   | 'lifecycle_pressure'
   | 'relationship_pressure';
@@ -104,6 +107,9 @@ export function analyzeModelingHints(schema: Schema): ModelingHint[] {
         hints.push(queryHandleHint(type, field, fieldPath));
       }
 
+      const derivationHint = fieldDerivationHint(type, field, fieldPath);
+      if (derivationHint) hints.push(derivationHint);
+
       const stdlibHint = stdlibTypeHint(type, field, fieldPath);
       if (stdlibHint) hints.push(stdlibHint);
 
@@ -113,6 +119,75 @@ export function analyzeModelingHints(schema: Schema): ModelingHint[] {
   });
 
   return hints;
+}
+
+function fieldDerivationHint(type: ObjectType, field: FieldDef, path: string): ModelingHint | null {
+  const derivation = field.derivation;
+  if (!derivation) return null;
+
+  const label = derivationKindLabel(derivation.kind);
+  const sourceCount = derivation.sources?.length ?? 0;
+  if (derivation.kind === 'snapshot') {
+    return {
+      id: hintId('derivation_policy', type.name, field.name, [derivation.kind]),
+      kind: 'derivation_policy',
+      signals: ['derivation_pressure'],
+      path,
+      typeName: type.name,
+      fieldName: field.name,
+      title: 'Snapshot field',
+      message: `${field.name} is a frozen snapshot. Drift is expected unless the product needs a stale indicator.`,
+      rationale:
+        'Snapshots preserve historical context, so Contexture should document intent instead of warning by default.',
+      fieldNames: [field.name],
+    };
+  }
+
+  if (sourceCount === 0) {
+    return {
+      id: hintId('derivation_policy', type.name, field.name, [derivation.kind, 'sources']),
+      kind: 'derivation_policy',
+      signals: ['derivation_pressure'],
+      path,
+      typeName: type.name,
+      fieldName: field.name,
+      title: 'Derivation source missing',
+      message: `${field.name} is marked as a ${label}, but no source fields are declared.`,
+      rationale:
+        'Source fields make invalidation and backfill responsibilities visible to app code reviewers.',
+      fieldNames: [field.name],
+    };
+  }
+
+  if (!derivation.refresh && !derivation.driftPolicy) {
+    return {
+      id: hintId('derivation_policy', type.name, field.name, [derivation.kind, 'refresh']),
+      kind: 'derivation_policy',
+      signals: ['derivation_pressure', 'lifecycle_pressure'],
+      path,
+      typeName: type.name,
+      fieldName: field.name,
+      title: 'Drift policy missing',
+      message: `${field.name} is stored from ${sourceCount} ${sourceCount === 1 ? 'source' : 'sources'} without a refresh or drift policy.`,
+      rationale:
+        'A stored derived value needs an explicit recompute cadence, stale behavior, or intentional drift policy.',
+      fieldNames: [field.name],
+    };
+  }
+
+  return {
+    id: hintId('derivation_policy', type.name, field.name, [derivation.kind, 'declared']),
+    kind: 'derivation_policy',
+    signals: ['derivation_pressure'],
+    path,
+    typeName: type.name,
+    fieldName: field.name,
+    title: 'Derivation policy',
+    message: `${field.name} is a ${label} with declared source and freshness policy.`,
+    rationale:
+      'Documented derivation lets Contexture surface intent without treating normal denormalization as a bug.',
+    fieldNames: [field.name],
+  };
 }
 
 function stringlyRefHint(

--- a/packages/core/src/op-tools.ts
+++ b/packages/core/src/op-tools.ts
@@ -117,6 +117,21 @@ const FieldDefSchema = z.object({
   optional: z.boolean().optional(),
   nullable: z.boolean().optional(),
   default: z.unknown().optional(),
+  serverDerived: z.boolean().optional(),
+  derivation: z
+    .object({
+      kind: z.enum(['computed', 'cachedHandle', 'snapshot', 'rollup', 'estimate']),
+      sources: z.array(z.string().min(1)).optional(),
+      refresh: z.enum(['onWrite', 'asyncJob', 'onRead', 'manual', 'frozen', 'external']).optional(),
+      driftPolicy: z.enum(['mustMatch', 'eventual', 'allowed', 'warnWhenStale']).optional(),
+      owner: z.enum(['backend', 'client', 'external']).optional(),
+      staleField: z.string().min(1).optional(),
+      confidenceField: z.string().min(1).optional(),
+    })
+    .describe(
+      'Derivation/provenance policy for stored computed, cached, snapshot, rollup, or estimated fields. Use sources for source field paths, refresh for recompute cadence, driftPolicy for acceptable staleness, and owner for write ownership.',
+    )
+    .optional(),
   sampleData: z
     .object({
       category: z.string().min(1).optional(),
@@ -305,6 +320,8 @@ export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
           optional: z.boolean().optional(),
           nullable: z.boolean().optional(),
           default: z.unknown().optional(),
+          serverDerived: z.boolean().optional(),
+          derivation: FieldDefSchema.shape.derivation,
         }),
       },
       ({ typeName, fieldName, patch }) => ({ kind: 'update_field', typeName, fieldName, patch }),

--- a/packages/core/src/playground-contract.ts
+++ b/packages/core/src/playground-contract.ts
@@ -1,3 +1,4 @@
+import { fieldIsRuntimeDerived } from './derivation';
 import type { FieldDef, FieldType, SampleDataHint, Schema, TypeDef } from './ir';
 
 export type PlaygroundControlKind =
@@ -207,10 +208,10 @@ function buildControl(
     fieldName: field.name,
     label: labelFor(field.name),
     description: field.description,
-    required: field.optional !== true && field.serverDerived !== true,
+    required: field.optional !== true && !fieldIsRuntimeDerived(field),
     nullable: field.nullable === true,
     defaultValue: field.default,
-    serverDerived: field.serverDerived === true,
+    serverDerived: fieldIsRuntimeDerived(field),
     sampleData: field.sampleData,
   };
   return { ...base, ...buildControlShape(field.type, typeByName, stack) } as PlaygroundControl;

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -49,7 +49,10 @@ export type SemanticIssueCode =
   | 'relationship_scope_field_missing'
   | 'relationship_set_null_requires_nullable'
   | 'relationship_cleanup_index_missing'
-  | 'relationship_ownership_scope_missing';
+  | 'relationship_ownership_scope_missing'
+  | 'derivation_missing_source'
+  | 'derivation_unknown_source'
+  | 'derivation_missing_refresh';
 
 export type SemanticIssueSeverity = 'error' | 'warning';
 
@@ -71,6 +74,7 @@ export function checkSemantic(schema: Schema, catalog?: StdlibCatalog): Semantic
     ...checkDuplicateFieldNames(schema),
     ...checkDuplicateConvexTableNames(schema),
     ...checkConvexTableShapes(schema),
+    ...checkDerivations(schema),
     ...checkDiscriminatedUnions(schema),
     ...checkEnums(schema),
   ]);
@@ -197,6 +201,101 @@ function checkImports(schema: Schema, catalog?: StdlibCatalog): SemanticIssueDra
     }
   });
   return issues;
+}
+
+function checkDerivations(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
+  const objects = schema.types.filter((type): type is ObjectType => type.kind === 'object');
+  const objectsByName = new Map(objects.map((type) => [type.name, type]));
+
+  objects.forEach((type, typeIndex) => {
+    const fieldNames = new Set(type.fields.map((field) => field.name));
+    type.fields.forEach((field, fieldIndex) => {
+      const derivation = field.derivation;
+      if (!derivation) return;
+      const path = `types.${typeIndex}.fields.${fieldIndex}.derivation`;
+      const sources = derivation.sources ?? [];
+
+      if (derivation.kind !== 'snapshot' && sources.length === 0) {
+        issues.push({
+          code: 'derivation_missing_source',
+          path: `${path}.sources`,
+          severity: 'warning',
+          message: `${type.name}.${field.name} declares a ${derivation.kind} derivation without source fields.`,
+          hint: 'Add source field paths so downstream app code and reviewers can see what invalidates this value.',
+        });
+      }
+
+      if (
+        derivation.kind !== 'snapshot' &&
+        sources.length > 0 &&
+        !derivation.refresh &&
+        !derivation.driftPolicy
+      ) {
+        issues.push({
+          code: 'derivation_missing_refresh',
+          path,
+          severity: 'warning',
+          message: `${type.name}.${field.name} can drift because it has sources but no refresh or drift policy.`,
+          hint: 'Declare whether it refreshes on write, asynchronously, on read, manually, or is allowed to drift.',
+        });
+      }
+
+      sources.forEach((source, sourceIndex) => {
+        if (sourcePathExists(source, type, fieldNames, objectsByName)) return;
+        issues.push({
+          code: 'derivation_unknown_source',
+          path: `${path}.sources.${sourceIndex}`,
+          severity: 'warning',
+          message: `${type.name}.${field.name} derivation source "${source}" does not match a known field path.`,
+          hint: 'Use a field on the same object, a nested path such as ingredients[].grams, or a qualified path such as Ingredient.allergens.',
+        });
+      });
+    });
+  });
+
+  return issues;
+}
+
+function sourcePathExists(
+  source: string,
+  owner: ObjectType,
+  ownerFieldNames: ReadonlySet<string>,
+  objectsByName: ReadonlyMap<string, ObjectType>,
+): boolean {
+  const normalized = source.replace(/\[\]/gu, '');
+  const [first, second] = normalized.split('.');
+  if (!first) return false;
+
+  const qualifiedType = objectsByName.get(first);
+  if (qualifiedType && second) {
+    return hasNestedFieldPath(qualifiedType, normalized.split('.').slice(1), objectsByName);
+  }
+
+  if (!ownerFieldNames.has(first)) return false;
+  return hasNestedFieldPath(owner, normalized.split('.'), objectsByName);
+}
+
+function hasNestedFieldPath(
+  type: ObjectType,
+  parts: readonly string[],
+  objectsByName: ReadonlyMap<string, ObjectType>,
+): boolean {
+  let current: ObjectType | undefined = type;
+  for (const part of parts) {
+    if (!current) return false;
+    const field = current.fields.find((candidate) => candidate.name === part);
+    if (!field) return false;
+    const refTarget = unwrapRefTarget(field.type);
+    current = refTarget ? objectsByName.get(refTarget) : undefined;
+  }
+  return true;
+}
+
+function unwrapRefTarget(type: FieldType): string | undefined {
+  if (type.kind === 'ref') return type.typeName;
+  if (type.kind === 'array') return unwrapRefTarget(type.element);
+  return undefined;
 }
 
 function checkRefs(schema: Schema, catalog?: StdlibCatalog): SemanticIssueDraft[] {

--- a/packages/core/tests/emit-form-validators.test.ts
+++ b/packages/core/tests/emit-form-validators.test.ts
@@ -55,4 +55,36 @@ describe('emitFormValidators', () => {
       'export const ArtworkCreateValidator = createFormValidator(Artwork.omit({ sourceSearchText: true }));',
     );
   });
+
+  it('emits create validators that omit backend-owned derivation fields', () => {
+    const source = emitFormValidators(
+      {
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'Recipe',
+            fields: [
+              { name: 'title', type: { kind: 'string' } },
+              {
+                name: 'nutrition',
+                type: { kind: 'string' },
+                derivation: {
+                  kind: 'computed',
+                  owner: 'backend',
+                  sources: ['ingredients[].grams'],
+                  refresh: 'onWrite',
+                },
+              },
+            ],
+          },
+        ],
+      },
+      'recipe',
+    );
+
+    expect(source).toContain(
+      'export const RecipeCreateValidator = createFormValidator(Recipe.omit({ nutrition: true }));',
+    );
+  });
 });

--- a/packages/core/tests/modeling-hints.test.ts
+++ b/packages/core/tests/modeling-hints.test.ts
@@ -84,6 +84,75 @@ describe('analyzeModelingHints', () => {
     );
   });
 
+  it('surfaces incomplete derivation policy on stored computed fields', () => {
+    const hints = analyzeModelingHints({
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [
+            { name: 'ingredients', type: { kind: 'array', element: { kind: 'string' } } },
+            {
+              name: 'nutrition',
+              type: { kind: 'string' },
+              derivation: { kind: 'computed', sources: ['ingredients'], owner: 'backend' },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(hints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'derivation_policy',
+          fieldName: 'nutrition',
+          title: 'Drift policy missing',
+          message: expect.stringContaining('without a refresh or drift policy'),
+        }),
+      ]),
+    );
+  });
+
+  it('treats declared snapshots as intentional context rather than drift warnings', () => {
+    const hints = analyzeModelingHints({
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          table: true,
+          fields: [
+            {
+              name: 'recipeTitle',
+              type: { kind: 'string' },
+              derivation: { kind: 'snapshot', sources: ['Recipe.title'], refresh: 'frozen' },
+            },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [{ name: 'title', type: { kind: 'string' } }],
+        },
+      ],
+    });
+
+    expect(hints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'derivation_policy',
+          fieldName: 'recipeTitle',
+          title: 'Snapshot field',
+          message: expect.stringContaining('frozen snapshot'),
+        }),
+      ]),
+    );
+  });
+
   it('identifies embedded collections and explains when the shape can remain embedded', () => {
     const hints = analyzeModelingHints(misprintSlice);
 

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -572,6 +572,74 @@ describe('checkSemantic — imports', () => {
   });
 });
 
+describe('checkSemantic — derivations', () => {
+  it('warns when stored derived fields have sources but no freshness policy', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Recipe',
+          fields: [
+            { name: 'ingredients', type: { kind: 'array', element: { kind: 'string' } } },
+            {
+              name: 'nutrition',
+              type: { kind: 'string' },
+              derivation: {
+                kind: 'computed',
+                sources: ['ingredients'],
+                owner: 'backend',
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema).map((issue) => issue.code)).toContain(
+      'derivation_missing_refresh',
+    );
+  });
+
+  it('warns when derivation sources do not resolve to known field paths', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Ingredient',
+          fields: [{ name: 'allergens', type: { kind: 'array', element: { kind: 'string' } } }],
+        },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          fields: [
+            {
+              name: 'containsAllergens',
+              type: { kind: 'boolean' },
+              derivation: {
+                kind: 'rollup',
+                sources: ['Ingredient.unknownAllergens'],
+                refresh: 'asyncJob',
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'derivation_unknown_source',
+          severity: 'warning',
+          message: expect.stringContaining('Ingredient.unknownAllergens'),
+        }),
+      ]),
+    );
+  });
+});
+
 describe('checkSemantic — duplicates', () => {
   it('rejects duplicate type names', () => {
     const schema: Schema = {


### PR DESCRIPTION
## Summary
- add structured field derivation metadata for computed, cached handle, snapshot, rollup, and estimate fields
- surface derivation policy in semantic warnings, modeling advice, field detail controls, and field-row chips
- preserve legacy serverDerived behavior for create validators/playground via shared runtime-derived helpers

## Verification
- bun run ci
- Storybook visual smoke: derivation controls render in DetailPanel field story; existing Storybook detail stories have broader partial styling issues unrelated to this patch

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783085333&installation_id=136251083&pr_number=369&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F369&signature=7a77e9422f017a82dabc057f4b5914ec08c7fd2e58c30f3aaf1010765836c74d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->