### PR TITLE
feat(core): add operational advice warnings

### DIFF
--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -803,7 +803,7 @@ function FieldAdvicePopover({
               onClick={openInChat}
             >
               <MessageSquare aria-hidden="true" className="size-3.5" />
-              Ask in chat
+              Discuss in chat
             </Button>
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/components/detail/ValidationIssues.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/ValidationIssues.tsx
@@ -40,12 +40,18 @@ export function ValidationIssues({
                   className="h-auto min-h-8 min-w-0 flex-1 justify-start px-1.5 py-1 text-left text-xs hover:bg-destructive/10"
                 >
                   <span className="whitespace-normal">
+                    <span className="block font-mono text-[10px] text-muted-foreground/80">
+                      {error.code}
+                    </span>
                     <span>{error.message}</span>
                     <span className="ml-1 text-muted-foreground/70">{error.path}</span>
                   </span>
                 </Button>
               ) : (
                 <span className="min-w-0 flex-1">
+                  <span className="block font-mono text-[10px] text-muted-foreground/80">
+                    {error.code}
+                  </span>
                   <span>{error.message}</span>
                   <span className="ml-1 text-muted-foreground/70">{error.path}</span>
                 </span>

--- a/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
+++ b/apps/desktop/src/renderer/src/components/dialogs/ReconcileModal.tsx
@@ -382,8 +382,8 @@ export function ReconcileModal(): React.JSX.Element {
         if (!open) close();
       }}
     >
-      <DialogContent className="max-w-6xl w-full">
-        <DialogHeader>
+      <DialogContent className="flex max-h-[calc(100vh-2rem)] w-full max-w-6xl flex-col overflow-hidden">
+        <DialogHeader className="shrink-0">
           <DialogTitle>Reconcile changes</DialogTitle>
           <DialogDescription>
             <code className="font-mono">{displayName}</code> changed outside Contexture. Review the
@@ -392,7 +392,7 @@ export function ReconcileModal(): React.JSX.Element {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
           <div className="rounded-md border bg-muted/20 px-3 py-2 text-sm">
             <div>{reconcileStatusCopy(driftStatus)}</div>
             {status === 'ready' && totalCount > 0 && (
@@ -499,7 +499,7 @@ export function ReconcileModal(): React.JSX.Element {
             </div>
           </div>
 
-          <div className="flex flex-col border rounded-md overflow-hidden min-h-[360px]">
+          <div className="flex min-h-[360px] flex-col overflow-hidden rounded-md border">
             <div className="flex flex-wrap items-center justify-between gap-3 px-3 py-2 border-b bg-muted/30">
               <div>
                 <div className="text-xs font-medium">{activeDiffTitle}</div>
@@ -531,7 +531,7 @@ export function ReconcileModal(): React.JSX.Element {
                 </button>
               </div>
             </div>
-            <div className="flex-1 overflow-auto max-h-[60vh]">
+            <div className="min-h-[240px] flex-1 overflow-auto">
               {status === 'loading' && (
                 <p className="p-3 text-sm text-muted-foreground">Loading…</p>
               )}
@@ -597,7 +597,7 @@ export function ReconcileModal(): React.JSX.Element {
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="shrink-0">
           <Button variant="ghost" onClick={close}>
             Leave dirty
           </Button>

--- a/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -12,13 +12,15 @@ import { getAnalyticsOptOut, setAnalyticsOptOut } from '@renderer/lib/analytics'
 import { estimateTokenCount } from '@renderer/services/tokens';
 import { type ValidationError, validate } from '@renderer/services/validation';
 import { parseTypePath, repairForValidationError } from '@renderer/services/validation-repairs';
+import { useChatComposerStore } from '@renderer/store/chat-composer';
 import { useConvexVersionStore } from '@renderer/store/convex-version';
 import { useDocumentStore } from '@renderer/store/document';
 import { sourceLabel, useModelSyncStore } from '@renderer/store/model-sync';
 import { useGraphSelectionStore } from '@renderer/store/selection';
+import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import { useUndoStore } from '@renderer/store/undo';
 import { STDLIB_REGISTRY } from '@shared/stdlib-registry';
-import { BarChart3, Circle, CircleAlert, Lightbulb } from 'lucide-react';
+import { BarChart3, Circle, CircleAlert, Lightbulb, MessageSquare } from 'lucide-react';
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -125,6 +127,16 @@ export function StatusBar(): React.JSX.Element {
       click(repair.focusTypeName, 'replace');
       useGraphSelectionStore.getState().focus(repair.focusTypeName);
     }
+    setPopoverOpen(false);
+  }
+
+  function handleFixInChat(error: ValidationError): void {
+    useChatComposerStore.getState().setPendingChatMessage({
+      message: validationChatPrompt(error),
+      context: ['## Current IR', '```json', JSON.stringify(schema, null, 2), '```'].join('\n'),
+    });
+    useUIChromeStore.getState().setSidebarTab('chat');
+    useUIChromeStore.getState().setSidebarVisible(true);
     setPopoverOpen(false);
   }
 
@@ -245,7 +257,7 @@ export function StatusBar(): React.JSX.Element {
               </button>
             </PopoverTrigger>
             <PopoverContent className="w-96 p-0" align="end">
-              <div className="max-h-64 overflow-y-auto">
+              <div className="max-h-96 overflow-y-auto">
                 {validationIssues.map((err) => {
                   const repair = repairForValidationError(schema, err);
                   const Icon = err.severity === 'error' ? CircleAlert : Lightbulb;
@@ -288,6 +300,14 @@ export function StatusBar(): React.JSX.Element {
                           {repair.label}
                         </button>
                       )}
+                      <button
+                        type="button"
+                        onClick={() => handleFixInChat(err)}
+                        className="inline-flex shrink-0 items-center gap-1 self-start rounded border border-border px-2 py-1 text-[11px] text-foreground hover:bg-background"
+                      >
+                        <MessageSquare aria-hidden="true" className="size-3" />
+                        Fix in chat
+                      </button>
                     </div>
                   );
                 })}
@@ -317,6 +337,22 @@ export function StatusBar(): React.JSX.Element {
       </TooltipProvider>
     </div>
   );
+}
+
+function validationChatPrompt(error: ValidationError): string {
+  return [
+    'Help me resolve this Contexture validation issue.',
+    '',
+    `Code: ${error.code}`,
+    `Severity: ${error.severity}`,
+    `Path: ${error.path}`,
+    `Message: ${error.message}`,
+    error.hint ? `Hint: ${error.hint}` : null,
+    '',
+    'Please review the current IR and suggest the smallest safe model change. If the fix should be app-runtime owned instead of modeled, explain the runtime contract to document.',
+  ]
+    .filter((line): line is string => line !== null)
+    .join('\n');
 }
 
 function convexVersionStatusLabel(version: {

--- a/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -18,7 +18,7 @@ import { sourceLabel, useModelSyncStore } from '@renderer/store/model-sync';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { useUndoStore } from '@renderer/store/undo';
 import { STDLIB_REGISTRY } from '@shared/stdlib-registry';
-import { BarChart3, Circle, CircleAlert } from 'lucide-react';
+import { BarChart3, Circle, CircleAlert, Lightbulb } from 'lucide-react';
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -71,8 +71,17 @@ export function StatusBar(): React.JSX.Element {
     }
   }, [schema, filePath, typeCount]);
 
-  const errors = useMemo(() => validate(schema, { stdlib: STDLIB_REGISTRY }), [schema]);
-  const errorCount = errors.length;
+  const validationIssues = useMemo(() => validate(schema, { stdlib: STDLIB_REGISTRY }), [schema]);
+  const validationErrors = useMemo(
+    () => validationIssues.filter((issue) => issue.severity === 'error'),
+    [validationIssues],
+  );
+  const validationWarnings = useMemo(
+    () => validationIssues.filter((issue) => issue.severity === 'warning'),
+    [validationIssues],
+  );
+  const errorCount = validationErrors.length;
+  const warningCount = validationWarnings.length;
 
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [analyticsOff, setAnalyticsOff] = useState(() => getAnalyticsOptOut());
@@ -120,7 +129,11 @@ export function StatusBar(): React.JSX.Element {
   }
 
   const tokenDisplay = tokenCount > 0 ? `~${tokenCount.toLocaleString()} tokens` : '0 tokens';
-  const hasIssues = errorCount > 0;
+  const hasIssues = validationIssues.length > 0;
+  const statusLabel =
+    errorCount > 0
+      ? `${errorCount} ${errorCount === 1 ? 'error' : 'errors'}`
+      : `${warningCount} ${warningCount === 1 ? 'advisory' : 'advisories'}`;
 
   return (
     <div
@@ -219,19 +232,23 @@ export function StatusBar(): React.JSX.Element {
                 type="button"
                 className={cn(
                   'flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-muted transition-colors',
-                  'text-destructive',
+                  errorCount > 0 ? 'text-destructive' : 'text-warning',
                 )}
+                aria-label={statusLabel}
               >
-                <CircleAlert className="size-3" />
-                <span>
-                  {errorCount} {errorCount === 1 ? 'error' : 'errors'}
-                </span>
+                {errorCount > 0 ? (
+                  <CircleAlert className="size-3" />
+                ) : (
+                  <Lightbulb className="size-3" />
+                )}
+                <span>{statusLabel}</span>
               </button>
             </PopoverTrigger>
             <PopoverContent className="w-96 p-0" align="end">
               <div className="max-h-64 overflow-y-auto">
-                {errors.map((err) => {
+                {validationIssues.map((err) => {
                   const repair = repairForValidationError(schema, err);
+                  const Icon = err.severity === 'error' ? CircleAlert : Lightbulb;
                   return (
                     <div
                       key={`${err.code}:${err.path}`}
@@ -243,7 +260,12 @@ export function StatusBar(): React.JSX.Element {
                         className="min-w-0 flex-1 text-left"
                       >
                         <div className="flex items-start gap-2">
-                          <CircleAlert className="size-3 shrink-0 mt-0.5 text-destructive" />
+                          <Icon
+                            className={cn(
+                              'size-3 shrink-0 mt-0.5',
+                              err.severity === 'error' ? 'text-destructive' : 'text-warning',
+                            )}
+                          />
                           <div className="min-w-0">
                             <div className="font-medium truncate">{err.message}</div>
                             <div className="text-muted-foreground/70 truncate">{err.path}</div>

--- a/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -267,8 +267,15 @@ export function StatusBar(): React.JSX.Element {
                             )}
                           />
                           <div className="min-w-0">
-                            <div className="font-medium truncate">{err.message}</div>
-                            <div className="text-muted-foreground/70 truncate">{err.path}</div>
+                            <div className="mb-0.5 font-mono text-[10px] text-muted-foreground/80">
+                              {err.code}
+                            </div>
+                            <div className="font-medium whitespace-normal break-words">
+                              {err.message}
+                            </div>
+                            <div className="text-muted-foreground/70 whitespace-normal break-all">
+                              {err.path}
+                            </div>
                           </div>
                         </div>
                       </button>

--- a/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -264,50 +264,54 @@ export function StatusBar(): React.JSX.Element {
                   return (
                     <div
                       key={`${err.code}:${err.path}`}
-                      className="flex gap-2 border-b border-border px-3 py-2 text-xs last:border-b-0 hover:bg-muted"
+                      className="space-y-2 border-b border-border px-3 py-2 text-xs last:border-b-0 hover:bg-muted"
                     >
-                      <button
-                        type="button"
-                        onClick={() => handleErrorClick(err)}
-                        className="min-w-0 flex-1 text-left"
-                      >
-                        <div className="flex items-start gap-2">
-                          <Icon
-                            className={cn(
-                              'size-3 shrink-0 mt-0.5',
-                              err.severity === 'error' ? 'text-destructive' : 'text-warning',
-                            )}
-                          />
-                          <div className="min-w-0">
-                            <div className="mb-0.5 font-mono text-[10px] text-muted-foreground/80">
-                              {err.code}
-                            </div>
-                            <div className="font-medium whitespace-normal break-words">
-                              {err.message}
-                            </div>
-                            <div className="text-muted-foreground/70 whitespace-normal break-all">
-                              {err.path}
-                            </div>
-                          </div>
-                        </div>
-                      </button>
-                      {repair && (
+                      <div className="flex gap-2">
                         <button
                           type="button"
-                          onClick={() => handleRepair(err)}
-                          className="self-start rounded border border-border px-2 py-1 text-[11px] text-foreground hover:bg-background"
+                          onClick={() => handleErrorClick(err)}
+                          className="min-w-0 flex-1 text-left"
                         >
-                          {repair.label}
+                          <div className="flex items-start gap-2">
+                            <Icon
+                              className={cn(
+                                'size-3 shrink-0 mt-0.5',
+                                err.severity === 'error' ? 'text-destructive' : 'text-warning',
+                              )}
+                            />
+                            <div className="min-w-0">
+                              <div className="mb-0.5 font-mono text-[10px] text-muted-foreground/80">
+                                {err.code}
+                              </div>
+                              <div className="font-medium whitespace-normal break-words">
+                                {err.message}
+                              </div>
+                              <div className="text-muted-foreground/70 whitespace-normal break-all">
+                                {err.path}
+                              </div>
+                            </div>
+                          </div>
                         </button>
-                      )}
-                      <button
-                        type="button"
-                        onClick={() => handleFixInChat(err)}
-                        className="inline-flex shrink-0 items-center gap-1 self-start rounded border border-border px-2 py-1 text-[11px] text-foreground hover:bg-background"
-                      >
-                        <MessageSquare aria-hidden="true" className="size-3" />
-                        Fix in chat
-                      </button>
+                        {repair && (
+                          <button
+                            type="button"
+                            onClick={() => handleRepair(err)}
+                            className="self-start rounded border border-border px-2 py-1 text-[11px] text-foreground hover:bg-background"
+                          >
+                            {repair.label}
+                          </button>
+                        )}
+                      </div>
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          onClick={() => handleFixInChat(err)}
+                          className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[11px] text-foreground hover:bg-background"
+                        >
+                          <MessageSquare aria-hidden="true" className="size-3" />
+                          Discuss in chat
+                        </button>
+                      </div>
                     </div>
                   );
                 })}

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -254,6 +254,7 @@ describe('DetailPanel', () => {
     render(<DetailPanel selection={{ typeName: 'Role' }} />);
 
     const issues = screen.getByRole('region', { name: 'Validation issues' });
+    expect(within(issues).getByText('enum_empty')).toBeInTheDocument();
     expect(within(issues).getByText(/must have at least one value/i)).toBeInTheDocument();
     expect(within(issues).getByText('types.0.values')).toBeInTheDocument();
   });
@@ -303,6 +304,7 @@ describe('DetailPanel', () => {
     render(<DetailPanel selection={{ typeName: 'Post', fieldName: 'author' }} />);
 
     const issues = screen.getByRole('region', { name: 'Validation issues' });
+    expect(within(issues).getByText('unresolved_ref')).toBeInTheDocument();
     expect(within(issues).getByText(/Unresolved ref "Author"/i)).toBeInTheDocument();
     expect(within(issues).getByText('types.0.fields.0.type')).toBeInTheDocument();
   });

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -319,7 +319,7 @@ describe('TypeDetail', () => {
 
       expect(screen.getByText('Query handle')).toBeInTheDocument();
       expect(screen.getByText(/useful for filtering/i)).toBeInTheDocument();
-      fireEvent.click(screen.getByRole('button', { name: 'Ask in chat' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Discuss in chat' }));
 
       expect(useUIChromeStore.getState().sidebarTab).toBe('chat');
       expect(useChatComposerStore.getState().pendingChatMessage?.message).toContain('Post.title');

--- a/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
+++ b/apps/desktop/tests/components/dialogs/ReconcileModal.test.tsx
@@ -89,6 +89,36 @@ afterEach(() => {
 });
 
 describe('ReconcileModal', () => {
+  it('keeps the reconcile workflow scrollable within the viewport', () => {
+    useReconcileStore.getState().open(ZOD_PATH);
+    useReconcileStore.getState().setReady(
+      Array.from({ length: 12 }, (_, index) => ({
+        id: `op-${index}`,
+        label: `Add field generatedField${index} to Plot`,
+        lossy: false,
+        provenance: 'deterministic',
+        op: {
+          kind: 'add_field',
+          typeName: 'Plot',
+          field: { name: `generatedField${index}`, type: { kind: 'string' } },
+        },
+      })),
+      'hand edited source',
+    );
+
+    render(<ReconcileModal />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveClass('max-h-[calc(100vh-2rem)]', 'overflow-hidden', 'flex');
+    expect(screen.getByText('Generated file change').closest('.overflow-y-auto')).toHaveClass(
+      'min-h-0',
+      'flex-1',
+    );
+    expect(screen.getByRole('button', { name: /apply selected ops/i }).closest('div')).toHaveClass(
+      'shrink-0',
+    );
+  });
+
   it('regenerates a generated file from the current IR even when reconcile analysis failed', async () => {
     useDriftStore.getState().setDetected([{ path: ZOD_PATH, status: 'unreadable' }]);
     useReconcileStore.getState().open(ZOD_PATH);

--- a/apps/desktop/tests/components/status-bar/StatusBar.test.tsx
+++ b/apps/desktop/tests/components/status-bar/StatusBar.test.tsx
@@ -1,7 +1,9 @@
 import type { Schema } from '@contexture/core/ir';
 import { StatusBar } from '@renderer/components/status-bar/StatusBar';
+import { useChatComposerStore } from '@renderer/store/chat-composer';
 import { useConvexVersionStore } from '@renderer/store/convex-version';
 import { useGraphSelectionStore } from '@renderer/store/selection';
+import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import { useUndoStore } from '@renderer/store/undo';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -21,7 +23,9 @@ function seed(schema: Schema) {
 describe('StatusBar validation repairs', () => {
   beforeEach(() => {
     seed({ version: '1', types: [] });
+    useChatComposerStore.getState().setPendingChatMessage(null);
     useGraphSelectionStore.getState().clear();
+    useUIChromeStore.setState({ sidebarTab: 'schema', sidebarVisible: false });
     useConvexVersionStore.getState().reset();
   });
 
@@ -63,11 +67,45 @@ describe('StatusBar validation repairs', () => {
     expect(screen.queryByRole('button', { name: '1 error' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '1 advisory' }));
+    expect(
+      screen.getByText('operational_timezone_missing').closest('.overflow-y-auto'),
+    ).toHaveClass('max-h-96');
     expect(screen.getByText('operational_timezone_missing')).toBeVisible();
     expect(screen.getByText(/Household-scoped field "PantryItem.expiresOn"/i)).toHaveClass(
       'whitespace-normal',
       'break-words',
     );
+  });
+
+  it('opens a validation issue in chat with IR context', () => {
+    seed({
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'PantryItem',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            { name: 'expiresOn', type: { kind: 'date' } },
+          ],
+        },
+      ],
+    });
+    render(<StatusBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: '1 advisory' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Fix in chat' }));
+
+    expect(useUIChromeStore.getState()).toMatchObject({
+      sidebarTab: 'chat',
+      sidebarVisible: true,
+    });
+    const pending = useChatComposerStore.getState().pendingChatMessage;
+    expect(pending?.message).toContain('Code: operational_timezone_missing');
+    expect(pending?.message).toContain('Path: types.0.fields');
+    expect(pending?.context).toContain('"name": "PantryItem"');
   });
 
   it('does not offer duplicate enum value repair without index-addressed ops', () => {

--- a/apps/desktop/tests/components/status-bar/StatusBar.test.tsx
+++ b/apps/desktop/tests/components/status-bar/StatusBar.test.tsx
@@ -41,6 +41,31 @@ describe('StatusBar validation repairs', () => {
     });
   });
 
+  it('labels warning-only validation issues as advisories', () => {
+    seed({
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'PantryItem',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            { name: 'expiresOn', type: { kind: 'date' } },
+          ],
+        },
+      ],
+    });
+    render(<StatusBar />);
+
+    expect(screen.getByRole('button', { name: '1 advisory' })).toBeVisible();
+    expect(screen.queryByRole('button', { name: '1 error' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '1 advisory' }));
+    expect(screen.getByText(/Household-scoped field "PantryItem.expiresOn"/i)).toBeVisible();
+  });
+
   it('does not offer duplicate enum value repair without index-addressed ops', () => {
     seed({
       version: '1',

--- a/apps/desktop/tests/components/status-bar/StatusBar.test.tsx
+++ b/apps/desktop/tests/components/status-bar/StatusBar.test.tsx
@@ -63,7 +63,11 @@ describe('StatusBar validation repairs', () => {
     expect(screen.queryByRole('button', { name: '1 error' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '1 advisory' }));
-    expect(screen.getByText(/Household-scoped field "PantryItem.expiresOn"/i)).toBeVisible();
+    expect(screen.getByText('operational_timezone_missing')).toBeVisible();
+    expect(screen.getByText(/Household-scoped field "PantryItem.expiresOn"/i)).toHaveClass(
+      'whitespace-normal',
+      'break-words',
+    );
   });
 
   it('does not offer duplicate enum value repair without index-addressed ops', () => {

--- a/apps/desktop/tests/components/status-bar/StatusBar.test.tsx
+++ b/apps/desktop/tests/components/status-bar/StatusBar.test.tsx
@@ -96,7 +96,9 @@ describe('StatusBar validation repairs', () => {
     render(<StatusBar />);
 
     fireEvent.click(screen.getByRole('button', { name: '1 advisory' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Fix in chat' }));
+    const discussButton = screen.getByRole('button', { name: 'Discuss in chat' });
+    expect(discussButton.parentElement).toHaveClass('justify-end');
+    fireEvent.click(discussButton);
 
     expect(useUIChromeStore.getState()).toMatchObject({
       sidebarTab: 'chat',

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -1194,14 +1194,18 @@ function isLikelyClientSurfaceEnum(
   owner: ObjectType,
   schema: Schema,
 ): boolean {
-  const haystack = `${schema.metadata?.description ?? ''} ${owner.description ?? ''} ${
+  const surfaceText = `${schema.metadata?.description ?? ''} ${owner.description ?? ''} ${
     field.description ?? ''
-  } ${owner.name} ${field.name} ${enumName}`.toLowerCase();
-  return (
-    /\b(client|mobile|web|api|surface|status|equipment|allergen|dietary|profile|cooking)\b/u.test(
-      haystack,
-    ) && /^(.*Status|Equipment|CookingMethod|Allergen|DietaryProfile)$/u.test(enumName)
-  );
+  }`.toLowerCase();
+  const names = `${owner.name} ${field.name} ${enumName}`;
+  const clientSurface = /\b(client|mobile|web|api|surface)\b/u.test(surfaceText);
+  if (
+    clientSurface &&
+    /^(.*Status|Equipment|CookingMethod|Allergen|DietaryProfile)$/u.test(enumName)
+  ) {
+    return true;
+  }
+  return /^(Equipment|CookingMethod|Allergen|DietaryProfile)$/u.test(names);
 }
 
 function hasUpdatedAtField(type: ObjectType): boolean {

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -70,7 +70,12 @@ export type SemanticIssueCode =
   | 'derivation_missing_source'
   | 'derivation_unknown_source'
   | 'derivation_missing_refresh'
-  | 'derivation_owner_not_writable';
+  | 'derivation_owner_not_writable'
+  | 'operational_timezone_missing'
+  | 'operational_inbound_idempotency_missing'
+  | 'operational_enum_evolution'
+  | 'operational_conflict_token_missing'
+  | 'operational_notification_model_missing';
 
 export type SemanticIssueSeverity = 'error' | 'warning';
 
@@ -97,6 +102,7 @@ export function checkSemantic(schema: Schema, catalog?: StdlibCatalog): Semantic
     ...checkDerivations(schema),
     ...checkDiscriminatedUnions(schema),
     ...checkEnums(schema),
+    ...checkOperationalAdvice(schema),
   ]);
 }
 
@@ -1034,6 +1040,220 @@ function checkEnums(schema: Schema): SemanticIssueDraft[] {
     });
   });
   return issues;
+}
+
+function checkOperationalAdvice(schema: Schema): SemanticIssueDraft[] {
+  return [
+    ...checkTimezoneAdvice(schema),
+    ...checkInboundIdempotencyAdvice(schema),
+    ...checkEnumEvolutionAdvice(schema),
+    ...checkConflictTokenAdvice(schema),
+    ...checkNotificationAdvice(schema),
+  ];
+}
+
+function checkTimezoneAdvice(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
+  const objects = schema.types.filter((type): type is ObjectType => type.kind === 'object');
+  const likelyHousehold = objects.find((type) => type.name === 'Household');
+  if (!likelyHousehold || hasTimezoneField(likelyHousehold)) return issues;
+
+  const temporalField = objects
+    .flatMap((type, typeIndex) =>
+      type.fields.map((field, fieldIndex) => ({ type, typeIndex, field, fieldIndex })),
+    )
+    .find(({ type, field }) => {
+      if (type.name === likelyHousehold.name && field.name === 'timeZoneId') return false;
+      return isHouseholdScoped(type) && isHouseholdLocalTemporalField(field);
+    });
+
+  if (!temporalField) return issues;
+  issues.push({
+    code: 'operational_timezone_missing',
+    severity: 'warning',
+    path: `types.${schema.types.indexOf(likelyHousehold)}.fields`,
+    message: `Household-scoped field "${temporalField.type.name}.${temporalField.field.name}" has local calendar or scheduling semantics, but Household has no timezone field.`,
+    hint: 'Add Household.timeZoneId as a ref to place.TimeZoneId so server jobs, week boundaries, expiry checks, and travelling clients use the same household-local clock.',
+  });
+  return issues;
+}
+
+function checkInboundIdempotencyAdvice(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
+  const objects = schema.types.filter((type): type is ObjectType => type.kind === 'object');
+  const channelIdentityIndex = objects.findIndex((type) => type.name === 'ChannelIdentity');
+  if (channelIdentityIndex === -1) return issues;
+  if (objects.some(isInboundDeliveryStateType)) return issues;
+
+  issues.push({
+    code: 'operational_inbound_idempotency_missing',
+    severity: 'warning',
+    path: `types.${schema.types.indexOf(objects[channelIdentityIndex] as TypeDef)}`,
+    message:
+      'ChannelIdentity models conversational identity, but no inbound delivery or message state is modeled.',
+    hint: 'Ensure the app runtime owns webhook idempotency and pending conversation state, or add a table such as InboundMessage/WebhookEvent with provider message ids and processing status.',
+  });
+  return issues;
+}
+
+function checkEnumEvolutionAdvice(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
+  const enumNames = new Set(
+    schema.types.filter((type) => type.kind === 'enum').map((type) => type.name),
+  );
+  if (enumNames.size === 0) return issues;
+
+  schema.types.forEach((type, typeIndex) => {
+    if (type.kind !== 'object') return;
+    type.fields.forEach((field, fieldIndex) => {
+      const enumName = unwrapRefTarget(field.type);
+      if (!enumName || !enumNames.has(enumName)) return;
+      if (!isLikelyClientSurfaceEnum(enumName, field, type, schema)) return;
+      issues.push({
+        code: 'operational_enum_evolution',
+        severity: 'warning',
+        path: `types.${typeIndex}.fields.${fieldIndex}.type`,
+        message: `${type.name}.${field.name} uses closed enum "${enumName}" in a likely client-facing surface.`,
+        hint: 'Keep the enum closed for internal safety, but make web/mobile/API clients render unknown values gracefully or map them at the compatibility boundary.',
+      });
+    });
+  });
+
+  return dedupeIssues(issues);
+}
+
+function checkConflictTokenAdvice(schema: Schema): SemanticIssueDraft[] {
+  const issues: SemanticIssueDraft[] = [];
+  schema.types.forEach((type, typeIndex) => {
+    if (type.kind !== 'object' || type.table !== true) return;
+    if (!hasUpdatedAtField(type) || hasConflictTokenField(type)) return;
+    const arrayFieldIndex = type.fields.findIndex(isCollaborativeArrayField);
+    if (arrayFieldIndex === -1) return;
+    const arrayField = type.fields[arrayFieldIndex];
+    if (!arrayField) return;
+    issues.push({
+      code: 'operational_conflict_token_missing',
+      severity: 'warning',
+      path: `types.${typeIndex}.fields.${arrayFieldIndex}`,
+      message: `${type.name}.${arrayField.name} is a shared-looking array on a table with updatedAt but no conflict token.`,
+      hint: 'For offline or optimistic edits, add a version/revision/etag field or move independently edited array items into scoped child rows.',
+    });
+  });
+  return issues;
+}
+
+function checkNotificationAdvice(schema: Schema): SemanticIssueDraft[] {
+  if (!mentionsNotificationCapability(schema)) return [];
+  const objects = schema.types.filter((type): type is ObjectType => type.kind === 'object');
+  if (objects.some(isNotificationStateType) && objects.some(isNotificationEndpointType)) return [];
+
+  return [
+    {
+      code: 'operational_notification_model_missing',
+      severity: 'warning',
+      path: 'types',
+      message:
+        'The model notes mention outbound reminders, notifications, or push, but notification state is incomplete.',
+      hint: 'If outbound notifications are in scope, model delivery endpoints and preferences, such as UserDevice, NotificationPreference, ScheduledNotification, or NotificationDelivery.',
+    },
+  ];
+}
+
+function hasTimezoneField(type: ObjectType): boolean {
+  return type.fields.some((field) => {
+    if (/^(timeZoneId|timezone|timeZone)$/u.test(field.name)) return true;
+    return field.type.kind === 'ref' && field.type.typeName === 'place.TimeZoneId';
+  });
+}
+
+function isHouseholdScoped(type: ObjectType): boolean {
+  if (type.name === 'Household') return true;
+  return type.fields.some((field) => field.name === 'householdId');
+}
+
+function isHouseholdLocalTemporalField(field: ObjectType['fields'][number]): boolean {
+  const haystack = `${field.name} ${field.description ?? ''}`.toLowerCase();
+  if (field.name === 'createdAt' || field.name === 'updatedAt') return false;
+  return (
+    /(expires|expiry|expired|suppresseduntil|scheduled|reminder|notify|planned|weekstart|weekboundary|today|localdate)/u.test(
+      haystack,
+    ) ||
+    (field.type.kind === 'date' && /(expires|planned|scheduled|week|reminder)/u.test(haystack))
+  );
+}
+
+function isInboundDeliveryStateType(type: ObjectType): boolean {
+  return /(InboundMessage|WebhookEvent|WebhookDelivery|MessageDelivery|ConversationSession|PendingIntent|PendingConfirmation)/u.test(
+    type.name,
+  );
+}
+
+function isLikelyClientSurfaceEnum(
+  enumName: string,
+  field: ObjectType['fields'][number],
+  owner: ObjectType,
+  schema: Schema,
+): boolean {
+  const haystack = `${schema.metadata?.description ?? ''} ${owner.description ?? ''} ${
+    field.description ?? ''
+  } ${owner.name} ${field.name} ${enumName}`.toLowerCase();
+  return (
+    /\b(client|mobile|web|api|surface|status|equipment|allergen|dietary|profile|cooking)\b/u.test(
+      haystack,
+    ) && /^(.*Status|Equipment|CookingMethod|Allergen|DietaryProfile)$/u.test(enumName)
+  );
+}
+
+function hasUpdatedAtField(type: ObjectType): boolean {
+  return type.fields.some((field) => field.name === 'updatedAt');
+}
+
+function hasConflictTokenField(type: ObjectType): boolean {
+  return type.fields.some((field) =>
+    /^(version|revision|etag|rowVersion|lockVersion)$/u.test(field.name),
+  );
+}
+
+function isCollaborativeArrayField(field: ObjectType['fields'][number]): boolean {
+  if (field.type.kind !== 'array') return false;
+  return /^(items|listItems|meals|tasks|todos|entries|shoppingItems|planMeals)$/u.test(field.name);
+}
+
+function mentionsNotificationCapability(schema: Schema): boolean {
+  const text = [
+    schema.metadata?.name,
+    schema.metadata?.description,
+    ...schema.types.map((type) => type.description),
+    ...schema.types.flatMap((type) =>
+      type.kind === 'object' ? type.fields.map((field) => field.description) : [],
+    ),
+  ]
+    .filter((item): item is string => Boolean(item))
+    .join(' ')
+    .toLowerCase();
+  return /\b(push|notification|notifications|notify|reminder|reminders|expiry warning|expiry warnings)\b/u.test(
+    text,
+  );
+}
+
+function isNotificationStateType(type: ObjectType): boolean {
+  return /(ScheduledNotification|NotificationDelivery|NotificationJob|Reminder)/u.test(type.name);
+}
+
+function isNotificationEndpointType(type: ObjectType): boolean {
+  return /(UserDevice|DeviceToken|PushSubscription|NotificationPreference|OutboundChannel)/u.test(
+    type.name,
+  );
+}
+
+function dedupeIssues(issues: SemanticIssueDraft[]): SemanticIssueDraft[] {
+  const seen = new Set<string>();
+  return issues.filter((issue) => {
+    const key = `${issue.code}:${issue.path}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 function stdlibNamespaceFromPath(path: ImportDecl['path']): string | null {

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -7,7 +7,7 @@ const STDLIB: StdlibCatalog = {
   hasType: (ns, name) => {
     const types: Record<string, ReadonlySet<string>> = {
       common: new Set(['Email', 'URL', 'ISODateTime']),
-      place: new Set(['CountryCode', 'Address']),
+      place: new Set(['CountryCode', 'Address', 'TimeZoneId']),
       money: new Set(['Money', 'CurrencyCode']),
     };
     return types[ns]?.has(name) ?? false;
@@ -924,5 +924,143 @@ describe('checkSemantic — enums', () => {
       'enum_empty',
       'enum_duplicate_value',
     ]);
+  });
+});
+
+describe('checkSemantic — operational advice', () => {
+  it('warns when household-local temporal fields have no household timezone', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'object', name: 'Household', table: true, fields: [] },
+        {
+          kind: 'object',
+          name: 'PantryItem',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            { name: 'expiresOn', type: { kind: 'date' } },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema, STDLIB)).toEqual([
+      expect.objectContaining({
+        code: 'operational_timezone_missing',
+        severity: 'warning',
+        hint: expect.stringContaining('place.TimeZoneId'),
+      }),
+    ]);
+  });
+
+  it('does not warn for household-local temporal fields when household has a timezone', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Household',
+          table: true,
+          fields: [{ name: 'timeZoneId', type: { kind: 'ref', typeName: 'place.TimeZoneId' } }],
+        },
+        {
+          kind: 'object',
+          name: 'PantryItem',
+          table: true,
+          fields: [
+            { name: 'householdId', type: { kind: 'ref', typeName: 'Household' } },
+            { name: 'expiresOn', type: { kind: 'date' } },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema, STDLIB).map((issue) => issue.code)).not.toContain(
+      'operational_timezone_missing',
+    );
+  });
+
+  it('warns when channel identities have no inbound runtime state', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'ChannelIdentity',
+          table: true,
+          fields: [
+            { name: 'provider', type: { kind: 'string' } },
+            { name: 'externalId', type: { kind: 'string' } },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema).map((issue) => issue.code)).toContain(
+      'operational_inbound_idempotency_missing',
+    );
+  });
+
+  it('warns for likely client-facing closed enums', () => {
+    const schema: Schema = {
+      version: '1',
+      metadata: { description: 'Mobile and web meal planning app.' },
+      types: [
+        { kind: 'enum', name: 'Equipment', values: [{ value: 'oven' }] },
+        {
+          kind: 'object',
+          name: 'Recipe',
+          table: true,
+          fields: [
+            {
+              name: 'equipment',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'Equipment' } },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema)).toEqual([
+      expect.objectContaining({
+        code: 'operational_enum_evolution',
+        severity: 'warning',
+        hint: expect.stringContaining('unknown values'),
+      }),
+    ]);
+  });
+
+  it('warns when collaborative array edits have updatedAt but no conflict token', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'ShoppingList',
+          table: true,
+          fields: [
+            { name: 'updatedAt', type: { kind: 'ref', typeName: 'common.ISODateTime' } },
+            { name: 'items', type: { kind: 'array', element: { kind: 'string' } } },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema, STDLIB).map((issue) => issue.code)).toContain(
+      'operational_conflict_token_missing',
+    );
+  });
+
+  it('warns when notification notes have no outbound model', () => {
+    const schema: Schema = {
+      version: '1',
+      metadata: { description: 'Sends push reminders and expiry warnings.' },
+      types: [{ kind: 'object', name: 'Household', table: true, fields: [] }],
+    };
+
+    expect(checkSemantic(schema).map((issue) => issue.code)).toContain(
+      'operational_notification_model_missing',
+    );
   });
 });

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -1031,6 +1031,25 @@ describe('checkSemantic — operational advice', () => {
     ]);
   });
 
+  it('does not warn for ordinary status enums without client-surface context', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        { kind: 'enum', name: 'PostStatus', values: [{ value: 'draft' }, { value: 'live' }] },
+        {
+          kind: 'object',
+          name: 'Post',
+          table: true,
+          fields: [{ name: 'status', type: { kind: 'ref', typeName: 'PostStatus' } }],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema).map((issue) => issue.code)).not.toContain(
+      'operational_enum_evolution',
+    );
+  });
+
   it('warns when collaborative array edits have updatedAt but no conflict token', () => {
     const schema: Schema = {
       version: '1',


### PR DESCRIPTION
## Summary
- add warning-grade operational advice to semantic validation for timezone, inbound idempotency, enum evolution, conflict tokens, and notification model gaps
- keep the advice advisory only so apply gates still block only semantic errors
- cover the new advice families in semantic-validation tests

## Tests
- bun run test -- tests/semantic-validation.test.ts (packages/core)
- bun run typecheck (packages/core)
- bun run test (packages/core)
- bun run check
- commit hook: turbo typecheck && turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783101576&installation_id=136251083&pr_number=376&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F376&signature=44d0892cadc83e2c89a77a8041b7b8f4a2b8ef4d672849836759f61a76249c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->