### PR TITLE
feat: flag collaborative embedded collections

### DIFF
--- a/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/ChatPanel.tsx
@@ -38,6 +38,7 @@ import type {
   SchemaAgentModelOptionDescriptor,
 } from '@renderer/chat/useSchemaAgentChat';
 import { useAgentTurnsStore } from '@renderer/store/agent-turns';
+import { useChatComposerStore } from '@renderer/store/chat-composer';
 import { useDocumentStore } from '@renderer/store/document';
 import { useUndoStore } from '@renderer/store/undo';
 import { code } from '@streamdown/code';
@@ -137,6 +138,8 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
   const desynced = chat.desynced;
   const recentAgentTurn = useAgentTurnsStore((s) => s.turns[0] ?? null);
   const agentTurns = useAgentTurnsStore((s) => s.turns);
+  const pendingChatMessage = useChatComposerStore((s) => s.pendingChatMessage);
+  const setPendingChatMessage = useChatComposerStore((s) => s.setPendingChatMessage);
   const hasUsableModel = providerModels.some((option) => option.id === modelSelectValue);
   const canCompose =
     isReady && !isStreaming && hasUsableModel && !modelsLoading && !modelsUnavailable;
@@ -241,6 +244,50 @@ export function ChatPanel({ chat }: ChatPanelProps): React.JSX.Element {
     if (!desynced || !activeThreadId) return;
     markThreadDesynced(activeThreadId);
   }, [desynced, activeThreadId, markThreadDesynced]);
+
+  useEffect(() => {
+    if (!pendingChatMessage) return;
+    if (filePath === null) {
+      enterDocumentScope(null);
+    } else {
+      if (activeThreadId && messages.length === 0) {
+        deleteThread(activeThreadId, filePath);
+      }
+      createFileThread({
+        provider,
+        model,
+        effort: thinkingBudget,
+        modelOptions: currentModelOptions,
+        filePath,
+      });
+    }
+
+    hydrateHistory({ version: '1', messages: [] });
+    setInput(
+      [pendingChatMessage.message, pendingChatMessage.context]
+        .filter((part) => part.trim().length > 0)
+        .join('\n\n'),
+    );
+    prevMessagesRef.current = [];
+    prevAgentTurnsRef.current = [];
+    setShowThreadList(false);
+    setPendingChatMessage(null);
+  }, [
+    activeThreadId,
+    createFileThread,
+    currentModelOptions,
+    deleteThread,
+    enterDocumentScope,
+    filePath,
+    hydrateHistory,
+    messages.length,
+    model,
+    pendingChatMessage,
+    provider,
+    setPendingChatMessage,
+    setShowThreadList,
+    thinkingBudget,
+  ]);
 
   useEffect(() => {
     if (!isStreaming) setResponsePending(false);

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -19,13 +19,16 @@ import type { FieldDef, FieldType, IndexDef, Schema, TypeDef } from '@contexture
 import type { ModelingHint } from '@contexture/core/modeling-hints';
 import type { TypeUpdatePatch } from '@contexture/core/ops';
 import type { ValidationError } from '@renderer/services/validation';
+import { useChatComposerStore } from '@renderer/store/chat-composer';
 import { usePlaygroundStore } from '@renderer/store/playground';
 import { useGraphSelectionStore } from '@renderer/store/selection';
+import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import {
   ChevronDown,
   ChevronUp,
   Hash,
   Lightbulb,
+  MessageSquare,
   Play,
   Plus,
   SlidersHorizontal,
@@ -645,7 +648,11 @@ function ObjectBody({
                 </TableCell>
                 {showAdviceColumn && (
                   <TableCell className="w-14 px-1 py-1.5 text-center">
-                    <FieldAdvicePopover fieldName={f.name} hints={fieldHints} />
+                    <FieldAdvicePopover
+                      typeName={type.name}
+                      fieldName={f.name}
+                      hints={fieldHints}
+                    />
                   </TableCell>
                 )}
                 <TableCell className="w-36 px-1 py-1.5 text-right">
@@ -730,9 +737,11 @@ function ObjectBody({
 }
 
 function FieldAdvicePopover({
+  typeName,
   fieldName,
   hints,
 }: {
+  typeName: string;
   fieldName: string;
   hints: readonly ModelingHint[];
 }) {
@@ -740,6 +749,15 @@ function FieldAdvicePopover({
 
   const [primary, ...secondary] = hints;
   if (!primary) return null;
+  const toneColor = advisoryToneColor(hints);
+  const openInChat = () => {
+    useChatComposerStore.getState().setPendingChatMessage({
+      message: advisoryChatPrompt({ typeName, fieldName, primary, hints }),
+      context: '',
+    });
+    useUIChromeStore.getState().setSidebarTab('chat');
+    useUIChromeStore.getState().setSidebarVisible(true);
+  };
 
   return (
     <Popover>
@@ -749,15 +767,20 @@ function FieldAdvicePopover({
           variant="ghost"
           size="icon"
           aria-label={`Modeling advice for ${fieldName}`}
-          className="relative h-7 w-7 border border-transparent text-muted-foreground hover:text-primary data-[state=open]:text-primary"
-          style={toneSurfaceStyle('var(--inspector-advisory)', 12, 0)}
+          className="relative h-7 w-7 border shadow-[0_0_0_1px_color-mix(in_oklch,currentColor_10%,transparent)] transition-colors hover:bg-accent/70 data-[state=open]:bg-accent"
+          style={toneSurfaceStyle(toneColor, 18, 48)}
         >
-          <LightbulbIcon />
-          {secondary.length > 0 && (
-            <span className="absolute -right-0.5 -top-0.5 grid h-3.5 min-w-3.5 place-items-center rounded-full bg-accent px-1 text-[9px] leading-none text-accent-foreground">
-              {hints.length}
-            </span>
-          )}
+          <LightbulbIcon color={toneColor} />
+          <span
+            className="absolute -right-0.5 -top-0.5 grid h-3.5 min-w-3.5 place-items-center rounded-full border border-background px-1 text-[9px] font-semibold leading-none"
+            style={{
+              background: toneColor,
+              color:
+                toneColor === 'var(--warning)' ? 'var(--warning-foreground)' : 'var(--background)',
+            }}
+          >
+            {hints.length}
+          </span>
         </Button>
       </PopoverTrigger>
       <PopoverContent align="end" side="left" className="w-80 p-3 text-xs">
@@ -770,14 +793,62 @@ function FieldAdvicePopover({
               ))}
             </div>
           )}
+          <div className="border-t border-border/70 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 w-full justify-start gap-1.5 text-xs"
+              onClick={openInChat}
+            >
+              <MessageSquare aria-hidden="true" className="size-3.5" />
+              Ask in chat
+            </Button>
+          </div>
         </div>
       </PopoverContent>
     </Popover>
   );
 }
 
-function LightbulbIcon(): React.JSX.Element {
-  return <Lightbulb aria-hidden="true" className="size-3.5" />;
+function advisoryChatPrompt({
+  typeName,
+  fieldName,
+  primary,
+  hints,
+}: {
+  typeName: string;
+  fieldName: string;
+  primary: ModelingHint;
+  hints: readonly ModelingHint[];
+}): string {
+  const signals = [...new Set(hints.flatMap((hint) => hint.signals))].join(', ');
+  return [
+    `Help me resolve this Contexture modeling advisory for ${typeName}.${fieldName}.`,
+    '',
+    `Primary advisory: ${primary.title}`,
+    `Message: ${primary.message}`,
+    `Rationale: ${primary.rationale}`,
+    signals ? `Signals: ${signals}` : null,
+    '',
+    'Please review the current IR and guide me through the smallest safe resolution. If extracting a child table is appropriate, explain the table, refs, ownership scope, and indexes before applying changes.',
+  ]
+    .filter((line): line is string => line !== null)
+    .join('\n');
+}
+
+function LightbulbIcon({ color }: { color: string }): React.JSX.Element {
+  return <Lightbulb aria-hidden="true" className="size-3.5" style={{ color }} />;
+}
+
+function advisoryToneColor(hints: readonly ModelingHint[]): string {
+  return hints.some((hint) =>
+    hint.signals.some(
+      (signal) => signal === 'concurrency_pressure' || signal === 'document_size_pressure',
+    ),
+  )
+    ? 'var(--warning)'
+    : 'var(--inspector-advisory)';
 }
 
 function FieldIndexPopover({

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -20,6 +20,8 @@
  *    Adjacency (neighbour-dimming in `TypeNode`) is computed here on
  *    every render — cheap because it's O(edges).
  */
+
+import { analyzeModelingHints } from '@contexture/core/modeling-hints';
 import {
   applyNodeChanges,
   Background,
@@ -176,10 +178,14 @@ function GraphCanvasInner({
   const setSidebarVisible = useUIChromeStore((s) => s.setSidebarVisible);
 
   const validationErrors = useMemo(() => validate(schema, { stdlib: STDLIB_REGISTRY }), [schema]);
+  const modelingHints = useMemo(() => analyzeModelingHints(schema), [schema]);
 
   const { nodes: builtNodes, edges: builtEdges }: BuildGraphResult = useMemo(() => {
     const highlighted = new Set(highlightedNodeIds);
-    const graph = applyValidationHighlights(buildGraph({ schema, positions }), validationErrors);
+    const graph = applyValidationHighlights(
+      buildGraph({ schema, positions, modelingHints }),
+      validationErrors,
+    );
     return {
       ...graph,
       nodes: graph.nodes.map((node) =>
@@ -188,7 +194,7 @@ function GraphCanvasInner({
           : node,
       ),
     };
-  }, [schema, positions, highlightedNodeIds, validationErrors]);
+  }, [schema, positions, modelingHints, highlightedNodeIds, validationErrors]);
 
   const graphLayout = useGraphLayoutStore((s) => s.graphLayout);
   const showEnums = graphLayout.showEnums;

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -19,7 +19,7 @@
  * later slice.
  */
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
-import { Focus, Table2 } from 'lucide-react';
+import { Focus, Lightbulb, Table2 } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
@@ -525,6 +525,9 @@ function FieldRowButton({
   const stdlibSummary = field.stdlibTarget ? field.summary.replace(/^→\s*/, '') : undefined;
   const isUnionRef = field.refTargetKind === 'discriminatedUnion';
   const hoverTarget = field.enumTarget ?? field.stdlibTarget;
+  const showModelingAdvice = field.modelingHintTone === 'warning';
+  const modelingHintColor =
+    field.modelingHintTone === 'warning' ? 'var(--warning)' : 'var(--inspector-advisory)';
   const button = (
     <button
       type="button"
@@ -532,6 +535,7 @@ function FieldRowButton({
       data-field-name={field.name}
       data-selected-field={selected ? 'true' : undefined}
       data-validation-issues={hasValidationIssues ? 'true' : undefined}
+      data-modeling-advice={showModelingAdvice ? field.modelingHintTone : undefined}
       onClick={(ev) => onFieldClick(field, ev)}
       onFocus={() => {
         setHighlighted(true);
@@ -614,16 +618,12 @@ function FieldRowButton({
         {field.nullable ? ' | null' : ''}
       </span>
       <span
-        data-testid={
-          field.enumTarget
-            ? 'type-node-field-enum-summary'
-            : field.stdlibTarget
-              ? 'type-node-field-stdlib-summary'
-              : field.refTarget
-                ? 'type-node-field-ref-summary'
-                : undefined
-        }
         style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: 4,
+          minWidth: 0,
           color: refTargetSelected
             ? 'var(--graph-node-selected)'
             : selected
@@ -649,44 +649,75 @@ function FieldRowButton({
           fontSize: 9,
           fontWeight: refTargetSelected ? 700 : 400,
           overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-          minWidth: 0,
         }}
       >
-        {field.enumTarget ? (
+        {showModelingAdvice && field.modelingHintCount ? (
           <span
-            data-testid="type-node-field-enum-affordance"
-            style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-          >
-            {enumSummary}
-          </span>
-        ) : field.stdlibTarget ? (
-          <span
-            data-testid="type-node-field-stdlib-affordance"
-            style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-          >
-            {stdlibSummary}
-          </span>
-        ) : isUnionRef ? (
-          <span
-            data-testid="type-node-field-union-affordance"
+            data-testid="type-node-field-advice"
+            title={`${field.modelingHintCount} modeling ${
+              field.modelingHintCount === 1 ? 'advisory' : 'advisories'
+            }`}
             style={{
-              display: 'inline-flex',
-              alignItems: 'baseline',
-              maxWidth: '100%',
-              minWidth: 0,
-              gap: 3,
+              display: 'inline-grid',
+              placeItems: 'center',
+              flex: '0 0 auto',
+              width: 13,
+              height: 13,
+              borderRadius: 999,
+              background: `color-mix(in oklch, ${modelingHintColor} 18%, transparent)`,
+              color: modelingHintColor,
+              boxShadow: `inset 0 0 0 1px color-mix(in oklch, ${modelingHintColor} 48%, transparent)`,
             }}
           >
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {field.summary}
-            </span>
-            <span style={{ color: 'var(--muted-foreground)', fontWeight: 400 }}>· union</span>
+            <Lightbulb aria-hidden="true" className="size-2.5" />
           </span>
-        ) : (
-          field.summary
-        )}
+        ) : null}
+        <span
+          data-testid={
+            field.enumTarget
+              ? 'type-node-field-enum-summary'
+              : field.stdlibTarget
+                ? 'type-node-field-stdlib-summary'
+                : field.refTarget
+                  ? 'type-node-field-ref-summary'
+                  : undefined
+          }
+          style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {field.enumTarget ? (
+            <span
+              data-testid="type-node-field-enum-affordance"
+              style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
+              {enumSummary}
+            </span>
+          ) : field.stdlibTarget ? (
+            <span
+              data-testid="type-node-field-stdlib-affordance"
+              style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
+              {stdlibSummary}
+            </span>
+          ) : isUnionRef ? (
+            <span
+              data-testid="type-node-field-union-affordance"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'baseline',
+                maxWidth: '100%',
+                minWidth: 0,
+                gap: 3,
+              }}
+            >
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {field.summary}
+              </span>
+              <span style={{ color: 'var(--muted-foreground)', fontWeight: 400 }}>· union</span>
+            </span>
+          ) : (
+            field.summary
+          )}
+        </span>
       </span>
     </button>
   );

--- a/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
+++ b/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
@@ -28,6 +28,7 @@
  */
 
 import type { FieldDef, FieldType, Schema, TypeDef } from '@contexture/core/ir';
+import type { ModelingHint } from '@contexture/core/modeling-hints';
 import { STDLIB_REGISTRY, STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registry';
 import type { Edge, Node } from '@xyflow/react';
 
@@ -77,6 +78,8 @@ export interface FieldRow {
   /** Bundled stdlib metadata when this field references `namespace.Type`. */
   stdlibTarget?: StdlibTargetRow;
   validationIssueCount?: number;
+  modelingHintCount?: number;
+  modelingHintTone?: 'advisory' | 'warning';
 }
 
 export interface EnumTargetRow {
@@ -109,6 +112,7 @@ export interface RefEdgeData extends Record<string, unknown> {
 export interface BuildGraphInput {
   schema: Schema;
   positions?: Record<string, { x: number; y: number }>;
+  modelingHints?: readonly ModelingHint[];
 }
 
 export interface BuildGraphResult {
@@ -118,13 +122,18 @@ export interface BuildGraphResult {
 
 const DEFAULT_POSITION = { x: 0, y: 0 };
 
-export function buildGraph({ schema, positions }: BuildGraphInput): BuildGraphResult {
+export function buildGraph({
+  schema,
+  positions,
+  modelingHints = [],
+}: BuildGraphInput): BuildGraphResult {
   const localNames = new Set(schema.types.map((t) => t.name));
   const localTypes = new Map(schema.types.map((type) => [type.name, type]));
   const tableTypes = schema.types.filter(isTableType);
+  const fieldHintMap = fieldModelingHintMap(modelingHints);
 
   const nodes: Node<TypeNodeData>[] = schema.types.map((t, schemaIndex) =>
-    localNodeFor(t, schemaIndex, positions?.[t.name] ?? DEFAULT_POSITION, localTypes),
+    localNodeFor(t, schemaIndex, positions?.[t.name] ?? DEFAULT_POSITION, localTypes, fieldHintMap),
   );
 
   // Collect edges + shadow nodes for targets that point outside the local
@@ -216,6 +225,7 @@ function localNodeFor(
   schemaIndex: number,
   position: { x: number; y: number },
   localTypes: ReadonlyMap<string, TypeDef>,
+  fieldHintMap: ReadonlyMap<string, FieldModelingHintSummary>,
 ): Node<TypeNodeData> {
   return {
     id: type.name,
@@ -227,7 +237,12 @@ function localNodeFor(
       kind: type.kind,
       description: type.description,
       enumValues: type.kind === 'enum' ? type.values.map(enumValueRow) : undefined,
-      fields: type.kind === 'object' ? type.fields.map((field) => fieldRow(field, localTypes)) : [],
+      fields:
+        type.kind === 'object'
+          ? type.fields.map((field) =>
+              fieldRow(field, localTypes, fieldHintMap.get(fieldHintKey(type.name, field.name))),
+            )
+          : [],
       imported: false,
       table: type.kind === 'object' && type.table === true ? true : undefined,
       canAddFields: type.kind === 'object' ? true : undefined,
@@ -298,7 +313,16 @@ function enumValueRow(value: { value: string; description?: string }): EnumValue
   };
 }
 
-function fieldRow(field: FieldDef, localTypes: ReadonlyMap<string, TypeDef>): FieldRow {
+interface FieldModelingHintSummary {
+  count: number;
+  tone: 'advisory' | 'warning';
+}
+
+function fieldRow(
+  field: FieldDef,
+  localTypes: ReadonlyMap<string, TypeDef>,
+  modelingHint?: FieldModelingHintSummary,
+): FieldRow {
   const target = unwrapRefTarget(field.type);
   const refTargetType = target ? localTypes.get(target) : undefined;
   const enumTarget = refTargetType?.kind === 'enum' ? refTargetType : undefined;
@@ -318,7 +342,41 @@ function fieldRow(field: FieldDef, localTypes: ReadonlyMap<string, TypeDef>): Fi
         }
       : undefined,
     stdlibTarget,
+    modelingHintCount: modelingHint?.count,
+    modelingHintTone: modelingHint?.tone,
   };
+}
+
+function fieldModelingHintMap(
+  modelingHints: readonly ModelingHint[],
+): Map<string, FieldModelingHintSummary> {
+  const hintsByField = new Map<string, ModelingHint[]>();
+  for (const hint of modelingHints) {
+    if (!hint.fieldName) continue;
+    const key = fieldHintKey(hint.typeName, hint.fieldName);
+    const existing = hintsByField.get(key) ?? [];
+    existing.push(hint);
+    hintsByField.set(key, existing);
+  }
+
+  const summaries = new Map<string, FieldModelingHintSummary>();
+  for (const [key, hints] of hintsByField) {
+    summaries.set(key, {
+      count: hints.length,
+      tone: hints.some(hasHighPressureModelingSignal) ? 'warning' : 'advisory',
+    });
+  }
+  return summaries;
+}
+
+function fieldHintKey(typeName: string, fieldName: string): string {
+  return `${typeName}:${fieldName}`;
+}
+
+function hasHighPressureModelingSignal(hint: ModelingHint): boolean {
+  return hint.signals.some(
+    (signal) => signal === 'concurrency_pressure' || signal === 'document_size_pressure',
+  );
 }
 
 function stdlibTargetRow(typeName: string): StdlibTargetRow | undefined {

--- a/apps/desktop/src/shared/system-prompt.ts
+++ b/apps/desktop/src/shared/system-prompt.ts
@@ -49,6 +49,10 @@ export function buildSystemPromptAppend(input: BuildSystemPromptAppendInput): st
     '',
     renderOpCatalogue(),
     '',
+    '## Convex collection modeling',
+    '',
+    COLLECTION_MODELING_RULES.trim(),
+    '',
     '## Stdlib-first modeling',
     '',
     STDLIB_RULES.trim(),
@@ -134,6 +138,16 @@ Skills are available and auto-load on topic match:
   (Email, URL, UUID, ISODate, Money, CountryCode, PhoneNumber, …).
 - \`generate-sample\` — use when the user asks for sample / fixture /
   example data for a type.
+`;
+
+const COLLECTION_MODELING_RULES = `
+For arrays of embedded child objects on a Convex table, model the tradeoff
+explicitly. Inline arrays are fine for read-mostly owned value data. Prefer a
+child table with parent and tenant refs when the collection is edited item by
+item, used from multiple app surfaces, needs stable child ids for commands,
+needs Convex indexes, or may grow with snapshots/media/generated payloads.
+Common examples include shopping list items, meal plan meals, tasks, checklist
+entries, and other collaborative lists.
 `;
 
 const STDLIB_RULES = `

--- a/apps/desktop/tests/chat/__snapshots__/system-prompt.test.ts.snap
+++ b/apps/desktop/tests/chat/__snapshots__/system-prompt.test.ts.snap
@@ -54,6 +54,16 @@ Skills are available and auto-load on topic match:
 - \`remove_index\` { typeName: string; name: string }
 - \`replace_schema\` { schema: Schema }   # escape hatch; full IR
 
+## Convex collection modeling
+
+For arrays of embedded child objects on a Convex table, model the tradeoff
+explicitly. Inline arrays are fine for read-mostly owned value data. Prefer a
+child table with parent and tenant refs when the collection is edited item by
+item, used from multiple app surfaces, needs stable child ids for commands,
+needs Convex indexes, or may grow with snapshots/media/generated payloads.
+Common examples include shopping list items, meal plan meals, tasks, checklist
+entries, and other collaborative lists.
+
 ## Stdlib-first modeling
 
 Before creating or leaving a primitive field for a common value format, check

--- a/apps/desktop/tests/chat/system-prompt.test.ts
+++ b/apps/desktop/tests/chat/system-prompt.test.ts
@@ -90,6 +90,15 @@ describe('buildSystemPromptAppend', () => {
     expect(prompt).toContain('{ kind: "ref", typeName: "namespace.Type" }');
   });
 
+  it('instructs agents to split collaborative embedded collections into child tables', () => {
+    const prompt = buildSystemPromptAppend({ stdlibRegistry: EMPTY_STDLIB });
+    expect(prompt).toContain('## Convex collection modeling');
+    expect(prompt).toContain('used from multiple app surfaces');
+    expect(prompt).toContain('stable child ids');
+    expect(prompt).toContain('shopping list items');
+    expect(prompt).toContain('meal plan meals');
+  });
+
   it('is deterministic across stdlib-entry orderings', () => {
     const a: StdlibRegistry = {
       entries: [

--- a/apps/desktop/tests/components/chat/ChatPanel.test.tsx
+++ b/apps/desktop/tests/components/chat/ChatPanel.test.tsx
@@ -7,6 +7,7 @@ import { useChatThreadStore } from '@renderer/chat/useChatThreads';
 import type { SchemaAgentChatState } from '@renderer/chat/useSchemaAgentChat';
 import { ChatPanel } from '@renderer/components/chat/ChatPanel';
 import { useAgentTurnsStore } from '@renderer/store/agent-turns';
+import { useChatComposerStore } from '@renderer/store/chat-composer';
 import { useDocumentStore } from '@renderer/store/document';
 import { useUndoStore } from '@renderer/store/undo';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
@@ -104,6 +105,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  useChatComposerStore.getState().setPendingChatMessage(null);
   vi.clearAllMocks();
 });
 
@@ -547,6 +549,28 @@ describe('ChatPanel', () => {
 
     await waitFor(() => expect(localStorage.getItem('contexture-active-thread')).toBeNull());
     expect(JSON.parse(localStorage.getItem('contexture-chat-threads') ?? '[]')).toEqual([]);
+  });
+
+  it('opens pending advisory context as a fresh chat draft', async () => {
+    useDocumentStore.setState({ filePath: '/repo/plantry.contexture.json' });
+    useChatComposerStore.getState().setPendingChatMessage({
+      message: 'Help me resolve ShoppingList.items.',
+      context: 'Advisory: Collaborative embedded collection',
+    });
+    const hydrateHistory = vi.fn();
+
+    render(<ChatPanel chat={makeChat({ hydrateHistory })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-input')).toHaveValue(
+        'Help me resolve ShoppingList.items.\n\nAdvisory: Collaborative embedded collection',
+      );
+    });
+    expect(useChatComposerStore.getState().pendingChatMessage).toBeNull();
+    expect(
+      useChatThreadStore.getState().threadsForFile('/repo/plantry.contexture.json'),
+    ).toHaveLength(1);
+    expect(hydrateHistory).toHaveBeenCalledWith({ version: '1', messages: [] });
   });
 
   it('auto-grows the textarea via CSS field-sizing with an 8-line cap and scroll overflow', async () => {

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -7,8 +7,10 @@ import type { TypeDef } from '@contexture/core/ir';
 import type { ModelingHint } from '@contexture/core/modeling-hints';
 import { FOCUS_TYPE_NAME_EVENT, TypeDetail } from '@renderer/components/detail/TypeDetail';
 import type { ValidationError } from '@renderer/services/validation';
+import { useChatComposerStore } from '@renderer/store/chat-composer';
 import type { Op } from '@renderer/store/ops';
 import { useGraphSelectionStore } from '@renderer/store/selection';
+import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -36,6 +38,8 @@ function setup(
 describe('TypeDetail', () => {
   afterEach(() => {
     useGraphSelectionStore.getState().clear();
+    useChatComposerStore.getState().setPendingChatMessage(null);
+    useUIChromeStore.getState().setSidebarTab('properties');
     cleanup();
   });
 
@@ -315,6 +319,36 @@ describe('TypeDetail', () => {
 
       expect(screen.getByText('Query handle')).toBeInTheDocument();
       expect(screen.getByText(/useful for filtering/i)).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Ask in chat' }));
+
+      expect(useUIChromeStore.getState().sidebarTab).toBe('chat');
+      expect(useChatComposerStore.getState().pendingChatMessage?.message).toContain('Post.title');
+      expect(useChatComposerStore.getState().pendingChatMessage?.message).toContain('Query handle');
+    });
+
+    it('uses warning emphasis for high-pressure field modeling advice', () => {
+      setup({ ...base, table: true }, [
+        {
+          id: 'v1:embedded_collection:Post:title:PostTitle',
+          kind: 'embedded_collection',
+          signals: [
+            'embedded_collection_pressure',
+            'relationship_pressure',
+            'concurrency_pressure',
+          ],
+          path: 'types.0.fields.1',
+          typeName: 'Post',
+          fieldName: 'title',
+          title: 'Collaborative embedded collection',
+          message: 'Row identity avoids whole-array lost updates.',
+          rationale: 'Collaborative item edits are safer as scoped child table rows.',
+          fieldNames: ['title'],
+        },
+      ]);
+
+      const trigger = screen.getByRole('button', { name: /modeling advice for title/i });
+      expect(trigger.getAttribute('style')).toContain('var(--warning)');
+      expect(trigger).toHaveTextContent('1');
     });
 
     it('shows and edits the emitted Convex table name when table:true', () => {

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -428,6 +428,58 @@ describe('TypeNode', () => {
     });
   });
 
+  it('marks field rows with modeling advice on the canvas node', () => {
+    const data: TypeNodeData = {
+      typeName: 'ShoppingList',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'items',
+          summary: '→ ShoppingListItem[]',
+          optional: false,
+          nullable: false,
+          refTarget: 'ShoppingListItem',
+          modelingHintCount: 1,
+          modelingHintTone: 'warning',
+        },
+      ],
+    };
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    const field = screen.getByTestId('type-node-field');
+    const advice = screen.getByTestId('type-node-field-advice');
+
+    expect(field.dataset.modelingAdvice).toBe('warning');
+    expect(advice).toHaveAttribute('title', '1 modeling advisory');
+    expect(advice.getAttribute('style')).toContain('var(--warning)');
+    expect(screen.getByTestId('type-node-field-ref-summary')).toHaveTextContent(
+      '→ ShoppingListItem[]',
+    );
+  });
+
+  it('keeps low-pressure modeling advice out of canvas field rows', () => {
+    const data: TypeNodeData = {
+      typeName: 'Post',
+      kind: 'object',
+      imported: false,
+      fields: [
+        {
+          name: 'title',
+          summary: 'string',
+          optional: false,
+          nullable: false,
+          modelingHintCount: 1,
+          modelingHintTone: 'advisory',
+        },
+      ],
+    };
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId('type-node-field').dataset.modelingAdvice).toBeUndefined();
+    expect(screen.queryByTestId('type-node-field-advice')).not.toBeInTheDocument();
+  });
+
   it('renders local enum refs as inline enum affordances with hover details', () => {
     vi.useFakeTimers();
     const data: TypeNodeData = {

--- a/apps/desktop/tests/graph/schema-to-graph.test.ts
+++ b/apps/desktop/tests/graph/schema-to-graph.test.ts
@@ -184,6 +184,54 @@ describe('buildGraph', () => {
     ]);
   });
 
+  it('passes field modeling hint summaries into node data', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'ShoppingList',
+          table: true,
+          fields: [
+            {
+              name: 'items',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'ShoppingListItem' } },
+            },
+          ],
+        },
+        { kind: 'object', name: 'ShoppingListItem', fields: [] },
+      ],
+    };
+
+    const { nodes } = buildGraph({
+      schema,
+      modelingHints: [
+        {
+          id: 'v1:embedded_collection:ShoppingList:items:ShoppingListItem',
+          kind: 'embedded_collection',
+          signals: [
+            'embedded_collection_pressure',
+            'relationship_pressure',
+            'concurrency_pressure',
+          ],
+          path: 'types.0.fields.0',
+          typeName: 'ShoppingList',
+          fieldName: 'items',
+          title: 'Collaborative embedded collection',
+          message: 'Row identity avoids whole-array lost updates.',
+          rationale: 'Collaborative item edits are safer as scoped child table rows.',
+          fieldNames: ['items'],
+        },
+      ],
+    });
+
+    expect(nodes[0].data.fields[0]).toMatchObject({
+      name: 'items',
+      modelingHintCount: 1,
+      modelingHintTone: 'warning',
+    });
+  });
+
   it('can apply validation highlights to affected nodes and fields', () => {
     const schema: Schema = {
       version: '1',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { readdir, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import {
+  analyzeModelingHints,
   assertContextureIrPath,
   buildConvexCapabilityManifest,
   checkGeneratedBundle,
@@ -268,6 +269,7 @@ interface InspectJson {
   typeCount: number;
   types: InspectJsonType[];
   imports: Array<{ kind: ImportDecl['kind']; alias: string; path: string }>;
+  modelingHints: ReturnType<typeof analyzeModelingHints>;
 }
 
 function typeToInspectJson(type: TypeDef): InspectJsonType {
@@ -317,6 +319,7 @@ function buildInspectJson(schema: Schema, irPath: string): InspectJson {
       alias: imp.alias,
       path: imp.path,
     })),
+    modelingHints: analyzeModelingHints(schema),
   };
 }
 
@@ -366,6 +369,16 @@ function renderInspectText(summary: InspectJson): string {
     lines.push('Imports:');
     for (const imp of summary.imports) {
       lines.push(`  ${imp.alias} -> ${imp.path}`);
+    }
+  }
+
+  if (summary.modelingHints.length > 0) {
+    lines.push('Modeling advisories:');
+    for (const hint of summary.modelingHints) {
+      const location = hint.fieldName ? `${hint.typeName}.${hint.fieldName}` : hint.typeName;
+      const signals = hint.signals.length > 0 ? ` [${hint.signals.join(', ')}]` : '';
+      lines.push(`  ${location}: ${hint.title}${signals}`);
+      lines.push(`    ${hint.message}`);
     }
   }
 

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -101,6 +101,58 @@ describe('@contexture/cli', () => {
       kind: 'enum',
       values: ['draft', 'live'],
     });
+    expect(parsed.modelingHints).toEqual(expect.any(Array));
+  });
+
+  it('includes modeling advisories in inspect output for agents', async () => {
+    const { dir, irPath } = await fixtureProject();
+    await writeFile(
+      irPath,
+      `${JSON.stringify({
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'ShoppingList',
+            table: true,
+            fields: [
+              {
+                name: 'items',
+                type: { kind: 'array', element: { kind: 'ref', typeName: 'ShoppingListItem' } },
+              },
+            ],
+          },
+          {
+            kind: 'object',
+            name: 'ShoppingListItem',
+            fields: [
+              { name: 'ingredientName', type: { kind: 'string' } },
+              { name: 'checked', type: { kind: 'boolean' } },
+            ],
+          },
+        ],
+      })}\n`,
+    );
+
+    const jsonResult = await runCli(dir, ['inspect', '--json']);
+    expect(jsonResult.exitCode).toBe(0);
+    const parsed = JSON.parse(jsonResult.stdout);
+    expect(parsed.modelingHints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'embedded_collection',
+          typeName: 'ShoppingList',
+          fieldName: 'items',
+          title: 'Collaborative embedded collection',
+          signals: expect.arrayContaining(['concurrency_pressure']),
+        }),
+      ]),
+    );
+
+    const textResult = await runCli(dir, ['inspect']);
+    expect(textResult.exitCode).toBe(0);
+    expect(textResult.stdout).toContain('Modeling advisories:');
+    expect(textResult.stdout).toContain('ShoppingList.items: Collaborative embedded collection');
   });
 
   it('inspects schema as human-readable text', async () => {

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -162,6 +162,53 @@ describe('Contexture MCP server', () => {
         agent: expect.objectContaining({
           preferredMutationTools: expect.arrayContaining(['add_field', 'rename_type', 'add_index']),
         }),
+        modelingHints: expect.any(Array),
+      });
+    });
+  });
+
+  it('includes modeling advisories in MCP inspect output', async () => {
+    const irPath = await fixtureIr({
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'ShoppingList',
+          table: true,
+          fields: [
+            {
+              name: 'items',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'ShoppingListItem' } },
+            },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'ShoppingListItem',
+          fields: [
+            { name: 'ingredientName', type: { kind: 'string' } },
+            { name: 'checked', type: { kind: 'boolean' } },
+          ],
+        },
+      ],
+    });
+
+    await withClient(async (client) => {
+      const result = await client.callTool({
+        name: 'inspect_contexture',
+        arguments: { irPath },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        modelingHints: expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'embedded_collection',
+            typeName: 'ShoppingList',
+            fieldName: 'items',
+            title: 'Collaborative embedded collection',
+            signals: expect.arrayContaining(['concurrency_pressure']),
+          }),
+        ]),
       });
     });
   });

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -6,6 +6,7 @@ import { checkGeneratedBundle, writeGeneratedBundle } from './generated-bundle-w
 import { GENERATED_TARGETS } from './generated-targets';
 import type { FieldType, Schema, TypeDef } from './ir';
 import { load } from './load';
+import { analyzeModelingHints } from './modeling-hints';
 import { createOpTools } from './op-tools';
 import { OpSchema } from './ops';
 import { assertContextureIrPath, bundlePathsFor } from './paths';
@@ -63,6 +64,44 @@ const GeneratedTargetInspectSchema = z.object({
   enabled: z.boolean(),
 });
 
+const ModelingHintInspectSchema = z.object({
+  id: z.string(),
+  kind: z.enum([
+    'owned_value_object',
+    'possible_entity',
+    'query_handle',
+    'derivation_policy',
+    'embedded_collection',
+    'stdlib_type',
+    'stringly_ref',
+  ]),
+  signals: z.array(
+    z.enum([
+      'identity_pressure',
+      'query_pressure',
+      'derivation_pressure',
+      'embedded_collection_pressure',
+      'concurrency_pressure',
+      'document_size_pressure',
+      'lifecycle_pressure',
+      'relationship_pressure',
+    ]),
+  ),
+  path: z.string(),
+  typeName: z.string(),
+  fieldName: z.string().optional(),
+  title: z.string(),
+  message: z.string(),
+  rationale: z.string(),
+  fieldNames: z.array(z.string()),
+  action: z
+    .union([
+      z.object({ kind: z.literal('use_stdlib_type'), typeName: z.string() }),
+      z.object({ kind: z.literal('convert_to_ref'), typeName: z.string() }),
+    ])
+    .optional(),
+});
+
 const InspectOutput = {
   path: z.string(),
   version: z.literal('1'),
@@ -78,6 +117,7 @@ const InspectOutput = {
   ),
   outputConfig: z.unknown().optional(),
   generatedTargets: z.array(GeneratedTargetInspectSchema),
+  modelingHints: z.array(ModelingHintInspectSchema),
   agent: z.object({
     preferredMutationTools: z.array(z.string()),
     safeLoop: z.array(z.string()),
@@ -487,6 +527,7 @@ function buildInspectSummary(
       path: target.path(paths),
       enabled: target.enabled(schema),
     })),
+    modelingHints: analyzeModelingHints(schema),
     agent: {
       preferredMutationTools,
       safeLoop: [

--- a/packages/core/src/modeling-hints.ts
+++ b/packages/core/src/modeling-hints.ts
@@ -17,6 +17,8 @@ export type ModelingSignal =
   | 'query_pressure'
   | 'derivation_pressure'
   | 'embedded_collection_pressure'
+  | 'concurrency_pressure'
+  | 'document_size_pressure'
   | 'lifecycle_pressure'
   | 'relationship_pressure';
 
@@ -52,7 +54,27 @@ interface TypeUsage {
   collection: boolean;
 }
 
+interface EmbeddedCollectionPressure {
+  concurrentEditing: boolean;
+  documentSize: boolean;
+}
+
 const QUERY_HANDLE_NAME = /(^|_)(kind|state|status|slug|key)$|name$|searchtext$|date$|at$|year$/i;
+
+const COLLABORATIVE_COLLECTION_FIELD_NAMES = new Set([
+  'entries',
+  'items',
+  'listItems',
+  'meals',
+  'planMeals',
+  'tasks',
+  'todos',
+]);
+
+const MUTABLE_CHILD_FIELD_NAME = /(^|_)(checked|completed|done|status|state|cooked|purchased)$/i;
+
+const HEAVY_CHILD_FIELD_NAME =
+  /(^|_)(audio|audioUrl|storageId|media|image|imageUrl|snapshot|nutrition|transcript|payload|content)$/i;
 
 const IDENTITY_FIELD_NAMES = new Set([
   'id',
@@ -274,19 +296,68 @@ function embeddedCollectionHint(
   path: string,
   elementType: ObjectType,
 ): ModelingHint {
+  const pressure = embeddedCollectionPressure(ownerType, field, elementType);
+  const signals: ModelingSignal[] = ['embedded_collection_pressure', 'relationship_pressure'];
+  if (pressure.concurrentEditing) signals.push('concurrency_pressure');
+  if (pressure.documentSize) signals.push('document_size_pressure');
+
   return {
     id: hintId('embedded_collection', ownerType.name, field.name, [elementType.name]),
     kind: 'embedded_collection',
-    signals: ['embedded_collection_pressure', 'relationship_pressure'],
+    signals,
     path,
     typeName: ownerType.name,
     fieldName: field.name,
-    title: 'Embedded collection',
-    message: `This field stores a collection of ${elementType.name} objects. Keep it embedded if the items only belong to ${ownerType.name}. Consider a table if items need independent lifecycle, reuse, or querying.`,
-    rationale:
-      'Arrays are a good fit for owned child data, but shared or independently queried items often want table identity.',
+    title: pressure.concurrentEditing ? 'Collaborative embedded collection' : 'Embedded collection',
+    message: embeddedCollectionMessage(ownerType, field, elementType, pressure),
+    rationale: embeddedCollectionRationale(pressure),
     fieldNames: [field.name],
   };
+}
+
+function embeddedCollectionMessage(
+  ownerType: ObjectType,
+  field: FieldDef,
+  elementType: ObjectType,
+  pressure: EmbeddedCollectionPressure,
+): string {
+  if (pressure.concurrentEditing) {
+    return `This field stores mutable ${elementType.name} rows inside ${ownerType.name}. Consider a table when people may edit individual ${field.name} from multiple surfaces: row identity avoids whole-array lost updates, gives commands a stable child id, and makes Convex indexes possible.`;
+  }
+
+  if (pressure.documentSize) {
+    return `This field stores a potentially heavy collection of ${elementType.name} objects. Keep it embedded if the items are read-mostly and owned by ${ownerType.name}; consider a table if snapshots, media, or generated payloads could push document size or need targeted queries.`;
+  }
+
+  return `This field stores a collection of ${elementType.name} objects. Keep it embedded if the items only belong to ${ownerType.name}. Consider a table if items need independent lifecycle, stable ids, concurrent edits, reuse, or querying.`;
+}
+
+function embeddedCollectionRationale(pressure: EmbeddedCollectionPressure): string {
+  if (pressure.concurrentEditing) {
+    return 'Convex array elements are not independently addressable or indexable, so collaborative item edits are safer as scoped child table rows.';
+  }
+  if (pressure.documentSize) {
+    return 'Embedded arrays are convenient, but repeated snapshots, media, and generated payloads can grow the parent document and limit query handles.';
+  }
+  return 'Arrays are a good fit for owned child data, but shared or independently queried items often want table identity.';
+}
+
+function embeddedCollectionPressure(
+  ownerType: ObjectType,
+  field: FieldDef,
+  elementType: ObjectType,
+): EmbeddedCollectionPressure {
+  const concurrentEditing =
+    ownerType.table === true &&
+    (COLLABORATIVE_COLLECTION_FIELD_NAMES.has(field.name) ||
+      elementType.fields.some((childField) => MUTABLE_CHILD_FIELD_NAME.test(childField.name)));
+
+  const documentSize = elementType.fields.some((childField) => {
+    if (childField.derivation?.kind === 'snapshot') return true;
+    return HEAVY_CHILD_FIELD_NAME.test(childField.name);
+  });
+
+  return { concurrentEditing, documentSize };
 }
 
 function queryHandleHint(type: ObjectType, field: FieldDef, path: string): ModelingHint {

--- a/packages/core/tests/modeling-hints.test.ts
+++ b/packages/core/tests/modeling-hints.test.ts
@@ -162,11 +162,107 @@ describe('analyzeModelingHints', () => {
           kind: 'embedded_collection',
           typeName: 'Artwork',
           fieldName: 'media',
-          signals: ['embedded_collection_pressure', 'relationship_pressure'],
+          signals: expect.arrayContaining([
+            'embedded_collection_pressure',
+            'relationship_pressure',
+          ]),
         }),
       ]),
     );
     expect(hints.find((hint) => hint.fieldName === 'media')?.message).toMatch(/Keep it embedded/i);
+  });
+
+  it('warns when collaborative child rows are embedded in a table document', () => {
+    const hints = analyzeModelingHints({
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'ShoppingList',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'string' } },
+            {
+              name: 'items',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'ShoppingListItem' } },
+            },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'ShoppingListItem',
+          fields: [
+            { name: 'ingredientName', type: { kind: 'string' } },
+            { name: 'quantity', type: { kind: 'number' } },
+            { name: 'checked', type: { kind: 'boolean' } },
+          ],
+        },
+      ],
+    });
+
+    const itemsHint = hints.find(
+      (hint) => hint.kind === 'embedded_collection' && hint.fieldName === 'items',
+    );
+
+    expect(itemsHint).toEqual(
+      expect.objectContaining({
+        title: 'Collaborative embedded collection',
+        signals: ['embedded_collection_pressure', 'relationship_pressure', 'concurrency_pressure'],
+        message: expect.stringContaining('whole-array lost updates'),
+        rationale: expect.stringContaining('not independently addressable or indexable'),
+      }),
+    );
+    expect(itemsHint?.message).toContain('stable child id');
+    expect(itemsHint?.message).toContain('Convex indexes');
+  });
+
+  it('surfaces document-size pressure for embedded meal snapshots', () => {
+    const hints = analyzeModelingHints({
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'MealPlan',
+          table: true,
+          fields: [
+            { name: 'weekStartDate', type: { kind: 'string' } },
+            {
+              name: 'meals',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'MealPlanMeal' } },
+            },
+          ],
+        },
+        {
+          kind: 'object',
+          name: 'MealPlanMeal',
+          fields: [
+            { name: 'date', type: { kind: 'string' } },
+            { name: 'slot', type: { kind: 'string' } },
+            {
+              name: 'nutritionSnapshot',
+              type: { kind: 'string' },
+              derivation: { kind: 'snapshot', sources: ['Recipe.nutrition'], refresh: 'frozen' },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(hints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'embedded_collection',
+          fieldName: 'meals',
+          signals: [
+            'embedded_collection_pressure',
+            'relationship_pressure',
+            'concurrency_pressure',
+            'document_size_pressure',
+          ],
+          message: expect.stringContaining('multiple surfaces'),
+        }),
+      ]),
+    );
   });
 
   it('emits positive owned value object guidance for embedded owned structure', () => {


### PR DESCRIPTION
## Summary
- strengthens embedded collection modeling hints for collaborative child rows, stable child ids, Convex indexing, and document-size pressure
- teaches the Contexture assistant prompt to prefer child tables for multi-surface item-by-item collections
- adds Plantry-shaped regression coverage for shopping list items and meal plan meals

## Checks
- bun run test -- tests/modeling-hints.test.ts (packages/core)
- bun run test -- tests/chat/system-prompt.test.ts -u (apps/desktop)
- bun run typecheck
- bun run lint
- bun run ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783086837&installation_id=136251083&pr_number=370&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F370&signature=78e0e44e2f00bfa7ba96211e05f2797e1b03a1bcb864af51a65d778654927985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->