### PR TITLE
feat(desktop): polish graph inspector workflows

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.43",
+  "version": "0.15.45",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",
@@ -35,6 +35,7 @@
     "@electron-toolkit/utils": "^4.0.0",
     "@hookform/resolvers": "^5.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@sentry/electron": "^7.10.0",
     "electron-updater": "^6.8.3",
     "react-hook-form": "^7.76.1",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -25,10 +25,12 @@ import {
 import type { Schema, TypeDef } from '@contexture/core/ir';
 import { STDLIB_REGISTRY, STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registry';
 import {
+  AlertCircle,
   Bot,
   Boxes,
   CheckCircle2,
   ChevronDown,
+  ChevronUp,
   Clock,
   FileCode2,
   FilePlus2,
@@ -37,6 +39,7 @@ import {
   Maximize2,
   MessageSquare,
   Minimize2,
+  MoreHorizontal,
   MousePointer2,
   Play,
   SlidersHorizontal,
@@ -55,6 +58,7 @@ import { ReconcileModal } from './components/dialogs/ReconcileModal';
 import { TYPE_EDGE_SELECT_EVENT } from './components/graph/edge-select-event';
 import { GraphBackground } from './components/graph/GraphBackground';
 import { type CanvasPosition, GraphCanvas } from './components/graph/GraphCanvas';
+import { GraphLegend } from './components/graph/GraphLegend';
 import { type CreateTypeKind, createFieldOp, createTypeOp } from './components/graph/interactions';
 import { TYPE_NODE_EVENT } from './components/graph/nodes/TypeNode';
 import { DriftBanner } from './components/hud/DriftBanner';
@@ -74,7 +78,25 @@ import { GraphControlsPanel } from './components/toolbar/GraphControlsPanel';
 import { Toolbar } from './components/toolbar/Toolbar';
 import { TypeKindBadge, type TypeKindLabel } from './components/toolbar/type-kind-badge';
 import { UpdateBanner } from './components/UpdateBanner';
+import { Alert, AlertDescription, AlertTitle } from './components/ui/alert';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from './components/ui/alert-dialog';
 import { Button } from './components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from './components/ui/dropdown-menu';
 import {
   Empty,
   EmptyDescription,
@@ -97,6 +119,7 @@ import { useDocumentStore } from './store/document';
 import { useDriftStore } from './store/drift';
 import { useGraphLayoutStore } from './store/layout-config';
 import { useModelSyncStore } from './store/model-sync';
+import { usePlaygroundStore } from './store/playground';
 import { type EdgeSelection, type FieldSelection, useGraphSelectionStore } from './store/selection';
 import { useUIChromeStore } from './store/ui-chrome';
 import { useUndoStore } from './store/undo';
@@ -116,6 +139,9 @@ export default function App(): React.JSX.Element {
   );
   const [showGraphControls, setShowGraphControls] = useState(false);
   const [inspectorCompact, setInspectorCompact] = useState(false);
+  const [inspectorActionsOpen, setInspectorActionsOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteInspectorError, setDeleteInspectorError] = useState<string | null>(null);
   const [agentSetupCopied, setAgentSetupCopied] = useState<'install' | 'convex-ai-files' | null>(
     null,
   );
@@ -136,6 +162,7 @@ export default function App(): React.JSX.Element {
   const filePath = useDocumentStore((s) => s.filePath);
   const convexVersion = useConvexVersionStore();
   const driftedPaths = useDriftStore((s) => s.driftedPaths);
+  const graphLayout = useGraphLayoutStore((s) => s.graphLayout);
 
   // Drive the collapse/expand imperative API from the UI-store flag so
   // the Toolbar's sidebar button toggles the same thing as a user drag
@@ -176,6 +203,13 @@ export default function App(): React.JSX.Element {
     document.addEventListener(TYPE_EDGE_SELECT_EVENT, onEdgeSelect);
     return () => document.removeEventListener(TYPE_EDGE_SELECT_EVENT, onEdgeSelect);
   }, []);
+
+  useEffect(() => {
+    if (!sidebarVisible || activeTab !== 'playground' || !selectedNodeId) return;
+    const selectedType = schema.types.find((type) => type.name === selectedNodeId);
+    if (selectedType?.kind !== 'object' || selectedType.table !== true) return;
+    usePlaygroundStore.getState().selectType(selectedType.name);
+  }, [activeTab, schema, selectedNodeId, sidebarVisible]);
 
   const createType = useCallback((kind: CreateTypeKind): void => {
     const op = createTypeOp(useUndoStore.getState().schema, kind);
@@ -396,27 +430,34 @@ export default function App(): React.JSX.Element {
       : selectedEdge
         ? edgeSelectionLabel(selectedEdge)
         : detailTypeName;
+  const inspectorDeleteLabel = selectedField
+    ? `field ${selectedField.fieldName}`
+    : detailTypeName
+      ? `type ${detailTypeName}`
+      : 'selection';
+  const canDeleteInspectorSelection = detailType !== undefined && selectedEdge === null;
   const inspectorLinkedToChat = activeTab === 'chat' && pendingChatMessage !== null;
   const backToSelectedType = useCallback((): void => {
     if (!selectedField) return;
     useGraphSelectionStore.getState().selectField(null);
     useGraphSelectionStore.getState().focus(selectedField.typeName);
   }, [selectedField]);
-  const deleteInspectorSelection = useCallback((): void => {
+  const deleteInspectorSelection = useCallback((): string | null => {
     if (selectedField) {
       const result = useUndoStore.getState().apply({
         kind: 'remove_field',
         typeName: selectedField.typeName,
         fieldName: selectedField.fieldName,
       });
-      if ('error' in result) return;
+      if ('error' in result) return result.error;
       useGraphSelectionStore.getState().selectField(null);
-      return;
+      return null;
     }
-    if (!detailTypeName || !detailType) return;
+    if (!detailTypeName || !detailType) return 'Nothing is selected to delete.';
     const result = useUndoStore.getState().apply({ kind: 'delete_type', name: detailTypeName });
-    if ('error' in result) return;
+    if ('error' in result) return result.error;
     useGraphSelectionStore.getState().clear();
+    return null;
   }, [detailType, detailTypeName, selectedField]);
   const openSelectedTypeInPlayground = useCallback((): void => {
     if (!detailTypeName) return;
@@ -424,6 +465,10 @@ export default function App(): React.JSX.Element {
     useUIChromeStore.getState().setSidebarVisible(true);
     setActiveTab('playground');
   }, [detailTypeName, setActiveTab, setPlaygroundScope]);
+  const selectPlaygroundEntity = useCallback((typeName: string): void => {
+    useGraphSelectionStore.getState().click(typeName, 'replace');
+    useGraphSelectionStore.getState().focus(typeName);
+  }, []);
   const selectActivityTab = useCallback(
     (tab: typeof activeTab): void => {
       if (tab === 'playground') setPlaygroundScope({ mode: 'all' });
@@ -435,6 +480,10 @@ export default function App(): React.JSX.Element {
     typeof selectedNodeId === 'string' && STDLIB_TYPE_DEFINITIONS.has(selectedNodeId)
       ? selectedNodeId
       : undefined;
+  const playgroundHighlightedTypeName =
+    playgroundScope.mode === 'selected' && detailTypeName === playgroundScope.typeName
+      ? playgroundScope.typeName
+      : null;
   const hasSelection = detailTypeName !== null && detailTypeName !== undefined;
   const onboardingState = useMemo(
     () =>
@@ -576,23 +625,41 @@ export default function App(): React.JSX.Element {
             <ModelSyncBanner />
             <div className="relative flex-1 min-h-0">
               {hasSchema && (
-                <div className="absolute top-2 left-2 z-20">
-                  <Popover open={showGraphControls} onOpenChange={setShowGraphControls}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="secondary"
-                        className="h-8 px-2 gap-1.5 shadow-sm"
-                        aria-label="Graph controls"
-                        title="Graph controls"
-                      >
-                        <SlidersHorizontal className="size-4" />
-                        <ChevronDown className="size-3" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="p-0 w-72" align="start">
-                      <GraphControlsPanel onClose={() => setShowGraphControls(false)} />
-                    </PopoverContent>
-                  </Popover>
+                <div className="absolute top-2 left-2 z-20 flex items-start gap-2">
+                  <GraphLegend
+                    showEnumNodes={graphLayout.showEnums}
+                    showStdlibNodes={graphLayout.showStdlib}
+                  />
+                  <section
+                    aria-label="Graph controls"
+                    className="overflow-hidden rounded-xl border border-border/80 bg-card/95 text-xs text-card-foreground shadow-sm backdrop-blur"
+                  >
+                    <button
+                      type="button"
+                      className="flex h-[38px] w-full min-w-40 items-center justify-between gap-3 px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      aria-expanded={showGraphControls}
+                      aria-label={
+                        showGraphControls ? 'Collapse graph controls' : 'Expand graph controls'
+                      }
+                      title="Graph controls"
+                      onClick={() => setShowGraphControls((open) => !open)}
+                    >
+                      <span className="flex min-w-0 items-center gap-2">
+                        <SlidersHorizontal className="size-4" aria-hidden="true" />
+                        <span>Graph Controls</span>
+                      </span>
+                      {showGraphControls ? (
+                        <ChevronUp className="size-3.5" aria-hidden="true" />
+                      ) : (
+                        <ChevronDown className="size-3.5" aria-hidden="true" />
+                      )}
+                    </button>
+                    {showGraphControls && (
+                      <div className="w-72 border-t border-border/70">
+                        <GraphControlsPanel />
+                      </div>
+                    )}
+                  </section>
                 </div>
               )}
               {hasSchema ? (
@@ -610,108 +677,190 @@ export default function App(): React.JSX.Element {
                         : 'w-[min(24rem,calc(100%-1.5rem))]'
                     }`}
                   >
-                    <div className="grid h-14 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-border/70 px-3 py-2">
-                      <div className="min-w-0">
-                        <div className="mb-0.5 flex h-5 min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
-                          {selectedField && selectedField.typeName === detailTypeName ? (
-                            <>
-                              <span className="truncate">Canvas</span>
-                              <span aria-hidden="true" className="text-border">
-                                /
-                              </span>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                className="-ml-1 h-5 max-w-32 px-1.5 text-xs text-muted-foreground hover:text-foreground"
-                                onClick={backToSelectedType}
-                                aria-label={`Back to ${selectedField.typeName} fields`}
-                              >
-                                <span className="truncate">{selectedField.typeName}</span>
-                              </Button>
-                              <span aria-hidden="true" className="text-border">
-                                /
-                              </span>
-                              <span className="truncate">{selectedField.fieldName}</span>
-                            </>
-                          ) : (
-                            <>
-                              <span className="truncate">Canvas</span>
-                              {detailTypeName && (
+                    <div className="px-3 py-2.5">
+                      {inspectorCompact ? (
+                        <div className="grid min-h-8 min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+                          <div className="min-w-0 truncate text-sm font-semibold text-foreground">
+                            {inspectorTitle ?? 'Inspector'}
+                          </div>
+                          <button
+                            type="button"
+                            className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                            aria-label="Expand inspector"
+                            title="Expand inspector"
+                            onClick={() => setInspectorCompact(false)}
+                          >
+                            <Maximize2 className="size-3.5" aria-hidden="true" />
+                          </button>
+                        </div>
+                      ) : (
+                        <div className="grid min-h-[4.25rem] grid-rows-[auto_auto] gap-1.5">
+                          <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+                            <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+                              {selectedField && selectedField.typeName === detailTypeName ? (
                                 <>
+                                  <span className="truncate">Canvas</span>
                                   <span aria-hidden="true" className="text-border">
                                     /
                                   </span>
-                                  <span className="truncate">{detailTypeName}</span>
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    className="-ml-1 h-5 max-w-32 px-1.5 text-xs text-muted-foreground hover:text-foreground"
+                                    onClick={backToSelectedType}
+                                    aria-label={`Back to ${selectedField.typeName} fields`}
+                                  >
+                                    <span className="truncate">{selectedField.typeName}</span>
+                                  </Button>
+                                  <span aria-hidden="true" className="text-border">
+                                    /
+                                  </span>
+                                  <span className="truncate">{selectedField.fieldName}</span>
+                                </>
+                              ) : (
+                                <>
+                                  <span className="truncate">Canvas</span>
+                                  {detailTypeName && (
+                                    <>
+                                      <span aria-hidden="true" className="text-border">
+                                        /
+                                      </span>
+                                      <span className="truncate">{detailTypeName}</span>
+                                    </>
+                                  )}
                                 </>
                               )}
-                            </>
-                          )}
-                        </div>
-                        <div className="flex min-w-0 items-center gap-1.5">
-                          <div className="truncate text-sm font-semibold text-foreground">
-                            {inspectorTitle ?? 'Inspector'}
+                            </div>
+                            <button
+                              type="button"
+                              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                              aria-label="Collapse inspector"
+                              title="Collapse inspector"
+                              onClick={() => setInspectorCompact(true)}
+                            >
+                              <Minimize2 className="size-3.5" aria-hidden="true" />
+                            </button>
                           </div>
-                          {inspectorKind && inspectorKind !== 'ref' && (
-                            <TypeKindBadge kind={inspectorKind} />
-                          )}
-                          {inspectorKind === 'ref' && (
-                            <span className="shrink-0 rounded border border-reference/35 bg-reference/10 px-1.5 py-0 text-[9px] font-medium uppercase tracking-wide text-reference-text">
-                              edge
-                            </span>
-                          )}
+                          <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+                            <div className="flex min-w-0 items-center gap-1.5">
+                              <div className="min-w-0 truncate text-sm font-semibold text-foreground">
+                                {inspectorTitle ?? 'Inspector'}
+                              </div>
+                              <div className="shrink-0">
+                                {inspectorKind && inspectorKind !== 'ref' && (
+                                  <TypeKindBadge kind={inspectorKind} />
+                                )}
+                                {inspectorKind === 'ref' && (
+                                  <span className="w-fit rounded border border-reference/35 bg-reference/10 px-1.5 py-0 text-[9px] font-medium uppercase tracking-wide text-reference-text">
+                                    edge
+                                  </span>
+                                )}
+                              </div>
+                              {inspectorLinkedToChat && (
+                                <span className="inline-flex h-6 shrink-0 items-center gap-1 rounded-full border border-reference/25 bg-reference/10 px-2 text-[10px] font-medium text-reference-text">
+                                  <MessageSquare className="size-3" aria-hidden="true" />
+                                  Linked
+                                </span>
+                              )}
+                            </div>
+                            <div className="flex shrink-0 items-center gap-1">
+                              {detailTypeName && (
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-7 px-2 text-xs"
+                                  onClick={openSelectedTypeInPlayground}
+                                >
+                                  <Play aria-hidden="true" className="size-3.5" />
+                                  Try
+                                </Button>
+                              )}
+                              {canDeleteInspectorSelection && (
+                                <DropdownMenu
+                                  open={inspectorActionsOpen}
+                                  onOpenChange={setInspectorActionsOpen}
+                                >
+                                  <DropdownMenuTrigger asChild>
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="icon"
+                                      className="h-7 w-7 text-muted-foreground"
+                                      aria-label="Open selection actions"
+                                      onClick={() => setInspectorActionsOpen(true)}
+                                    >
+                                      <MoreHorizontal aria-hidden="true" className="size-3.5" />
+                                    </Button>
+                                  </DropdownMenuTrigger>
+                                  <DropdownMenuContent align="end">
+                                    <DropdownMenuItem
+                                      className="text-destructive focus:text-destructive"
+                                      onSelect={(event) => {
+                                        event.preventDefault();
+                                        setInspectorActionsOpen(false);
+                                        setDeleteInspectorError(null);
+                                        setDeleteDialogOpen(true);
+                                      }}
+                                    >
+                                      <Trash2 aria-hidden="true" className="size-4" />
+                                      Delete...
+                                    </DropdownMenuItem>
+                                  </DropdownMenuContent>
+                                </DropdownMenu>
+                              )}
+                            </div>
+                          </div>
                         </div>
-                      </div>
-                      <div className="flex shrink-0 items-center gap-1.5">
-                        {inspectorLinkedToChat && (
-                          <span className="inline-flex h-6 items-center gap-1 rounded-full border border-reference/25 bg-reference/10 px-2 text-[10px] font-medium text-reference-text">
-                            <MessageSquare className="size-3" aria-hidden="true" />
-                            Linked
-                          </span>
-                        )}
-                        {hasSelection && detailTypeName && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="h-7 px-2 text-xs"
-                            onClick={openSelectedTypeInPlayground}
-                          >
-                            <Play aria-hidden="true" className="size-3.5" />
-                            Try
-                          </Button>
-                        )}
-                        {detailType && !selectedEdge && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                            aria-label={
-                              selectedField
-                                ? `Delete field ${selectedField.fieldName}`
-                                : `Delete type ${detailTypeName}`
-                            }
-                            onClick={deleteInspectorSelection}
-                          >
-                            <Trash2 aria-hidden="true" className="size-3.5" />
-                          </Button>
-                        )}
-                        <button
-                          type="button"
-                          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                          aria-label={inspectorCompact ? 'Expand inspector' : 'Collapse inspector'}
-                          title={inspectorCompact ? 'Expand inspector' : 'Collapse inspector'}
-                          onClick={() => setInspectorCompact((compact) => !compact)}
-                        >
-                          {inspectorCompact ? (
-                            <Maximize2 className="size-3.5" aria-hidden="true" />
-                          ) : (
-                            <Minimize2 className="size-3.5" aria-hidden="true" />
-                          )}
-                        </button>
-                      </div>
+                      )}
                     </div>
+                    <AlertDialog
+                      open={deleteDialogOpen}
+                      onOpenChange={(open) => {
+                        setDeleteDialogOpen(open);
+                        if (!open) setDeleteInspectorError(null);
+                      }}
+                    >
+                      <AlertDialogContent size="sm">
+                        <AlertDialogHeader>
+                          <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+                            <Trash2 aria-hidden="true" />
+                          </AlertDialogMedia>
+                          <AlertDialogTitle>Delete {inspectorDeleteLabel}?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This will remove the selected {selectedField ? 'field' : 'type'} from
+                            the model. You can undo this action afterwards.
+                          </AlertDialogDescription>
+                          {deleteInspectorError && (
+                            <Alert variant="destructive" className="mt-1 text-left">
+                              <AlertCircle aria-hidden="true" />
+                              <AlertTitle>Delete blocked</AlertTitle>
+                              <AlertDescription>{deleteInspectorError}</AlertDescription>
+                            </Alert>
+                          )}
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel onClick={() => setDeleteInspectorError(null)}>
+                            Cancel
+                          </AlertDialogCancel>
+                          <AlertDialogAction
+                            variant="destructive"
+                            onClick={(event) => {
+                              const error = deleteInspectorSelection();
+                              if (error) {
+                                event.preventDefault();
+                                setDeleteInspectorError(error);
+                              } else {
+                                setDeleteInspectorError(null);
+                              }
+                            }}
+                          >
+                            Delete
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
                     {!inspectorCompact && (
                       <div className="min-h-0 flex-1 overflow-y-auto">
                         {hasSelection ? (
@@ -819,9 +968,8 @@ export default function App(): React.JSX.Element {
                 >
                   <PlaygroundPanel
                     schema={schema}
-                    highlightedTypeName={
-                      playgroundScope.mode === 'selected' ? playgroundScope.typeName : null
-                    }
+                    highlightedTypeName={playgroundHighlightedTypeName}
+                    onSelectEntity={selectPlaygroundEntity}
                   />
                 </div>
                 <div className={activeTab !== 'stdlib' ? 'hidden' : 'flex-1 min-h-0 flex flex-col'}>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -430,6 +430,12 @@ export default function App(): React.JSX.Element {
       : selectedEdge
         ? edgeSelectionLabel(selectedEdge)
         : detailTypeName;
+  const inspectorSelectionKind =
+    selectedField && selectedField.typeName === detailTypeName
+      ? 'field'
+      : selectedEdge
+        ? 'edge'
+        : inspectorKind;
   const inspectorDeleteLabel = selectedField
     ? `field ${selectedField.fieldName}`
     : detailTypeName
@@ -748,10 +754,22 @@ export default function App(): React.JSX.Element {
                                 {inspectorTitle ?? 'Inspector'}
                               </div>
                               <div className="shrink-0">
-                                {inspectorKind && inspectorKind !== 'ref' && (
-                                  <TypeKindBadge kind={inspectorKind} />
+                                {inspectorSelectionKind === 'field' && (
+                                  <span
+                                    className="w-fit rounded border border-border bg-muted/40 px-1.5 py-0 text-[9px] font-medium uppercase tracking-wide text-muted-foreground"
+                                    data-testid="inspector-selection-badge"
+                                  >
+                                    field
+                                  </span>
                                 )}
-                                {inspectorKind === 'ref' && (
+                                {inspectorSelectionKind &&
+                                  inspectorSelectionKind !== 'field' &&
+                                  inspectorSelectionKind !== 'edge' &&
+                                  inspectorSelectionKind !== 'ref' && (
+                                    <TypeKindBadge kind={inspectorSelectionKind} />
+                                  )}
+                                {(inspectorSelectionKind === 'edge' ||
+                                  inspectorSelectionKind === 'ref') && (
                                   <span className="w-fit rounded border border-reference/35 bg-reference/10 px-1.5 py-0 text-[9px] font-medium uppercase tracking-wide text-reference-text">
                                     edge
                                   </span>

--- a/apps/desktop/src/renderer/src/components/detail/EdgeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/EdgeDetail.tsx
@@ -66,9 +66,11 @@ function edgeKindMeta(data: RefEdgeData): { icon: LucideIcon; label: string } {
 
 function Row({ term, detail }: { term: string; detail: string }) {
   return (
-    <div className="flex justify-between">
+    <div className="grid grid-cols-[5.5rem_minmax(0,1fr)] gap-3">
       <dt className="text-muted-foreground">{term}</dt>
-      <dd>{detail}</dd>
+      <dd className="min-w-0 truncate text-right" title={detail}>
+        {detail}
+      </dd>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/FieldDetail.tsx
@@ -1207,9 +1207,9 @@ function RefTargetPicker({
           variant="outline"
           aria-label="target"
           aria-expanded={open}
-          className="h-8 w-full justify-between px-2 text-left text-xs font-normal"
+          className="h-8 min-w-0 w-full justify-between px-2 text-left text-xs font-normal"
         >
-          <span className="truncate">{currentLabel}</span>
+          <span className="min-w-0 truncate">{currentLabel}</span>
           <ChevronsUpDown aria-hidden="true" className="ml-2 h-3.5 w-3.5 opacity-60" />
         </Button>
       </PopoverTrigger>
@@ -1413,9 +1413,9 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
   // Wrap the label around its control so `getByLabelText` in tests and
   // click-to-focus for users both work without juggling `htmlFor` ids.
   return (
-    <Label className="grid grid-cols-[80px_1fr] items-center gap-2 text-[11px] text-muted-foreground">
+    <Label className="grid min-w-0 grid-cols-[80px_minmax(0,1fr)] items-center gap-2 text-[11px] text-muted-foreground">
       <span>{label}</span>
-      {children}
+      <span className="min-w-0">{children}</span>
     </Label>
   );
 }

--- a/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/detail/TypeDetail.tsx
@@ -139,7 +139,7 @@ export function TypeDetail({
       <ModelShapeHints hints={modelingHints} />
 
       {type.kind === 'object' && <ObjectBody type={type} dispatch={dispatch} />}
-      <SampleDataSection type={type} dispatch={dispatch} />
+      {type.kind !== 'enum' && <SampleDataSection type={type} dispatch={dispatch} />}
       {type.kind === 'object' && (
         <ConvexSection type={type} dispatch={dispatch} validationErrors={validationErrors} />
       )}

--- a/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphCanvas.tsx
@@ -53,7 +53,6 @@ import { useUndoStore } from '../../store/undo';
 import { FOCUS_TYPE_NAME_EVENT } from '../detail/TypeDetail';
 import { TYPE_EDGE_SELECT_EVENT } from './edge-select-event';
 import { RefEdge } from './edges/RefEdge';
-import { GraphLegend } from './GraphLegend';
 import { filterGraphView } from './graph-view';
 import {
   type ConnectPayload,
@@ -627,7 +626,6 @@ function GraphCanvasInner({
             pattern reads as texture not noise on both light and dark. */}
         <Background gap={28} size={0.8} color="var(--graph-dot)" />
         <Controls showInteractive={false} />
-        <GraphLegend showEnumNodes={showEnums} showStdlibNodes={showStdlib} />
       </ReactFlow>
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
@@ -1,218 +1,250 @@
 /**
- * Canvas legend — Zod/Contexture edition.
+ * Canvas legend.
  *
- * Pins to the bottom-right of the graph. Collapsed by default so it
- * stays out of the way; expanded view names every visual affordance
- * the canvas uses so new users can decode the diagram at a glance.
- *
- * Matches the `TypeDef` kinds, inline enum marker, table subtype marker,
- * and the edge modes (field ref, inferred table id, union variant,
- * cross-boundary import). Colours are pulled from `globals.css` so theme
- * changes flow through without edits here.
+ * Mirrors the current graph vocabulary: compact type badges, relationship
+ * strokes from `RefEdge`, and the few field cues that are otherwise easy
+ * to miss on first use.
  */
-import { ChevronDown, ChevronUp, Table2 } from 'lucide-react';
+import {
+  Box,
+  ChevronDown,
+  ChevronUp,
+  GitBranch,
+  ListChecks,
+  Map as MapIcon,
+  Table2,
+} from 'lucide-react';
+import type { CSSProperties, ReactNode } from 'react';
 import { memo, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { TypeKindBadge, type TypeKindLabel } from '../toolbar/type-kind-badge';
 
 interface EdgeItem {
   label: string;
+  description: string;
   color: string;
   dash?: string;
 }
 
 const EDGE_ITEMS: readonly EdgeItem[] = [
   {
-    label: 'Modeled ref',
+    label: 'Field ref',
+    description: 'A ref field points at another type.',
     color: 'var(--graph-edge-fk)',
   },
   {
-    label: 'Inferred table id',
+    label: 'Inferred id',
+    description: 'A table id field was recognized from the model.',
     color: 'var(--graph-edge-import)',
-    dash: '6,4',
+    dash: '6 4',
   },
   {
     label: 'Union variant',
+    description: 'A discriminated union includes this variant.',
     color: 'var(--graph-edge-union)',
-    dash: '2,4',
+    dash: '2 4',
   },
   {
-    label: 'Import (cross-boundary)',
-    color: 'var(--graph-edge-import)',
-    dash: '6,4',
-  },
-  {
-    label: 'Active selection',
+    label: 'Active path',
+    description: 'Selection, adjacency, or preview focus.',
     color: 'var(--graph-edge-active)',
   },
 ];
 
-interface NodeItem {
+interface TypeItem {
+  kind: TypeKindLabel;
   label: string;
-  /** Header swatch colour — matches `headerColorFor` in `TypeNode`. */
-  header: string;
-  table?: boolean;
-  /** Border style. Imported refs render dashed; everything else solid. */
-  style?: 'solid' | 'dashed';
+  icon: React.JSX.Element | null;
 }
 
-const NODE_ITEMS: readonly NodeItem[] = [
-  { label: 'Object', header: 'var(--graph-node-header-bg)' },
-  { label: 'Table', header: 'var(--graph-node-table-header-bg)', table: true },
-  {
-    label: 'Discriminated union',
-    header: 'color-mix(in oklch, var(--chart-4) 85%, transparent)',
-  },
-  {
-    label: 'Raw (escape hatch)',
-    header: 'color-mix(in oklch, var(--muted-foreground) 55%, transparent)',
-  },
-  {
-    label: 'Imported',
-    header: 'var(--graph-node-header-bg)',
-    style: 'dashed',
-  },
-  {
-    label: 'Stdlib',
-    header: 'color-mix(in oklch, var(--chart-2) 72%, var(--graph-node-header-bg))',
-    style: 'dashed',
-  },
-  {
-    label: 'Selected',
-    header: 'var(--graph-node-selected)',
-  },
+const BASE_TYPE_ITEMS: readonly TypeItem[] = [
+  { kind: 'object', label: 'Object', icon: <Box className="size-3.5" aria-hidden="true" /> },
+  { kind: 'table', label: 'Table', icon: <Table2 className="size-3.5" aria-hidden="true" /> },
+  { kind: 'union', label: 'Union', icon: <GitBranch className="size-3.5" aria-hidden="true" /> },
+  { kind: 'raw', label: 'Raw', icon: null },
 ];
 
+const ENUM_TYPE_ITEM: TypeItem = {
+  kind: 'enum',
+  label: 'Enum',
+  icon: <ListChecks className="size-3.5" aria-hidden="true" />,
+};
+
 export const GraphLegend = memo(function GraphLegend({
-  showEnumNodes = false,
   showStdlibNodes = false,
+  className,
 }: {
   showEnumNodes?: boolean;
   showStdlibNodes?: boolean;
+  className?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const visibleNodeItems = showStdlibNodes
-    ? NODE_ITEMS
-    : NODE_ITEMS.filter((item) => item.label !== 'Stdlib');
-  const nodeItems = showEnumNodes
-    ? [
-        ...visibleNodeItems.slice(0, 2),
-        {
-          label: 'Enum',
-          header: 'color-mix(in oklch, var(--chart-3) 85%, transparent)',
-        },
-        ...visibleNodeItems.slice(2),
-      ]
-    : visibleNodeItems;
+  const typeItems = [
+    BASE_TYPE_ITEMS[0],
+    BASE_TYPE_ITEMS[1],
+    ENUM_TYPE_ITEM,
+    ...BASE_TYPE_ITEMS.slice(2),
+  ];
 
   return (
-    <div
-      className="absolute bottom-3 right-3 z-10 rounded-lg border border-border bg-background/80 backdrop-blur-md shadow-md text-xs select-none"
-      style={{ minWidth: 150 }}
+    <section
+      aria-label="Graph legend"
+      className={cn(
+        'overflow-hidden rounded-xl border border-border/80 bg-card/95 text-xs text-card-foreground shadow-sm backdrop-blur',
+        className,
+      )}
     >
       <button
         type="button"
-        className="flex items-center justify-between w-full px-2.5 py-1.5 text-[10px] font-semibold text-muted-foreground uppercase tracking-wide hover:text-foreground transition-colors"
+        className="flex h-[38px] w-full min-w-32 items-center justify-between gap-3 px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
         aria-label={expanded ? 'Collapse legend' : 'Expand legend'}
       >
-        Legend
-        {expanded ? <ChevronDown className="size-3" /> : <ChevronUp className="size-3" />}
+        <span className="flex min-w-0 items-center gap-2">
+          <MapIcon className="size-4" aria-hidden="true" />
+          <span>Legend</span>
+        </span>
+        {expanded ? (
+          <ChevronUp className="size-3.5" aria-hidden="true" />
+        ) : (
+          <ChevronDown className="size-3.5" aria-hidden="true" />
+        )}
       </button>
 
       {expanded && (
-        <div className="px-2.5 pb-2 space-y-2">
-          <div className="space-y-1">
-            <span className="text-[9px] text-muted-foreground font-medium uppercase">Edges</span>
-            {EDGE_ITEMS.map((item) => (
-              <div key={item.label} className="flex items-center gap-2">
-                <svg width="24" height="8" className="shrink-0" aria-hidden="true">
-                  <title>{`${item.label} edge swatch`}</title>
-                  <line
-                    x1="0"
-                    y1="4"
-                    x2="24"
-                    y2="4"
-                    stroke={item.color}
-                    strokeWidth="2"
-                    strokeDasharray={item.dash}
+        <div className="w-72 border-t border-border/70">
+          <LegendSection title="Types">
+            <div className="grid grid-cols-2 gap-1.5">
+              {typeItems.map((item) => (
+                <TypeLegendItem key={item.kind} item={item} />
+              ))}
+              {showStdlibNodes && (
+                <div className="flex min-w-0 items-center gap-2 rounded-md border border-dashed border-border bg-background/55 px-2 py-1.5">
+                  <span
+                    aria-hidden="true"
+                    className="size-2.5 rounded-full"
+                    style={{
+                      background:
+                        'color-mix(in oklch, var(--chart-2) 72%, var(--graph-node-header-bg))',
+                    }}
                   />
-                </svg>
-                <span className="text-foreground">{item.label}</span>
+                  <span className="truncate text-foreground">Stdlib</span>
+                </div>
+              )}
+              <div className="flex min-w-0 items-center gap-2 rounded-md border border-dashed border-border bg-background/55 px-2 py-1.5">
+                <span
+                  aria-hidden="true"
+                  className="h-3 w-4 rounded-sm border border-dashed border-muted-foreground/80"
+                />
+                <span className="truncate text-foreground">Imported</span>
               </div>
-            ))}
-          </div>
+            </div>
+          </LegendSection>
 
-          <div className="space-y-1">
-            <span className="text-[9px] text-muted-foreground font-medium uppercase">Fields</span>
-            <div className="flex items-center gap-2">
-              <span className="text-[9px]" style={{ color: 'var(--graph-edge-property)' }}>
-                → Reference
-              </span>
-              <span className="text-foreground">Object ref</span>
+          <LegendSection title="Relationships">
+            <div className="space-y-1">
+              {EDGE_ITEMS.map((item) => (
+                <EdgeLegendItem key={item.label} item={item} />
+              ))}
             </div>
-            <div className="flex items-center gap-2">
-              <span
-                className="inline-flex min-w-0 items-baseline gap-0.5 text-[9px]"
+          </LegendSection>
+
+          <LegendSection title="Fields" last>
+            <div className="grid gap-1.5">
+              <FieldCue
+                sample="-> Customer"
+                label="Object ref"
                 style={{ color: 'var(--graph-edge-property)' }}
-              >
-                <span>→ Source</span>
-                <span style={{ color: 'var(--muted-foreground)', fontWeight: 400 }}>· union</span>
-              </span>
-              <span className="text-foreground">Union ref</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <span
-                aria-hidden="true"
-                className="text-[9px]"
+              />
+              <FieldCue
+                sample="-> Event · union"
+                label="Union ref"
+                style={{ color: 'var(--graph-edge-property)' }}
+              />
+              <FieldCue
+                sample="Status enum"
+                label="Inline enum"
                 style={{
                   color: 'var(--muted-foreground)',
                   fontFamily: 'var(--font-mono)',
                 }}
-              >
-                Status enum
-              </span>
-              <span className="text-foreground">Inline enum</span>
+              />
             </div>
-          </div>
-
-          <div className="space-y-1">
-            <span className="text-[9px] text-muted-foreground font-medium uppercase">Nodes</span>
-            {nodeItems.map((item) => (
-              <div key={item.label} className="flex items-center gap-2">
-                <div
-                  aria-hidden="true"
-                  className="relative shrink-0 overflow-hidden rounded"
-                  style={{
-                    width: 18,
-                    height: 12,
-                    background: 'var(--graph-node-body-bg)',
-                    border: `1px ${item.style ?? 'solid'} var(--graph-node-border)`,
-                    boxShadow: `inset 0 3px 0 ${item.header}`,
-                  }}
-                >
-                  {item.table ? (
-                    <>
-                      <span
-                        className="absolute inset-y-0 left-0"
-                        style={{
-                          width: 3,
-                          background: 'var(--graph-node-table-accent)',
-                        }}
-                      />
-                      <Table2
-                        size={8}
-                        strokeWidth={2.2}
-                        className="absolute right-0.5 top-0.5 text-white"
-                      />
-                    </>
-                  ) : null}
-                </div>
-                <span className="text-foreground">{item.label}</span>
-              </div>
-            ))}
-          </div>
+          </LegendSection>
         </div>
       )}
-    </div>
+    </section>
   );
 });
+
+function LegendSection({
+  title,
+  children,
+  last = false,
+}: {
+  title: string;
+  children: ReactNode;
+  last?: boolean;
+}): React.JSX.Element {
+  return (
+    <div className={last ? 'px-3 py-2.5' : 'border-b border-border/70 px-3 py-2.5'}>
+      <div className="mb-2 text-[10px] font-semibold text-muted-foreground">{title}</div>
+      {children}
+    </div>
+  );
+}
+
+function TypeLegendItem({ item }: { item: TypeItem }): React.JSX.Element {
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-2 rounded-md bg-background/55 px-2 py-1.5">
+      <span className="flex min-w-0 items-center gap-1.5 text-foreground">
+        {item.icon}
+        <span className="truncate">{item.label}</span>
+      </span>
+      <TypeKindBadge kind={item.kind} />
+    </div>
+  );
+}
+
+function EdgeLegendItem({ item }: { item: EdgeItem }): React.JSX.Element {
+  return (
+    <div className="grid grid-cols-[2.25rem_minmax(0,1fr)] items-center gap-2 rounded-md px-1 py-1">
+      <svg width="36" height="10" className="shrink-0" aria-hidden="true">
+        <line
+          x1="1"
+          y1="5"
+          x2="35"
+          y2="5"
+          stroke={item.color}
+          strokeWidth="2"
+          strokeDasharray={item.dash}
+          strokeLinecap="round"
+        />
+      </svg>
+      <div className="min-w-0">
+        <div className="truncate text-foreground">{item.label}</div>
+        <div className="truncate text-[10px] text-muted-foreground">{item.description}</div>
+      </div>
+    </div>
+  );
+}
+
+function FieldCue({
+  sample,
+  label,
+  style,
+}: {
+  sample: string;
+  label: string;
+  style: CSSProperties;
+}): React.JSX.Element {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md bg-background/55 px-2 py-1.5">
+      <span className="min-w-0 truncate text-[10px]" style={style}>
+        {sample}
+      </span>
+      <span className="shrink-0 text-foreground">{label}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/playground/PlaygroundPanel.tsx
@@ -8,7 +8,10 @@ import {
   type PlaygroundEntity,
   type PlaygroundRefControl,
 } from '@contexture/core/playground-contract';
-import { generatePlaygroundFixtures } from '@contexture/core/playground-fixtures';
+import {
+  generatePlaygroundFixtures,
+  type PlaygroundFixtureWarning,
+} from '@contexture/core/playground-fixtures';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registry';
 import {
@@ -39,6 +42,7 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from '../ui/field';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '../ui/hover-card';
 import { Input } from '../ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
@@ -47,14 +51,24 @@ import { Textarea } from '../ui/textarea';
 interface PlaygroundPanelProps {
   schema: Schema;
   highlightedTypeName?: string | null;
+  onSelectEntity?: (typeName: string) => void;
+}
+
+interface SeedNoticeState {
+  generatedCount: number;
+  warnings: PlaygroundFixtureWarning[];
 }
 
 export function PlaygroundPanel({
   schema,
   highlightedTypeName = null,
+  onSelectEntity,
 }: PlaygroundPanelProps): React.JSX.Element {
   const [panelRef, isCompact] = useCompactPanel();
   const [formOpen, setFormOpen] = useState(false);
+  const [dismissedUnavailableTypeName, setDismissedUnavailableTypeName] = useState<string | null>(
+    null,
+  );
   const contract = useMemo(
     () => buildPlaygroundContract(schema, { externalTypes: STDLIB_TYPE_DEFINITIONS }),
     [schema],
@@ -74,18 +88,22 @@ export function PlaygroundPanel({
     ? contract.entities.find((entity) => entity.typeName === highlightedTypeName)
     : undefined;
   const highlightedUnavailable = highlightedTypeName !== null && !highlightedEntity;
+  const showHighlightedUnavailable =
+    highlightedUnavailable && dismissedUnavailableTypeName !== highlightedTypeName;
 
   useEffect(() => {
     const typeNames = contract.entities.map((entity) => entity.typeName);
     setScope(scopeId, typeNames);
-    if (highlightedEntity && selectedTypeName !== highlightedEntity.typeName) {
-      selectType(highlightedEntity.typeName);
-      return;
-    }
     if (typeNames.length > 0 && (!selectedTypeName || !typeNames.includes(selectedTypeName))) {
       selectType(typeNames[0] ?? null);
     }
-  }, [contract.entities, highlightedEntity, scopeId, selectType, selectedTypeName, setScope]);
+  }, [contract.entities, scopeId, selectType, selectedTypeName, setScope]);
+
+  const selectEntity = (typeName: string | null) => {
+    selectType(typeName);
+    if (highlightedUnavailable) setDismissedUnavailableTypeName(highlightedTypeName);
+    if (typeName) onSelectEntity?.(typeName);
+  };
 
   const selectedEntity =
     contract.entities.find((entity) => entity.typeName === selectedTypeName) ??
@@ -95,7 +113,7 @@ export function PlaygroundPanel({
   const selectedRecord = records.find((record) => record.id === selectedRecordId) ?? null;
   const recordCount = Object.values(recordsByType).reduce((sum, list) => sum + list.length, 0);
   const formRecord = formOpen ? selectedRecord : null;
-  const [seedNotice, setSeedNotice] = useState<string | null>(null);
+  const [seedNotice, setSeedNotice] = useState<SeedNoticeState | null>(null);
 
   const openNewRecord = () => {
     if (!selectedEntity) return;
@@ -125,11 +143,7 @@ export function PlaygroundPanel({
       (sum, list) => sum + list.length,
       0,
     );
-    setSeedNotice(
-      result.warnings.length > 0
-        ? `Seeded ${generatedCount} records with ${result.warnings.length} warnings.`
-        : `Seeded ${generatedCount} records.`,
-    );
+    setSeedNotice({ generatedCount, warnings: result.warnings });
   };
 
   if (contract.entities.length === 0) {
@@ -154,10 +168,12 @@ export function PlaygroundPanel({
       <PanelHeader
         recordCount={recordCount}
         highlightedTypeName={highlightedEntity?.typeName ?? highlightedTypeName}
-        highlightedUnavailable={highlightedUnavailable}
+        highlightedUnavailable={showHighlightedUnavailable}
         onSeedAll={() => seedRecords('all')}
+        seedNotice={seedNotice}
+        onDismissSeedNotice={() => setSeedNotice(null)}
       />
-      {highlightedUnavailable && (
+      {showHighlightedUnavailable && (
         <div className="border-t border-warning/25 bg-warning/10 px-3 py-2 text-xs text-warning">
           {highlightedTypeName} is not available in Playground. Choose a table from the entity list.
         </div>
@@ -169,7 +185,7 @@ export function PlaygroundPanel({
             selectedTypeName={selectedEntity?.typeName ?? null}
             highlightedTypeName={highlightedEntity?.typeName ?? null}
             recordsByType={recordsByType}
-            onSelect={selectType}
+            onSelect={selectEntity}
             compact
           />
           {selectedEntity && (
@@ -181,9 +197,6 @@ export function PlaygroundPanel({
                 onSeedCurrent={() => seedRecords('current')}
                 onClear={() => clearType(selectedEntity.typeName)}
               />
-              {seedNotice && (
-                <SeedNotice message={seedNotice} onDismiss={() => setSeedNotice(null)} />
-              )}
               <div className="relative min-h-0 flex-1">
                 <RecordTable
                   entity={selectedEntity}
@@ -220,13 +233,13 @@ export function PlaygroundPanel({
           )}
         </div>
       ) : (
-        <div className="grid min-h-0 flex-1 grid-cols-[12rem_minmax(0,1fr)] border-t">
+        <div className="grid min-h-0 flex-1 grid-cols-[14rem_minmax(0,1fr)] border-t">
           <EntityNav
             entities={contract.entities}
             selectedTypeName={selectedEntity?.typeName ?? null}
             highlightedTypeName={highlightedEntity?.typeName ?? null}
             recordsByType={recordsByType}
-            onSelect={selectType}
+            onSelect={selectEntity}
           />
           {selectedEntity && (
             <section className="flex min-h-0 flex-col">
@@ -237,9 +250,6 @@ export function PlaygroundPanel({
                 onSeedCurrent={() => seedRecords('current')}
                 onClear={() => clearType(selectedEntity.typeName)}
               />
-              {seedNotice && (
-                <SeedNotice message={seedNotice} onDismiss={() => setSeedNotice(null)} />
-              )}
               <div className="relative min-h-0 flex-1">
                 <RecordTable
                   entity={selectedEntity}
@@ -290,7 +300,7 @@ export function ScopedPlaygroundWorkbench({
 }): React.JSX.Element | null {
   const [panelRef, isCompact] = useCompactPanel(680);
   const [formOpen, setFormOpen] = useState(false);
-  const [seedNotice, setSeedNotice] = useState<string | null>(null);
+  const [seedNotice, setSeedNotice] = useState<SeedNoticeState | null>(null);
   const contract = useMemo(
     () => buildPlaygroundContract(schema, { externalTypes: STDLIB_TYPE_DEFINITIONS }),
     [schema],
@@ -342,11 +352,7 @@ export function ScopedPlaygroundWorkbench({
       (sum, list) => sum + list.length,
       0,
     );
-    setSeedNotice(
-      result.warnings.length > 0
-        ? `Seeded ${generatedCount} records with ${result.warnings.length} warnings.`
-        : `Seeded ${generatedCount} records.`,
-    );
+    setSeedNotice({ generatedCount, warnings: result.warnings });
   };
 
   return (
@@ -363,7 +369,7 @@ export function ScopedPlaygroundWorkbench({
         onClear={() => clearType(entity.typeName)}
         scoped
       />
-      {seedNotice && <SeedNotice message={seedNotice} onDismiss={() => setSeedNotice(null)} />}
+      {seedNotice && <SeedNotice notice={seedNotice} onDismiss={() => setSeedNotice(null)} />}
       <div
         className={cn(
           'relative grid min-h-0 flex-1 bg-muted/10',
@@ -483,7 +489,7 @@ function EntityNav({
         key={entity.typeName}
         onClick={() => onSelect(entity.typeName)}
         className={cn(
-          'flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm transition-colors',
+          'flex w-full flex-col items-start gap-1 rounded-md px-2 py-2 text-left text-sm transition-colors',
           selectedTypeName === entity.typeName
             ? 'bg-primary/10 text-primary'
             : highlighted
@@ -491,17 +497,15 @@ function EntityNav({
               : 'text-foreground hover:bg-muted',
         )}
       >
-        <span className="flex min-w-0 items-center gap-1.5">
-          <span className="min-w-0 truncate">{entity.typeName}</span>
-          {highlighted && (
-            <span className="shrink-0 rounded-full bg-reference/15 px-1.5 py-0 text-[9px] font-medium text-reference-text">
-              current
-            </span>
-          )}
-        </span>
-        <Badge variant="secondary" className="ml-2 shrink-0">
+        <Badge variant="secondary" className="h-4 min-w-5 justify-center px-1 text-[9px]">
           {count}
         </Badge>
+        <span className="block w-full min-w-0 truncate leading-5">{entity.typeName}</span>
+        {highlighted && (
+          <span className="w-fit rounded-full bg-reference/15 px-1.5 py-0 text-[9px] font-medium leading-4 text-reference-text">
+            current
+          </span>
+        )}
       </button>
     );
   });
@@ -521,14 +525,18 @@ function PanelHeader({
   highlightedTypeName,
   highlightedUnavailable,
   onSeedAll,
+  seedNotice,
+  onDismissSeedNotice,
 }: {
   recordCount: number;
   highlightedTypeName?: string | null;
   highlightedUnavailable?: boolean;
   onSeedAll?: () => void;
+  seedNotice?: SeedNoticeState | null;
+  onDismissSeedNotice?: () => void;
 }): React.JSX.Element {
   return (
-    <header className="flex h-14 items-center justify-between px-3">
+    <header className="flex h-14 items-center justify-between gap-3 px-3">
       <div className="min-w-0">
         <div className="flex items-center gap-2">
           <h2 className="text-sm font-semibold">Playground</h2>
@@ -545,6 +553,9 @@ function PanelHeader({
         </p>
       </div>
       <div className="flex shrink-0 items-center gap-2">
+        {seedNotice && onDismissSeedNotice && (
+          <SeedNotice notice={seedNotice} onDismiss={onDismissSeedNotice} />
+        )}
         <Badge variant="outline">{recordCount} records</Badge>
         {onSeedAll && (
           <Button
@@ -750,20 +761,68 @@ function InlineRecordEditor({
 }
 
 function SeedNotice({
-  message,
+  notice,
   onDismiss,
 }: {
-  message: string;
+  notice: SeedNoticeState;
   onDismiss: () => void;
 }): React.JSX.Element {
+  const message =
+    notice.warnings.length > 0
+      ? `Seeded ${notice.generatedCount} records, ${notice.warnings.length} warnings`
+      : `Seeded ${notice.generatedCount} records`;
+  const warningSummaries = seedWarningSummaries(notice.warnings);
+
   return (
-    <div className="flex items-center justify-between gap-2 border-b bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
-      <span className="min-w-0 truncate">{message}</span>
+    <div className="flex max-w-64 items-center gap-1.5 rounded-md border border-primary/20 bg-primary/5 px-2 py-1 text-xs text-muted-foreground">
+      {notice.warnings.length > 0 ? (
+        <HoverCard openDelay={150} closeDelay={80}>
+          <HoverCardTrigger asChild>
+            <button
+              type="button"
+              className="min-w-0 truncate text-left underline decoration-dotted"
+            >
+              {message}
+            </button>
+          </HoverCardTrigger>
+          <HoverCardContent align="end" className="w-80 p-0">
+            <div className="border-b px-3 py-2">
+              <div className="text-sm font-medium">Seed warnings</div>
+              <div className="text-xs text-muted-foreground">
+                Generated records skipped fields where fixtures could not satisfy the model.
+              </div>
+            </div>
+            <div className="max-h-64 overflow-y-auto p-2">
+              {warningSummaries.slice(0, 20).map((summary) => (
+                <div key={summary.key} className="rounded-sm px-2 py-1.5 text-xs">
+                  <div className="flex items-center justify-between gap-2 font-medium text-foreground">
+                    <span>
+                      {summary.typeName}
+                      {summary.fieldName ? `.${summary.fieldName}` : ''}
+                    </span>
+                    {summary.count > 1 && (
+                      <span className="text-[10px] text-muted-foreground">x{summary.count}</span>
+                    )}
+                  </div>
+                  <div className="text-muted-foreground">{summary.message}</div>
+                </div>
+              ))}
+              {warningSummaries.length > 20 && (
+                <div className="px-2 py-1 text-xs text-muted-foreground">
+                  {warningSummaries.length - 20} more warning groups hidden.
+                </div>
+              )}
+            </div>
+          </HoverCardContent>
+        </HoverCard>
+      ) : (
+        <span className="min-w-0 truncate">{message}</span>
+      )}
       <Button
         type="button"
         variant="ghost"
         size="icon"
-        className="h-6 w-6"
+        className="h-5 w-5 shrink-0"
         aria-label="Dismiss seed notice"
         onClick={onDismiss}
       >
@@ -771,6 +830,22 @@ function SeedNotice({
       </Button>
     </div>
   );
+}
+
+function seedWarningSummaries(
+  warnings: readonly PlaygroundFixtureWarning[],
+): Array<PlaygroundFixtureWarning & { key: string; count: number }> {
+  const byKey = new Map<string, PlaygroundFixtureWarning & { key: string; count: number }>();
+  for (const warning of warnings) {
+    const key = `${warning.typeName}:${warning.fieldName ?? ''}:${warning.message}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.count += 1;
+      continue;
+    }
+    byKey.set(key, { ...warning, key, count: 1 });
+  }
+  return [...byKey.values()];
 }
 
 function PlaygroundRecordForm({

--- a/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/toolbar/GraphControlsPanel.tsx
@@ -15,17 +15,17 @@
  * canvas is mounted.
  */
 import { useGraphLayoutStore } from '@renderer/store/layout-config';
-import { Maximize2, RefreshCw, X } from 'lucide-react';
+import { Maximize2, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  segmentedControlItemClass,
+  segmentedControlSelectedClass,
+} from '@/components/ui/button-group';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Slider } from '@/components/ui/slider';
 import { cn } from '@/lib/utils';
 
-interface Props {
-  onClose: () => void;
-}
-
-export function GraphControlsPanel({ onClose }: Props): React.JSX.Element {
+export function GraphControlsPanel(): React.JSX.Element {
   const graphLayout = useGraphLayoutStore((s) => s.graphLayout);
   const setGraphLayout = useGraphLayoutStore((s) => s.setGraphLayout);
   const resetGraphControls = useGraphLayoutStore((s) => s.resetToDefaults);
@@ -52,13 +52,6 @@ export function GraphControlsPanel({ onClose }: Props): React.JSX.Element {
 
   return (
     <div>
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
-        <span className="text-xs font-semibold text-foreground">Graph Controls</span>
-        <Button variant="ghost" size="icon" className="size-6" onClick={onClose}>
-          <X className="size-3.5" />
-        </Button>
-      </div>
-
       <div className="px-3 py-2 space-y-1.5 border-b border-border">
         <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
           Layout
@@ -74,10 +67,11 @@ export function GraphControlsPanel({ onClose }: Props): React.JSX.Element {
                 key={layoutMode}
                 htmlFor={`graph-layout-mode-${layoutMode}`}
                 className={cn(
-                  'flex cursor-pointer items-center justify-center px-2 text-xs font-medium text-muted-foreground transition-colors',
-                  'border-l border-border first:border-l-0 hover:bg-accent hover:text-foreground',
+                  'flex cursor-pointer items-center justify-center px-2 text-xs font-medium',
+                  'border-l border-border first:border-l-0',
+                  segmentedControlItemClass,
                   'focus-within:z-10 focus-within:ring-1 focus-within:ring-ring',
-                  graphLayout.layoutMode === layoutMode && 'bg-muted text-foreground',
+                  graphLayout.layoutMode === layoutMode && segmentedControlSelectedClass,
                 )}
               >
                 <input

--- a/apps/desktop/src/renderer/src/components/ui/alert-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+import * as React from 'react';
+import { type ButtonProps, buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content> & {
+    size?: 'default' | 'sm';
+  }
+>(({ className, size = 'default', ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        size === 'sm' ? 'max-w-sm' : 'max-w-lg',
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col items-center gap-2 text-center sm:items-start sm:text-left',
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = 'AlertDialogHeader';
+
+const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = 'AlertDialogFooter';
+
+const AlertDialogMedia = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        'flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground [&_svg]:size-5',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+AlertDialogMedia.displayName = 'AlertDialogMedia';
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold', className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> &
+    Pick<ButtonProps, 'variant' | 'size'>
+>(({ className, variant, size, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants({ variant, size }), className)}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel> &
+    Pick<ButtonProps, 'variant' | 'size'>
+>(({ className, variant = 'outline', size, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(buttonVariants({ variant, size }), className)}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/apps/desktop/src/renderer/src/components/ui/alert.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/alert.tsx
@@ -1,0 +1,44 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border px-4 py-3 text-sm [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-3.5 [&>svg]:size-4 [&>svg]:text-current [&>svg~*]:pl-7',
+  {
+    variants: {
+      variant: {
+        default: 'border-border bg-background text-foreground',
+        destructive:
+          'border-destructive/50 bg-destructive/10 text-destructive dark:border-destructive/50 dark:bg-destructive/20',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+));
+Alert.displayName = 'Alert';
+
+const AlertTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h5 ref={ref} className={cn('font-medium leading-none tracking-tight', className)} {...props} />
+  ),
+);
+AlertTitle.displayName = 'AlertTitle';
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('text-sm opacity-90', className)} {...props} />
+));
+AlertDescription.displayName = 'AlertDescription';
+
+export { Alert, AlertDescription, AlertTitle };

--- a/apps/desktop/src/renderer/src/components/ui/button-group.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/button-group.tsx
@@ -2,6 +2,15 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+const segmentedControlSelectedClass =
+  'bg-primary/20 text-primary hover:bg-primary/25 hover:text-primary';
+
+const segmentedControlActiveStateClass =
+  'data-[state=active]:bg-primary/20 data-[state=active]:text-primary data-[state=active]:hover:bg-primary/25 data-[state=active]:hover:text-primary';
+
+const segmentedControlItemClass =
+  'text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary';
+
 const ButtonGroup = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & {
@@ -50,4 +59,11 @@ const ButtonGroupText = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HT
 );
 ButtonGroupText.displayName = 'ButtonGroupText';
 
-export { ButtonGroup, ButtonGroupSeparator, ButtonGroupText };
+export {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+  segmentedControlActiveStateClass,
+  segmentedControlItemClass,
+  segmentedControlSelectedClass,
+};

--- a/apps/desktop/src/renderer/src/components/ui/tabs.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/tabs.tsx
@@ -4,6 +4,7 @@ import * as TabsPrimitive from '@radix-ui/react-tabs';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { segmentedControlActiveStateClass, segmentedControlItemClass } from './button-group';
 
 const Tabs = TabsPrimitive.Root;
 
@@ -14,7 +15,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-10 items-center justify-center rounded-md bg-card p-1 text-muted-foreground',
+      'inline-flex h-10 items-center justify-center rounded-md border border-input bg-background p-1 text-muted-foreground shadow-sm',
       className,
     )}
     {...props}
@@ -29,7 +30,9 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex h-full items-center justify-center whitespace-nowrap rounded-sm px-3 py-0 text-sm font-medium ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+      segmentedControlItemClass,
+      segmentedControlActiveStateClass,
       className,
     )}
     {...props}

--- a/apps/desktop/tests/components/App.codex.test.tsx
+++ b/apps/desktop/tests/components/App.codex.test.tsx
@@ -196,7 +196,9 @@ describe('App Codex-first copy', () => {
     useGraphSelectionStore.getState().click('Sowing', 'replace');
     useGraphSelectionStore.getState().selectField({ typeName: 'Sowing', fieldName: 'plot' });
 
-    await user.click(await screen.findByRole('button', { name: 'Delete field plot' }));
+    await user.click(await screen.findByLabelText('Open selection actions'));
+    await user.click(await screen.findByText('Delete...'));
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
 
     const sowing = useUndoStore.getState().schema.types.find((type) => type.name === 'Sowing');
     expect(sowing).toMatchObject({

--- a/apps/desktop/tests/components/App.codex.test.tsx
+++ b/apps/desktop/tests/components/App.codex.test.tsx
@@ -179,6 +179,7 @@ describe('App Codex-first copy', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Properties inspector')).toHaveTextContent('plot');
     });
+    expect(screen.getByTestId('inspector-selection-badge')).toHaveTextContent('field');
     expect(screen.queryByTestId('field-detail-header')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Back to Sowing fields' })).toBeInTheDocument();
 

--- a/apps/desktop/tests/components/App.keyboard.test.tsx
+++ b/apps/desktop/tests/components/App.keyboard.test.tsx
@@ -15,6 +15,7 @@ import { useGraphLayoutStore } from '@renderer/store/layout-config';
 import { useGraphSelectionStore } from '@renderer/store/selection';
 import { useUndoStore } from '@renderer/store/undo';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const unsub = () => undefined;
@@ -96,6 +97,63 @@ describe('App global keyboard', () => {
     fireEvent.keyDown(document, { key: 'Delete' });
     expect(useUndoStore.getState().schema.types).toEqual([]);
     expect(useGraphSelectionStore.getState().state.primaryNodeId).toBeNull();
+  });
+
+  it('deletes the inspector selection after menu confirmation', async () => {
+    const user = userEvent.setup();
+    useUndoStore.getState().apply({
+      kind: 'add_type',
+      type: { kind: 'object', name: 'Plot', fields: [] },
+    });
+    useGraphSelectionStore.getState().click('Plot', 'replace');
+    render(<App />);
+
+    await user.click(screen.getByLabelText('Open selection actions'));
+    await user.click(await screen.findByText('Delete...'));
+
+    expect(await screen.findByText('Delete type Plot?')).toBeInTheDocument();
+    expect(useUndoStore.getState().schema.types).toHaveLength(1);
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(useUndoStore.getState().schema.types).toEqual([]));
+    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBeNull();
+  });
+
+  it('surfaces an inspector delete error when a type is still referenced', async () => {
+    const user = userEvent.setup();
+    useUndoStore.getState().apply({
+      kind: 'replace_schema',
+      schema: {
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'Recipe',
+            fields: [{ name: 'status', type: { kind: 'ref', typeName: 'RecipeStatus' } }],
+          },
+          {
+            kind: 'enum',
+            name: 'RecipeStatus',
+            values: [{ value: 'draft' }, { value: 'published' }],
+          },
+        ],
+      },
+    });
+    useGraphSelectionStore.getState().click('RecipeStatus', 'replace');
+    render(<App />);
+
+    await user.click(screen.getByLabelText('Open selection actions'));
+    await user.click(await screen.findByText('Delete...'));
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unresolved ref "RecipeStatus"');
+    expect(screen.getByText('Delete type RecipeStatus?')).toBeInTheDocument();
+    expect(useUndoStore.getState().schema.types.map((type) => type.name)).toEqual([
+      'Recipe',
+      'RecipeStatus',
+    ]);
+    expect(useGraphSelectionStore.getState().state.primaryNodeId).toBe('RecipeStatus');
   });
 
   it('F2 opens properties and focuses the selected type name', async () => {

--- a/apps/desktop/tests/components/detail/TypeDetail.test.tsx
+++ b/apps/desktop/tests/components/detail/TypeDetail.test.tsx
@@ -711,6 +711,11 @@ describe('TypeDetail', () => {
       expect(screen.getByDisplayValue('Planting time.')).toBeInTheDocument();
     });
 
+    it('does not show type-level sample data controls for enums', () => {
+      setup({ ...type, sampleData: { category: 'food' } });
+      expect(screen.queryByText('Sample data')).not.toBeInTheDocument();
+    });
+
     it('renders documented enum compatibility contracts', () => {
       setup({
         ...type,

--- a/apps/desktop/tests/components/graph/GraphLegend.test.tsx
+++ b/apps/desktop/tests/components/graph/GraphLegend.test.tsx
@@ -13,25 +13,21 @@ describe('GraphLegend', () => {
     expect(screen.getByText('Table')).toBeInTheDocument();
   });
 
-  it('documents quiet modeled refs and active selection separately', () => {
+  it('documents quiet field refs and active paths separately', () => {
     render(<GraphLegend />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Expand legend' }));
 
-    expect(screen.getByText('Modeled ref')).toBeInTheDocument();
-    expect(screen.getByText('Active selection')).toBeInTheDocument();
+    expect(screen.getByText('Field ref')).toBeInTheDocument();
+    expect(screen.getByText('Active path')).toBeInTheDocument();
   });
 
-  it('documents inline enums by default and only shows enum nodes when expanded in controls', () => {
-    const { rerender } = render(<GraphLegend />);
+  it('documents enum nodes and inline enums by default', () => {
+    render(<GraphLegend />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Expand legend' }));
 
     expect(screen.getByText('Inline enum')).toBeInTheDocument();
-    expect(screen.queryByText('Enum')).not.toBeInTheDocument();
-
-    rerender(<GraphLegend showEnumNodes />);
-
     expect(screen.getByText('Enum')).toBeInTheDocument();
   });
 });

--- a/apps/desktop/tests/components/playground/PlaygroundPanel.test.tsx
+++ b/apps/desktop/tests/components/playground/PlaygroundPanel.test.tsx
@@ -3,7 +3,7 @@ import { PlaygroundPanel } from '@renderer/components/playground/PlaygroundPanel
 import { usePlaygroundStore } from '@renderer/store/playground';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const schema: Schema = {
   version: '1',
@@ -22,6 +22,11 @@ const schema: Schema = {
       kind: 'object',
       name: 'Team',
       table: true,
+      fields: [{ name: 'name', type: { kind: 'string' } }],
+    },
+    {
+      kind: 'object',
+      name: 'RecipeDietarySuitability',
       fields: [{ name: 'name', type: { kind: 'string' } }],
     },
   ],
@@ -103,13 +108,65 @@ describe('PlaygroundPanel', () => {
     expect(screen.queryByDisplayValue(/Unknown reference target/u)).not.toBeInTheDocument();
   });
 
-  it('highlights an inspector-selected type while keeping all entities available', () => {
+  it('highlights an inspector-selected type without replacing the current entity', () => {
     render(<PlaygroundPanel schema={schema} highlightedTypeName="Team" />);
 
     expect(
       screen.getByText('Inspector selection is highlighted in the model.'),
     ).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: 'Select entity' })).toHaveTextContent('Team');
+    expect(screen.getByText('Team')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Select entity' })).toHaveTextContent('User');
+  });
+
+  it('reports manual entity selection so the canvas can focus the type', async () => {
+    const user = userEvent.setup();
+    const onSelectEntity = vi.fn();
+    render(<PlaygroundPanel schema={schema} onSelectEntity={onSelectEntity} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Select entity' }));
+    await user.click(screen.getByRole('option', { name: 'Team (0)' }));
+
+    expect(onSelectEntity).toHaveBeenCalledWith('Team');
+  });
+
+  it('dismisses an unavailable Try target after choosing a table entity', async () => {
+    const user = userEvent.setup();
+    render(<PlaygroundPanel schema={schema} highlightedTypeName="RecipeDietarySuitability" />);
+
+    expect(
+      screen.getByText(
+        'RecipeDietarySuitability is not available in Playground. Choose a table from the entity list.',
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('combobox', { name: 'Select entity' }));
+    await user.click(screen.getByRole('option', { name: 'Team (0)' }));
+
+    expect(
+      screen.queryByText(
+        'RecipeDietarySuitability is not available in Playground. Choose a table from the entity list.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clears an unavailable Try target when the highlight is removed', () => {
+    const { rerender } = render(
+      <PlaygroundPanel schema={schema} highlightedTypeName="RecipeDietarySuitability" />,
+    );
+
+    expect(
+      screen.getByText(
+        'RecipeDietarySuitability is not available in Playground. Choose a table from the entity list.',
+      ),
+    ).toBeInTheDocument();
+
+    rerender(<PlaygroundPanel schema={schema} highlightedTypeName={null} />);
+
+    expect(
+      screen.queryByText(
+        'RecipeDietarySuitability is not available in Playground. Choose a table from the entity list.',
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it('places the all-entities seed action in the Playground header', () => {

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.43",
+      "version": "0.15.45",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.150",
         "@contexture/core": "workspace:*",
@@ -33,6 +33,7 @@
         "@electron-toolkit/utils": "^4.0.0",
         "@hookform/resolvers": "^5.4.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@sentry/electron": "^7.10.0",
         "electron-updater": "^6.8.3",
         "react-hook-form": "^7.76.1",
@@ -780,6 +781,8 @@
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-alert-dialog": ["@radix-ui/react-alert-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw=="],
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
@@ -3078,6 +3081,8 @@
     "@pierre/diffs/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
+
+    "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 


### PR DESCRIPTION
## Summary
- polish graph legend and graph controls placement, sizing, and shared segmented control states
- refine playground selection/warning behavior and inspector header/action layout
- add destructive delete confirmation with surfaced semantic errors, hide enum sample-data controls, and bump desktop to 0.15.45

## Checks
- bun run lint
- bun run typecheck
- bun run test -- tests/components/detail/TypeDetail.test.tsx tests/components/App.keyboard.test.tsx tests/components/graph/GraphLegend.test.tsx tests/components/playground/PlaygroundPanel.test.tsx
- pre-commit: turbo typecheck + turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783178963&installation_id=136251083&pr_number=382&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F382&signature=2fddac2e77b38262383ae317ca7eb26843476599f11972ddb388101b34854809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->