### PR TITLE
docs: note derived writer boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Design your domain once in source-of-truth `.contexture.json`, then emit the
 Convex schema, validators, and supporting typed surfaces your products and
 agents need: Zod, JSON Schema, schema indexes, MCP tools, and opt-in AI tool
 definitions.
+Derived fields can also declare writer boundaries so generated form and agent
+input contracts do not accidentally accept values owned by backend or external
+systems.
 
 Built for engineers who want humans and agents to change the model, regenerate
 artifacts, and prove drift is gone before the code ships.


### PR DESCRIPTION
## Summary
- document that derived fields can declare writer boundaries for generated form and agent input contracts

## Verification
- pre-commit hook ran `turbo typecheck` and `turbo test` when the docs commit was created

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783096587&installation_id=136251083&pr_number=374&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F374&signature=abc2d1fe1352ea43b2fcacce5b800526747de5b2f3b91e3e938a62273d4af024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->