### PR TITLE
Keep the inspector floating over the canvas

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -56,6 +56,7 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@storybook/addon-essentials": "8",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -4,17 +4,13 @@
  * Primary desktop layout:
  *
  *   ┌───────────────────────── Toolbar ─────────────────────────┐
- *   ├──────────────────────────────────────────┬────────────────┤
- *   │                                          │ SidePanel      │
- *   │             GraphCanvas                  │  (Detail /     │
- *   │                                          │   Chat /       │
- *   │                                          │   Schema)      │
- *   │                                          │  + ActivityBar │
+ *   ├────────────────────────────────┬──────────────────────────┤
+ *   │   GraphCanvas + Inspector      │ Activity drawer + rail   │
  *   ├──────────────────────────── StatusBar ───┴────────────────┤
  *   └───────────────────────────────────────────────────────────┘
  *
- * Canvas and side panel sit inside a `ResizablePanelGroup` so the
- * split is drag-adjustable and the side panel can collapse when
+ * Canvas and right workspace sit inside a `ResizablePanelGroup` so the
+ * split is drag-adjustable and the workspace can collapse when
  * `useUIChromeStore.sidebarVisible` is false (toggled by the Toolbar's
  * sidebar button).
  */
@@ -26,7 +22,7 @@ import {
   previewableGeneratedTargets,
   setGeneratedTargetOutputDir,
 } from '@contexture/core/generated-targets';
-import type { Schema } from '@contexture/core/ir';
+import type { Schema, TypeDef } from '@contexture/core/ir';
 import { STDLIB_REGISTRY, STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registry';
 import {
   Bot,
@@ -38,8 +34,13 @@ import {
   FilePlus2,
   FolderOpen,
   GitCompareArrows,
+  Maximize2,
+  MessageSquare,
+  Minimize2,
   MousePointer2,
+  Play,
   SlidersHorizontal,
+  Trash2,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import type { PanelImperativeHandle } from 'react-resizable-panels';
@@ -55,7 +56,7 @@ import { TYPE_EDGE_SELECT_EVENT } from './components/graph/edge-select-event';
 import { GraphBackground } from './components/graph/GraphBackground';
 import { type CanvasPosition, GraphCanvas } from './components/graph/GraphCanvas';
 import { type CreateTypeKind, createFieldOp, createTypeOp } from './components/graph/interactions';
-import { TYPE_NODE_EVENT, TYPE_NODE_OBJECT_EVENT } from './components/graph/nodes/TypeNode';
+import { TYPE_NODE_EVENT } from './components/graph/nodes/TypeNode';
 import { DriftBanner } from './components/hud/DriftBanner';
 import { ModelSyncBanner } from './components/hud/ModelSyncBanner';
 import { PlaygroundPanel } from './components/playground/PlaygroundPanel';
@@ -71,6 +72,7 @@ import { StatusBar } from './components/status-bar/StatusBar';
 import { StdlibPanel } from './components/stdlib/StdlibPanel';
 import { GraphControlsPanel } from './components/toolbar/GraphControlsPanel';
 import { Toolbar } from './components/toolbar/Toolbar';
+import { TypeKindBadge, type TypeKindLabel } from './components/toolbar/type-kind-badge';
 import { UpdateBanner } from './components/UpdateBanner';
 import { Button } from './components/ui/button';
 import {
@@ -89,6 +91,7 @@ import { useModelSync } from './hooks/useModelSync';
 import { useProjectAutoSave } from './hooks/useProjectAutoSave';
 import { useSessionPersistence } from './hooks/useSessionPersistence';
 import allotment from './samples/allotment.contexture.json' with { type: 'json' };
+import { useChatComposerStore } from './store/chat-composer';
 import { useConvexVersionStore } from './store/convex-version';
 import { useDocumentStore } from './store/document';
 import { useDriftStore } from './store/drift';
@@ -112,6 +115,7 @@ export default function App(): React.JSX.Element {
     [setLayout],
   );
   const [showGraphControls, setShowGraphControls] = useState(false);
+  const [inspectorCompact, setInspectorCompact] = useState(false);
   const [agentSetupCopied, setAgentSetupCopied] = useState<'install' | 'convex-ai-files' | null>(
     null,
   );
@@ -123,7 +127,10 @@ export default function App(): React.JSX.Element {
   const highlightedNodeIds = useModelSyncStore((s) => s.highlightedNodeIds);
   const activeTab = useUIChromeStore((s) => s.sidebarTab);
   const setActiveTab = useUIChromeStore((s) => s.setSidebarTab);
+  const playgroundScope = useUIChromeStore((s) => s.playgroundScope);
+  const setPlaygroundScope = useUIChromeStore((s) => s.setPlaygroundScope);
   const sidebarVisible = useUIChromeStore((s) => s.sidebarVisible);
+  const pendingChatMessage = useChatComposerStore((s) => s.pendingChatMessage);
   const sidebarRef = useRef<PanelImperativeHandle>(null);
   const isDirty = useDocumentStore((s) => s.isDirty);
   const filePath = useDocumentStore((s) => s.filePath);
@@ -151,8 +158,6 @@ export default function App(): React.JSX.Element {
       useGraphSelectionStore
         .getState()
         .selectField({ typeName: detail.typeName, fieldName: detail.fieldName });
-      useUIChromeStore.getState().setSidebarVisible(true);
-      useUIChromeStore.getState().setSidebarTab('properties');
     }
     document.addEventListener(TYPE_NODE_EVENT, onFieldSelect);
     return () => document.removeEventListener(TYPE_NODE_EVENT, onFieldSelect);
@@ -163,23 +168,10 @@ export default function App(): React.JSX.Element {
   }, [filePath]);
 
   useEffect(() => {
-    function onTypeSelect(event: Event): void {
-      const detail = (event as CustomEvent<{ typeName?: unknown }>).detail;
-      if (typeof detail?.typeName !== 'string') return;
-      useUIChromeStore.getState().setSidebarVisible(true);
-      useUIChromeStore.getState().setSidebarTab('properties');
-    }
-    document.addEventListener(TYPE_NODE_OBJECT_EVENT, onTypeSelect);
-    return () => document.removeEventListener(TYPE_NODE_OBJECT_EVENT, onTypeSelect);
-  }, []);
-
-  useEffect(() => {
     function onEdgeSelect(event: Event): void {
       const detail = (event as CustomEvent<EdgeSelection>).detail;
       if (typeof detail?.edgeId !== 'string' || !detail.data) return;
       useGraphSelectionStore.getState().selectEdge(detail);
-      useUIChromeStore.getState().setSidebarVisible(true);
-      useUIChromeStore.getState().setSidebarTab('properties');
     }
     document.addEventListener(TYPE_EDGE_SELECT_EVENT, onEdgeSelect);
     return () => document.removeEventListener(TYPE_EDGE_SELECT_EVENT, onEdgeSelect);
@@ -193,8 +185,6 @@ export default function App(): React.JSX.Element {
     if (kind === 'enum') useGraphLayoutStore.getState().setGraphLayout({ showEnums: true });
     useGraphSelectionStore.getState().click(typeName, 'replace');
     useGraphSelectionStore.getState().focus(typeName);
-    useUIChromeStore.getState().setSidebarVisible(true);
-    useUIChromeStore.getState().setSidebarTab('properties');
     window.setTimeout(() => {
       document.dispatchEvent(new CustomEvent(FOCUS_TYPE_NAME_EVENT, { detail: { typeName } }));
     }, 0);
@@ -209,16 +199,12 @@ export default function App(): React.JSX.Element {
     if ('error' in result) return;
     useGraphSelectionStore.getState().selectField({ typeName, fieldName: op.field.name });
     useGraphSelectionStore.getState().focus({ nodeId: typeName, fieldName: op.field.name });
-    useUIChromeStore.getState().setSidebarVisible(true);
-    useUIChromeStore.getState().setSidebarTab('properties');
   }, []);
 
   const focusSelectedTypeName = useCallback((): void => {
     const typeName = useGraphSelectionStore.getState().state.primaryNodeId;
     if (!typeName) return;
     useGraphSelectionStore.getState().click(typeName, 'replace');
-    useUIChromeStore.getState().setSidebarVisible(true);
-    useUIChromeStore.getState().setSidebarTab('properties');
     window.setTimeout(() => {
       document.dispatchEvent(new CustomEvent(FOCUS_TYPE_NAME_EVENT, { detail: { typeName } }));
     }, 0);
@@ -364,7 +350,6 @@ export default function App(): React.JSX.Element {
   const startNewModel = useCallback((): void => {
     fileMenu.handleNew();
     useUIChromeStore.getState().setSidebarVisible(true);
-    useUIChromeStore.getState().setSidebarTab('properties');
   }, [fileMenu]);
 
   const openExistingModel = useCallback((): void => {
@@ -400,6 +385,52 @@ export default function App(): React.JSX.Element {
   }, []);
 
   const detailTypeName = selectedField?.typeName ?? selectedEdge?.data.sourceType ?? selectedNodeId;
+  const detailType =
+    typeof detailTypeName === 'string'
+      ? schema.types.find((type) => type.name === detailTypeName)
+      : undefined;
+  const inspectorKind = detailType ? typeKindLabel(detailType) : selectedEdge ? 'ref' : null;
+  const inspectorTitle =
+    selectedField && selectedField.typeName === detailTypeName
+      ? selectedField.fieldName
+      : selectedEdge
+        ? edgeSelectionLabel(selectedEdge)
+        : detailTypeName;
+  const inspectorLinkedToChat = activeTab === 'chat' && pendingChatMessage !== null;
+  const backToSelectedType = useCallback((): void => {
+    if (!selectedField) return;
+    useGraphSelectionStore.getState().selectField(null);
+    useGraphSelectionStore.getState().focus(selectedField.typeName);
+  }, [selectedField]);
+  const deleteInspectorSelection = useCallback((): void => {
+    if (selectedField) {
+      const result = useUndoStore.getState().apply({
+        kind: 'remove_field',
+        typeName: selectedField.typeName,
+        fieldName: selectedField.fieldName,
+      });
+      if ('error' in result) return;
+      useGraphSelectionStore.getState().selectField(null);
+      return;
+    }
+    if (!detailTypeName || !detailType) return;
+    const result = useUndoStore.getState().apply({ kind: 'delete_type', name: detailTypeName });
+    if ('error' in result) return;
+    useGraphSelectionStore.getState().clear();
+  }, [detailType, detailTypeName, selectedField]);
+  const openSelectedTypeInPlayground = useCallback((): void => {
+    if (!detailTypeName) return;
+    setPlaygroundScope({ mode: 'selected', typeName: detailTypeName });
+    useUIChromeStore.getState().setSidebarVisible(true);
+    setActiveTab('playground');
+  }, [detailTypeName, setActiveTab, setPlaygroundScope]);
+  const selectActivityTab = useCallback(
+    (tab: typeof activeTab): void => {
+      if (tab === 'playground') setPlaygroundScope({ mode: 'all' });
+      setActiveTab(tab);
+    },
+    [setActiveTab, setPlaygroundScope],
+  );
   const selectedStdlibTypeName =
     typeof selectedNodeId === 'string' && STDLIB_TYPE_DEFINITIONS.has(selectedNodeId)
       ? selectedNodeId
@@ -565,11 +596,164 @@ export default function App(): React.JSX.Element {
                 </div>
               )}
               {hasSchema ? (
-                <GraphCanvas
-                  positions={positions}
-                  onPositionsChange={setPositions}
-                  highlightedNodeIds={highlightedNodeIds}
-                />
+                <>
+                  <GraphCanvas
+                    positions={positions}
+                    onPositionsChange={setPositions}
+                    highlightedNodeIds={highlightedNodeIds}
+                  />
+                  <aside
+                    aria-label="Properties inspector"
+                    className={`absolute right-3 top-3 z-20 flex max-h-[calc(100%-1.5rem)] flex-col overflow-hidden rounded-xl border border-border/80 bg-card/95 shadow-[0_12px_28px_rgba(0,0,0,0.18)] backdrop-blur transition-[width,max-height,box-shadow] duration-150 ease-out ${
+                      inspectorCompact
+                        ? 'w-[min(18rem,calc(100%-1.5rem))]'
+                        : 'w-[min(24rem,calc(100%-1.5rem))]'
+                    }`}
+                  >
+                    <div className="grid h-14 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-border/70 px-3 py-2">
+                      <div className="min-w-0">
+                        <div className="mb-0.5 flex h-5 min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+                          {selectedField && selectedField.typeName === detailTypeName ? (
+                            <>
+                              <span className="truncate">Canvas</span>
+                              <span aria-hidden="true" className="text-border">
+                                /
+                              </span>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="-ml-1 h-5 max-w-32 px-1.5 text-xs text-muted-foreground hover:text-foreground"
+                                onClick={backToSelectedType}
+                                aria-label={`Back to ${selectedField.typeName} fields`}
+                              >
+                                <span className="truncate">{selectedField.typeName}</span>
+                              </Button>
+                              <span aria-hidden="true" className="text-border">
+                                /
+                              </span>
+                              <span className="truncate">{selectedField.fieldName}</span>
+                            </>
+                          ) : (
+                            <>
+                              <span className="truncate">Canvas</span>
+                              {detailTypeName && (
+                                <>
+                                  <span aria-hidden="true" className="text-border">
+                                    /
+                                  </span>
+                                  <span className="truncate">{detailTypeName}</span>
+                                </>
+                              )}
+                            </>
+                          )}
+                        </div>
+                        <div className="flex min-w-0 items-center gap-1.5">
+                          <div className="truncate text-sm font-semibold text-foreground">
+                            {inspectorTitle ?? 'Inspector'}
+                          </div>
+                          {inspectorKind && inspectorKind !== 'ref' && (
+                            <TypeKindBadge kind={inspectorKind} />
+                          )}
+                          {inspectorKind === 'ref' && (
+                            <span className="shrink-0 rounded border border-reference/35 bg-reference/10 px-1.5 py-0 text-[9px] font-medium uppercase tracking-wide text-reference-text">
+                              edge
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1.5">
+                        {inspectorLinkedToChat && (
+                          <span className="inline-flex h-6 items-center gap-1 rounded-full border border-reference/25 bg-reference/10 px-2 text-[10px] font-medium text-reference-text">
+                            <MessageSquare className="size-3" aria-hidden="true" />
+                            Linked
+                          </span>
+                        )}
+                        {hasSelection && detailTypeName && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 px-2 text-xs"
+                            onClick={openSelectedTypeInPlayground}
+                          >
+                            <Play aria-hidden="true" className="size-3.5" />
+                            Try
+                          </Button>
+                        )}
+                        {detailType && !selectedEdge && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                            aria-label={
+                              selectedField
+                                ? `Delete field ${selectedField.fieldName}`
+                                : `Delete type ${detailTypeName}`
+                            }
+                            onClick={deleteInspectorSelection}
+                          >
+                            <Trash2 aria-hidden="true" className="size-3.5" />
+                          </Button>
+                        )}
+                        <button
+                          type="button"
+                          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                          aria-label={inspectorCompact ? 'Expand inspector' : 'Collapse inspector'}
+                          title={inspectorCompact ? 'Expand inspector' : 'Collapse inspector'}
+                          onClick={() => setInspectorCompact((compact) => !compact)}
+                        >
+                          {inspectorCompact ? (
+                            <Maximize2 className="size-3.5" aria-hidden="true" />
+                          ) : (
+                            <Minimize2 className="size-3.5" aria-hidden="true" />
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                    {!inspectorCompact && (
+                      <div className="min-h-0 flex-1 overflow-y-auto">
+                        {hasSelection ? (
+                          <DetailPanel
+                            selection={{
+                              edge: selectedEdge?.data,
+                              typeName: detailTypeName ?? undefined,
+                              fieldName:
+                                selectedField && selectedField.typeName === detailTypeName
+                                  ? selectedField.fieldName
+                                  : undefined,
+                            }}
+                            onClearSelection={() => {
+                              useGraphSelectionStore.getState().selectField(null);
+                              useGraphSelectionStore.getState().selectEdge(null);
+                            }}
+                            onClearSelectedField={() =>
+                              useGraphSelectionStore.getState().selectField(null)
+                            }
+                            onSelectField={(typeName, fieldName) => {
+                              useGraphSelectionStore
+                                .getState()
+                                .selectField({ typeName, fieldName });
+                            }}
+                          />
+                        ) : (
+                          <Empty className="border-0 p-4">
+                            <EmptyHeader>
+                              <EmptyMedia variant="icon">
+                                <MousePointer2 />
+                              </EmptyMedia>
+                              <EmptyTitle className="text-sm font-medium">No selection</EmptyTitle>
+                              <EmptyDescription className="text-xs">
+                                Select a type on the canvas to view and edit its properties.
+                              </EmptyDescription>
+                            </EmptyHeader>
+                          </Empty>
+                        )}
+                      </div>
+                    )}
+                  </aside>
+                </>
               ) : (
                 <EmptyState
                   onNewModel={startNewModel}
@@ -598,84 +782,59 @@ export default function App(): React.JSX.Element {
           panelRef={sidebarRef}
         >
           <div className="flex h-full bg-background">
-            <div className="flex-1 min-w-0 overflow-hidden flex flex-col">
-              <div className={activeTab !== 'properties' ? 'hidden' : 'flex-1 overflow-y-auto'}>
-                {hasSelection ? (
-                  <DetailPanel
-                    selection={{
-                      edge: selectedEdge?.data,
-                      typeName: detailTypeName ?? undefined,
-                      fieldName:
-                        selectedField && selectedField.typeName === detailTypeName
-                          ? selectedField.fieldName
-                          : undefined,
-                    }}
-                    onClearSelection={() => {
-                      useGraphSelectionStore.getState().selectField(null);
-                      useGraphSelectionStore.getState().selectEdge(null);
-                    }}
-                    onClearSelectedField={() => useGraphSelectionStore.getState().selectField(null)}
-                    onSelectField={(typeName, fieldName) => {
-                      useGraphSelectionStore.getState().selectField({ typeName, fieldName });
-                    }}
-                  />
-                ) : (
-                  <Empty className="border-0 p-4">
-                    <EmptyHeader>
-                      <EmptyMedia variant="icon">
-                        <MousePointer2 />
-                      </EmptyMedia>
-                      <EmptyTitle className="text-sm font-medium">No selection</EmptyTitle>
-                      <EmptyDescription className="text-xs">
-                        Select a type on the canvas to view and edit its properties.
-                      </EmptyDescription>
-                    </EmptyHeader>
-                  </Empty>
-                )}
-              </div>
-              <div className={activeTab !== 'chat' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
-                <ChatPanel chat={chat} />
-              </div>
-              <div className={activeTab !== 'review' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
-                <ReviewPanel schema={schema} />
-              </div>
-              <div className={activeTab !== 'schema' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
-                {hasSchema && (
-                  <OnboardingLoopPanel
-                    state={onboardingState}
+            <div className="flex min-w-0 flex-1 overflow-hidden border-l border-border/70 bg-background">
+              <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                <div className={activeTab !== 'chat' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
+                  <ChatPanel chat={chat} />
+                </div>
+                <div className={activeTab !== 'review' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
+                  <ReviewPanel schema={schema} />
+                </div>
+                <div className={activeTab !== 'schema' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
+                  {hasSchema && (
+                    <OnboardingLoopPanel
+                      state={onboardingState}
+                      convexVersion={convexVersion}
+                      agentSetupCopied={agentSetupCopied}
+                      onCopyAgentSetup={copyAgentSetupText}
+                    />
+                  )}
+                  <SchemaPanel
+                    sources={schemaEmissions.sources}
+                    isEmpty={!hasSchema}
+                    error={schemaEmissions.error}
+                    onCopy={copyToClipboard}
+                    onEnableOutput={enableSchemaOutput}
+                    onOutputDirChange={updateSchemaOutputDir}
+                    documentFilePath={filePath}
+                    onOpenGeneratedFile={openGeneratedFile}
+                    schemaFileName={schemaFileName}
+                    schema={schema}
                     convexVersion={convexVersion}
-                    agentSetupCopied={agentSetupCopied}
-                    onCopyAgentSetup={copyAgentSetupText}
+                    showAgentSetup={!hasSchema}
                   />
-                )}
-                <SchemaPanel
-                  sources={schemaEmissions.sources}
-                  isEmpty={!hasSchema}
-                  error={schemaEmissions.error}
-                  onCopy={copyToClipboard}
-                  onEnableOutput={enableSchemaOutput}
-                  onOutputDirChange={updateSchemaOutputDir}
-                  documentFilePath={filePath}
-                  onOpenGeneratedFile={openGeneratedFile}
-                  schemaFileName={schemaFileName}
-                  schema={schema}
-                  convexVersion={convexVersion}
-                  showAgentSetup={!hasSchema}
-                />
-              </div>
-              <div
-                className={activeTab !== 'playground' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}
-              >
-                <PlaygroundPanel schema={schema} />
-              </div>
-              <div className={activeTab !== 'stdlib' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
-                <StdlibPanel schema={schema} focusedTypeName={selectedStdlibTypeName} />
-              </div>
-              <div className={activeTab !== 'changes' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
-                <ChangesPanel />
+                </div>
+                <div
+                  className={activeTab !== 'playground' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}
+                >
+                  <PlaygroundPanel
+                    schema={schema}
+                    highlightedTypeName={
+                      playgroundScope.mode === 'selected' ? playgroundScope.typeName : null
+                    }
+                  />
+                </div>
+                <div className={activeTab !== 'stdlib' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>
+                  <StdlibPanel schema={schema} focusedTypeName={selectedStdlibTypeName} />
+                </div>
+                <div
+                  className={activeTab !== 'changes' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}
+                >
+                  <ChangesPanel />
+                </div>
               </div>
             </div>
-            <ActivityBar activeTab={activeTab} onTabChange={setActiveTab} />
+            <ActivityBar activeTab={activeTab} onTabChange={selectActivityTab} />
           </div>
         </ResizablePanel>
       </ResizablePanelGroup>
@@ -685,6 +844,19 @@ export default function App(): React.JSX.Element {
       <ReconcileModal />
     </div>
   );
+}
+
+function typeKindLabel(type: TypeDef): TypeKindLabel {
+  if (type.kind === 'object') return type.table ? 'table' : 'object';
+  if (type.kind === 'enum') return 'enum';
+  if (type.kind === 'discriminatedUnion') return 'union';
+  return 'raw';
+}
+
+function edgeSelectionLabel(edge: EdgeSelection): string {
+  if (edge.data.sourceField) return edge.data.sourceField;
+  if (edge.data.relation === 'unionVariant') return edge.data.targetType;
+  return `${edge.data.sourceType} edge`;
 }
 
 function edgeSelectionExists(schema: Schema, edge: EdgeSelection['data']): boolean {

--- a/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.stories.tsx
+++ b/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.stories.tsx
@@ -6,7 +6,7 @@ const meta = {
   title: 'Components/ActivityBar',
   component: ActivityBar,
   args: {
-    activeTab: 'properties',
+    activeTab: 'chat',
     onTabChange: fn(),
   },
   parameters: {
@@ -16,10 +16,6 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-export const Properties: Story = {
-  args: { activeTab: 'properties' },
-};
 
 export const Chat: Story = {
   args: { activeTab: 'chat' },

--- a/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
+++ b/apps/desktop/src/renderer/src/components/activity-bar/ActivityBar.tsx
@@ -1,4 +1,4 @@
-import type { SidebarTab } from '@renderer/store/ui-chrome';
+import type { SidebarToolTab } from '@renderer/store/ui-chrome';
 import {
   BookOpen,
   FileBracesCorner,
@@ -6,17 +6,15 @@ import {
   History,
   ListChecks,
   MessageSquare,
-  MousePointer2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ActivityBarProps {
-  activeTab: SidebarTab;
-  onTabChange: (tab: SidebarTab) => void;
+  activeTab: SidebarToolTab;
+  onTabChange: (tab: SidebarToolTab) => void;
 }
 
-const TABS: Array<{ id: SidebarTab; icon: React.ReactNode; label: string }> = [
-  { id: 'properties', icon: <MousePointer2 className="size-4" />, label: 'Properties' },
+const TABS: Array<{ id: SidebarToolTab; icon: React.ReactNode; label: string }> = [
   { id: 'chat', icon: <MessageSquare className="size-4" />, label: 'Chat' },
   { id: 'review', icon: <ListChecks className="size-4" />, label: 'Review' },
   { id: 'changes', icon: <History className="size-4" />, label: 'Changes' },

--- a/apps/desktop/src/renderer/src/components/detail/DetailPanel.stories.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/DetailPanel.stories.tsx
@@ -128,7 +128,6 @@ export const FieldProperties: Story = {
         modelingHints={hints.filter((hint) => hint.fieldName === 'status')}
         availableTypeNames={['Customer', 'Venue', 'Payment']}
         tableIndexes={tableType.indexes}
-        onBackToType={fn()}
       />
     </StoryFrame>
   ),

--- a/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/DetailPanel.tsx
@@ -168,11 +168,6 @@ export function DetailPanel({
         onCreateAndSelectRefTarget={(selectTarget) =>
           createReferencedObjectTypeAndSelect(field.name, selectTarget)
         }
-        onBackToType={() => {
-          onClearSelectedField?.();
-          useGraphSelectionStore.getState().selectField(null);
-          useGraphSelectionStore.getState().focus(type.name);
-        }}
         validationErrors={validationErrorsForField(validationErrors, typeIndex, fieldIndex)}
         validationRepairForIssue={repairForIssue}
         onDiscussValidationIssue={discussIssue}
@@ -218,7 +213,6 @@ export function DetailPanel({
       useGraphSelectionStore.getState().click(typeName, 'replace');
       useGraphSelectionStore.getState().focus(typeName);
       useUIChromeStore.getState().setSidebarVisible(true);
-      useUIChromeStore.getState().setSidebarTab('properties');
       document.dispatchEvent(new CustomEvent(FOCUS_TYPE_NAME_EVENT, { detail: { typeName } }));
     }, 0);
 
@@ -259,7 +253,6 @@ export function DetailPanel({
       useGraphSelectionStore.getState().click(typeName, 'replace');
       useGraphSelectionStore.getState().focus(typeName);
       useUIChromeStore.getState().setSidebarVisible(true);
-      useUIChromeStore.getState().setSidebarTab('properties');
       document.dispatchEvent(new CustomEvent(FOCUS_TYPE_NAME_EVENT, { detail: { typeName } }));
     }, 0);
   }

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -11,7 +11,7 @@
  * nothing here mutates the store directly.
  */
 
-import { type DerivationWriter, derivationKindLabel } from '@contexture/core/derivation';
+import type { DerivationWriter } from '@contexture/core/derivation';
 import {
   type FixtureValueType,
   listFixtureGenerators,
@@ -22,17 +22,8 @@ import type { ModelingHint } from '@contexture/core/modeling-hints';
 import { TYPE_NODE_REF_PREVIEW_EVENT } from '@renderer/components/graph/ref-preview-event';
 import type { ValidationError } from '@renderer/services/validation';
 import { STDLIB_TYPE_OPTIONS, type StdlibTypeOption } from '@shared/stdlib-registry';
-import {
-  ArrowLeft,
-  ChevronDown,
-  ChevronsUpDown,
-  CircleHelp,
-  Lightbulb,
-  MoreHorizontal,
-  Trash2,
-} from 'lucide-react';
+import { ChevronDown, ChevronsUpDown, CircleHelp, Lightbulb } from 'lucide-react';
 import type React from 'react';
-import type { CSSProperties } from 'react';
 import { useState } from 'react';
 import type { Op } from '../../store/ops';
 import { Badge } from '../ui/badge';
@@ -47,12 +38,6 @@ import {
   CommandItem,
   CommandList,
 } from '../ui/command';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '../ui/dropdown-menu';
 import { Field, FieldGroup, FieldLabel } from '../ui/field';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
@@ -105,7 +90,6 @@ export interface FieldDetailProps {
   tableIndexes?: readonly IndexDef[];
   onCreateRefTarget?: () => string | undefined;
   onCreateAndSelectRefTarget?: (selectTarget: (typeName: string) => void) => void;
-  onBackToType?: () => void;
 }
 
 export function FieldDetail({
@@ -120,7 +104,6 @@ export function FieldDetail({
   tableIndexes,
   onCreateRefTarget,
   onCreateAndSelectRefTarget,
-  onBackToType,
 }: FieldDetailProps) {
   const update = (patch: Partial<FieldDef>) =>
     dispatch({ kind: 'update_field', typeName, fieldName: field.name, patch });
@@ -131,9 +114,6 @@ export function FieldDetail({
     tableIndexes
       ?.filter((index) => index.fields.includes(field.name))
       .map((index) => ({ index, position: index.fields.indexOf(field.name) })) ?? [];
-  const primaryIndex = indexMemberships[0];
-  const parentKindLabel = tableIndexes ? 'table' : 'object';
-  const sampleLabel = sampleDataLabel(field);
   const addIndex = () => {
     if (!tableIndexes || hasSingleFieldIndex) return;
     dispatch({
@@ -145,104 +125,6 @@ export function FieldDetail({
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="field-detail">
-      <header
-        className="flex min-h-20 shrink-0 items-start justify-between gap-3 border-b bg-muted/20 px-3 py-3"
-        style={inspectorHeaderStyle(fieldKindColor(field.type))}
-        data-testid="field-detail-header"
-      >
-        <div className="min-w-0 space-y-2">
-          <div
-            className="truncate text-[11px] font-medium uppercase tracking-wide"
-            style={{ color: fieldKindColor(field.type) }}
-          >
-            {parentKindLabel} / {typeName}
-          </div>
-          <div className="flex min-w-0 items-center gap-2">
-            {onBackToType && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={onBackToType}
-                className="h-7 shrink-0 px-1.5 text-xs text-muted-foreground hover:text-foreground"
-                aria-label="Back to table fields"
-              >
-                <ArrowLeft aria-hidden="true" className="size-3.5" />
-                Fields
-              </Button>
-            )}
-            <h2 className="truncate text-lg font-semibold leading-tight text-foreground">
-              {field.name}
-            </h2>
-          </div>
-          <div className="flex flex-wrap items-center gap-1.5">
-            <Badge
-              variant="outline"
-              className="h-5 rounded-md px-1.5 text-[11px]"
-              style={toneSurfaceStyle(fieldKindColor(field.type), 14, 50)}
-            >
-              {fieldTypeSummary(field.type)}
-            </Badge>
-            <Badge variant="secondary" className="h-5 rounded-md px-1.5 text-[11px]">
-              {field.optional ? 'optional' : 'required'}
-            </Badge>
-            {field.nullable && (
-              <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
-                nullable
-              </Badge>
-            )}
-            {field.serverDerived && !field.derivation && (
-              <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
-                server derived
-              </Badge>
-            )}
-            {field.derivation && (
-              <Badge
-                variant="outline"
-                className="h-5 rounded-md px-1.5 text-[11px]"
-                style={toneSurfaceStyle(derivationTone(field.derivation), 14, 50)}
-              >
-                {derivationKindLabel(field.derivation.kind)}
-              </Badge>
-            )}
-            {primaryIndex && (
-              <Badge
-                variant="outline"
-                className="h-5 rounded-md px-1.5 text-[11px]"
-                style={toneSurfaceStyle('var(--inspector-index)', 14, 50)}
-              >
-                indexed
-              </Badge>
-            )}
-            <Badge variant="outline" className="h-5 rounded-md px-1.5 text-[11px]">
-              sample: {sampleLabel}
-            </Badge>
-          </div>
-        </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label={`Field actions for ${field.name}`}
-              className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-            >
-              <MoreHorizontal aria-hidden="true" className="size-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              className="text-destructive focus:text-destructive"
-              onSelect={() => dispatch({ kind: 'remove_field', typeName, fieldName: field.name })}
-            >
-              <Trash2 aria-hidden="true" />
-              Delete field
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </header>
-
       <div className="min-h-0 flex-1 overflow-y-auto p-3">
         <div className="space-y-3">
           <ValidationIssues
@@ -958,22 +840,6 @@ function fixtureValueTypeForField(fieldType: FieldType): FixtureValueType {
     case 'array':
       return 'unknown';
   }
-}
-
-function fieldTypeSummary(fieldType: FieldType): string {
-  if (fieldType.kind === 'array') return `list<${fieldTypeSummary(fieldType.element)}>`;
-  if (fieldType.kind === 'ref') return `ref ${fieldType.typeName}`;
-  return fieldType.kind;
-}
-
-function sampleDataLabel(field: FieldDef): string {
-  const generatorId = field.sampleData?.generator;
-  if (!generatorId) return 'Auto';
-  return (
-    listFixtureGenerators({ valueType: fixtureValueTypeForField(field.type) }).find(
-      (generator) => generator.id === generatorId,
-    )?.label ?? generatorId
-  );
 }
 
 /**
@@ -1725,53 +1591,6 @@ function parseSourceList(value: string): string[] | undefined {
     .map((entry) => entry.trim())
     .filter(Boolean);
   return sources.length > 0 ? sources : undefined;
-}
-
-function derivationTone(derivation: DerivationPolicy): string {
-  if (
-    derivation.kind !== 'snapshot' &&
-    (derivation.sources?.length ?? 0) > 0 &&
-    !derivation.refresh &&
-    !derivation.driftPolicy
-  ) {
-    return 'var(--warning)';
-  }
-  return derivation.kind === 'snapshot' ? 'var(--success)' : 'var(--inspector-advisory)';
-}
-
-function fieldKindColor(fieldType: FieldType): string {
-  switch (fieldType.kind) {
-    case 'string':
-      return 'var(--inspector-field-string)';
-    case 'number':
-      return 'var(--inspector-field-number)';
-    case 'boolean':
-      return 'var(--inspector-field-boolean)';
-    case 'date':
-      return 'var(--inspector-field-date)';
-    case 'literal':
-      return 'var(--inspector-field-literal)';
-    case 'ref':
-      return 'var(--inspector-field-ref)';
-    case 'array':
-      return 'var(--inspector-field-array)';
-  }
-}
-
-function inspectorHeaderStyle(color: string): CSSProperties {
-  return {
-    background: 'var(--background)',
-    borderColor: `color-mix(in oklch, ${color} 34%, var(--border))`,
-    boxShadow: `inset 0 -2px 0 color-mix(in oklch, ${color} 24%, transparent)`,
-  };
-}
-
-function toneSurfaceStyle(color: string, background = 12, border = 44): CSSProperties {
-  return {
-    background: `color-mix(in oklch, ${color} ${background}%, transparent)`,
-    borderColor: `color-mix(in oklch, ${color} ${border}%, var(--border))`,
-    color: `color-mix(in oklch, ${color} 78%, var(--foreground))`,
-  };
 }
 
 function nextFieldIndexName(indexes: readonly IndexDef[], fieldName: string): string {

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -27,16 +27,14 @@ import type { ModelingHint } from '@contexture/core/modeling-hints';
 import type { TypeUpdatePatch } from '@contexture/core/ops';
 import type { ValidationError } from '@renderer/services/validation';
 import { useChatComposerStore } from '@renderer/store/chat-composer';
-import { usePlaygroundStore } from '@renderer/store/playground';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { useUIChromeStore } from '@renderer/store/ui-chrome';
 import {
   ChevronDown,
   ChevronUp,
-  Hash,
+  GripVertical,
   Lightbulb,
   MessageSquare,
-  Play,
   Plus,
   SlidersHorizontal,
   Trash2,
@@ -46,10 +44,8 @@ import { type CSSProperties, useEffect, useId, useMemo, useRef, useState } from 
 import { cn } from '@/lib/utils';
 import type { Op } from '../../store/ops';
 import { nextFieldName } from '../graph/interactions';
-import { ScopedPlaygroundWorkbench } from '../playground/PlaygroundPanel';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
-import { ButtonGroup } from '../ui/button-group';
 import { Checkbox } from '../ui/checkbox';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
 import {
@@ -64,8 +60,8 @@ import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { Switch } from '../ui/switch';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Textarea } from '../ui/textarea';
 import { HintBody, ModelShapeHints } from './ModelShapeHints';
 import { type ValidationIssueRepair, ValidationIssues } from './ValidationIssues';
@@ -73,7 +69,6 @@ import { type ValidationIssueRepair, ValidationIssues } from './ValidationIssues
 const CONVEX_RESERVED_PREFIX_MSG = "Convex reserves names starting with '_'";
 export const FOCUS_TYPE_NAME_EVENT = 'contexture:focus-type-name';
 const AUTO_SAMPLE_DATA = '__auto__';
-const EMPTY_TABLE_RECORDS: readonly unknown[] = [];
 
 function isConvexReservedName(name: string): boolean {
   return name.startsWith('_');
@@ -105,7 +100,6 @@ export interface TypeDetailProps {
 
 export function TypeDetail({
   type,
-  schema,
   dispatch,
   dispatchBatch,
   modelingHints = [],
@@ -117,63 +111,23 @@ export function TypeDetail({
 }: TypeDetailProps) {
   const isTable = type.kind === 'object' && type.table === true;
   const nameReserved = isTable && isConvexReservedName(type.name);
-  const recordsByType = usePlaygroundStore((state) => state.recordsByType);
-  const tableRecords = isTable
-    ? (recordsByType[type.name] ?? EMPTY_TABLE_RECORDS)
-    : EMPTY_TABLE_RECORDS;
 
   if (isTable && type.kind === 'object') {
     return (
       <TableTypeDetail
         type={type}
-        schema={schema}
         dispatch={dispatch}
         modelingHints={modelingHints}
         validationErrors={validationErrors}
         validationRepairForIssue={validationRepairForIssue}
         onDiscussValidationIssue={onDiscussValidationIssue}
-        recordsCount={tableRecords.length}
         reserved={nameReserved}
       />
     );
   }
 
   return (
-    <div className="space-y-4 p-3 pt-0">
-      <header
-        className="-mx-3 flex min-h-20 items-center justify-between border-b bg-muted/20 px-3 py-3"
-        style={inspectorHeaderStyle(inspectorTypeColor(type))}
-        data-testid="type-detail-header"
-      >
-        <div className="min-w-0">
-          <div
-            className="truncate text-[11px] font-medium uppercase tracking-wide"
-            style={{ color: inspectorTypeColor(type) }}
-          >
-            {isTable ? 'table' : type.kind}
-          </div>
-          <h2 className="truncate text-lg font-semibold leading-tight text-foreground">
-            {type.name}
-          </h2>
-          <div
-            aria-hidden="true"
-            className="h-[1.25rem] truncate text-sm font-medium leading-snug text-muted-foreground"
-          />
-        </div>
-        <div className="flex items-center gap-1.5">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label={`Delete type ${type.name}`}
-            onClick={() => dispatch({ kind: 'delete_type', name: type.name })}
-            className="h-7 w-7 text-muted-foreground hover:text-destructive"
-          >
-            <Trash2 aria-hidden="true" />
-          </Button>
-        </div>
-      </header>
-
+    <div className="space-y-4 p-3">
       <ValidationIssues
         errors={validationErrors}
         onDiscussIssue={onDiscussValidationIssue}
@@ -206,26 +160,21 @@ export function TypeDetail({
 
 function TableTypeDetail({
   type,
-  schema,
   dispatch,
   modelingHints,
   validationErrors,
   validationRepairForIssue,
   onDiscussValidationIssue,
-  recordsCount,
   reserved,
 }: {
   type: Extract<TypeDef, { kind: 'object' }>;
-  schema?: Schema;
   dispatch: (op: Op) => void;
   modelingHints: readonly ModelingHint[];
   validationErrors: readonly ValidationError[];
   validationRepairForIssue?: (error: ValidationError) => ValidationIssueRepair | null;
   onDiscussValidationIssue?: (error: ValidationError) => void;
-  recordsCount: number;
   reserved: boolean;
 }) {
-  const defaultMode = recordsCount > 0 ? 'try' : 'shape';
   const { tableHints, fieldHintsByName } = useMemo(
     () => splitTableModelingHints(modelingHints),
     [modelingHints],
@@ -239,56 +188,8 @@ function TableTypeDetail({
   const suggestionCount = suggestedIndexes(type).length;
 
   return (
-    <Tabs key={type.name} defaultValue={defaultMode} className="flex h-full min-h-0 flex-col">
-      <header
-        className="flex min-h-20 shrink-0 items-center justify-between border-b bg-muted/20 px-3 py-3"
-        style={inspectorHeaderStyle('var(--inspector-type-table)')}
-        data-testid="type-detail-header"
-      >
-        <div className="min-w-0">
-          <div
-            className="truncate text-[11px] font-medium uppercase tracking-wide"
-            style={{ color: 'var(--inspector-type-table)' }}
-          >
-            table
-          </div>
-          <h2 className="truncate text-lg font-semibold leading-tight text-foreground">
-            {type.name}
-          </h2>
-          <div className="mt-2">
-            <TabsList asChild>
-              <ButtonGroup aria-label="Table inspector mode">
-                <TabsTrigger
-                  value="shape"
-                  className="h-8 gap-1.5 rounded-none border-0 px-3 text-xs first:rounded-l-md last:rounded-r-md data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=active]:shadow-none"
-                >
-                  <SlidersHorizontal aria-hidden="true" className="size-3.5" />
-                  Shape
-                </TabsTrigger>
-                <TabsTrigger
-                  value="try"
-                  className="h-8 gap-1.5 rounded-none border-0 px-3 text-xs first:rounded-l-md last:rounded-r-md data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=active]:shadow-none"
-                >
-                  <Play aria-hidden="true" className="size-3.5" />
-                  Try
-                </TabsTrigger>
-              </ButtonGroup>
-            </TabsList>
-          </div>
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label={`Delete type ${type.name}`}
-          onClick={() => dispatch({ kind: 'delete_type', name: type.name })}
-          className="h-7 w-7 text-muted-foreground hover:text-destructive"
-        >
-          <Trash2 aria-hidden="true" />
-        </Button>
-      </header>
-
-      <TabsContent value="shape" className="m-0 min-h-0 flex-1 overflow-y-auto p-3">
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
         <div className="space-y-4">
           <ValidationIssues
             errors={validationErrors}
@@ -302,7 +203,6 @@ function TableTypeDetail({
           <ObjectBody
             type={type}
             dispatch={dispatch}
-            quietControls
             fieldHintsByName={fieldHintsByName}
             fieldHintCount={fieldHintCount}
             fieldIndexInsights={fieldIndexInsights}
@@ -340,34 +240,8 @@ function TableTypeDetail({
             </CollapsibleContent>
           </Collapsible>
         </div>
-      </TabsContent>
-
-      <TabsContent value="try" className="m-0 min-h-0 flex-1 overflow-hidden">
-        <div className="flex h-full min-h-0 flex-col">
-          <ValidationIssues
-            errors={validationErrors}
-            onDiscussIssue={onDiscussValidationIssue}
-            onIssueClick={(error) => selectFieldFromValidationIssue(type, error)}
-            repairForIssue={validationRepairForIssue}
-          />
-          <details className="shrink-0 border-b bg-muted/10 px-3 py-2">
-            <summary className="cursor-pointer list-none text-xs font-medium text-muted-foreground transition-colors hover:text-foreground">
-              Generation settings
-            </summary>
-            <div className="mt-2">
-              <SampleDataSection type={type} dispatch={dispatch} compact />
-            </div>
-          </details>
-          {schema ? (
-            <ScopedPlaygroundWorkbench schema={schema} typeName={type.name} className="flex-1" />
-          ) : (
-            <div className="grid flex-1 place-items-center p-6 text-center text-sm text-muted-foreground">
-              Sample records need a schema context.
-            </div>
-          )}
-        </div>
-      </TabsContent>
-    </Tabs>
+      </div>
+    </div>
   );
 }
 
@@ -524,19 +398,19 @@ function DescriptionField({ type, dispatch }: TypeDetailProps) {
 function ObjectBody({
   type,
   dispatch,
-  quietControls = false,
   fieldHintsByName,
   fieldHintCount = 0,
   fieldIndexInsights,
 }: {
   type: Extract<TypeDef, { kind: 'object' }>;
   dispatch: (op: Op) => void;
-  quietControls?: boolean;
   fieldHintsByName?: ReadonlyMap<string, readonly ModelingHint[]>;
   fieldHintCount?: number;
   fieldIndexInsights?: ReadonlyMap<string, FieldIndexInsight>;
 }) {
   const fieldOrder = type.fields.map((field) => field.name);
+  const [draggedFieldName, setDraggedFieldName] = useState<string | null>(null);
+  const [dropTargetFieldName, setDropTargetFieldName] = useState<string | null>(null);
   const addField = () => {
     const field: FieldDef = { name: nextFieldName(type.fields), type: { kind: 'string' } };
     dispatch({
@@ -553,6 +427,13 @@ function ObjectBody({
     if (!fieldName) return;
     nextOrder.splice(toIndex, 0, fieldName);
     dispatch({ kind: 'reorder_fields', typeName: type.name, order: nextOrder });
+  };
+  const moveFieldByName = (fromFieldName: string, toFieldName: string) => {
+    if (fromFieldName === toFieldName) return;
+    const fromIndex = fieldOrder.indexOf(fromFieldName);
+    const toIndex = fieldOrder.indexOf(toFieldName);
+    if (fromIndex === -1 || toIndex === -1) return;
+    moveField(fromIndex, toIndex);
   };
 
   if (type.fields.length === 0) {
@@ -578,7 +459,6 @@ function ObjectBody({
     );
   }
   const isTable = type.table === true;
-  const showAdviceColumn = Boolean(fieldHintsByName && fieldHintsByName.size > 0);
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between">
@@ -595,55 +475,117 @@ function ObjectBody({
           Add field
         </Button>
       </div>
-      <Table className="text-xs">
+      <Table className="table-fixed text-xs">
         <TableHeader>
           <TableRow className="hover:bg-transparent">
-            <TableHead className="h-7 px-2">Name</TableHead>
-            <TableHead className="h-7 w-20 px-2 text-center">Optional</TableHead>
-            <TableHead className="h-7 px-2 text-right">Type</TableHead>
-            {showAdviceColumn && (
-              <TableHead className="h-7 w-14 px-1 text-center">
-                <span className="sr-only">Advice</span>
-              </TableHead>
-            )}
-            <TableHead className="h-7 w-36 px-1 text-right">
+            <TableHead className="h-7 w-7 px-0">
+              <span className="sr-only">Order</span>
+            </TableHead>
+            <TableHead className="h-7 min-w-36 px-1">Name</TableHead>
+            <TableHead className="h-7 w-[4.75rem] px-1 text-center">Optional</TableHead>
+            <TableHead className="h-7 w-[4.5rem] px-1 text-right">
               <span className="sr-only">Actions</span>
             </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
-          {type.fields.map((f, fieldIndex) => {
+          {type.fields.map((f) => {
             const reserved = isTable && isConvexReservedName(f.name);
             const fieldHints = fieldHintsByName?.get(f.name) ?? [];
             const fieldIndexInsight = fieldIndexInsights?.get(f.name);
+            const isDropTarget = dropTargetFieldName === f.name && draggedFieldName !== f.name;
             return (
               <TableRow
                 key={f.name}
                 data-testid="object-field-summary"
                 data-reserved={reserved || undefined}
                 title={reserved ? CONVEX_RESERVED_PREFIX_MSG : undefined}
-                className={cn('group', reserved && 'text-destructive')}
+                onDragEnter={() => {
+                  if (draggedFieldName) setDropTargetFieldName(f.name);
+                }}
+                onDragOver={(ev) => {
+                  ev.preventDefault();
+                  if (ev.dataTransfer) ev.dataTransfer.dropEffect = 'move';
+                }}
+                onDrop={(ev) => {
+                  ev.preventDefault();
+                  const source = draggedFieldName ?? ev.dataTransfer?.getData('text/plain');
+                  if (!source) return;
+                  moveFieldByName(source, f.name);
+                  setDraggedFieldName(null);
+                  setDropTargetFieldName(null);
+                }}
+                onDragEnd={() => {
+                  setDraggedFieldName(null);
+                  setDropTargetFieldName(null);
+                }}
+                className={cn(
+                  'group',
+                  isDropTarget &&
+                    'bg-reference/10 shadow-[inset_0_2px_0_var(--reference)] hover:bg-reference/10',
+                  draggedFieldName === f.name && 'opacity-45',
+                  reserved && 'text-destructive',
+                )}
               >
-                <TableCell className="px-2 py-1.5 font-medium">
-                  <Input
-                    aria-label={`Field name ${f.name}`}
-                    defaultValue={f.name}
-                    className="h-7 px-2 text-xs font-medium"
-                    onBlur={(ev) => {
-                      const next = ev.target.value.trim();
-                      if (next && next !== f.name) {
-                        dispatch({
-                          kind: 'update_field',
-                          typeName: type.name,
-                          fieldName: f.name,
-                          patch: { name: next },
-                        });
-                      }
+                <TableCell className="px-0 py-1.5 align-middle">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 cursor-grab text-muted-foreground/65 hover:text-foreground active:cursor-grabbing"
+                    aria-label={`Drag field ${f.name} to reorder`}
+                    draggable
+                    onDragStart={(ev) => {
+                      setDraggedFieldName(f.name);
+                      setDropTargetFieldName(null);
+                      ev.dataTransfer.effectAllowed = 'move';
+                      ev.dataTransfer.setData('text/plain', f.name);
                     }}
-                  />
+                    title="Drag to reorder"
+                  >
+                    <GripVertical aria-hidden="true" className="size-3.5" />
+                  </Button>
                 </TableCell>
-                <TableCell className="px-2 py-1.5 text-center">
-                  <Checkbox
+                <TableCell className="px-1 py-1.5 font-medium">
+                  <div className="min-w-0">
+                    <div className="mb-1 flex min-w-0 flex-wrap items-center gap-1">
+                      <FieldKindPill fieldType={f.type} />
+                      {f.derivation && <FieldDerivationPill field={f} />}
+                      {fieldIndexInsight && fieldIndexInsight.memberships.length > 0 && (
+                        <Badge
+                          variant="outline"
+                          className="h-4 rounded px-1 text-[10px]"
+                          style={toneSurfaceStyle('var(--inspector-index)', 12, 50)}
+                        >
+                          indexed
+                        </Badge>
+                      )}
+                      <FieldAdvicePopover
+                        typeName={type.name}
+                        fieldName={f.name}
+                        hints={fieldHints}
+                      />
+                    </div>
+                    <Input
+                      aria-label={`Field name ${f.name}`}
+                      defaultValue={f.name}
+                      className="h-7 min-w-0 px-2 text-xs font-medium"
+                      onBlur={(ev) => {
+                        const next = ev.target.value.trim();
+                        if (next && next !== f.name) {
+                          dispatch({
+                            kind: 'update_field',
+                            typeName: type.name,
+                            fieldName: f.name,
+                            patch: { name: next },
+                          });
+                        }
+                      }}
+                    />
+                  </div>
+                </TableCell>
+                <TableCell className="px-1 py-1.5 text-center">
+                  <Switch
                     aria-label={`${f.name} optional`}
                     checked={f.optional === true}
                     onCheckedChange={(v) =>
@@ -656,38 +598,9 @@ function ObjectBody({
                     }
                   />
                 </TableCell>
-                <TableCell className="px-2 py-1.5 text-right">
-                  <div className="inline-flex items-center justify-end gap-1">
-                    {f.derivation && <FieldDerivationPill field={f} />}
-                    <FieldKindPill fieldType={f.type} />
-                  </div>
-                </TableCell>
-                {showAdviceColumn && (
-                  <TableCell className="w-14 px-1 py-1.5 text-center">
-                    <FieldAdvicePopover
-                      typeName={type.name}
-                      fieldName={f.name}
-                      hints={fieldHints}
-                    />
-                  </TableCell>
-                )}
-                <TableCell className="w-36 px-1 py-1.5 text-right">
+                <TableCell className="w-[4.5rem] px-1 py-1.5 text-right">
                   <div className="inline-flex items-center justify-end gap-0.5">
-                    {fieldIndexInsight && (
-                      <FieldIndexPopover
-                        typeName={type.name}
-                        fieldName={f.name}
-                        insight={fieldIndexInsight}
-                        dispatch={dispatch}
-                      />
-                    )}
-                    <div
-                      className={cn(
-                        'inline-flex items-center gap-0.5 transition-opacity',
-                        quietControls &&
-                          'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
-                      )}
-                    >
+                    <div className="inline-flex items-center gap-0.5">
                       <Button
                         type="button"
                         variant="ghost"
@@ -701,28 +614,6 @@ function ObjectBody({
                         className="h-7 w-7 text-muted-foreground hover:text-foreground"
                       >
                         <SlidersHorizontal aria-hidden="true" />
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        aria-label={`Move field ${f.name} earlier`}
-                        disabled={fieldIndex === 0}
-                        onClick={() => moveField(fieldIndex, fieldIndex - 1)}
-                        className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                      >
-                        <ChevronUp aria-hidden="true" />
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        aria-label={`Move field ${f.name} later`}
-                        disabled={fieldIndex === type.fields.length - 1}
-                        onClick={() => moveField(fieldIndex, fieldIndex + 1)}
-                        className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                      >
-                        <ChevronDown aria-hidden="true" />
                       </Button>
                       <Button
                         type="button"
@@ -761,7 +652,7 @@ function FieldAdvicePopover({
   fieldName: string;
   hints: readonly ModelingHint[];
 }) {
-  if (hints.length === 0) return <span aria-hidden="true" className="inline-block h-7 w-7" />;
+  if (hints.length === 0) return null;
 
   const [primary, ...secondary] = hints;
   if (!primary) return null;
@@ -783,12 +674,12 @@ function FieldAdvicePopover({
           variant="ghost"
           size="icon"
           aria-label={`Modeling advice for ${fieldName}`}
-          className="relative h-7 w-7 border shadow-[0_0_0_1px_color-mix(in_oklch,currentColor_10%,transparent)] transition-colors hover:bg-accent/70 data-[state=open]:bg-accent"
+          className="relative h-4 w-4 shrink-0 rounded p-0 shadow-[0_0_0_1px_color-mix(in_oklch,currentColor_10%,transparent)] transition-colors hover:bg-accent/70 data-[state=open]:bg-accent"
           style={toneSurfaceStyle(toneColor, 18, 48)}
         >
           <LightbulbIcon color={toneColor} />
           <span
-            className="absolute -right-0.5 -top-0.5 grid h-3.5 min-w-3.5 place-items-center rounded-full border border-background px-1 text-[9px] font-semibold leading-none"
+            className="absolute -right-1 -top-1 grid h-3 min-w-3 place-items-center rounded-full border border-background px-0.5 text-[8px] font-semibold leading-none"
             style={{
               background: toneColor,
               color:
@@ -854,7 +745,7 @@ function advisoryChatPrompt({
 }
 
 function LightbulbIcon({ color }: { color: string }): React.JSX.Element {
-  return <Lightbulb aria-hidden="true" className="size-3.5" style={{ color }} />;
+  return <Lightbulb aria-hidden="true" className="size-3" style={{ color }} />;
 }
 
 function advisoryToneColor(hints: readonly ModelingHint[]): string {
@@ -865,104 +756,6 @@ function advisoryToneColor(hints: readonly ModelingHint[]): string {
   )
     ? 'var(--warning)'
     : 'var(--inspector-advisory)';
-}
-
-function FieldIndexPopover({
-  typeName,
-  fieldName,
-  insight,
-  dispatch,
-}: {
-  typeName: string;
-  fieldName: string;
-  insight: FieldIndexInsight;
-  dispatch: (op: Op) => void;
-}) {
-  const isIndexed = insight.memberships.length > 0;
-  const suggestion = insight.suggestion;
-  if (!isIndexed && !suggestion) return null;
-
-  const triggerLabel = isIndexed ? `Index details for ${fieldName}` : `Add index for ${fieldName}`;
-
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label={triggerLabel}
-          className={cn(
-            'h-7 w-7 border border-transparent text-muted-foreground hover:text-primary data-[state=open]:text-primary',
-            !isIndexed &&
-              'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100',
-          )}
-          style={isIndexed ? toneSurfaceStyle('var(--inspector-index)', 14, 0) : undefined}
-        >
-          {isIndexed ? (
-            <Hash aria-hidden="true" className="size-3.5" />
-          ) : (
-            <Plus aria-hidden="true" />
-          )}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="end" side="left" className="w-72 p-3 text-xs">
-        <div className="space-y-3">
-          {isIndexed && (
-            <div className="space-y-2">
-              <div className="font-medium text-foreground">Indexed field</div>
-              <div className="space-y-1.5">
-                {insight.memberships.map((membership) => (
-                  <div
-                    key={membership.indexName}
-                    className="rounded-md border px-2 py-1.5"
-                    style={toneSurfaceStyle('var(--inspector-index)', 14, 50)}
-                  >
-                    <div className="font-mono text-[11px] text-foreground">
-                      {membership.indexName}
-                    </div>
-                    <div className="mt-0.5 text-[11px] text-muted-foreground">
-                      {membership.total === 1
-                        ? 'Single-field index'
-                        : `Position ${membership.position + 1} of ${membership.total}: ${membership.fields.join(
-                            ' -> ',
-                          )}`}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-          {suggestion && (
-            <div className={cn('space-y-2', isIndexed && 'border-t border-border/70 pt-2')}>
-              <div>
-                <div className="font-medium text-foreground">Suggested index</div>
-                <p className="mt-0.5 text-[11px] text-muted-foreground">
-                  Useful for lookups, filtering, or sorting on this field.
-                </p>
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() =>
-                  dispatch({
-                    kind: 'add_index',
-                    typeName,
-                    index: { name: suggestion.name, fields: suggestion.fields },
-                  })
-                }
-                className="h-7 px-2 text-xs"
-              >
-                <Plus aria-hidden="true" />
-                Add {suggestion.name}
-              </Button>
-            </div>
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
 }
 
 // TODO(#119): gate on output config mode once Contexture supports multiple emit targets.
@@ -1091,29 +884,18 @@ function ConvexSection({
               <p className="text-[11px] text-muted-foreground">
                 Field order affects Convex query prefixes.
               </p>
-              <Table className="text-xs">
-                <TableHeader>
-                  <TableRow className="hover:bg-transparent">
-                    <TableHead className="h-7 px-2">Index</TableHead>
-                    <TableHead className="h-7 px-2">Fields</TableHead>
-                    <TableHead className="h-7 w-9 px-1 text-right">
-                      <span className="sr-only">Actions</span>
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {indexes.map((idx, indexIndex) => (
-                    <IndexRow
-                      key={idx.name}
-                      typeName={type.name}
-                      index={idx}
-                      validationErrors={validationErrorsForIndex(validationErrors, indexIndex)}
-                      fieldNames={fieldNames}
-                      dispatch={dispatch}
-                    />
-                  ))}
-                </TableBody>
-              </Table>
+              <div className="space-y-2">
+                {indexes.map((idx, indexIndex) => (
+                  <IndexRow
+                    key={idx.name}
+                    typeName={type.name}
+                    index={idx}
+                    validationErrors={validationErrorsForIndex(validationErrors, indexIndex)}
+                    fieldNames={fieldNames}
+                    dispatch={dispatch}
+                  />
+                ))}
+              </div>
             </div>
           )}
           <div className="space-y-1.5 pt-1">
@@ -1139,30 +921,18 @@ function ConvexSection({
             {searchIndexes.length === 0 ? (
               <p className="text-xs text-muted-foreground">No search indexes yet.</p>
             ) : (
-              <Table className="text-xs">
-                <TableHeader>
-                  <TableRow className="hover:bg-transparent">
-                    <TableHead className="h-7 px-2">Search index</TableHead>
-                    <TableHead className="h-7 px-2">Search field</TableHead>
-                    <TableHead className="h-7 px-2">Filter fields</TableHead>
-                    <TableHead className="h-7 w-9 px-1 text-right">
-                      <span className="sr-only">Actions</span>
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {searchIndexes.map((index) => (
-                    <SearchIndexRow
-                      key={index.name}
-                      typeName={type.name}
-                      index={index}
-                      stringFieldNames={stringFieldNames}
-                      fieldNames={fieldNames}
-                      dispatch={dispatch}
-                    />
-                  ))}
-                </TableBody>
-              </Table>
+              <div className="space-y-2">
+                {searchIndexes.map((index) => (
+                  <SearchIndexRow
+                    key={index.name}
+                    typeName={type.name}
+                    index={index}
+                    stringFieldNames={stringFieldNames}
+                    fieldNames={fieldNames}
+                    dispatch={dispatch}
+                  />
+                ))}
+              </div>
             )}
           </div>
         </div>
@@ -1199,44 +969,61 @@ function SearchIndexRow({
   };
 
   return (
-    <TableRow className="hover:bg-transparent">
-      <TableCell className="px-2 py-1.5 align-top">
-        <Input
-          aria-label={`Search index name for ${index.name}`}
-          defaultValue={index.name}
-          className="h-8 px-2 text-xs"
-          onBlur={(ev) => {
-            const next = ev.target.value.trim();
-            if (next && next !== index.name) patchSearchIndex({ name: next });
-          }}
-        />
-        {index.staged !== undefined && (
-          <div className="mt-0.5 text-[11px] text-muted-foreground">
-            {index.staged ? 'staged backfill' : 'active'}
+    <div className="space-y-2 rounded-md border border-border/70 px-2 py-2 text-xs">
+      <div className="flex items-start gap-2">
+        <div className="grid min-w-0 flex-1 gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <div className="min-w-0 space-y-1">
+            <Label className="text-[11px] text-muted-foreground">Search index</Label>
+            <Input
+              aria-label={`Search index name for ${index.name}`}
+              defaultValue={index.name}
+              className="h-8 px-2 text-xs"
+              onBlur={(ev) => {
+                const next = ev.target.value.trim();
+                if (next && next !== index.name) patchSearchIndex({ name: next });
+              }}
+            />
+            {index.staged !== undefined && (
+              <div className="text-[11px] text-muted-foreground">
+                {index.staged ? 'staged backfill' : 'active'}
+              </div>
+            )}
           </div>
-        )}
-      </TableCell>
-      <TableCell className="px-2 py-1.5 align-top">
-        <Select
-          value={index.searchField}
-          onValueChange={(searchField) => patchSearchIndex({ searchField })}
+          <div className="min-w-0 space-y-1">
+            <Label className="text-[11px] text-muted-foreground">Search field</Label>
+            <Select
+              value={index.searchField}
+              onValueChange={(searchField) => patchSearchIndex({ searchField })}
+            >
+              <SelectTrigger
+                aria-label={`Search field for ${index.name}`}
+                className="h-8 min-w-0 px-2 font-mono text-xs"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {stringFieldNames.map((fieldName) => (
+                  <SelectItem key={fieldName} value={fieldName}>
+                    {fieldName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={`Delete search index ${index.name}`}
+          onClick={() => dispatch({ kind: 'remove_search_index', typeName, name: index.name })}
+          className="h-8 w-8 shrink-0 text-destructive hover:text-destructive"
         >
-          <SelectTrigger
-            aria-label={`Search field for ${index.name}`}
-            className="h-8 min-w-36 px-2 font-mono text-xs"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {stringFieldNames.map((fieldName) => (
-              <SelectItem key={fieldName} value={fieldName}>
-                {fieldName}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </TableCell>
-      <TableCell className="px-2 py-1.5 align-top">
+          <Trash2 aria-hidden="true" />
+        </Button>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-[11px] text-muted-foreground">Filter fields</Label>
         <div className="flex flex-wrap items-center gap-1.5">
           {filterFields.length === 0 ? (
             <span className="text-[11px] text-muted-foreground">None</span>
@@ -1276,20 +1063,8 @@ function SearchIndexRow({
             ariaLabel={`Add filter field to search index ${index.name}`}
           />
         </div>
-      </TableCell>
-      <TableCell className="w-9 px-1 py-1.5 text-right align-top">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label={`Delete search index ${index.name}`}
-          onClick={() => dispatch({ kind: 'remove_search_index', typeName, name: index.name })}
-          className="h-8 w-8 text-destructive hover:text-destructive"
-        >
-          <Trash2 aria-hidden="true" />
-        </Button>
-      </TableCell>
-    </TableRow>
+      </div>
+    </div>
   );
 }
 
@@ -1404,64 +1179,35 @@ function IndexRow({
   };
 
   return (
-    <TableRow
+    <div
       data-testid="convex-index-row"
       data-validation-issues={hasValidationIssues || undefined}
-      className={hasValidationIssues ? 'bg-destructive/10' : undefined}
+      className={cn(
+        'space-y-2 rounded-md border border-border/70 px-2 py-2 text-xs',
+        hasValidationIssues && 'bg-destructive/10',
+      )}
     >
-      <TableCell className="w-32 px-2 py-1.5 align-top">
-        <Input
-          aria-label={`Index name for ${index.name}`}
-          defaultValue={index.name}
-          aria-invalid={hasValidationIssues || undefined}
-          className="h-8 px-2 text-xs"
-          onBlur={(ev) => {
-            const next = ev.target.value.trim();
-            if (next && next !== index.name) {
-              dispatch({
-                kind: 'update_index',
-                typeName,
-                name: index.name,
-                patch: { name: next },
-              });
-            }
-          }}
-        />
-      </TableCell>
-      <TableCell className="px-2 py-1.5 align-top">
-        <div className="space-y-1.5">
-          <div className="flex flex-wrap items-center gap-1.5">
-            {index.fields.map((fieldName, fieldIndex) => (
-              <IndexFieldChip
-                key={fieldName}
-                indexName={index.name}
-                fieldName={fieldName}
-                position={fieldIndex}
-                total={index.fields.length}
-                onMoveEarlier={() => moveField(fieldIndex, fieldIndex - 1)}
-                onMoveLater={() => moveField(fieldIndex, fieldIndex + 1)}
-                onRemove={() => removeField(fieldName)}
-              />
-            ))}
-            <IndexFieldPicker
-              indexName={index.name}
-              availableFieldNames={availableFieldNames}
-              onSelect={appendField}
-            />
-          </div>
-          {hasValidationIssues && (
-            <ul
-              className="space-y-0.5 text-[11px] text-destructive"
-              aria-label={`Validation issues for index ${index.name}`}
-            >
-              {validationErrors.map((error) => (
-                <li key={`${error.code}:${error.path}`}>{error.message}</li>
-              ))}
-            </ul>
-          )}
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1 space-y-1">
+          <Label className="text-[11px] text-muted-foreground">Index</Label>
+          <Input
+            aria-label={`Index name for ${index.name}`}
+            defaultValue={index.name}
+            aria-invalid={hasValidationIssues || undefined}
+            className="h-8 px-2 text-xs"
+            onBlur={(ev) => {
+              const next = ev.target.value.trim();
+              if (next && next !== index.name) {
+                dispatch({
+                  kind: 'update_index',
+                  typeName,
+                  name: index.name,
+                  patch: { name: next },
+                });
+              }
+            }}
+          />
         </div>
-      </TableCell>
-      <TableCell className="w-9 px-1 py-1.5 text-right align-top">
         <Button
           type="button"
           variant="ghost"
@@ -1472,8 +1218,40 @@ function IndexRow({
         >
           <Trash2 aria-hidden="true" />
         </Button>
-      </TableCell>
-    </TableRow>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-[11px] text-muted-foreground">Fields</Label>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {index.fields.map((fieldName, fieldIndex) => (
+            <IndexFieldChip
+              key={fieldName}
+              indexName={index.name}
+              fieldName={fieldName}
+              position={fieldIndex}
+              total={index.fields.length}
+              onMoveEarlier={() => moveField(fieldIndex, fieldIndex - 1)}
+              onMoveLater={() => moveField(fieldIndex, fieldIndex + 1)}
+              onRemove={() => removeField(fieldName)}
+            />
+          ))}
+          <IndexFieldPicker
+            indexName={index.name}
+            availableFieldNames={availableFieldNames}
+            onSelect={appendField}
+          />
+        </div>
+        {hasValidationIssues && (
+          <ul
+            className="space-y-0.5 text-[11px] text-destructive"
+            aria-label={`Validation issues for index ${index.name}`}
+          >
+            {validationErrors.map((error) => (
+              <li key={`${error.code}:${error.path}`}>{error.message}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -2253,20 +2031,6 @@ function derivationPillTitle(field: FieldDef): string {
   return 'Derivation policy declared.';
 }
 
-function inspectorTypeColor(type: TypeDef): string {
-  if (type.kind === 'object' && type.table === true) return 'var(--inspector-type-table)';
-  switch (type.kind) {
-    case 'object':
-      return 'var(--inspector-type-object)';
-    case 'enum':
-      return 'var(--inspector-type-enum)';
-    case 'discriminatedUnion':
-      return 'var(--inspector-type-union)';
-    case 'raw':
-      return 'var(--inspector-type-raw)';
-  }
-}
-
 function fieldKindColor(fieldType: FieldType): string {
   switch (fieldType.kind) {
     case 'string':
@@ -2284,14 +2048,6 @@ function fieldKindColor(fieldType: FieldType): string {
     case 'array':
       return 'var(--inspector-field-array)';
   }
-}
-
-function inspectorHeaderStyle(color: string): CSSProperties {
-  return {
-    background: 'var(--background)',
-    borderColor: `color-mix(in oklch, ${color} 34%, var(--border))`,
-    boxShadow: `inset 0 -2px 0 color-mix(in oklch, ${color} 24%, transparent)`,
-  };
 }
 
 function toneSurfaceStyle(color: string, background = 12, border = 44): CSSProperties {

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -184,10 +184,7 @@ function GraphCanvasInner({
   const setAdjacencyResolver = useGraphSelectionStore((s) => s.setAdjacencyResolver);
   const focusTarget = useGraphSelectionStore((s) => s.state.focusTarget);
   const consumeFocus = useGraphSelectionStore((s) => s.consumeFocus);
-  const sidebarTab = useUIChromeStore((s) => s.sidebarTab);
   const sidebarVisible = useUIChromeStore((s) => s.sidebarVisible);
-  const setSidebarTab = useUIChromeStore((s) => s.setSidebarTab);
-  const setSidebarVisible = useUIChromeStore((s) => s.setSidebarVisible);
 
   const validationErrors = useMemo(() => validate(schema, { stdlib: STDLIB_REGISTRY }), [schema]);
   const modelingHints = useMemo(() => analyzeModelingHints(schema), [schema]);
@@ -302,7 +299,7 @@ function GraphCanvasInner({
 
   useEffect(() => {
     if ((showEnums && showStdlib) || !selectedNodeId) return;
-    if (sidebarVisible && sidebarTab === 'properties') return;
+    if (sidebarVisible) return;
     const selectedNode = builtNodes.find((node) => node.id === selectedNodeId);
     if (
       selectedNode &&
@@ -311,7 +308,7 @@ function GraphCanvasInner({
     ) {
       clearNodes();
     }
-  }, [builtNodes, clearNodes, selectedNodeId, showEnums, showStdlib, sidebarTab, sidebarVisible]);
+  }, [builtNodes, clearNodes, selectedNodeId, showEnums, showStdlib, sidebarVisible]);
 
   // ELK once the nodes have measured DOM dimensions.
   const { runLayout } = useELKLayout();
@@ -492,32 +489,18 @@ function GraphCanvasInner({
       if ('error' in result) return;
       click(typeName, 'replace');
       useGraphSelectionStore.getState().focus({ nodeId: typeName, fieldName: op.field.name });
-      setSidebarVisible(true);
-      setSidebarTab('properties');
     },
-    [click, setSidebarTab, setSidebarVisible],
+    [click],
   );
 
   const focusSelectedTypeName = useCallback((): void => {
     if (!selectedNodeId) return;
-    setSidebarVisible(true);
-    setSidebarTab('properties');
     setTimeout(() => {
       document.dispatchEvent(
         new CustomEvent(FOCUS_TYPE_NAME_EVENT, { detail: { typeName: selectedNodeId } }),
       );
     }, 0);
-  }, [selectedNodeId, setSidebarTab, setSidebarVisible]);
-
-  // Double-click a node → focus its properties in the sidebar.
-  const onNodeDoubleClick: ReactFlowProps['onNodeDoubleClick'] = useCallback(
-    (_event, node) => {
-      click(node.id, 'replace');
-      setSidebarVisible(true);
-      setSidebarTab('properties');
-    },
-    [click, setSidebarVisible, setSidebarTab],
-  );
+  }, [selectedNodeId]);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -561,12 +544,10 @@ function GraphCanvasInner({
       const detail = (ev as CustomEvent<{ typeName?: unknown }>).detail;
       if (typeof detail?.typeName !== 'string') return;
       click(detail.typeName, 'replace');
-      setSidebarVisible(true);
-      setSidebarTab('properties');
     };
     document.addEventListener(TYPE_NODE_TARGET_PROPERTIES_EVENT, handler);
     return () => document.removeEventListener(TYPE_NODE_TARGET_PROPERTIES_EVENT, handler);
-  }, [click, setSidebarTab, setSidebarVisible]);
+  }, [click]);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -630,7 +611,6 @@ function GraphCanvasInner({
         onNodeClick={(evt, node) => {
           click(node.id, clickModeFromEvent(evt));
         }}
-        onNodeDoubleClick={onNodeDoubleClick}
         onPaneClick={() => clearNodes()}
         onEdgeClick={(_, edge) => {
           const data = edge.data as RefEdgeData | undefined;

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -46,9 +46,13 @@ import { Textarea } from '../ui/textarea';
 
 interface PlaygroundPanelProps {
   schema: Schema;
+  highlightedTypeName?: string | null;
 }
 
-export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Element {
+export function PlaygroundPanel({
+  schema,
+  highlightedTypeName = null,
+}: PlaygroundPanelProps): React.JSX.Element {
   const [panelRef, isCompact] = useCompactPanel();
   const [formOpen, setFormOpen] = useState(false);
   const contract = useMemo(
@@ -66,14 +70,22 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
   const clearType = usePlaygroundStore((state) => state.clearType);
   const setScope = usePlaygroundStore((state) => state.setScope);
   const scopeId = useMemo(() => schemaScopeId(schema), [schema]);
+  const highlightedEntity = highlightedTypeName
+    ? contract.entities.find((entity) => entity.typeName === highlightedTypeName)
+    : undefined;
+  const highlightedUnavailable = highlightedTypeName !== null && !highlightedEntity;
 
   useEffect(() => {
     const typeNames = contract.entities.map((entity) => entity.typeName);
     setScope(scopeId, typeNames);
+    if (highlightedEntity && selectedTypeName !== highlightedEntity.typeName) {
+      selectType(highlightedEntity.typeName);
+      return;
+    }
     if (typeNames.length > 0 && (!selectedTypeName || !typeNames.includes(selectedTypeName))) {
       selectType(typeNames[0] ?? null);
     }
-  }, [contract.entities, scopeId, selectType, selectedTypeName, setScope]);
+  }, [contract.entities, highlightedEntity, scopeId, selectType, selectedTypeName, setScope]);
 
   const selectedEntity =
     contract.entities.find((entity) => entity.typeName === selectedTypeName) ??
@@ -139,12 +151,23 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
 
   return (
     <div ref={panelRef} className="flex h-full min-h-0 flex-col overflow-hidden">
-      <PanelHeader recordCount={recordCount} />
+      <PanelHeader
+        recordCount={recordCount}
+        highlightedTypeName={highlightedEntity?.typeName ?? highlightedTypeName}
+        highlightedUnavailable={highlightedUnavailable}
+        onSeedAll={() => seedRecords('all')}
+      />
+      {highlightedUnavailable && (
+        <div className="border-t border-warning/25 bg-warning/10 px-3 py-2 text-xs text-warning">
+          {highlightedTypeName} is not available in Playground. Choose a table from the entity list.
+        </div>
+      )}
       {isCompact ? (
         <div className="flex min-h-0 flex-1 flex-col border-t">
           <EntityNav
             entities={contract.entities}
             selectedTypeName={selectedEntity?.typeName ?? null}
+            highlightedTypeName={highlightedEntity?.typeName ?? null}
             recordsByType={recordsByType}
             onSelect={selectType}
             compact
@@ -156,7 +179,6 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
                 records={records}
                 onNew={openNewRecord}
                 onSeedCurrent={() => seedRecords('current')}
-                onSeedAll={() => seedRecords('all')}
                 onClear={() => clearType(selectedEntity.typeName)}
               />
               {seedNotice && (
@@ -202,6 +224,7 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
           <EntityNav
             entities={contract.entities}
             selectedTypeName={selectedEntity?.typeName ?? null}
+            highlightedTypeName={highlightedEntity?.typeName ?? null}
             recordsByType={recordsByType}
             onSelect={selectType}
           />
@@ -212,7 +235,6 @@ export function PlaygroundPanel({ schema }: PlaygroundPanelProps): React.JSX.Ele
                 records={records}
                 onNew={openNewRecord}
                 onSeedCurrent={() => seedRecords('current')}
-                onSeedAll={() => seedRecords('all')}
                 onClear={() => clearType(selectedEntity.typeName)}
               />
               {seedNotice && (
@@ -338,7 +360,6 @@ export function ScopedPlaygroundWorkbench({
         records={records}
         onNew={openNewRecord}
         onSeedCurrent={seedRecords}
-        onSeedAll={seedRecords}
         onClear={() => clearType(entity.typeName)}
         scoped
       />
@@ -410,12 +431,14 @@ function useCompactPanel(threshold = 760): readonly [RefObject<HTMLDivElement | 
 function EntityNav({
   entities,
   selectedTypeName,
+  highlightedTypeName,
   recordsByType,
   onSelect,
   compact = false,
 }: {
   entities: PlaygroundEntity[];
   selectedTypeName: string | null;
+  highlightedTypeName?: string | null;
   recordsByType: Record<string, PlaygroundRecord[]>;
   onSelect: (typeName: string | null) => void;
   compact?: boolean;
@@ -453,6 +476,7 @@ function EntityNav({
 
   const buttons = entities.map((entity) => {
     const count = recordsByType[entity.typeName]?.length ?? 0;
+    const highlighted = highlightedTypeName === entity.typeName;
     return (
       <button
         type="button"
@@ -462,10 +486,19 @@ function EntityNav({
           'flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm transition-colors',
           selectedTypeName === entity.typeName
             ? 'bg-primary/10 text-primary'
-            : 'text-foreground hover:bg-muted',
+            : highlighted
+              ? 'bg-reference/10 text-reference-text hover:bg-reference/15'
+              : 'text-foreground hover:bg-muted',
         )}
       >
-        <span className="min-w-0 truncate">{entity.typeName}</span>
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="min-w-0 truncate">{entity.typeName}</span>
+          {highlighted && (
+            <span className="shrink-0 rounded-full bg-reference/15 px-1.5 py-0 text-[9px] font-medium text-reference-text">
+              current
+            </span>
+          )}
+        </span>
         <Badge variant="secondary" className="ml-2 shrink-0">
           {count}
         </Badge>
@@ -483,16 +516,50 @@ function EntityNav({
   );
 }
 
-function PanelHeader({ recordCount }: { recordCount: number }): React.JSX.Element {
+function PanelHeader({
+  recordCount,
+  highlightedTypeName,
+  highlightedUnavailable,
+  onSeedAll,
+}: {
+  recordCount: number;
+  highlightedTypeName?: string | null;
+  highlightedUnavailable?: boolean;
+  onSeedAll?: () => void;
+}): React.JSX.Element {
   return (
     <header className="flex h-14 items-center justify-between px-3">
       <div className="min-w-0">
-        <h2 className="text-sm font-semibold">Playground</h2>
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold">Playground</h2>
+          {highlightedTypeName && (
+            <Badge variant={highlightedUnavailable ? 'outline' : 'secondary'} className="max-w-36">
+              <span className="truncate">{highlightedTypeName}</span>
+            </Badge>
+          )}
+        </div>
         <p className="truncate text-xs text-muted-foreground">
-          Create sample records from the model.
+          {highlightedTypeName
+            ? 'Inspector selection is highlighted in the model.'
+            : 'Create sample records from the model.'}
         </p>
       </div>
-      <Badge variant="outline">{recordCount} records</Badge>
+      <div className="flex shrink-0 items-center gap-2">
+        <Badge variant="outline">{recordCount} records</Badge>
+        {onSeedAll && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2"
+            aria-label="Seed all entities"
+            onClick={onSeedAll}
+          >
+            <Sparkles aria-hidden="true" />
+            All
+          </Button>
+        )}
+      </div>
     </header>
   );
 }
@@ -502,7 +569,6 @@ function EntityToolbar({
   records,
   onNew,
   onSeedCurrent,
-  onSeedAll,
   onClear,
   scoped = false,
 }: {
@@ -510,7 +576,6 @@ function EntityToolbar({
   records: PlaygroundRecord[];
   onNew: () => void;
   onSeedCurrent: () => void;
-  onSeedAll: () => void;
   onClear: () => void;
   scoped?: boolean;
 }): React.JSX.Element {
@@ -609,19 +674,6 @@ function EntityToolbar({
         >
           <Sparkles aria-hidden="true" />
         </Button>
-        {!scoped && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-8 px-2"
-            aria-label="Seed all entities"
-            onClick={onSeedAll}
-          >
-            <Sparkles aria-hidden="true" />
-            All
-          </Button>
-        )}
         <Button
           type="button"
           variant="ghost"

--- a/apps/desktop/src/renderer/src/components/review/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/review/ReviewPanel.tsx
@@ -279,7 +279,6 @@ function focusPath(schema: Schema, path: string): void {
     useGraphSelectionStore.getState().selectField(null);
     useGraphSelectionStore.getState().focus(target.typeName);
   }
-  useUIChromeStore.getState().setSidebarTab('properties');
   useUIChromeStore.getState().setSidebarVisible(true);
 }
 

--- a/apps/desktop/src/renderer/src/components/ui/switch.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import * as SwitchPrimitive from '@radix-ui/react-switch';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitive.Root
+    ref={ref}
+    className={cn(
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-muted-foreground/35 shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary',
+      className,
+    )}
+    {...props}
+  >
+    <SwitchPrimitive.Thumb
+      className={cn(
+        'pointer-events-none block size-4 rounded-full bg-background shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0.5',
+      )}
+    />
+  </SwitchPrimitive.Root>
+));
+Switch.displayName = SwitchPrimitive.Root.displayName;
+
+export { Switch };

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -28,7 +28,7 @@
   --card-foreground: #4c4f69;
   --popover: #f9fafc;
   --popover-foreground: #4c4f69;
-  --primary: #8839ef;
+  --primary: #1e66f5;
   --primary-foreground: #eff1f5;
   --secondary: #e6e9ef;
   --secondary-foreground: #4c4f69;
@@ -41,7 +41,7 @@
   --destructive-foreground: #eff1f5;
   --border: #bcc0cc;
   --input: #ccd0da;
-  --ring: #7287fd;
+  --ring: #1e66f5;
   --chart-1: #8839ef;
   --chart-2: #04a5e5;
   --chart-3: #df8e1d;
@@ -111,7 +111,7 @@
   --card-foreground: #cdd6f4;
   --popover: #313244;
   --popover-foreground: #cdd6f4;
-  --primary: #cba6f7;
+  --primary: #89b4fa;
   --primary-foreground: #11111b;
   --secondary: #313244;
   --secondary-foreground: #cdd6f4;
@@ -124,7 +124,7 @@
   --destructive-foreground: #11111b;
   --border: #45475a;
   --input: #45475a;
-  --ring: #b4befe;
+  --ring: #89b4fa;
   --chart-1: #cba6f7;
   --chart-2: #74c7ec;
   --chart-3: #f9e2af;

--- a/apps/desktop/src/renderer/src/store/ui-chrome.ts
+++ b/apps/desktop/src/renderer/src/store/ui-chrome.ts
@@ -9,14 +9,8 @@ import { create } from 'zustand';
 
 export type Theme = 'dark' | 'light';
 export type ThemePreference = Theme | 'system';
-export type SidebarTab =
-  | 'properties'
-  | 'chat'
-  | 'review'
-  | 'schema'
-  | 'playground'
-  | 'stdlib'
-  | 'changes';
+export type SidebarToolTab = 'chat' | 'review' | 'schema' | 'playground' | 'stdlib' | 'changes';
+export type PlaygroundScope = { mode: 'all' } | { mode: 'selected'; typeName: string };
 
 const THEME_STORAGE_KEY = 'theme';
 
@@ -25,14 +19,16 @@ interface UIChromeStoreShape {
   resolvedTheme: Theme;
   chatOpen: boolean;
   sidebarVisible: boolean;
-  sidebarTab: SidebarTab;
+  sidebarTab: SidebarToolTab;
+  playgroundScope: PlaygroundScope;
 
   setTheme(theme: ThemePreference): void;
   toggleTheme(): void;
   setChatOpen(open: boolean): void;
   toggleSidebar(): void;
   setSidebarVisible(visible: boolean): void;
-  setSidebarTab(tab: SidebarTab): void;
+  setSidebarTab(tab: SidebarToolTab): void;
+  setPlaygroundScope(scope: PlaygroundScope): void;
 }
 
 function systemTheme(): Theme {
@@ -70,6 +66,7 @@ export const useUIChromeStore = create<UIChromeStoreShape>((set) => ({
   chatOpen: true,
   sidebarVisible: true,
   sidebarTab: 'chat',
+  playgroundScope: { mode: 'all' },
 
   setTheme: (theme) => {
     const resolvedTheme = resolveTheme(theme);
@@ -88,6 +85,7 @@ export const useUIChromeStore = create<UIChromeStoreShape>((set) => ({
   toggleSidebar: () => set((state) => ({ sidebarVisible: !state.sidebarVisible })),
   setSidebarVisible: (visible) => set({ sidebarVisible: visible }),
   setSidebarTab: (tab) => set({ sidebarTab: tab }),
+  setPlaygroundScope: (scope) => set({ playgroundScope: scope }),
 }));
 
 if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {

--- a/apps/desktop/tests/components/App.codex.test.tsx
+++ b/apps/desktop/tests/components/App.codex.test.tsx
@@ -16,7 +16,8 @@ beforeEach(() => {
   useDocumentStore.getState().resetForNewBundle();
   useGraphSelectionStore.getState().clear();
   useUIChromeStore.getState().setSidebarVisible(true);
-  useUIChromeStore.getState().setSidebarTab('properties');
+  useUIChromeStore.getState().setSidebarTab('chat');
+  useUIChromeStore.getState().setPlaygroundScope({ mode: 'all' });
   (window as unknown as { contexture: unknown }).contexture = {
     file: {
       openDialog: vi.fn(async () => null),
@@ -126,6 +127,105 @@ describe('App Codex-first copy', () => {
     await waitFor(() => {
       expect(screen.getByLabelText(/Agent: Convex AI files: ready/)).toHaveTextContent('2/2');
     });
+  });
+
+  it('keeps the inspector floating on the canvas with compact chrome', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('start-load-sample'));
+
+    const inspector = await screen.findByLabelText('Properties inspector');
+    expect(inspector).toHaveTextContent('Inspector');
+    expect(inspector).toHaveTextContent('Select a type on the canvas');
+
+    await user.click(screen.getByRole('button', { name: 'Collapse inspector' }));
+    expect(screen.getByRole('button', { name: 'Expand inspector' })).toBeInTheDocument();
+    expect(inspector).not.toHaveTextContent('Select a type on the canvas');
+    expect(useUIChromeStore.getState().sidebarTab).toBe('schema');
+  });
+
+  it('opens the selected type in the Playground drawer from the inspector', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('start-load-sample'));
+    useGraphSelectionStore.getState().click('Sowing', 'replace');
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Properties inspector')).toHaveTextContent('Sowing');
+    });
+    await user.click(screen.getByRole('button', { name: 'Try' }));
+
+    expect(useUIChromeStore.getState().sidebarTab).toBe('playground');
+    expect(useUIChromeStore.getState().playgroundScope).toEqual({
+      mode: 'selected',
+      typeName: 'Sowing',
+    });
+    expect(
+      screen.getByText('Inspector selection is highlighted in the model.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Select entity' })).toHaveTextContent('Sowing');
+  });
+
+  it('uses the floating inspector header as field breadcrumb navigation', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('start-load-sample'));
+    useGraphSelectionStore.getState().click('Sowing', 'replace');
+    useGraphSelectionStore.getState().selectField({ typeName: 'Sowing', fieldName: 'plot' });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Properties inspector')).toHaveTextContent('plot');
+    });
+    expect(screen.queryByTestId('field-detail-header')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back to Sowing fields' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Back to Sowing fields' }));
+
+    expect(useGraphSelectionStore.getState().state.selectedField).toBeNull();
+    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('Sowing');
+  });
+
+  it('deletes the selected field from the floating inspector header', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('start-load-sample'));
+    useGraphSelectionStore.getState().click('Sowing', 'replace');
+    useGraphSelectionStore.getState().selectField({ typeName: 'Sowing', fieldName: 'plot' });
+
+    await user.click(await screen.findByRole('button', { name: 'Delete field plot' }));
+
+    const sowing = useUndoStore.getState().schema.types.find((type) => type.name === 'Sowing');
+    expect(sowing).toMatchObject({
+      kind: 'object',
+      fields: expect.not.arrayContaining([expect.objectContaining({ name: 'plot' })]),
+    });
+    expect(useGraphSelectionStore.getState().state.selectedField).toBeNull();
+  });
+
+  it('keeps the activity drawer closed when selecting a canvas table', async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('start-load-sample'));
+    useUIChromeStore.getState().setSidebarVisible(false);
+
+    const headers = await screen.findAllByTestId('type-node-header');
+    const sowingHeader = headers.find((header) => header.textContent?.includes('Sowing'));
+    expect(sowingHeader).toBeDefined();
+    fireEvent.click(sowingHeader as HTMLElement);
+
+    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('Sowing');
+    expect(useUIChromeStore.getState().sidebarVisible).toBe(false);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Properties inspector')).toHaveTextContent('Sowing');
+    });
+
+    fireEvent.doubleClick(sowingHeader as HTMLElement);
+
+    expect(useUIChromeStore.getState().sidebarVisible).toBe(false);
   });
 
   it('explains readiness checks from the grouped status tiles', async () => {

--- a/apps/desktop/tests/components/App.keyboard.test.tsx
+++ b/apps/desktop/tests/components/App.keyboard.test.tsx
@@ -129,7 +129,8 @@ describe('App global keyboard', () => {
       new CustomEvent(TYPE_NODE_EVENT, { detail: { typeName: 'Plot', fieldName: 'name' } }),
     );
 
-    expect(await screen.findByTestId('field-detail')).toHaveTextContent('name');
+    expect(await screen.findByTestId('field-detail')).toBeInTheDocument();
+    expect(screen.getByLabelText('Properties inspector')).toHaveTextContent('name');
   });
 
   it('Delete removes a selected field before deleting the selected type', async () => {
@@ -149,7 +150,8 @@ describe('App global keyboard', () => {
     document.dispatchEvent(
       new CustomEvent(TYPE_NODE_EVENT, { detail: { typeName: 'Plot', fieldName: 'name' } }),
     );
-    expect(await screen.findByTestId('field-detail')).toHaveTextContent('name');
+    expect(await screen.findByTestId('field-detail')).toBeInTheDocument();
+    expect(screen.getByLabelText('Properties inspector')).toHaveTextContent('name');
     fireEvent.keyDown(document, { key: 'Delete' });
 
     expect(useUndoStore.getState().schema.types[0]).toMatchObject({
@@ -255,7 +257,8 @@ describe('App global keyboard', () => {
       name: 'Plot',
       fields: [{ name: 'field1', type: { kind: 'string' } }],
     });
-    expect(await screen.findByTestId('field-detail')).toHaveTextContent('field1');
+    expect(await screen.findByTestId('field-detail')).toBeInTheDocument();
+    expect(screen.getByLabelText('Properties inspector')).toHaveTextContent('field1');
   });
 
   it('Cmd+Shift+F does nothing when the selected type cannot have fields', () => {
@@ -310,7 +313,8 @@ describe('App global keyboard', () => {
     expect(await screen.findByText('Modeled ref edge')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit field' }));
 
-    expect(await screen.findByTestId('field-detail')).toHaveTextContent('harvest');
+    expect(await screen.findByTestId('field-detail')).toBeInTheDocument();
+    expect(screen.getByLabelText('Properties inspector')).toHaveTextContent('harvest');
     expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('Plot');
     expect(useGraphSelectionStore.getState().state.edgeId).toBeNull();
   });

--- a/apps/desktop/tests/components/activity-bar/ActivityBar.test.tsx
+++ b/apps/desktop/tests/components/activity-bar/ActivityBar.test.tsx
@@ -4,10 +4,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 describe('ActivityBar', () => {
   it('orders tabs by the model-building workflow', () => {
-    render(<ActivityBar activeTab="properties" onTabChange={vi.fn()} />);
+    render(<ActivityBar activeTab="chat" onTabChange={vi.fn()} />);
 
     expect(
       screen.getAllByRole('button').map((button) => button.getAttribute('aria-label')),
-    ).toEqual(['Properties', 'Chat', 'Review', 'Changes', 'Schema', 'Playground', 'Stdlib']);
+    ).toEqual(['Chat', 'Review', 'Changes', 'Schema', 'Playground', 'Stdlib']);
   });
 });

--- a/apps/desktop/tests/components/detail/DetailPanel.test.tsx
+++ b/apps/desktop/tests/components/detail/DetailPanel.test.tsx
@@ -81,7 +81,7 @@ describe('DetailPanel', () => {
     seed({ version: '1', types: [] });
     useGraphSelectionStore.getState().clear();
     useUIChromeStore.getState().setSidebarVisible(true);
-    useUIChromeStore.getState().setSidebarTab('properties');
+    useUIChromeStore.getState().setSidebarTab('chat');
     useChatComposerStore.getState().setPendingChatMessage(null);
   });
   afterEach(cleanup);
@@ -94,50 +94,13 @@ describe('DetailPanel', () => {
   it('renders TypeDetail when a type is selected', () => {
     seed(plotSchema);
     render(<DetailPanel selection={{ typeName: 'Plot' }} />);
-    const header = screen.getByTestId('type-detail-header');
-    expect(header).toContainElement(screen.getByRole('heading', { name: 'Plot' }));
-    expect(header).toHaveTextContent('object');
-  });
-
-  it('shows the scoped sample-record workbench when a table type is selected', async () => {
-    const user = userEvent.setup();
-    seed(artworkSchema);
-    render(<DetailPanel selection={{ typeName: 'Artwork' }} />);
-
-    expect(screen.getByRole('tab', { name: 'Shape' })).toBeInTheDocument();
-    await user.click(screen.getByRole('tab', { name: 'Try' }));
-
-    const workbench = screen.getByRole('region', { name: 'Artwork sample records' });
-    expect(
-      within(workbench).getByRole('button', { name: 'Generate 5 records' }),
-    ).toBeInTheDocument();
-    expect(within(workbench).getByRole('button', { name: 'Add manually' })).toBeInTheDocument();
-    expect(within(workbench).getByText('No sample records yet')).toBeInTheDocument();
+    expect(screen.getByLabelText('Name')).toHaveValue('Plot');
   });
 
   it('renders FieldDetail when a type + field are selected', () => {
     seed(plotSchema);
     render(<DetailPanel selection={{ typeName: 'Plot', fieldName: 'name' }} />);
     expect(screen.getByTestId('field-detail')).toBeInTheDocument();
-  });
-
-  it('returns from field detail to the selected type when Back to table fields is clicked', () => {
-    seed(plotSchema);
-    useGraphSelectionStore.getState().selectField({ typeName: 'Plot', fieldName: 'name' });
-    const onClearSelectedField = vi.fn();
-
-    render(
-      <DetailPanel
-        selection={{ typeName: 'Plot', fieldName: 'name' }}
-        onClearSelectedField={onClearSelectedField}
-      />,
-    );
-    fireEvent.click(screen.getByRole('button', { name: 'Back to table fields' }));
-
-    expect(useGraphSelectionStore.getState().state.selectedField).toBeNull();
-    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('Plot');
-    expect(useGraphSelectionStore.getState().state.focusTarget).toEqual({ nodeId: 'Plot' });
-    expect(onClearSelectedField).toHaveBeenCalledOnce();
   });
 
   it('keeps field detail focused on the field after it is renamed', async () => {
@@ -434,44 +397,6 @@ describe('DetailPanel', () => {
     expect(useUndoStore.getState().schema.types).toEqual(
       expect.arrayContaining([expect.objectContaining({ kind: 'object', name: 'Author' })]),
     );
-  });
-
-  it('clears graph and app selection after deleting the selected type from details', () => {
-    seed(plotSchema);
-    useGraphSelectionStore.getState().click('Plot', 'replace');
-    const onClearSelection = vi.fn();
-
-    render(<DetailPanel selection={{ typeName: 'Plot' }} onClearSelection={onClearSelection} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Delete type Plot' }));
-
-    expect(useUndoStore.getState().schema.types).toEqual([]);
-    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBeNull();
-    expect(onClearSelection).toHaveBeenCalledOnce();
-  });
-
-  it('returns to the type selection after deleting the selected field from details', async () => {
-    const user = userEvent.setup();
-    seed(plotSchema);
-    useGraphSelectionStore.getState().click('Plot', 'replace');
-    const onClearSelectedField = vi.fn();
-
-    render(
-      <DetailPanel
-        selection={{ typeName: 'Plot', fieldName: 'name' }}
-        onClearSelectedField={onClearSelectedField}
-      />,
-    );
-    await user.click(screen.getByRole('button', { name: 'Field actions for name' }));
-    await user.click(await screen.findByRole('menuitem', { name: 'Delete field' }));
-
-    expect(useUndoStore.getState().schema.types[0]).toMatchObject({
-      kind: 'object',
-      name: 'Plot',
-      fields: [],
-    });
-    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('Plot');
-    expect(useGraphSelectionStore.getState().state.focusTarget).toEqual({ nodeId: 'Plot' });
-    expect(onClearSelectedField).toHaveBeenCalledOnce();
   });
 
   it('renders EdgeDetail when an edge is selected', () => {

--- a/apps/desktop/tests/components/detail/FieldDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/FieldDetail.test.tsx
@@ -18,7 +18,6 @@ function setup(
   availableTypeNames: readonly string[] = [],
   onCreateRefTarget?: () => string | undefined,
   tableIndexes?: readonly IndexDef[],
-  onBackToType?: () => void,
 ) {
   const dispatch = vi.fn<(op: Op) => void>();
   render(
@@ -30,7 +29,6 @@ function setup(
       availableTypeNames={availableTypeNames}
       onCreateRefTarget={onCreateRefTarget}
       tableIndexes={tableIndexes}
-      onBackToType={onBackToType}
     />,
   );
   return { dispatch };
@@ -45,39 +43,16 @@ async function chooseSelectOption(label: string, option: string) {
 describe('FieldDetail', () => {
   afterEach(cleanup);
 
-  it('renders the selected field title as a panel header', () => {
-    setup({ name: 'showPrice', type: { kind: 'boolean' } }, [], [], undefined, undefined, vi.fn());
+  it('renders the selected field editor content without its own header', () => {
+    setup({ name: 'showPrice', type: { kind: 'boolean' } });
 
-    const header = screen.getByTestId('field-detail-header');
-    expect(header).toContainElement(screen.getByRole('heading', { name: 'showPrice' }));
-    expect(header).toHaveTextContent('object / Plot');
-    expect(screen.getByRole('button', { name: 'Back to table fields' })).toHaveTextContent(
-      'Fields',
-    );
-    expect(screen.getByRole('heading', { name: 'showPrice' })).toHaveClass('text-lg');
+    expect(screen.getByTestId('field-detail')).toBeInTheDocument();
+    expect(screen.getByLabelText('Name')).toHaveValue('showPrice');
     expect(screen.getAllByText('boolean').length).toBeGreaterThan(0);
-    expect(screen.getByText('required')).toBeInTheDocument();
-    expect(screen.getByText(/sample:/)).toBeInTheDocument();
-    expect(header).toHaveClass('border-b');
-    expect(header).toHaveClass('bg-muted/20');
     expect(screen.getByText('Presence')).toBeInTheDocument();
     expect(screen.getByText('Default value')).toBeInTheDocument();
     expect(screen.getByText('Sample data')).toBeInTheDocument();
-  });
-
-  it('calls the back handler from the field sub-view header', () => {
-    const onBackToType = vi.fn();
-    setup(
-      { name: 'showPrice', type: { kind: 'boolean' } },
-      [],
-      [],
-      undefined,
-      undefined,
-      onBackToType,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Back to table fields' }));
-    expect(onBackToType).toHaveBeenCalledOnce();
+    expect(screen.queryByTestId('field-detail-header')).not.toBeInTheDocument();
   });
 
   it('string: min/max/regex/format controls; blur dispatches update_field', () => {
@@ -143,18 +118,6 @@ describe('FieldDetail', () => {
       typeName: 'Plot',
       fieldName: 'name',
       patch: { name: 'title' },
-    });
-  });
-
-  it('dispatches remove_field when the field delete action is clicked', async () => {
-    const user = userEvent.setup();
-    const { dispatch } = setup({ name: 'name', type: { kind: 'string' } });
-    await user.click(screen.getByRole('button', { name: 'Field actions for name' }));
-    await user.click(await screen.findByRole('menuitem', { name: 'Delete field' }));
-    expect(dispatch).toHaveBeenCalledWith({
-      kind: 'remove_field',
-      typeName: 'Plot',
-      fieldName: 'name',
     });
   });
 
@@ -250,7 +213,6 @@ describe('FieldDetail', () => {
     setup({ name: 'author', type: { kind: 'ref', typeName: 'User' } }, [], [], undefined, [
       { name: 'by_author', fields: ['author'] },
     ]);
-    expect(screen.getByText('indexed')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'by_author' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Add index for author' })).not.toBeInTheDocument();
   });

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -39,7 +39,7 @@ describe('TypeDetail', () => {
   afterEach(() => {
     useGraphSelectionStore.getState().clear();
     useChatComposerStore.getState().setPendingChatMessage(null);
-    useUIChromeStore.getState().setSidebarTab('properties');
+    useUIChromeStore.getState().setSidebarTab('chat');
     cleanup();
   });
 
@@ -55,31 +55,18 @@ describe('TypeDetail', () => {
 
     it('renders name, kind, and each field summary', () => {
       setup(type);
-      const header = screen.getByTestId('type-detail-header');
-      expect(header).toContainElement(screen.getByRole('heading', { name: 'Plot' }));
-      expect(header).toHaveTextContent('object');
-      expect(header).toHaveClass('border-b');
-      expect(header).toHaveClass('min-h-20');
-      expect(header.querySelector('[aria-hidden="true"]')).toHaveClass('h-[1.25rem]');
+      expect(screen.getByLabelText('Name')).toHaveValue('Plot');
+      expect(screen.queryByTestId('type-detail-header')).not.toBeInTheDocument();
       const rows = screen.getAllByTestId('object-field-summary');
       expect(rows).toHaveLength(2);
       expect(screen.getByDisplayValue('area')).toBeInTheDocument();
       expect(rows[1]).not.toHaveTextContent('?');
     });
 
-    it('renders field optionality as editable checkboxes', () => {
+    it('renders field optionality as editable switches', () => {
       setup(type);
       expect(screen.getByLabelText('name optional')).not.toBeChecked();
       expect(screen.getByLabelText('area optional')).toBeChecked();
-    });
-
-    it('dispatches delete_type when the type delete action is clicked', () => {
-      const { dispatch } = setup(type);
-      fireEvent.click(screen.getByRole('button', { name: 'Delete type Plot' }));
-      expect(dispatch).toHaveBeenCalledWith({
-        kind: 'delete_type',
-        name: 'Plot',
-      });
     });
 
     it('dispatches add_field when Add field is clicked', () => {
@@ -177,9 +164,21 @@ describe('TypeDetail', () => {
       });
     });
 
-    it('dispatches reorder_fields when a field is moved later', () => {
+    it('dispatches reorder_fields when a field is dragged later', () => {
       const { dispatch } = setup(type);
-      fireEvent.click(screen.getByRole('button', { name: 'Move field name later' }));
+      const rows = screen.getAllByTestId('object-field-summary');
+      const nameHandle = screen.getByLabelText('Drag field name to reorder');
+      const dataTransfer = {
+        effectAllowed: '',
+        dropEffect: '',
+        getData: vi.fn(() => 'name'),
+        setData: vi.fn(),
+      };
+      fireEvent.dragStart(nameHandle, { dataTransfer });
+      fireEvent.dragEnter(rows[1]);
+      expect(rows[1]).toHaveClass('bg-reference/10');
+      fireEvent.dragOver(rows[1]);
+      fireEvent.drop(rows[1], { dataTransfer });
       expect(dispatch).toHaveBeenCalledWith({
         kind: 'reorder_fields',
         typeName: 'Plot',
@@ -187,10 +186,15 @@ describe('TypeDetail', () => {
       });
     });
 
-    it('disables field move buttons at the list boundaries', () => {
+    it('uses compact drag handles instead of visible move buttons', () => {
       setup(type);
-      expect(screen.getByRole('button', { name: 'Move field name earlier' })).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'Move field area later' })).toBeDisabled();
+      expect(screen.getByLabelText('Drag field name to reorder')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Move field name earlier' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Move field area later' }),
+      ).not.toBeInTheDocument();
     });
 
     it('dispatches rename_type when the name input blurs with a new value', () => {

--- a/apps/desktop/tests/components/playground/PlaygroundPanel.test.tsx
+++ b/apps/desktop/tests/components/playground/PlaygroundPanel.test.tsx
@@ -18,6 +18,12 @@ const schema: Schema = {
         { name: 'tagIds', type: { kind: 'array', element: { kind: 'string' } } },
       ],
     },
+    {
+      kind: 'object',
+      name: 'Team',
+      table: true,
+      fields: [{ name: 'name', type: { kind: 'string' } }],
+    },
   ],
 };
 
@@ -95,6 +101,24 @@ describe('PlaygroundPanel', () => {
     expect(screen.getByLabelText('Name')).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: 'Country' })).toBeInTheDocument();
     expect(screen.queryByDisplayValue(/Unknown reference target/u)).not.toBeInTheDocument();
+  });
+
+  it('highlights an inspector-selected type while keeping all entities available', () => {
+    render(<PlaygroundPanel schema={schema} highlightedTypeName="Team" />);
+
+    expect(
+      screen.getByText('Inspector selection is highlighted in the model.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Select entity' })).toHaveTextContent('Team');
+  });
+
+  it('places the all-entities seed action in the Playground header', () => {
+    render(<PlaygroundPanel schema={schema} />);
+
+    const header = screen.getByRole('banner');
+    expect(header).toHaveTextContent('0 records');
+    expect(header).toContainElement(screen.getByRole('button', { name: 'Seed all entities' }));
+    expect(screen.getByRole('button', { name: 'Seed current entity' })).toBeInTheDocument();
   });
 
   it('packs record form fields at the top of the scroll area', async () => {

--- a/apps/desktop/tests/components/review/ReviewPanel.test.tsx
+++ b/apps/desktop/tests/components/review/ReviewPanel.test.tsx
@@ -70,7 +70,8 @@ describe('ReviewPanel', () => {
       typeName: 'Project',
       fieldName: 'tags',
     });
-    expect(useUIChromeStore.getState().sidebarTab).toBe('properties');
+    expect(useUIChromeStore.getState().sidebarTab).toBe('review');
+    expect(useUIChromeStore.getState().sidebarVisible).toBe(true);
   });
 
   it('seeds chat with review context', () => {

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@storybook/addon-essentials": "8",
@@ -833,6 +834,8 @@
     "@radix-ui/react-slider": ["@radix-ui/react-slider@1.3.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-switch": ["@radix-ui/react-switch@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ=="],
 
     "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
 


### PR DESCRIPTION
## Summary
- move Properties out of the activity rail so tool tabs only switch Chat, Review, Changes, Schema, Playground, and Stdlib
- render the Inspector as a persistent floating panel in the canvas top-right, with Codex-style rounded borders and lifted surface treatment
- flatten type and field identity into one stable Inspector header with `Canvas / Type / field` breadcrumb navigation, header-owned delete actions, and no duplicated inner headers
- add live selection presence in the Inspector header: selected name, kind/edge badge, compact/expand control, and a Try launcher
- move table sample-record workbench out of the floating Inspector and into the Playground drawer
- make the Inspector Try launcher open Playground with the selected entity highlighted while preserving all entity navigation
- keep direct Playground rail navigation global, so users can browse the whole model without clearing hidden filters
- move Playground's all-entities seed action into the Playground header beside the total record count
- keep canvas selection passive: clicking or double-clicking nodes updates the floating Inspector without opening the activity drawer
- tighten table field rows for the compact Inspector: drag handles with drop feedback, switches for Optional, always-visible actions, type/index badges in the name column, and compact advisory lightbulb badges beside field metadata
- simplify field details and table details so identity lives in the floating Inspector header instead of duplicated inner headers
- rework advanced schema output index/search-index editors as stacked rows instead of cramped tables
- shift routine selected/control color toward the app blue while keeping mauve/purple for special accents
- show a subtle linked-to-chat badge when chat is the active handoff surface with pending context
- keep explicit handoff actions such as Try, Discuss in chat, Stdlib links, and start-screen agent entry opening the drawer when needed

## Verification
- bun run test -- tests/components/App.keyboard.test.tsx tests/components/App.codex.test.tsx tests/components/detail/TypeDetail.test.tsx tests/components/detail/DetailPanel.test.tsx tests/components/detail/FieldDetail.test.tsx tests/components/playground/PlaygroundPanel.test.tsx (apps/desktop)
- bun run typecheck (apps/desktop)
- bun run lint
- pre-commit hook: turbo typecheck and turbo test

Note: jsdom still prints existing canvas/getContext and NaN SVG attribute warnings in App tests, but the suites pass.
