### PR TITLE
Fix Convex package detection for monorepo outputs

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.42",
+  "version": "0.15.43",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/main/ipc/convex.ts
+++ b/apps/desktop/src/main/ipc/convex.ts
@@ -2,7 +2,12 @@ import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { dirname, join, parse } from 'node:path';
 import { promisify } from 'node:util';
-import { CONTEXTURE_SUPPORTED_CONVEX_VERSION, projectDirFor } from '@contexture/core';
+import {
+  CONTEXTURE_SUPPORTED_CONVEX_VERSION,
+  load as loadIR,
+  projectDirFor,
+} from '@contexture/core';
+import { bundlePathsFor } from '@contexture/core/paths';
 import { ipcMain } from 'electron';
 import { z } from 'zod';
 import { IpcString, parseIpcPayload } from './validation';
@@ -54,7 +59,7 @@ const ConvexVersionInputSchema = z.object({ irPath: IpcString }).strict();
 export async function getConvexVersionInfo(input: unknown): Promise<ConvexVersionInfo> {
   const { irPath } = parseIpcPayload('convex:version-info', ConvexVersionInputSchema, input);
   try {
-    const packagePath = await findPackageJson(projectDirFor(irPath));
+    const packagePath = await targetPackageJsonFor(irPath);
     if (!packagePath) {
       return {
         emitterVersion: CONTEXTURE_SUPPORTED_CONVEX_VERSION,
@@ -107,7 +112,7 @@ export async function getConvexAgentReadinessInfo(
   const { irPath } = parseIpcPayload('convex:agent-readiness', ConvexVersionInputSchema, input);
   const run = deps.execFile ?? execFileAsync;
   const env = deps.env ?? process.env;
-  const appDir = await targetAppDirFor(irPath);
+  const appDir = projectDirFor(irPath);
   const convexAiFiles = await probeConvexAiFiles(run, env, appDir);
   const contextureMcp = await probeContextureMcp(run, env);
   return { convexAiFiles, contextureMcp };
@@ -137,9 +142,23 @@ async function findPackageJson(startDir: string): Promise<string | null> {
   return null;
 }
 
-async function targetAppDirFor(irPath: string): Promise<string> {
-  const packagePath = await findPackageJson(projectDirFor(irPath));
-  return packagePath ? dirname(packagePath) : projectDirFor(irPath);
+async function targetPackageJsonFor(irPath: string): Promise<string | null> {
+  const configuredPackagePath = await findPackageJson(await convexOutputAppDirFor(irPath));
+  if (configuredPackagePath) return configuredPackagePath;
+  return findPackageJson(projectDirFor(irPath));
+}
+
+async function convexOutputAppDirFor(irPath: string): Promise<string> {
+  const schema = await readOptionalSchema(irPath);
+  return dirname(bundlePathsFor(irPath, schema).convex);
+}
+
+async function readOptionalSchema(irPath: string) {
+  try {
+    return loadIR(await readFile(irPath, 'utf8')).schema;
+  } catch {
+    return undefined;
+  }
 }
 
 async function probeConvexAiFiles(

--- a/apps/desktop/src/main/reconcile/convex-cli-validation.ts
+++ b/apps/desktop/src/main/reconcile/convex-cli-validation.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname, join, parse } from 'node:path';
 import { promisify } from 'node:util';
 import type { Schema } from '@contexture/core';
 import { bundlePathsFor, generatedTargetForPath } from '@contexture/core/paths';
@@ -57,7 +57,11 @@ export async function validateReconciledConvexProject(
     return { status: 'skipped', reason: 'Target is not a Convex generated file.' };
   }
 
-  const projectDir = dirname(dirname(bundlePathsFor(input.irPath, input.schema).convex));
+  const projectDir = await findPackageDir(
+    dirname(bundlePathsFor(input.irPath, input.schema).convex),
+  );
+  if (!projectDir) return { status: 'skipped', reason: 'No project package.json found.' };
+
   const configured = await hasConvexCliValidationConfig(projectDir, deps.env ?? process.env);
   if (!configured.ok) return { status: 'skipped', reason: configured.reason };
 
@@ -82,6 +86,21 @@ export async function validateReconciledConvexProject(
       output: outputFromThrownExecError(err),
     };
   }
+}
+
+async function findPackageDir(startDir: string): Promise<string | null> {
+  let dir = startDir;
+  const root = parse(dir).root;
+  while (dir !== root) {
+    const candidate = join(dir, 'package.json');
+    try {
+      await readFile(candidate, 'utf8');
+      return dir;
+    } catch {
+      dir = dirname(dir);
+    }
+  }
+  return null;
 }
 
 async function hasConvexCliValidationConfig(

--- a/apps/desktop/tests/main/convex-ipc.test.ts
+++ b/apps/desktop/tests/main/convex-ipc.test.ts
@@ -55,6 +55,37 @@ describe('Convex version IPC helpers', () => {
     });
   });
 
+  it('reports Convex versions from the configured monorepo Convex package', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'contexture-convex-'));
+    const convexPackageDir = join(dir, 'packages/convex');
+    await mkdir(convexPackageDir, { recursive: true });
+    await writeFile(join(dir, 'package.json'), JSON.stringify({}), 'utf8');
+    await writeFile(
+      join(convexPackageDir, 'package.json'),
+      JSON.stringify({ dependencies: { convex: '^1.39.1' } }),
+      'utf8',
+    );
+    await writeFile(
+      join(dir, 'app.contexture.json'),
+      JSON.stringify({
+        version: '1',
+        types: [],
+        outputs: { convex: { dir: 'packages/convex' } },
+      }),
+      'utf8',
+    );
+
+    const result = await getConvexVersionInfo({
+      irPath: join(dir, 'app.contexture.json'),
+    });
+
+    expect(result).toMatchObject({
+      targetVersion: '^1.39.1',
+      targetPackagePath: join(convexPackageDir, 'package.json'),
+      status: 'ok',
+    });
+  });
+
   it('detects enabled Convex AI files and Contexture MCP from CLI output', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'contexture-convex-'));
     const appDir = join(dir, 'apps/todo');
@@ -97,6 +128,47 @@ describe('Convex version IPC helpers', () => {
       'codex',
       ['mcp', 'list'],
       expect.objectContaining({ env: process.env }),
+    );
+  });
+
+  it('probes Convex AI files from the model project root', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'contexture-convex-'));
+    const convexPackageDir = join(dir, 'packages/convex');
+    await mkdir(convexPackageDir, { recursive: true });
+    await writeFile(
+      join(convexPackageDir, 'package.json'),
+      JSON.stringify({ devDependencies: { convex: '1.40.0' } }),
+      'utf8',
+    );
+    await writeFile(
+      join(dir, 'app.contexture.json'),
+      JSON.stringify({
+        version: '1',
+        types: [],
+        outputs: { convex: { dir: 'packages/convex' } },
+      }),
+      'utf8',
+    );
+    const execFile = vi.fn<ExecFileLike>(async (file) => {
+      if (file === 'bunx') {
+        return {
+          stdout: `Convex AI files: enabled
+  ✔ Agent skills: installed, up to date
+`,
+        };
+      }
+      return {
+        stdout:
+          'Name        Command                                                             Args  Env  Cwd  Status   Auth\ncontexture  /Applications/Contexture.app/Contents/Resources/bin/contexture-mcp  -     -    -    enabled  Unsupported\n',
+      };
+    });
+
+    await getConvexAgentReadinessInfo({ irPath: join(dir, 'app.contexture.json') }, { execFile });
+
+    expect(execFile).toHaveBeenCalledWith(
+      'bunx',
+      ['convex', 'ai-files', 'status'],
+      expect.objectContaining({ cwd: dir }),
     );
   });
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.41",
+      "version": "0.15.43",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.150",
         "@contexture/core": "workspace:*",


### PR DESCRIPTION
## Summary
- Resolve target Convex package from the configured generated Convex output directory
- Run Convex AI-files readiness and reconcile validation from the detected package root
- Bump desktop app version to 0.15.43

## Tests
- bun run test -- tests/main/convex-ipc.test.ts tests/main/reconcile-ipc.test.ts
- bun run typecheck:node
- bunx biome check apps/desktop/src/main/ipc/convex.ts apps/desktop/src/main/reconcile/convex-cli-validation.ts apps/desktop/tests/main/convex-ipc.test.ts apps/desktop/package.json
- commit hook ran turbo typecheck and turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783155857&installation_id=136251083&pr_number=380&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F380&signature=6140f5f3faa28392b27e12e325c5f8a2796f17264a9640380796df3c58de502a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->