### PR TITLE
fix(desktop): render warning graph rows in warning tone

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.41",
+  "version": "0.15.42",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
@@ -24,6 +24,7 @@ import { STDLIB_REGISTRY, STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registr
 import { useMemo, useSyncExternalStore } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { useChatComposerStore } from '../../store/chat-composer';
 import type { Op } from '../../store/ops';
 import { useGraphSelectionStore } from '../../store/selection';
 import { useUIChromeStore } from '../../store/ui-chrome';
@@ -112,6 +113,14 @@ export function DetailPanel({
       },
     };
   };
+  const discussIssue = (error: ValidationError): void => {
+    useChatComposerStore.getState().setPendingChatMessage({
+      message: validationChatPrompt(error),
+      context: '',
+    });
+    useUIChromeStore.getState().setSidebarTab('chat');
+    useUIChromeStore.getState().setSidebarVisible(true);
+  };
 
   if (selection.edge) {
     return (
@@ -166,6 +175,7 @@ export function DetailPanel({
         }}
         validationErrors={validationErrorsForField(validationErrors, typeIndex, fieldIndex)}
         validationRepairForIssue={repairForIssue}
+        onDiscussValidationIssue={discussIssue}
         availableTypeNames={schema.types
           .filter((candidate) => candidate.name !== type.name)
           .map((candidate) => candidate.name)}
@@ -186,6 +196,7 @@ export function DetailPanel({
       modelingHints={modelingHints.filter((hint) => hint.typeName === type.name)}
       validationErrors={typeValidationErrors}
       validationRepairForIssue={repairForIssue}
+      onDiscussValidationIssue={discussIssue}
       availableTypeNames={schema.types
         .filter((candidate) => candidate.name !== type.name)
         .map((candidate) => candidate.name)}
@@ -252,6 +263,22 @@ export function DetailPanel({
       document.dispatchEvent(new CustomEvent(FOCUS_TYPE_NAME_EVENT, { detail: { typeName } }));
     }, 0);
   }
+}
+
+function validationChatPrompt(error: ValidationError): string {
+  return [
+    'Help me resolve this Contexture validation issue.',
+    '',
+    `Code: ${error.code}`,
+    `Severity: ${error.severity}`,
+    `Path: ${error.path}`,
+    `Message: ${error.message}`,
+    error.hint ? `Hint: ${error.hint}` : null,
+    '',
+    'Please review the current IR and suggest the smallest safe model change. If the fix should be app-runtime owned instead of modeled, explain the runtime contract to document.',
+  ]
+    .filter((line): line is string => line !== null)
+    .join('\n');
 }
 
 function EmptyState({ message }: { message: string }) {

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -100,6 +100,7 @@ export interface FieldDetailProps {
   modelingHints?: readonly ModelingHint[];
   validationErrors?: readonly ValidationError[];
   validationRepairForIssue?: (error: ValidationError) => ValidationIssueRepair | null;
+  onDiscussValidationIssue?: (error: ValidationError) => void;
   availableTypeNames?: readonly string[];
   tableIndexes?: readonly IndexDef[];
   onCreateRefTarget?: () => string | undefined;
@@ -114,6 +115,7 @@ export function FieldDetail({
   modelingHints = [],
   validationErrors = [],
   validationRepairForIssue,
+  onDiscussValidationIssue,
   availableTypeNames = [],
   tableIndexes,
   onCreateRefTarget,
@@ -243,7 +245,11 @@ export function FieldDetail({
 
       <div className="min-h-0 flex-1 overflow-y-auto p-3">
         <div className="space-y-3">
-          <ValidationIssues errors={validationErrors} repairForIssue={validationRepairForIssue} />
+          <ValidationIssues
+            errors={validationErrors}
+            onDiscussIssue={onDiscussValidationIssue}
+            repairForIssue={validationRepairForIssue}
+          />
 
           <FieldGroup>
             <Field>

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -15,7 +15,14 @@
 
 import { derivationKindLabel } from '@contexture/core/derivation';
 import { listFixtureModules } from '@contexture/core/fixture-generators';
-import type { FieldDef, FieldType, IndexDef, Schema, TypeDef } from '@contexture/core/ir';
+import type {
+  EnumEvolutionCompatibility,
+  FieldDef,
+  FieldType,
+  IndexDef,
+  Schema,
+  TypeDef,
+} from '@contexture/core/ir';
 import type { ModelingHint } from '@contexture/core/modeling-hints';
 import type { TypeUpdatePatch } from '@contexture/core/ops';
 import type { ValidationError } from '@renderer/services/validation';
@@ -91,6 +98,7 @@ export interface TypeDetailProps {
   modelingHints?: readonly ModelingHint[];
   validationErrors?: readonly ValidationError[];
   validationRepairForIssue?: (error: ValidationError) => ValidationIssueRepair | null;
+  onDiscussValidationIssue?: (error: ValidationError) => void;
   availableTypeNames?: readonly string[];
   availableObjectTypeNames?: readonly string[];
 }
@@ -103,6 +111,7 @@ export function TypeDetail({
   modelingHints = [],
   validationErrors = [],
   validationRepairForIssue,
+  onDiscussValidationIssue,
   availableTypeNames = [],
   availableObjectTypeNames = [],
 }: TypeDetailProps) {
@@ -122,6 +131,7 @@ export function TypeDetail({
         modelingHints={modelingHints}
         validationErrors={validationErrors}
         validationRepairForIssue={validationRepairForIssue}
+        onDiscussValidationIssue={onDiscussValidationIssue}
         recordsCount={tableRecords.length}
         reserved={nameReserved}
       />
@@ -166,6 +176,7 @@ export function TypeDetail({
 
       <ValidationIssues
         errors={validationErrors}
+        onDiscussIssue={onDiscussValidationIssue}
         onIssueClick={(error) => selectFieldFromValidationIssue(type, error)}
         repairForIssue={validationRepairForIssue}
       />
@@ -200,6 +211,7 @@ function TableTypeDetail({
   modelingHints,
   validationErrors,
   validationRepairForIssue,
+  onDiscussValidationIssue,
   recordsCount,
   reserved,
 }: {
@@ -209,6 +221,7 @@ function TableTypeDetail({
   modelingHints: readonly ModelingHint[];
   validationErrors: readonly ValidationError[];
   validationRepairForIssue?: (error: ValidationError) => ValidationIssueRepair | null;
+  onDiscussValidationIssue?: (error: ValidationError) => void;
   recordsCount: number;
   reserved: boolean;
 }) {
@@ -279,6 +292,7 @@ function TableTypeDetail({
         <div className="space-y-4">
           <ValidationIssues
             errors={validationErrors}
+            onDiscussIssue={onDiscussValidationIssue}
             onIssueClick={(error) => selectFieldFromValidationIssue(type, error)}
             repairForIssue={validationRepairForIssue}
           />
@@ -332,6 +346,7 @@ function TableTypeDetail({
         <div className="flex h-full min-h-0 flex-col">
           <ValidationIssues
             errors={validationErrors}
+            onDiscussIssue={onDiscussValidationIssue}
             onIssueClick={(error) => selectFieldFromValidationIssue(type, error)}
             repairForIssue={validationRepairForIssue}
           />
@@ -1768,6 +1783,7 @@ function EnumBody({
 
   return (
     <div className="space-y-2">
+      <EnumCompatibilitySection type={type} />
       <div className="flex items-center justify-between">
         <Label>Values</Label>
         <Button type="button" variant="ghost" size="sm" onClick={addValue} className="h-7 text-xs">
@@ -1870,6 +1886,60 @@ function EnumBody({
       )}
     </div>
   );
+}
+
+function EnumCompatibilitySection({ type }: { type: Extract<TypeDef, { kind: 'enum' }> }) {
+  const contract = type.compatibility?.enumEvolution;
+  if (!contract) return null;
+
+  return (
+    <section className="space-y-2 rounded-md border border-border/70 bg-muted/20 p-2.5">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="text-xs font-medium text-foreground">Compatibility contract</h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Unknown values: {enumEvolutionBehaviorSummary(contract.unknownValueBehavior)}
+          </p>
+        </div>
+        <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
+          documented
+        </Badge>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {contract.fallbackLabel && (
+          <Badge variant="secondary" className="h-5 rounded-md px-1.5 text-[11px]">
+            fallback: {contract.fallbackLabel}
+          </Badge>
+        )}
+        {contract.owner && (
+          <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
+            owner: {contract.owner}
+          </Badge>
+        )}
+        {(contract.clientSurfaces ?? []).map((surface) => (
+          <Badge key={surface} variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
+            {surface}
+          </Badge>
+        ))}
+      </div>
+      {contract.notes && (
+        <p className="text-xs leading-relaxed text-foreground/85">{contract.notes}</p>
+      )}
+    </section>
+  );
+}
+
+function enumEvolutionBehaviorSummary(
+  behavior: EnumEvolutionCompatibility['unknownValueBehavior'],
+): string {
+  switch (behavior) {
+    case 'preserve':
+      return 'preserve raw value and render fallback';
+    case 'fallbackOnly':
+      return 'render fallback without interpreting';
+    case 'rejectAtBoundary':
+      return 'reject at explicit boundary';
+  }
 }
 
 function enumDeleteDisabledReason(valueCount: number, isDuplicate: boolean): string | undefined {

--- a/apps/desktop/src/renderer/src/components/detail/ValidationIssues.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/ValidationIssues.tsx
@@ -1,5 +1,5 @@
 import type { ValidationError } from '@renderer/services/validation';
-import { CircleAlert } from 'lucide-react';
+import { CircleAlert, MessageSquare } from 'lucide-react';
 import { Button } from '../ui/button';
 
 export interface ValidationIssueRepair {
@@ -9,35 +9,57 @@ export interface ValidationIssueRepair {
 
 export function ValidationIssues({
   errors,
+  onDiscussIssue,
   onIssueClick,
   repairForIssue,
 }: {
   errors: readonly ValidationError[];
+  onDiscussIssue?: (error: ValidationError) => void;
   onIssueClick?: (error: ValidationError) => void;
   repairForIssue?: (error: ValidationError) => ValidationIssueRepair | null;
 }) {
   if (errors.length === 0) return null;
 
+  const hasErrors = errors.some((error) => error.severity === 'error');
+  const tone = hasErrors ? 'destructive' : 'warning';
+  const title = hasErrors
+    ? errors.length === 1
+      ? 'Validation issue'
+      : 'Validation issues'
+    : errors.length === 1
+      ? 'Advisory'
+      : 'Advisories';
+
   return (
     <section
       aria-label="Validation issues"
-      className="space-y-1 rounded-md border border-destructive/35 bg-destructive/10 p-2 text-xs"
+      className={`space-y-1 rounded-md border p-2 text-xs ${
+        tone === 'destructive'
+          ? 'border-destructive/35 bg-destructive/10'
+          : 'border-warning/35 bg-warning/10'
+      }`}
     >
-      <div className="flex items-center gap-1.5 font-medium text-destructive">
+      <div
+        className={`flex items-center gap-1.5 font-medium ${
+          tone === 'destructive' ? 'text-destructive' : 'text-warning'
+        }`}
+      >
         <CircleAlert aria-hidden="true" className="size-3.5" />
-        {errors.length === 1 ? 'Validation issue' : 'Validation issues'}
+        {title}
       </div>
       <ul className="space-y-1 text-foreground/90">
         {errors.map((error) => {
           const repair = repairForIssue?.(error);
+          const hoverClass =
+            error.severity === 'error' ? 'hover:bg-destructive/10' : 'hover:bg-warning/10';
           return (
-            <li key={`${error.code}:${error.path}`} className="flex items-start gap-2">
+            <li key={`${error.code}:${error.path}`} className="space-y-1.5">
               {onIssueClick ? (
                 <Button
                   type="button"
                   variant="ghost"
                   onClick={() => onIssueClick(error)}
-                  className="h-auto min-h-8 min-w-0 flex-1 justify-start px-1.5 py-1 text-left text-xs hover:bg-destructive/10"
+                  className={`h-auto min-h-8 w-full justify-start px-1.5 py-1 text-left text-xs ${hoverClass}`}
                 >
                   <span className="whitespace-normal">
                     <span className="block font-mono text-[10px] text-muted-foreground/80">
@@ -48,7 +70,7 @@ export function ValidationIssues({
                   </span>
                 </Button>
               ) : (
-                <span className="min-w-0 flex-1">
+                <span className="block min-w-0 px-1.5 py-1">
                   <span className="block font-mono text-[10px] text-muted-foreground/80">
                     {error.code}
                   </span>
@@ -56,16 +78,32 @@ export function ValidationIssues({
                   <span className="ml-1 text-muted-foreground/70">{error.path}</span>
                 </span>
               )}
-              {repair && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={repair.onApply}
-                  className="h-8 shrink-0 px-2 text-[11px]"
-                >
-                  {repair.label}
-                </Button>
+              {(repair || onDiscussIssue) && (
+                <div className="flex justify-end gap-1.5">
+                  {repair && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={repair.onApply}
+                      className="h-8 shrink-0 px-2 text-[11px]"
+                    >
+                      {repair.label}
+                    </Button>
+                  )}
+                  {onDiscussIssue && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onDiscussIssue(error)}
+                      className="h-8 shrink-0 gap-1 px-2 text-[11px]"
+                    >
+                      <MessageSquare aria-hidden="true" className="size-3" />
+                      Discuss in chat
+                    </Button>
+                  )}
+                </div>
               )}
             </li>
           );

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -101,23 +101,23 @@ export function focusedFieldFromTarget(target: GraphFocusTarget): FocusedField |
 
 export function applyValidationHighlights(
   graph: BuildGraphResult,
-  errors: readonly { path: string }[],
+  errors: readonly { path: string; severity?: 'error' | 'warning' }[],
 ): BuildGraphResult {
   if (errors.length === 0) return graph;
 
-  const typeIssueCounts = new Map<number, number>();
-  const fieldIssueCounts = new Map<string, number>();
+  const typeIssues = new Map<number, { count: number; tone: 'error' | 'warning' }>();
+  const fieldIssues = new Map<string, { count: number; tone: 'error' | 'warning' }>();
 
   for (const error of errors) {
     const typeMatch = error.path.match(/^types\.(\d+)/u);
     if (!typeMatch) continue;
     const typeIndex = Number(typeMatch[1]);
-    typeIssueCounts.set(typeIndex, (typeIssueCounts.get(typeIndex) ?? 0) + 1);
+    incrementIssue(typeIssues, typeIndex, error.severity);
 
     const fieldMatch = error.path.match(/^types\.\d+\.fields\.(\d+)/u);
     if (fieldMatch) {
       const key = `${typeIndex}:${Number(fieldMatch[1])}`;
-      fieldIssueCounts.set(key, (fieldIssueCounts.get(key) ?? 0) + 1);
+      incrementIssue(fieldIssues, key, error.severity);
     }
   }
 
@@ -127,21 +127,33 @@ export function applyValidationHighlights(
       if (node.type !== 'type') return node;
       const typeIndex = node.data.schemaIndex;
       if (typeIndex === undefined) return node;
-      const validationIssueCount = typeIssueCounts.get(typeIndex) ?? 0;
-      if (validationIssueCount === 0) return node;
+      const typeIssue = typeIssues.get(typeIndex);
+      if (!typeIssue) return node;
       return {
         ...node,
         data: {
           ...node.data,
-          validationIssueCount,
+          validationIssueCount: typeIssue.count,
+          validationIssueTone: typeIssue.tone,
           fields: node.data.fields.map((field: FieldRow, fieldIndex: number) => ({
             ...field,
-            validationIssueCount: fieldIssueCounts.get(`${typeIndex}:${fieldIndex}`) ?? undefined,
+            validationIssueCount: fieldIssues.get(`${typeIndex}:${fieldIndex}`)?.count,
+            validationIssueTone: fieldIssues.get(`${typeIndex}:${fieldIndex}`)?.tone,
           })),
         } satisfies TypeNodeData,
       };
     }),
   };
+}
+
+function incrementIssue<K>(
+  issues: Map<K, { count: number; tone: 'error' | 'warning' }>,
+  key: K,
+  severity: 'error' | 'warning' = 'error',
+): void {
+  const existing = issues.get(key);
+  const tone = severity === 'error' || existing?.tone === 'error' ? 'error' : 'warning';
+  issues.set(key, { count: (existing?.count ?? 0) + 1, tone });
 }
 
 export function GraphCanvas(props: GraphCanvasProps): React.JSX.Element {

--- a/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/nodes/TypeNode.tsx
@@ -100,6 +100,8 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
     (data.previewDimmed === true && !isSelected && !isPreviewPrimary && !isPreviewAdjacent);
   const isSyncHighlighted = data.syncHighlighted === true && !isSelected && !isAdjacent;
   const hasValidationIssues = (data.validationIssueCount ?? 0) > 0;
+  const validationIssueColor =
+    data.validationIssueTone === 'warning' ? 'var(--warning)' : 'var(--destructive)';
   const fieldsInSelectedType =
     isSelected && selectedEdge === null && selectedField?.typeName !== data.typeName;
 
@@ -246,7 +248,7 @@ export const TypeNode = memo(function TypeNode(props: NodeProps<TypeNodeKind>) {
             insetBlock: 0,
             insetInlineEnd: 0,
             width: 3,
-            background: 'var(--destructive)',
+            background: validationIssueColor,
             zIndex: 2,
           }}
         />
@@ -528,6 +530,8 @@ function FieldRowButton({
   const showModelingAdvice = field.modelingHintTone === 'warning';
   const modelingHintColor =
     field.modelingHintTone === 'warning' ? 'var(--warning)' : 'var(--inspector-advisory)';
+  const validationIssueColor =
+    field.validationIssueTone === 'warning' ? 'var(--warning)' : 'var(--destructive)';
   const button = (
     <button
       type="button"
@@ -586,7 +590,7 @@ function FieldRowButton({
                 : searchFocused
                   ? 'var(--graph-node-selected-bg)'
                   : hasValidationIssues
-                    ? 'color-mix(in oklch, var(--destructive) 10%, transparent)'
+                    ? `color-mix(in oklch, ${validationIssueColor} 10%, transparent)`
                     : undefined,
         boxShadow: selected
           ? `inset 2px 0 0 ${selectionAccent}, inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)`
@@ -595,7 +599,7 @@ function FieldRowButton({
             : searchFocused
               ? 'inset 3px 0 0 var(--graph-node-selected), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)'
               : hasValidationIssues
-                ? 'inset 3px 0 0 var(--destructive), inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)'
+                ? `inset 3px 0 0 ${validationIssueColor}, inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)`
                 : 'inset 0 -1px 0 color-mix(in oklch, var(--border) 82%, transparent)',
       }}
     >
@@ -608,7 +612,7 @@ function FieldRowButton({
               : highlighted
                 ? `color-mix(in oklch, ${selectionAccent} 38%, var(--foreground))`
                 : hasValidationIssues
-                  ? 'var(--destructive)'
+                  ? validationIssueColor
                   : 'var(--muted-foreground)',
           fontWeight: 400,
         }}

--- a/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
+++ b/apps/desktop/src/renderer/src/components/graph/schema-to-graph.ts
@@ -55,6 +55,7 @@ export interface TypeNodeData extends Record<string, unknown> {
   stdlib?: boolean;
   /** Local object nodes can create fields directly from the canvas. */
   canAddFields?: boolean;
+  validationIssueTone?: 'error' | 'warning';
 }
 
 export interface EnumValueRow {
@@ -78,6 +79,7 @@ export interface FieldRow {
   /** Bundled stdlib metadata when this field references `namespace.Type`. */
   stdlibTarget?: StdlibTargetRow;
   validationIssueCount?: number;
+  validationIssueTone?: 'error' | 'warning';
   modelingHintCount?: number;
   modelingHintTone?: 'advisory' | 'warning';
 }

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -11,6 +11,7 @@
 import type { Schema } from '@contexture/core/ir';
 import { DetailPanel } from '@renderer/components/detail/DetailPanel';
 import type { RefEdgeData } from '@renderer/components/graph/schema-to-graph';
+import { useChatComposerStore } from '@renderer/store/chat-composer';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import { useUndoStore } from '@renderer/store/undo';
@@ -81,6 +82,7 @@ describe('DetailPanel', () => {
     useGraphSelectionStore.getState().clear();
     useUIChromeStore.getState().setSidebarVisible(true);
     useUIChromeStore.getState().setSidebarTab('properties');
+    useChatComposerStore.getState().setPendingChatMessage(null);
   });
   afterEach(cleanup);
 
@@ -307,6 +309,111 @@ describe('DetailPanel', () => {
     expect(within(issues).getByText('unresolved_ref')).toBeInTheDocument();
     expect(within(issues).getByText(/Unresolved ref "Author"/i)).toBeInTheDocument();
     expect(within(issues).getByText('types.0.fields.0.type')).toBeInTheDocument();
+  });
+
+  it('renders field-level validation warnings as advisories', () => {
+    seedUnchecked({
+      version: '1',
+      metadata: { description: 'Mobile and web meal planning app.' },
+      types: [
+        { kind: 'enum', name: 'ChannelIdentityStatus', values: [{ value: 'active' }] },
+        {
+          kind: 'object',
+          name: 'ChannelIdentity',
+          table: true,
+          fields: [
+            {
+              name: 'status',
+              type: { kind: 'ref', typeName: 'ChannelIdentityStatus' },
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<DetailPanel selection={{ typeName: 'ChannelIdentity', fieldName: 'status' }} />);
+
+    const issues = screen.getByRole('region', { name: 'Validation issues' });
+    expect(within(issues).getByText('Advisory')).toBeInTheDocument();
+    expect(within(issues).getByText('operational_enum_evolution')).toBeInTheDocument();
+    expect(issues).toHaveClass('border-warning/35', 'bg-warning/10');
+    expect(issues).not.toHaveClass('border-destructive/35', 'bg-destructive/10');
+  });
+
+  it('opens field-level validation warnings in chat', () => {
+    seedUnchecked({
+      version: '1',
+      metadata: { description: 'Mobile and web meal planning app.' },
+      types: [
+        { kind: 'enum', name: 'ChannelIdentityStatus', values: [{ value: 'active' }] },
+        {
+          kind: 'object',
+          name: 'ChannelIdentity',
+          table: true,
+          fields: [
+            {
+              name: 'status',
+              type: { kind: 'ref', typeName: 'ChannelIdentityStatus' },
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<DetailPanel selection={{ typeName: 'ChannelIdentity', fieldName: 'status' }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Discuss in chat' }));
+
+    expect(useUIChromeStore.getState().sidebarTab).toBe('chat');
+    expect(useChatComposerStore.getState().pendingChatMessage?.message).toContain(
+      'operational_enum_evolution',
+    );
+    expect(useChatComposerStore.getState().pendingChatMessage?.message).toContain(
+      'Severity: warning',
+    );
+    expect(useChatComposerStore.getState().pendingChatMessage?.message).toContain(
+      'types.1.fields.0.type',
+    );
+  });
+
+  it('documents compatibility contracts from field-level enum evolution advisories', () => {
+    seedUnchecked({
+      version: '1',
+      metadata: { description: 'Mobile and web meal planning app.' },
+      types: [
+        { kind: 'enum', name: 'ChannelIdentityStatus', values: [{ value: 'active' }] },
+        {
+          kind: 'object',
+          name: 'ChannelIdentity',
+          table: true,
+          fields: [
+            {
+              name: 'status',
+              type: { kind: 'ref', typeName: 'ChannelIdentityStatus' },
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<DetailPanel selection={{ typeName: 'ChannelIdentity', fieldName: 'status' }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Document contract' }));
+
+    expect(useUndoStore.getState().schema.types[0]).toMatchObject({
+      kind: 'enum',
+      name: 'ChannelIdentityStatus',
+      compatibility: {
+        enumEvolution: {
+          unknownValueBehavior: 'preserve',
+          fallbackLabel: 'Unknown channel identity status',
+          clientSurfaces: ['web', 'mobile', 'api'],
+          owner: 'client',
+        },
+      },
+    });
+
+    cleanup();
+    render(<DetailPanel selection={{ typeName: 'ChannelIdentity', fieldName: 'status' }} />);
+    expect(screen.queryByRole('region', { name: 'Validation issues' })).not.toBeInTheDocument();
   });
 
   it('offers deterministic validation repair from the selected field details', () => {

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -707,6 +707,28 @@ describe('TypeDetail', () => {
       expect(screen.getByDisplayValue('Planting time.')).toBeInTheDocument();
     });
 
+    it('renders documented enum compatibility contracts', () => {
+      setup({
+        ...type,
+        compatibility: {
+          enumEvolution: {
+            unknownValueBehavior: 'preserve',
+            fallbackLabel: 'Unknown season',
+            clientSurfaces: ['web', 'api'],
+            owner: 'client',
+            notes: 'Clients must preserve unknown values at the compatibility boundary.',
+          },
+        },
+      });
+
+      expect(screen.getByText('Compatibility contract')).toBeInTheDocument();
+      expect(screen.getByText(/preserve raw value/i)).toBeInTheDocument();
+      expect(screen.getByText('fallback: Unknown season')).toBeInTheDocument();
+      expect(screen.getByText('owner: client')).toBeInTheDocument();
+      expect(screen.getByText('web')).toBeInTheDocument();
+      expect(screen.getByText('api')).toBeInTheDocument();
+    });
+
     it('dispatches add_value when Add value is clicked', () => {
       const { dispatch } = setup(type);
       fireEvent.click(screen.getByRole('button', { name: 'Add value' }));

--- a/apps/desktop/tests/components/graph/TypeNode.test.tsx
+++ b/apps/desktop/tests/components/graph/TypeNode.test.tsx
@@ -458,6 +458,35 @@ describe('TypeNode', () => {
     );
   });
 
+  it('uses warning color for field rows with warning validation issues', () => {
+    const data: TypeNodeData = {
+      typeName: 'RecipeSafetyAssessment',
+      kind: 'object',
+      imported: false,
+      validationIssueCount: 1,
+      validationIssueTone: 'warning',
+      fields: [
+        {
+          name: 'unknownDietaryProfiles',
+          summary: 'DietaryProfile[] enum',
+          optional: true,
+          nullable: false,
+          validationIssueCount: 1,
+          validationIssueTone: 'warning',
+        },
+      ],
+    };
+    render(<TypeNode {...makeProps(data)} />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId('type-node-validation-rail').getAttribute('style')).toContain(
+      'var(--warning)',
+    );
+    expect(screen.getByTestId('type-node-field').getAttribute('style')).toContain('var(--warning)');
+    expect(screen.getByTestId('type-node-field').getAttribute('style')).not.toContain(
+      'var(--destructive)',
+    );
+  });
+
   it('keeps low-pressure modeling advice out of canvas field rows', () => {
     const data: TypeNodeData = {
       typeName: 'Post',

--- a/apps/desktop/tests/graph/schema-to-graph.test.ts
+++ b/apps/desktop/tests/graph/schema-to-graph.test.ts
@@ -250,7 +250,43 @@ describe('buildGraph', () => {
 
     expect(graph.nodes[0].data).toMatchObject({
       validationIssueCount: 1,
+      validationIssueTone: 'error',
       fields: [expect.objectContaining({ name: 'author', validationIssueCount: 1 })],
+    });
+  });
+
+  it('preserves warning severity for validation highlights', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'RecipeSafetyAssessment',
+          fields: [
+            {
+              name: 'unknownDietaryProfiles',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'DietaryProfile' } },
+            },
+          ],
+        },
+        { kind: 'enum', name: 'DietaryProfile', values: [{ value: 'vegan' }] },
+      ],
+    };
+
+    const graph = applyValidationHighlights(buildGraph({ schema }), [
+      { path: 'types.0.fields.0.type', severity: 'warning' },
+    ]);
+
+    expect(graph.nodes[0].data).toMatchObject({
+      validationIssueCount: 1,
+      validationIssueTone: 'warning',
+      fields: [
+        expect.objectContaining({
+          name: 'unknownDietaryProfiles',
+          validationIssueCount: 1,
+          validationIssueTone: 'warning',
+        }),
+      ],
     });
   });
 
@@ -286,6 +322,7 @@ describe('buildGraph', () => {
       typeName: 'Post',
       schemaIndex: 1,
       validationIssueCount: 1,
+      validationIssueTone: 'error',
       fields: [expect.objectContaining({ name: 'author', validationIssueCount: 1 })],
     });
   });

--- a/packages/core/src/domain-brief.ts
+++ b/packages/core/src/domain-brief.ts
@@ -1,4 +1,11 @@
-import type { FieldDef, FieldType, ObjectInvariant, Schema, TypeDef } from './ir';
+import type {
+  EnumEvolutionCompatibility,
+  FieldDef,
+  FieldType,
+  ObjectInvariant,
+  Schema,
+  TypeDef,
+} from './ir';
 import { analyzeModelingHints, type ModelingHint } from './modeling-hints';
 import { checkSemantic, type SemanticIssue, type StdlibCatalog } from './semantic-validation';
 
@@ -13,6 +20,7 @@ export interface DomainBrief {
     tableCount: number;
     invariantCount: number;
     derivationCount: number;
+    compatibilityContractCount: number;
     relationshipCount: number;
     queryContractCount: number;
     unresolvedDecisionCount: number;
@@ -23,7 +31,12 @@ export interface DomainBrief {
   semanticWarnings: SemanticIssue[];
 }
 
-export type DomainDecisionKind = 'invariant' | 'derivation' | 'relationship' | 'query';
+export type DomainDecisionKind =
+  | 'invariant'
+  | 'derivation'
+  | 'compatibility'
+  | 'relationship'
+  | 'query';
 
 export interface DomainDecision {
   id: string;
@@ -77,6 +90,7 @@ export function buildDomainBrief(
         .length,
       invariantCount: countInvariants(schema),
       derivationCount: countDerivations(schema),
+      compatibilityContractCount: collectCompatibilityDecisions(schema).length,
       relationshipCount: collectRelationshipDecisions(schema).length,
       queryContractCount: collectQueryDecisions(schema).length,
       unresolvedDecisionCount: unresolvedDecisions.length,
@@ -92,6 +106,7 @@ function collectDeclaredDecisions(schema: Schema): DomainDecision[] {
   return [
     ...collectInvariantDecisions(schema),
     ...collectDerivationDecisions(schema),
+    ...collectCompatibilityDecisions(schema),
     ...collectRelationshipDecisions(schema),
     ...collectQueryDecisions(schema),
   ].sort((a, b) => a.id.localeCompare(b.id));
@@ -159,6 +174,45 @@ function collectDerivationDecisions(schema: Schema): DomainDecision[] {
     });
   });
   return decisions;
+}
+
+function collectCompatibilityDecisions(schema: Schema): DomainDecision[] {
+  const decisions: DomainDecision[] = [];
+  schema.types.forEach((type, typeIndex) => {
+    if (type.kind !== 'enum' || !type.compatibility?.enumEvolution) return;
+    const contract = type.compatibility.enumEvolution;
+    const parts = [
+      `${type.name} unknown enum values: ${enumEvolutionBehaviorLabel(contract.unknownValueBehavior)}`,
+      contract.fallbackLabel ? `fallback label "${contract.fallbackLabel}"` : null,
+      (contract.clientSurfaces?.length ?? 0) > 0
+        ? `surfaces: ${contract.clientSurfaces?.join(', ')}`
+        : null,
+      contract.owner ? `owner: ${contract.owner}` : null,
+      contract.notes ?? null,
+    ].filter((part): part is string => Boolean(part));
+    decisions.push({
+      id: `compatibility:enumEvolution:${type.name}`,
+      kind: 'compatibility',
+      title: `${type.name} enum evolution`,
+      scope: type.name,
+      path: `types.${typeIndex}.compatibility.enumEvolution`,
+      statement: `${parts.join('; ')}.`,
+    });
+  });
+  return decisions;
+}
+
+function enumEvolutionBehaviorLabel(
+  behavior: EnumEvolutionCompatibility['unknownValueBehavior'],
+): string {
+  switch (behavior) {
+    case 'preserve':
+      return 'preserve raw values and render a neutral fallback';
+    case 'fallbackOnly':
+      return 'render a neutral fallback without interpreting the value';
+    case 'rejectAtBoundary':
+      return 'reject unknown values at an explicit compatibility boundary';
+  }
 }
 
 function collectRelationshipDecisions(schema: Schema): DomainDecision[] {

--- a/packages/core/src/ir.ts
+++ b/packages/core/src/ir.ts
@@ -61,6 +61,22 @@ const SampleDataHintSchema = z.object({
 
 export type SampleDataHint = z.infer<typeof SampleDataHintSchema>;
 
+const EnumEvolutionCompatibilitySchema = z.object({
+  unknownValueBehavior: z.enum(['preserve', 'fallbackOnly', 'rejectAtBoundary']),
+  fallbackLabel: z.string().min(1).optional(),
+  clientSurfaces: z.array(z.string().min(1)).optional(),
+  owner: z.enum(['backend', 'client', 'api', 'external']).optional(),
+  notes: z.string().min(1).optional(),
+});
+
+export type EnumEvolutionCompatibility = z.infer<typeof EnumEvolutionCompatibilitySchema>;
+
+const TypeCompatibilitySchema = z.object({
+  enumEvolution: EnumEvolutionCompatibilitySchema.optional(),
+});
+
+export type TypeCompatibility = z.infer<typeof TypeCompatibilitySchema>;
+
 const DerivationPolicySchema = z.object({
   kind: z.enum(['computed', 'cachedHandle', 'snapshot', 'rollup', 'estimate']),
   sources: z.array(z.string().min(1)).optional(),
@@ -225,6 +241,7 @@ const EnumTypeDefSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
   sampleData: SampleDataHintSchema.optional(),
+  compatibility: TypeCompatibilitySchema.optional(),
   values: z.array(
     z.object({
       value: z.string().min(1),

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -1098,16 +1098,21 @@ function checkInboundIdempotencyAdvice(schema: Schema): SemanticIssueDraft[] {
 
 function checkEnumEvolutionAdvice(schema: Schema): SemanticIssueDraft[] {
   const issues: SemanticIssueDraft[] = [];
-  const enumNames = new Set(
-    schema.types.filter((type) => type.kind === 'enum').map((type) => type.name),
+  const enums = new Map(
+    schema.types
+      .filter((type): type is Extract<TypeDef, { kind: 'enum' }> => type.kind === 'enum')
+      .map((type) => [type.name, type]),
   );
-  if (enumNames.size === 0) return issues;
+  if (enums.size === 0) return issues;
 
   schema.types.forEach((type, typeIndex) => {
     if (type.kind !== 'object') return;
     type.fields.forEach((field, fieldIndex) => {
       const enumName = unwrapRefTarget(field.type);
-      if (!enumName || !enumNames.has(enumName)) return;
+      if (!enumName) return;
+      const enumType = enums.get(enumName);
+      if (!enumType) return;
+      if (enumType.compatibility?.enumEvolution) return;
       if (!isLikelyClientSurfaceEnum(enumName, field, type, schema)) return;
       issues.push({
         code: 'operational_enum_evolution',

--- a/packages/core/src/validation-repairs.ts
+++ b/packages/core/src/validation-repairs.ts
@@ -45,6 +45,40 @@ export function repairForValidationError(
 
   if (error.code === 'enum_duplicate_value' && type.kind === 'enum') return null;
 
+  if (
+    error.code === 'operational_enum_evolution' &&
+    type.kind === 'object' &&
+    loc.fieldIndex !== undefined
+  ) {
+    const field = type.fields[loc.fieldIndex];
+    const enumName = findRefTypeName(field?.type);
+    const enumType = schema.types.find(
+      (candidate): candidate is Extract<TypeDef, { kind: 'enum' }> =>
+        candidate.kind === 'enum' && candidate.name === enumName,
+    );
+    if (!field || !enumType) return null;
+    return {
+      label: 'Document contract',
+      op: {
+        kind: 'update_type',
+        name: enumType.name,
+        patch: typePatch({
+          compatibility: {
+            ...enumType.compatibility,
+            enumEvolution: {
+              unknownValueBehavior: 'preserve',
+              fallbackLabel: `Unknown ${humanizeTypeName(enumType.name).toLowerCase()}`,
+              clientSurfaces: ['web', 'mobile', 'api'],
+              owner: 'client',
+              notes: `${type.name}.${field.name} clients must preserve unknown ${enumType.name} values, render a neutral fallback, and avoid interpreting unknown values as safe or silently ignored.`,
+            },
+          },
+        }),
+      },
+      focusTypeName: enumType.name,
+    };
+  }
+
   if (error.code === 'unresolved_ref' && type.kind === 'object' && loc.fieldIndex !== undefined) {
     const field = type.fields[loc.fieldIndex];
     const refName = findRefTypeName(field?.type);
@@ -289,4 +323,11 @@ function discriminatorLiteralValue(typeName: string): string {
     .replace(/[^A-Za-z0-9]+/gu, '-')
     .replace(/^-+|-+$/gu, '')
     .toLowerCase();
+}
+
+function humanizeTypeName(typeName: string): string {
+  return typeName
+    .replace(/([a-z0-9])([A-Z])/gu, '$1 $2')
+    .replace(/[_-]+/gu, ' ')
+    .trim();
 }

--- a/packages/core/tests/domain-brief.test.ts
+++ b/packages/core/tests/domain-brief.test.ts
@@ -10,6 +10,19 @@ describe('domain brief', () => {
       types: [
         { kind: 'object', name: 'Tenant', table: true, fields: [] },
         {
+          kind: 'enum',
+          name: 'ProjectStatus',
+          compatibility: {
+            enumEvolution: {
+              unknownValueBehavior: 'preserve',
+              fallbackLabel: 'Unknown status',
+              clientSurfaces: ['web', 'api'],
+              owner: 'client',
+            },
+          },
+          values: [{ value: 'active' }],
+        },
+        {
           kind: 'object',
           name: 'Project',
           table: true,
@@ -67,10 +80,11 @@ describe('domain brief', () => {
     const brief = buildDomainBrief(schema);
 
     expect(brief.summary).toMatchObject({
-      typeCount: 3,
+      typeCount: 4,
       tableCount: 3,
       invariantCount: 1,
       derivationCount: 1,
+      compatibilityContractCount: 1,
       relationshipCount: 1,
       queryContractCount: 2,
     });
@@ -81,6 +95,11 @@ describe('domain brief', () => {
           id: 'invariant:Project:search-text-required',
         }),
         expect.objectContaining({ kind: 'derivation', id: 'derivation:Project:summary' }),
+        expect.objectContaining({
+          kind: 'compatibility',
+          id: 'compatibility:enumEvolution:ProjectStatus',
+          statement: expect.stringContaining('Unknown status'),
+        }),
         expect.objectContaining({ kind: 'relationship', id: 'relationship:Task:projectId' }),
         expect.objectContaining({ kind: 'query', id: 'query:index:Project:by_tenant' }),
         expect.objectContaining({ kind: 'query', id: 'query:search:Project:search_projects' }),

--- a/packages/core/tests/semantic-validation.test.ts
+++ b/packages/core/tests/semantic-validation.test.ts
@@ -1050,6 +1050,43 @@ describe('checkSemantic — operational advice', () => {
     );
   });
 
+  it('treats documented enum evolution compatibility as a resolved advisory', () => {
+    const schema: Schema = {
+      version: '1',
+      metadata: { description: 'Mobile and web meal planning app.' },
+      types: [
+        {
+          kind: 'enum',
+          name: 'DietaryProfile',
+          compatibility: {
+            enumEvolution: {
+              unknownValueBehavior: 'preserve',
+              fallbackLabel: 'Unknown dietary profile',
+              clientSurfaces: ['web', 'mobile', 'api'],
+              owner: 'client',
+            },
+          },
+          values: [{ value: 'vegan' }],
+        },
+        {
+          kind: 'object',
+          name: 'RecipeSafetyAssessment',
+          table: true,
+          fields: [
+            {
+              name: 'mergedDietaryProfiles',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'DietaryProfile' } },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema).map((issue) => issue.code)).not.toContain(
+      'operational_enum_evolution',
+    );
+  });
+
   it('warns when collaborative array edits have updatedAt but no conflict token', () => {
     const schema: Schema = {
       version: '1',

--- a/packages/core/tests/validation-repairs.test.ts
+++ b/packages/core/tests/validation-repairs.test.ts
@@ -59,4 +59,57 @@ describe('validation repairs', () => {
     expect(issue).toBeDefined();
     expect(issue ? repairForValidationError(schema, issue) : null).toBeNull();
   });
+
+  it('documents enum evolution compatibility for client-facing enum advisories', () => {
+    const schema: Schema = {
+      version: '1',
+      metadata: { description: 'Mobile and web meal planning app.' },
+      types: [
+        { kind: 'enum', name: 'DietaryProfile', values: [{ value: 'vegan' }] },
+        {
+          kind: 'object',
+          name: 'RecipeSafetyAssessment',
+          table: true,
+          fields: [
+            {
+              name: 'mergedDietaryProfiles',
+              type: { kind: 'array', element: { kind: 'ref', typeName: 'DietaryProfile' } },
+            },
+          ],
+        },
+      ],
+    };
+
+    const issue = checkSemantic(schema).find(
+      (candidate) => candidate.code === 'operational_enum_evolution',
+    );
+    const repair = issue ? repairForValidationError(schema, issue) : null;
+
+    expect(repair).toMatchObject({
+      label: 'Document contract',
+      focusTypeName: 'DietaryProfile',
+      op: {
+        kind: 'update_type',
+        name: 'DietaryProfile',
+        patch: {
+          compatibility: {
+            enumEvolution: {
+              unknownValueBehavior: 'preserve',
+              fallbackLabel: 'Unknown dietary profile',
+              clientSurfaces: ['web', 'mobile', 'api'],
+              owner: 'client',
+            },
+          },
+        },
+      },
+    });
+
+    const result = apply(schema, repair?.op ?? { kind: 'replace_schema', schema });
+    expect(result).toHaveProperty('schema');
+    if ('schema' in result) {
+      expect(checkSemantic(result.schema).map((candidate) => candidate.code)).not.toContain(
+        'operational_enum_evolution',
+      );
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Preserve validation severity when graph nodes and fields are highlighted
- Render warning/advisory validation rows with the warning color instead of destructive red
- Add regression coverage for warning severity mapping and rendered field-row styling

## Tests
- bun run test -- tests/graph/schema-to-graph.test.ts
- bun run test -- tests/components/graph/TypeNode.test.tsx
- bun run typecheck --filter=@contexture/desktop
- commit hook: turbo typecheck && turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783150482&installation_id=136251083&pr_number=379&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F379&signature=b451496628e1d574da2fed06d60be728dcaf8efc55900477a09d3a10eddb9e64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->