### PR TITLE
feat(core): support field comparison invariants

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.46",
+  "version": "0.15.47",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/packages/core/src/domain-brief.ts
+++ b/packages/core/src/domain-brief.ts
@@ -141,6 +141,8 @@ function invariantStatement(invariant: ObjectInvariant): string {
       return `Exactly one of ${invariant.fields.join(', ')} must be present.`;
     case 'mutuallyExclusive':
       return `${invariant.fields.join(', ')} are mutually exclusive.`;
+    case 'fieldComparison':
+      return `${invariant.left} must be ${invariant.operator} ${invariant.right}.`;
     case 'fieldPredicate':
       return `${invariant.field} must satisfy ${invariant.predicate.kind}.`;
     case 'uniqueInArray':

--- a/packages/core/src/emit-json-schema.ts
+++ b/packages/core/src/emit-json-schema.ts
@@ -161,6 +161,7 @@ function emitJsonSchemaInvariants(type: Extract<TypeDef, { kind: 'object' }>): o
         }
         break;
       case 'fieldPredicate':
+      case 'fieldComparison':
       case 'uniqueInArray':
         break;
     }

--- a/packages/core/src/emit-zod.ts
+++ b/packages/core/src/emit-zod.ts
@@ -38,10 +38,11 @@ export function emit(schema: Schema, sourcePath: string, options: EmitOptions = 
   const header = `// @contexture-generated — do not edit by hand. Regenerated on every IR save. Source: ${sourcePath}\n`;
   const zodImport = `import { z } from 'zod';\n`;
   const externalImports = renderExternalImports(ctx);
+  const helpers = schemaHasFieldComparisons(schema) ? `${renderFieldComparisonHelper()}\n` : '';
   const body = sortTypeDefs(schema.types, ctx)
     .map((t) => emitTypeDef(t, ctx))
     .join('');
-  return header + zodImport + externalImports + body;
+  return header + zodImport + externalImports + helpers + body;
 }
 
 interface EmitContext {
@@ -223,11 +224,29 @@ function emitInvariantCheck(invariant: ObjectInvariant): string {
       const fields = invariant.fields.map((field) => `'${field}'`).join(', ');
       return `  if ([${fields}].filter((field) => (value as Record<string, unknown>)[field] !== undefined && (value as Record<string, unknown>)[field] !== null).length > 1) ctx.addIssue({ code: z.ZodIssueCode.custom, path: [], message: 'Invariant "${invariant.name}" allows at most one of: ${invariant.fields.join(', ')}.' });`;
     }
+    case 'fieldComparison':
+      return emitFieldComparisonCheck(invariant);
     case 'fieldPredicate':
       return emitFieldPredicateCheck(invariant);
     case 'uniqueInArray':
       return emitUniqueInArrayCheck(invariant);
   }
+}
+
+function emitFieldComparisonCheck(
+  invariant: Extract<ObjectInvariant, { kind: 'fieldComparison' }>,
+): string {
+  return [
+    `  {`,
+    `    const left = (value as Record<string, unknown>)['${invariant.left}'];`,
+    `    const right = (value as Record<string, unknown>)['${invariant.right}'];`,
+    `    if (left !== undefined && left !== null && right !== undefined && right !== null) {`,
+    `      const leftComparable = comparableInvariantValue(left);`,
+    `      const rightComparable = comparableInvariantValue(right);`,
+    `      if (leftComparable === null || rightComparable === null || !(leftComparable ${invariant.operator} rightComparable)) ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['${invariant.left}'], message: 'Invariant "${invariant.name}" requires ${invariant.left} ${invariant.operator} ${invariant.right}.' });`,
+    `    }`,
+    `  }`,
+  ].join('\n');
 }
 
 function emitFieldPredicateCheck(
@@ -273,6 +292,24 @@ function weekdayIndex(value: string): number {
   return ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'].indexOf(
     String(value),
   );
+}
+
+function schemaHasFieldComparisons(schema: Schema): boolean {
+  return schema.types.some(
+    (type) =>
+      type.kind === 'object' &&
+      (type.invariants ?? []).some((invariant) => invariant.kind === 'fieldComparison'),
+  );
+}
+
+function renderFieldComparisonHelper(): string {
+  return [
+    `function comparableInvariantValue(value: unknown): number | string | null {`,
+    `  if (typeof value === 'number' || typeof value === 'string') return value;`,
+    `  if (value instanceof Date) return value.getTime();`,
+    `  return null;`,
+    `}`,
+  ].join('\n');
 }
 
 function emitField(field: FieldDef, ctx: EmitContext): string {

--- a/packages/core/src/ir.ts
+++ b/packages/core/src/ir.ts
@@ -187,6 +187,15 @@ const MutuallyExclusiveInvariantSchema = z.object({
   fields: z.array(z.string().min(1)).min(2),
 });
 
+const FieldComparisonInvariantSchema = z.object({
+  kind: z.literal('fieldComparison'),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  left: z.string().min(1),
+  operator: z.enum(['<', '<=', '>', '>=', '===', '!==']),
+  right: z.string().min(1),
+});
+
 const FieldPredicateSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('weekday'),
@@ -216,6 +225,7 @@ export const ObjectInvariantSchema = z.discriminatedUnion('kind', [
   RequiresWhenInvariantSchema,
   ExactlyOneOfInvariantSchema,
   MutuallyExclusiveInvariantSchema,
+  FieldComparisonInvariantSchema,
   FieldPredicateInvariantSchema,
   UniqueInArrayInvariantSchema,
 ]);

--- a/packages/core/src/op-tools.ts
+++ b/packages/core/src/op-tools.ts
@@ -344,7 +344,7 @@ export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
     ),
     strictTool(
       'add_invariant',
-      'Add an object-level invariant such as requiresWhen, exactlyOneOf, mutuallyExclusive, fieldPredicate, or uniqueInArray.',
+      'Add an object-level invariant such as requiresWhen, exactlyOneOf, mutuallyExclusive, fieldComparison, fieldPredicate, or uniqueInArray.',
       {
         typeName: z.string().min(1),
         invariant: ObjectInvariantSchema,

--- a/packages/core/src/ops.ts
+++ b/packages/core/src/ops.ts
@@ -649,6 +649,12 @@ function renameInvariantField(
       };
     case 'fieldPredicate':
       return { ...invariant, field: invariant.field === from ? to : invariant.field };
+    case 'fieldComparison':
+      return {
+        ...invariant,
+        left: invariant.left === from ? to : invariant.left,
+        right: invariant.right === from ? to : invariant.right,
+      };
     case 'uniqueInArray':
       return {
         ...invariant,
@@ -668,6 +674,8 @@ function removeInvariantField(invariant: ObjectInvariant, fieldName: string): Ob
     case 'exactlyOneOf':
     case 'mutuallyExclusive':
       return { ...invariant, fields: invariant.fields.filter((field) => field !== fieldName) };
+    case 'fieldComparison':
+      return invariant;
     case 'fieldPredicate':
     case 'uniqueInArray':
       return invariant;

--- a/packages/core/src/semantic-validation.ts
+++ b/packages/core/src/semantic-validation.ts
@@ -46,6 +46,7 @@ export type SemanticIssueCode =
   | 'invariant_unknown_field'
   | 'invariant_unknown_array_field'
   | 'invariant_array_target_not_object'
+  | 'invariant_incompatible_field_types'
   | 'enum_empty'
   | 'enum_duplicate_value'
   | 'duplicate_convex_table_name'
@@ -897,6 +898,21 @@ function checkObjectInvariants(schema: Schema): SemanticIssueDraft[] {
         case 'fieldPredicate':
           checkField(invariant.field, 'field');
           break;
+        case 'fieldComparison': {
+          checkField(invariant.left, 'left');
+          checkField(invariant.right, 'right');
+          const left = fields.get(invariant.left);
+          const right = fields.get(invariant.right);
+          if (left && right && !fieldTypesComparable(left.type, right.type)) {
+            issues.push({
+              code: 'invariant_incompatible_field_types',
+              path: `${path}.operator`,
+              message: `Invariant "${invariant.name}" compares incompatible fields "${invariant.left}" and "${invariant.right}" on "${type.name}".`,
+              hint: 'Compare fields with compatible primitive/date-like types, or enforce this rule in application logic.',
+            });
+          }
+          break;
+        }
         case 'uniqueInArray': {
           const arrayField = fields.get(invariant.arrayField);
           if (!arrayField) {
@@ -939,6 +955,31 @@ function checkObjectInvariants(schema: Schema): SemanticIssueDraft[] {
   });
 
   return issues;
+}
+
+type ComparableFieldKind = 'number' | 'dateLike' | 'string' | 'unknown';
+
+function fieldTypesComparable(left: FieldType, right: FieldType): boolean {
+  const leftKind = comparableFieldKind(left);
+  const rightKind = comparableFieldKind(right);
+  if (leftKind === 'unknown' || rightKind === 'unknown') return true;
+  return leftKind === rightKind;
+}
+
+function comparableFieldKind(type: FieldType): ComparableFieldKind {
+  if (type.kind === 'number') return 'number';
+  if (type.kind === 'date') return 'dateLike';
+  if (type.kind === 'string') {
+    return type.format === 'datetime' ? 'dateLike' : 'string';
+  }
+  if (type.kind === 'ref') {
+    const parts = type.typeName.split('.');
+    const name = parts[parts.length - 1];
+    if (name === 'ISODate' || name === 'ISODateTime') return 'dateLike';
+    if (name === 'PositiveInt' || name === 'PositiveNumber') return 'number';
+    return 'unknown';
+  }
+  return 'unknown';
 }
 
 function effectiveFields(

--- a/packages/core/tests/domain-brief.test.ts
+++ b/packages/core/tests/domain-brief.test.ts
@@ -127,4 +127,36 @@ describe('domain brief', () => {
       summary: { typeCount: 1, tableCount: 1 },
     });
   });
+
+  it('describes field comparison invariants as declared contracts', () => {
+    const schema: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Batch',
+          fields: [
+            { name: 'acquiredDate', type: { kind: 'string' } },
+            { name: 'expiryDate', type: { kind: 'string' } },
+          ],
+          invariants: [
+            {
+              kind: 'fieldComparison',
+              name: 'expiry_after_acquired',
+              left: 'expiryDate',
+              operator: '>=',
+              right: 'acquiredDate',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(buildDomainBrief(schema).declaredDecisions).toEqual([
+      expect.objectContaining({
+        id: 'invariant:Batch:expiry_after_acquired',
+        statement: 'expiryDate must be >= acquiredDate.',
+      }),
+    ]);
+  });
 });

--- a/packages/core/tests/invariants.test.ts
+++ b/packages/core/tests/invariants.test.ts
@@ -4,7 +4,13 @@ import { emit as emitZod } from '../src/emit-zod';
 import type { Schema } from '../src/ir';
 import { IRSchema } from '../src/ir';
 import { apply } from '../src/ops';
-import { checkSemantic } from '../src/semantic-validation';
+import { checkSemantic, type StdlibCatalog } from '../src/semantic-validation';
+
+const commonStdlib: StdlibCatalog = {
+  namespaces: ['common'],
+  hasType: (namespace, typeName) =>
+    namespace === 'common' && (typeName === 'ISODate' || typeName === 'ISODateTime'),
+};
 
 const mealSchema: Schema = {
   version: '1',
@@ -94,6 +100,7 @@ describe('object invariants and composition', () => {
   it('mutates invariants through closed-world ops', () => {
     const start: Schema = {
       version: '1',
+      imports: [{ kind: 'stdlib', path: '@contexture/common', alias: 'common' }],
       types: [
         {
           kind: 'object',
@@ -138,6 +145,121 @@ describe('object invariants and composition', () => {
     if ('schema' in removed) {
       expect(removed.schema.types[0]).not.toHaveProperty('invariants');
     }
+  });
+
+  it('supports same-object field comparison invariants through ops and emitters', () => {
+    const start: Schema = {
+      version: '1',
+      types: [
+        {
+          kind: 'object',
+          name: 'Batch',
+          fields: [
+            { name: 'acquiredDate', type: { kind: 'ref', typeName: 'common.ISODate' } },
+            { name: 'expiryDate', type: { kind: 'ref', typeName: 'common.ISODate' } },
+          ],
+        },
+      ],
+    };
+
+    const added = apply(start, {
+      kind: 'add_invariant',
+      typeName: 'Batch',
+      invariant: {
+        kind: 'fieldComparison',
+        name: 'expiry_after_acquired',
+        left: 'expiryDate',
+        operator: '>=',
+        right: 'acquiredDate',
+      },
+    });
+
+    expect('schema' in added).toBe(true);
+    if (!('schema' in added)) return;
+    expect(checkSemantic(added.schema, commonStdlib)).toEqual([]);
+
+    const renamed = apply(added.schema, {
+      kind: 'update_field',
+      typeName: 'Batch',
+      fieldName: 'expiryDate',
+      patch: { name: 'expiresOn' },
+    });
+    expect('schema' in renamed).toBe(true);
+    if (!('schema' in renamed)) return;
+    expect(renamed.schema.types[0]).toMatchObject({
+      invariants: [{ left: 'expiresOn', right: 'acquiredDate' }],
+    });
+
+    const zodSource = emitZod(renamed.schema, 'batch.contexture.json');
+    expect(zodSource).toContain('leftComparable >= rightComparable');
+
+    const jsonSchema = emitJsonSchema(renamed.schema) as {
+      $defs: Record<string, Record<string, unknown>>;
+    };
+    expect(jsonSchema.$defs.Batch?.['x-contexture-invariants']).toEqual([
+      {
+        kind: 'fieldComparison',
+        name: 'expiry_after_acquired',
+        left: 'expiresOn',
+        operator: '>=',
+        right: 'acquiredDate',
+      },
+    ]);
+  });
+
+  it('rejects field comparison invariants that reference missing fields', () => {
+    const schema: Schema = {
+      version: '1',
+      imports: [{ kind: 'stdlib', path: '@contexture/common', alias: 'common' }],
+      types: [
+        {
+          kind: 'object',
+          name: 'Batch',
+          fields: [{ name: 'acquiredDate', type: { kind: 'ref', typeName: 'common.ISODate' } }],
+          invariants: [
+            {
+              kind: 'fieldComparison',
+              name: 'expiry_after_acquired',
+              left: 'expiryDate',
+              operator: '>=',
+              right: 'acquiredDate',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema).map((issue) => issue.code)).toContain('invariant_unknown_field');
+  });
+
+  it('rejects field comparison invariants across incompatible primitive types', () => {
+    const schema: Schema = {
+      version: '1',
+      imports: [{ kind: 'stdlib', path: '@contexture/common', alias: 'common' }],
+      types: [
+        {
+          kind: 'object',
+          name: 'Batch',
+          fields: [
+            { name: 'quantity', type: { kind: 'number' } },
+            { name: 'expiresOn', type: { kind: 'ref', typeName: 'common.ISODate' } },
+          ],
+          invariants: [
+            {
+              kind: 'fieldComparison',
+              name: 'quantity_after_expiry',
+              left: 'quantity',
+              operator: '>=',
+              right: 'expiresOn',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(checkSemantic(schema).map((issue) => issue.message)).toEqual([
+      'Invariant "quantity_after_expiry" compares incompatible fields "quantity" and "expiresOn" on "Batch".',
+    ]);
   });
 
   it('emits inherited fields and Zod refinement checks', () => {


### PR DESCRIPTION
## Summary
- add a fieldComparison object invariant for same-object field ordering/equality checks
- emit Zod superRefine enforcement and preserve comparison metadata in JSON Schema
- include comparison invariants in semantic validation, field rename handling, domain brief output, and agent tool descriptions
- bump @contexture/desktop to 0.15.47

## Verification
- bun run ci
- bun run test -- tests/invariants.test.ts tests/domain-brief.test.ts (packages/core)
- bun run test -- tests/main/op-tools.test.ts tests/chat/system-prompt.test.ts (apps/desktop)
- bun run test -- tests/cli.test.ts tests/mcp.test.ts (packages/cli)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783187388&installation_id=136251083&pr_number=384&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F384&signature=338bdc3d444602840297d17942727c0df523b9cca127a736ae29c7dec1599623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->