### PR TITLE
fix(desktop): sync chat tool readback context

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.45",
+  "version": "0.15.46",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/main/ipc/op-bridge.ts
+++ b/apps/desktop/src/main/ipc/op-bridge.ts
@@ -67,6 +67,19 @@ export function makeIpcForwardOp(
     });
 }
 
+export function syncTurnContextAfterForwardOp(
+  forwardOp: ForwardOpFn,
+  turnContext: TurnContext,
+): ForwardOpFn {
+  return async (op) => {
+    const result = await forwardOp(op);
+    if ('schema' in result) {
+      turnContext.pushIR(result.schema);
+    }
+    return result;
+  };
+}
+
 /**
  * Holds the IR snapshot the renderer pushes at turn-start so the
  * system-prompt builder can read it cheaply. Simple, single-slot

--- a/apps/desktop/src/main/ipc/schema-agent.ts
+++ b/apps/desktop/src/main/ipc/schema-agent.ts
@@ -30,7 +30,12 @@ import {
 import { createSchemaReadTools } from '../providers/schema-read-tools';
 import { generateReconcileProposal, type ReconcileProposalInput } from '../reconcile/proposals';
 import { ChatTurnController } from './chat-turn';
-import { type BridgeTransport, makeIpcForwardOp, TurnContext } from './op-bridge';
+import {
+  type BridgeTransport,
+  makeIpcForwardOp,
+  syncTurnContextAfterForwardOp,
+  TurnContext,
+} from './op-bridge';
 import { IpcString, parseIpcPayload } from './validation';
 
 export interface SchemaAgentIpc {
@@ -158,7 +163,8 @@ export function registerSchemaAgentIpc(mainWindow: BrowserWindow): SchemaAgentIp
     }
   });
 
-  const forwardOp = makeIpcForwardOp(toolTransport);
+  const turnContext = new TurnContext();
+  const forwardOp = syncTurnContextAfterForwardOp(makeIpcForwardOp(toolTransport), turnContext);
   const opToolDescriptors = [
     ...createSchemaReadTools(() => turnContext.current()),
     ...createOpTools(forwardOp),
@@ -173,7 +179,6 @@ export function registerSchemaAgentIpc(mainWindow: BrowserWindow): SchemaAgentIp
     if (provider !== 'codex' && provider !== 'claude') return null;
     return runtimes[provider];
   };
-  const turnContext = new TurnContext();
   const currentThreads: Partial<Record<ProviderKind, ProviderThreadRef>> = {};
   const currentModelOptions: Partial<
     Record<ProviderKind, { model?: string; effort?: string; options?: ModelOptions }>

--- a/apps/desktop/tests/main/op-tools-integration.test.ts
+++ b/apps/desktop/tests/main/op-tools-integration.test.ts
@@ -4,7 +4,10 @@
  * Proves that when Claude invokes an op tool, the renderer state
  * converges as expected and the SDK sees the result.
  */
+
+import { syncTurnContextAfterForwardOp, TurnContext } from '@main/ipc/op-bridge';
 import { createOpTools, type ForwardOp, type OpToolDescriptor } from '@main/ops';
+import { createSchemaReadTools } from '@main/providers/schema-read-tools';
 import { createContextureStore } from '@renderer/store/contexture';
 import { describe, expect, it } from 'vitest';
 
@@ -56,5 +59,31 @@ describe('op tools → renderer store (synthetic integration)', () => {
     expect(result).toMatchObject({ error: expect.any(String) });
     // Store unchanged.
     expect(store.getState().schema.types).toEqual([]);
+  });
+
+  it('keeps read tools in sync after a successful op in the same turn', async () => {
+    const initialSchema = {
+      version: '1',
+      types: [{ kind: 'object', name: 'Post', fields: [] }],
+    } as const;
+    const store = createContextureStore(initialSchema);
+    const turnContext = new TurnContext();
+    turnContext.pushIR(initialSchema);
+    const rawForward: ForwardOp = async (op) => store.getState().apply(op);
+    const tools = [
+      ...createSchemaReadTools(() => turnContext.current()),
+      ...createOpTools(syncTurnContextAfterForwardOp(rawForward, turnContext)),
+    ];
+
+    const setTableFlag = toolNamed(tools, 'set_table_flag');
+    const getType = toolNamed(tools, 'get_type');
+
+    await expect(setTableFlag.handler({ typeName: 'Post', table: true })).resolves.toMatchObject({
+      schema: expect.any(Object),
+    });
+    await expect(getType.handler({ typeName: 'Post' })).resolves.toMatchObject({
+      found: true,
+      type: expect.objectContaining({ name: 'Post', table: true }),
+    });
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "apps/desktop": {
       "name": "@contexture/desktop",
-      "version": "0.15.45",
+      "version": "0.15.46",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.150",
         "@contexture/core": "workspace:*",


### PR DESCRIPTION
## Summary
- sync successful schema op results back into the main-process turn context
- add a regression test covering op write followed by read tool readback in the same turn
- bump desktop app version to 0.15.46

## Tests
- bun run test -- tests/main/op-tools-integration.test.ts
- bun run typecheck:node
- pre-commit: turbo typecheck
- pre-commit: turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783185591&installation_id=136251083&pr_number=383&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F383&signature=e85d7614500b7e9a93a5a4a4dd0c876a1da19f09e1fdfd5842f61e1f2c3139da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->