### PR TITLE
fix: handle high-minimum fixture numbers

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.47",
+  "version": "0.15.48",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/packages/core/src/playground-fixtures.ts
+++ b/packages/core/src/playground-fixtures.ts
@@ -218,17 +218,9 @@ function generateControlValue(control: PlaygroundControl, ctx: GenerateValueCont
       if (fieldLooksLike(control.fieldName, ['quantity', 'amount', 'count'])) {
         return entityCategoryUsesFood(ctx.entityCategory)
           ? ctx.random.number({ min: 1, max: 12, int: true })
-          : ctx.random.number({
-              min: control.constraints.min ?? 1,
-              max: control.constraints.max ?? 20,
-              int: true,
-            });
+          : ctx.random.number(numberRange(control.constraints, { min: 1, max: 20, int: true }));
       }
-      return ctx.random.number({
-        min: control.constraints.min ?? 1,
-        max: control.constraints.max ?? 100,
-        int: control.constraints.int,
-      });
+      return ctx.random.number(numberRange(control.constraints, { min: 1, max: 100 }));
     case 'boolean':
       return ctx.random.boolean();
     case 'date':
@@ -284,11 +276,7 @@ function generateArrayElement(
     case 'text':
       return generateText(arrayScalarControl(element, fieldName), ctx);
     case 'number':
-      return ctx.random.number({
-        min: element.constraints.min ?? 1,
-        max: element.constraints.max ?? 20,
-        int: element.constraints.int,
-      });
+      return ctx.random.number(numberRange(element.constraints, { min: 1, max: 20 }));
     case 'boolean':
       return ctx.random.boolean();
     case 'date':
@@ -806,6 +794,15 @@ function isNameField(field: string, label: string): boolean {
 function fieldLooksLike(fieldName: string, needles: readonly string[]): boolean {
   const field = fieldName.toLowerCase();
   return needles.some((needle) => field.includes(needle));
+}
+
+function numberRange(
+  constraints: PlaygroundFieldConstraints,
+  fallback: { min: number; max: number; int?: boolean },
+): { min: number; max: number; int?: boolean } {
+  const min = constraints.min ?? fallback.min;
+  const max = constraints.max ?? Math.max(fallback.max, min + fallback.max - fallback.min);
+  return { min, max, int: constraints.int ?? fallback.int };
 }
 
 function singularFieldName(fieldName: string): string {

--- a/packages/core/tests/playground-fixtures.test.ts
+++ b/packages/core/tests/playground-fixtures.test.ts
@@ -204,6 +204,32 @@ describe('generatePlaygroundFixtures', () => {
     );
   });
 
+  it('generates high-minimum numbers without an explicit max', () => {
+    const result = generatePlaygroundFixtures(
+      {
+        version: '1',
+        types: [
+          {
+            kind: 'object',
+            name: 'Planting',
+            table: true,
+            fields: [
+              { name: 'cropName', type: { kind: 'string', min: 1 } },
+              { name: 'year', type: { kind: 'number', min: 2026, int: true } },
+            ],
+          },
+        ],
+      },
+      { seed: 'planting-year', count: 3 },
+    );
+
+    expect(result.warnings).toEqual([]);
+    expect(result.recordsByType.Planting?.map((record) => record.value.year)).toSatisfy(
+      (years: unknown) =>
+        Array.isArray(years) && years.every((year) => typeof year === 'number' && year >= 2026),
+    );
+  });
+
   it('uses entity-aware semantics for pantry and household records', () => {
     const result = generatePlaygroundFixtures(pantrySchema, {
       seed: 'pantry-demo',


### PR DESCRIPTION
## Summary
- bump desktop app version to 0.15.48
- generate fixture number ranges that respect high schema minimums when no max is set
- add regression coverage for Planting-style year fields

## Tests
- bun run test -- playground-fixtures.test.ts
- bun run typecheck
- pre-commit: turbo typecheck; turbo test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783189571&installation_id=136251083&pr_number=385&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F385&signature=77859f3cc39fb171a747d1a323bc51a4bbe5ad25adfe22cb0c114d1b3a475f88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->