### PR TITLE
Add model evolution policy

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contexture/desktop",
-  "version": "0.15.48",
+  "version": "0.15.49",
   "description": "Convex model editor with generated schema, validators, and agent-safe ops",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/applification/contexture",

--- a/apps/desktop/src/main/providers/schema-read-tools.ts
+++ b/apps/desktop/src/main/providers/schema-read-tools.ts
@@ -1,4 +1,5 @@
 import { buildDomainBrief } from '@contexture/core/domain-brief';
+import { describeEvolutionPolicy } from '@contexture/core/evolution-policy';
 import type { Schema, TypeDef } from '@contexture/core/ir';
 import { analyzeModelingHints } from '@contexture/core/modeling-hints';
 import { z } from 'zod';
@@ -66,7 +67,10 @@ export function createSchemaReadTools(getCurrentSchema: GetCurrentSchema): OpToo
       inputSchema: {},
       handler: async () => {
         const schema = readSchema(getCurrentSchema);
-        return buildDomainBrief(schema);
+        return {
+          evolutionPolicy: describeEvolutionPolicy(schema),
+          brief: buildDomainBrief(schema),
+        };
       },
     },
   ];
@@ -80,6 +84,7 @@ function schemaSummary(schema: Schema): Record<string, unknown> {
   return {
     version: schema.version,
     name: schema.metadata?.name,
+    evolutionPolicy: describeEvolutionPolicy(schema),
     typeCount: schema.types.length,
     types: schema.types.map(typeListItem),
     imports: schema.imports ?? [],

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@
  * sidebar button).
  */
 
+import { type EvolutionPolicy, getEvolutionPolicy } from '@contexture/core/evolution-policy';
 import {
   emitGeneratedTarget,
   enableGeneratedTarget,
@@ -22,7 +23,7 @@ import {
   previewableGeneratedTargets,
   setGeneratedTargetOutputDir,
 } from '@contexture/core/generated-targets';
-import type { Schema, TypeDef } from '@contexture/core/ir';
+import type { FieldType, Schema, TypeDef } from '@contexture/core/ir';
 import { STDLIB_REGISTRY, STDLIB_TYPE_DEFINITIONS } from '@shared/stdlib-registry';
 import {
   AlertCircle,
@@ -55,6 +56,7 @@ import { DetailPanel } from './components/detail/DetailPanel';
 import { FOCUS_TYPE_NAME_EVENT } from './components/detail/TypeDetail';
 import { DocumentDialogs } from './components/dialogs/DocumentDialogs';
 import { ReconcileModal } from './components/dialogs/ReconcileModal';
+import { EvolutionPolicyPanel } from './components/graph/EvolutionPolicyPanel';
 import { TYPE_EDGE_SELECT_EVENT } from './components/graph/edge-select-event';
 import { GraphBackground } from './components/graph/GraphBackground';
 import { type CanvasPosition, GraphCanvas } from './components/graph/GraphCanvas';
@@ -126,6 +128,7 @@ import { useUndoStore } from './store/undo';
 
 export default function App(): React.JSX.Element {
   const schema = useSyncExternalStore(useUndoStore.subscribe, () => useUndoStore.getState().schema);
+  const evolutionPolicy = getEvolutionPolicy(schema);
   const hasSchema = schema.types.length > 0;
 
   const layout = useDocumentStore((s) => s.layout);
@@ -163,6 +166,13 @@ export default function App(): React.JSX.Element {
   const convexVersion = useConvexVersionStore();
   const driftedPaths = useDriftStore((s) => s.driftedPaths);
   const graphLayout = useGraphLayoutStore((s) => s.graphLayout);
+  const legendVisibility = useMemo(
+    () => ({
+      showRawTypes: schema.types.some((type) => type.kind === 'raw'),
+      showImportedNodes: hasVisibleImportedNodes(schema, graphLayout.showStdlib),
+    }),
+    [graphLayout.showStdlib, schema],
+  );
 
   // Drive the collapse/expand imperative API from the UI-store flag so
   // the Toolbar's sidebar button toggles the same thing as a user drag
@@ -233,6 +243,10 @@ export default function App(): React.JSX.Element {
     if ('error' in result) return;
     useGraphSelectionStore.getState().selectField({ typeName, fieldName: op.field.name });
     useGraphSelectionStore.getState().focus({ nodeId: typeName, fieldName: op.field.name });
+  }, []);
+
+  const updateEvolutionPolicy = useCallback((policy: EvolutionPolicy): void => {
+    useUndoStore.getState().apply({ kind: 'set_evolution_policy', policy });
   }, []);
 
   const focusSelectedTypeName = useCallback((): void => {
@@ -631,10 +645,13 @@ export default function App(): React.JSX.Element {
             <ModelSyncBanner />
             <div className="relative flex-1 min-h-0">
               {hasSchema && (
-                <div className="absolute top-2 left-2 z-20 flex items-start gap-2">
+                <div className="absolute top-2 left-2 z-20 flex max-w-[calc(100%-1rem)] flex-wrap items-start gap-2">
+                  <EvolutionPolicyPanel policy={evolutionPolicy} onChange={updateEvolutionPolicy} />
                   <GraphLegend
                     showEnumNodes={graphLayout.showEnums}
                     showStdlibNodes={graphLayout.showStdlib}
+                    showRawTypes={legendVisibility.showRawTypes}
+                    showImportedNodes={legendVisibility.showImportedNodes}
                   />
                   <section
                     aria-label="Graph controls"
@@ -1017,6 +1034,48 @@ function typeKindLabel(type: TypeDef): TypeKindLabel {
   if (type.kind === 'enum') return 'enum';
   if (type.kind === 'discriminatedUnion') return 'union';
   return 'raw';
+}
+
+function hasVisibleImportedNodes(schema: Schema, showStdlibNodes: boolean): boolean {
+  const localNames = new Set(schema.types.map((type) => type.name));
+  return schema.types.some((type) => {
+    if (type.kind === 'discriminatedUnion') {
+      return type.variants.some((variant) =>
+        isVisibleImportedTarget(variant, localNames, showStdlibNodes),
+      );
+    }
+    if (type.kind !== 'object') return false;
+    return type.fields.some((field) => {
+      const target = unwrapRefTarget(field.type);
+      return target ? isVisibleImportedTarget(target, localNames, showStdlibNodes) : false;
+    });
+  });
+}
+
+function isVisibleImportedTarget(
+  typeName: string,
+  localNames: ReadonlySet<string>,
+  showStdlibNodes: boolean,
+): boolean {
+  const crossBoundary = typeName.includes('.') || !localNames.has(typeName);
+  if (!crossBoundary) return false;
+  return showStdlibNodes || !isStdlibRef(typeName);
+}
+
+function unwrapRefTarget(type: FieldType): string | undefined {
+  let current = type;
+  while (current.kind === 'array') current = current.element;
+  return current.kind === 'ref' ? current.typeName : undefined;
+}
+
+function isStdlibRef(typeName: string): boolean {
+  const [namespace, name, ...rest] = typeName.split('.');
+  return (
+    rest.length === 0 &&
+    namespace !== undefined &&
+    name !== undefined &&
+    STDLIB_REGISTRY.hasType(namespace, name)
+  );
 }
 
 function edgeSelectionLabel(edge: EdgeSelection): string {

--- a/apps/desktop/src/renderer/src/components/graph/EvolutionPolicyPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/EvolutionPolicyPanel.tsx
@@ -1,0 +1,152 @@
+import { describeEvolutionPolicy, type EvolutionPolicy } from '@contexture/core/evolution-policy';
+import {
+  ChevronDown,
+  ChevronUp,
+  type LucideIcon,
+  RotateCcw,
+  ShieldCheck,
+  Sparkles,
+} from 'lucide-react';
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+interface EvolutionPolicyPanelProps {
+  policy: EvolutionPolicy;
+  onChange: (policy: EvolutionPolicy) => void;
+}
+
+const POLICY_OPTIONS: Array<{
+  value: EvolutionPolicy;
+  label: string;
+  summary: string;
+  impact: string;
+  icon: LucideIcon;
+}> = [
+  {
+    value: 'preserveData',
+    label: 'Preserve data',
+    summary: 'Assume real data may exist.',
+    impact: 'Agents prefer additive, migration-aware changes and call out destructive risk.',
+    icon: ShieldCheck,
+  },
+  {
+    value: 'resettable',
+    label: 'Resettable',
+    summary: 'Data can be dropped or regenerated.',
+    impact: 'Agents can propose breaking remodels, with a brief reset-impact note.',
+    icon: RotateCcw,
+  },
+  {
+    value: 'scratch',
+    label: 'Scratch',
+    summary: 'No meaningful data is expected.',
+    impact: 'Agents can freely rename, delete, restructure, or replace the model.',
+    icon: Sparkles,
+  },
+];
+
+export function EvolutionPolicyPanel({
+  policy,
+  onChange,
+}: EvolutionPolicyPanelProps): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const current = describeEvolutionPolicy(policy);
+  const currentOption =
+    POLICY_OPTIONS.find((option) => option.value === policy) ?? POLICY_OPTIONS[0];
+  const CurrentIcon = currentOption.icon;
+
+  return (
+    <section
+      aria-label="Evolution policy"
+      className="overflow-hidden rounded-xl border border-border/80 bg-card/95 text-xs text-card-foreground shadow-sm backdrop-blur"
+    >
+      <button
+        type="button"
+        className={cn(
+          'flex h-[38px] w-full min-w-44 items-center justify-between gap-3 px-3 text-xs font-medium transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+          policy === 'preserveData' ? 'text-muted-foreground' : 'bg-secondary text-foreground',
+        )}
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-label={expanded ? 'Collapse evolution policy' : 'Expand evolution policy'}
+        title={`Evolution policy: ${current.label}`}
+      >
+        <span className="flex min-w-0 items-center gap-2">
+          <span
+            className="grid size-5 shrink-0 place-items-center rounded-md border border-primary/35 bg-primary/15 text-primary"
+            aria-hidden="true"
+          >
+            <CurrentIcon className="size-3.5" />
+          </span>
+          <span className="truncate">Evolution Policy</span>
+        </span>
+        {expanded ? (
+          <ChevronUp className="size-3.5" aria-hidden="true" />
+        ) : (
+          <ChevronDown className="size-3.5" aria-hidden="true" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="w-80 border-t border-border/70">
+          <div className="border-b border-border/70 px-3 py-2.5">
+            <div className="text-[10px] font-semibold text-muted-foreground">Current posture</div>
+            <p className="mt-1 text-xs leading-relaxed text-foreground">{current.guidance}</p>
+          </div>
+
+          <fieldset className="grid gap-1.5 px-2 py-2" aria-label="Evolution policy options">
+            {POLICY_OPTIONS.map((option) => {
+              const selected = option.value === policy;
+              const OptionIcon = option.icon;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={cn(
+                    'grid gap-1 rounded-lg border px-2.5 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                    selected
+                      ? 'border-primary/45 bg-primary/20 text-primary hover:bg-primary/25 hover:text-primary'
+                      : 'border-transparent text-muted-foreground hover:border-border hover:bg-primary/10 hover:text-primary',
+                  )}
+                  aria-pressed={selected}
+                  onClick={() => onChange(option.value)}
+                >
+                  <span className="flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-2">
+                      <span
+                        aria-hidden="true"
+                        className={cn(
+                          'grid size-5 shrink-0 place-items-center rounded-md border',
+                          selected
+                            ? 'border-primary/45 bg-primary/15 text-primary'
+                            : 'border-current/50 bg-background/35 text-current',
+                        )}
+                      >
+                        <OptionIcon className="size-3.5" />
+                      </span>
+                      <span className="text-xs font-medium">{option.label}</span>
+                    </span>
+                    {selected && (
+                      <span className="rounded-full bg-primary/20 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                        Active
+                      </span>
+                    )}
+                  </span>
+                  <span className="pl-7 text-[11px] leading-snug">{option.summary}</span>
+                  <span
+                    className={cn(
+                      'pl-7 text-[11px] leading-snug',
+                      selected ? 'text-primary/80' : 'text-muted-foreground',
+                    )}
+                  >
+                    {option.impact}
+                  </span>
+                </button>
+              );
+            })}
+          </fieldset>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/GraphLegend.tsx
@@ -9,6 +9,7 @@ import {
   Box,
   ChevronDown,
   ChevronUp,
+  Code2,
   GitBranch,
   ListChecks,
   Map as MapIcon,
@@ -61,7 +62,7 @@ const BASE_TYPE_ITEMS: readonly TypeItem[] = [
   { kind: 'object', label: 'Object', icon: <Box className="size-3.5" aria-hidden="true" /> },
   { kind: 'table', label: 'Table', icon: <Table2 className="size-3.5" aria-hidden="true" /> },
   { kind: 'union', label: 'Union', icon: <GitBranch className="size-3.5" aria-hidden="true" /> },
-  { kind: 'raw', label: 'Raw', icon: null },
+  { kind: 'raw', label: 'Raw', icon: <Code2 className="size-3.5" aria-hidden="true" /> },
 ];
 
 const ENUM_TYPE_ITEM: TypeItem = {
@@ -72,19 +73,19 @@ const ENUM_TYPE_ITEM: TypeItem = {
 
 export const GraphLegend = memo(function GraphLegend({
   showStdlibNodes = false,
+  showRawTypes = false,
+  showImportedNodes = false,
   className,
 }: {
   showEnumNodes?: boolean;
   showStdlibNodes?: boolean;
+  showRawTypes?: boolean;
+  showImportedNodes?: boolean;
   className?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const typeItems = [
-    BASE_TYPE_ITEMS[0],
-    BASE_TYPE_ITEMS[1],
-    ENUM_TYPE_ITEM,
-    ...BASE_TYPE_ITEMS.slice(2),
-  ];
+  const typeItems = [BASE_TYPE_ITEMS[0], BASE_TYPE_ITEMS[1], ENUM_TYPE_ITEM, BASE_TYPE_ITEMS[2]];
+  if (showRawTypes) typeItems.push(BASE_TYPE_ITEMS[3]);
 
   return (
     <section
@@ -132,13 +133,15 @@ export const GraphLegend = memo(function GraphLegend({
                   <span className="truncate text-foreground">Stdlib</span>
                 </div>
               )}
-              <div className="flex min-w-0 items-center gap-2 rounded-md border border-dashed border-border bg-background/55 px-2 py-1.5">
-                <span
-                  aria-hidden="true"
-                  className="h-3 w-4 rounded-sm border border-dashed border-muted-foreground/80"
-                />
-                <span className="truncate text-foreground">Imported</span>
-              </div>
+              {showImportedNodes && (
+                <div className="flex min-w-0 items-center gap-2 rounded-md border border-dashed border-border bg-background/55 px-2 py-1.5">
+                  <span
+                    aria-hidden="true"
+                    className="h-3 w-4 shrink-0 rounded-sm border border-dashed border-muted-foreground/80"
+                  />
+                  <span className="truncate text-foreground">Imported</span>
+                </div>
+              )}
             </div>
           </LegendSection>
 
@@ -197,10 +200,9 @@ function LegendSection({
 
 function TypeLegendItem({ item }: { item: TypeItem }): React.JSX.Element {
   return (
-    <div className="flex min-w-0 items-center justify-between gap-2 rounded-md bg-background/55 px-2 py-1.5">
-      <span className="flex min-w-0 items-center gap-1.5 text-foreground">
+    <div className="flex min-w-0 items-center gap-2 rounded-md bg-background/55 px-2 py-1.5">
+      <span className="flex shrink-0 items-center text-foreground" title={item.label}>
         {item.icon}
-        <span className="truncate">{item.label}</span>
       </span>
       <TypeKindBadge kind={item.kind} />
     </div>

--- a/apps/desktop/src/shared/system-prompt.ts
+++ b/apps/desktop/src/shared/system-prompt.ts
@@ -48,6 +48,10 @@ export function buildSystemPromptAppend(input: BuildSystemPromptAppendInput): st
     '',
     renderOpCatalogue(),
     '',
+    '## Evolution policy',
+    '',
+    EVOLUTION_POLICY_RULES.trim(),
+    '',
     '## Convex collection modeling',
     '',
     COLLECTION_MODELING_RULES.trim(),
@@ -135,6 +139,9 @@ paste the IR. Prefer targeted reads over requesting the full schema. If the
 exact full IR is truly necessary, call \`inspect_current_schema\` with
 \`includeSchema: true\`.
 
+Before planning model changes, inspect the current \`evolutionPolicy\` and
+follow it. Do not rely on prior chat memory for data-preservation posture.
+
 Prefer surgical ops over \`replace_schema\`; the bulk rewrite is an escape
 hatch, not a default. When the user explicitly attaches files, their contents
 appear in an \`<attached_files>\` block before the message; use them as context,
@@ -147,6 +154,21 @@ Skills are available and auto-load on topic match:
   (Email, URL, UUID, ISODate, Money, CountryCode, PhoneNumber, …).
 - \`generate-sample\` — use when the user asks for sample / fixture /
   example data for a type.
+`;
+
+const EVOLUTION_POLICY_RULES = `
+Contexture models carry an \`evolutionPolicy\` in metadata. Read it before
+proposing changes:
+
+- \`preserveData\`: real data may exist. Prefer additive, migration-aware
+  model changes and call out destructive data risk before deletes, renames, or
+  incompatible reshapes.
+- \`resettable\`: data may exist, but it can be discarded or regenerated. You
+  may propose breaking remodels when they simplify the model; mention reset
+  impact briefly instead of designing full migrations.
+- \`scratch\`: this is exploratory and no meaningful data is expected. You may
+  freely propose renames, deletes, restructures, and replacement models without
+  repeated migration warnings.
 `;
 
 const COLLECTION_MODELING_RULES = `
@@ -192,6 +214,7 @@ interface OpSpec {
 }
 
 const OP_CATALOGUE: OpSpec[] = [
+  { name: 'set_evolution_policy', shape: '{ policy: "preserveData"|"resettable"|"scratch" }' },
   { name: 'add_type', shape: '{ payload: TypeDef }' },
   { name: 'update_type', shape: "{ name: string; patch: Partial<Omit<TypeDef, 'kind'|'name'>> }" },
   { name: 'rename_type', shape: '{ from: string; to: string }' },

--- a/apps/desktop/tests/chat/__snapshots__/system-prompt.test.ts.snap
+++ b/apps/desktop/tests/chat/__snapshots__/system-prompt.test.ts.snap
@@ -25,6 +25,9 @@ paste the IR. Prefer targeted reads over requesting the full schema. If the
 exact full IR is truly necessary, call \`inspect_current_schema\` with
 \`includeSchema: true\`.
 
+Before planning model changes, inspect the current \`evolutionPolicy\` and
+follow it. Do not rely on prior chat memory for data-preservation posture.
+
 Prefer surgical ops over \`replace_schema\`; the bulk rewrite is an escape
 hatch, not a default. When the user explicitly attaches files, their contents
 appear in an \`<attached_files>\` block before the message; use them as context,
@@ -40,6 +43,7 @@ Skills are available and auto-load on topic match:
 
 ## Op vocabulary
 
+- \`set_evolution_policy\` { policy: "preserveData"|"resettable"|"scratch" }
 - \`add_type\` { payload: TypeDef }
 - \`update_type\` { name: string; patch: Partial<Omit<TypeDef, 'kind'|'name'>> }
 - \`rename_type\` { from: string; to: string }
@@ -68,6 +72,21 @@ Skills are available and auto-load on topic match:
 - \`update_search_index\` { typeName: string; name: string; patch: Partial<SearchIndexDef> }
 - \`remove_search_index\` { typeName: string; name: string }
 - \`replace_schema\` { schema: Schema }   # escape hatch; full IR
+
+## Evolution policy
+
+Contexture models carry an \`evolutionPolicy\` in metadata. Read it before
+proposing changes:
+
+- \`preserveData\`: real data may exist. Prefer additive, migration-aware
+  model changes and call out destructive data risk before deletes, renames, or
+  incompatible reshapes.
+- \`resettable\`: data may exist, but it can be discarded or regenerated. You
+  may propose breaking remodels when they simplify the model; mention reset
+  impact briefly instead of designing full migrations.
+- \`scratch\`: this is exploratory and no meaningful data is expected. You may
+  freely propose renames, deletes, restructures, and replacement models without
+  repeated migration warnings.
 
 ## Convex collection modeling
 

--- a/apps/desktop/tests/chat/system-prompt.test.ts
+++ b/apps/desktop/tests/chat/system-prompt.test.ts
@@ -41,6 +41,7 @@ describe('buildSystemPromptAppend', () => {
     const prompt = buildSystemPromptAppend({ stdlibRegistry: EMPTY_STDLIB });
     for (const op of [
       'add_type',
+      'set_evolution_policy',
       'update_type',
       'rename_type',
       'delete_type',
@@ -104,6 +105,15 @@ describe('buildSystemPromptAppend', () => {
     expect(prompt).toContain('stable child ids');
     expect(prompt).toContain('shopping list items');
     expect(prompt).toContain('meal plan meals');
+  });
+
+  it('instructs agents to inspect and follow evolutionPolicy', () => {
+    const prompt = buildSystemPromptAppend({ stdlibRegistry: EMPTY_STDLIB });
+    expect(prompt).toContain('## Evolution policy');
+    expect(prompt).toContain('inspect the current `evolutionPolicy`');
+    expect(prompt).toContain('`preserveData`');
+    expect(prompt).toContain('`resettable`');
+    expect(prompt).toContain('`scratch`');
   });
 
   it('is deterministic across stdlib-entry orderings', () => {

--- a/apps/desktop/tests/components/graph/EvolutionPolicyPanel.test.tsx
+++ b/apps/desktop/tests/components/graph/EvolutionPolicyPanel.test.tsx
@@ -1,0 +1,46 @@
+import { EvolutionPolicyPanel } from '@renderer/components/graph/EvolutionPolicyPanel';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('EvolutionPolicyPanel', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('summarizes the active policy while collapsed', () => {
+    render(<EvolutionPolicyPanel policy="scratch" onChange={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Expand evolution policy' })).toHaveAttribute(
+      'title',
+      'Evolution policy: Scratch',
+    );
+    expect(
+      screen.queryByRole('group', { name: 'Evolution policy options' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('explains the policy options when expanded', () => {
+    render(<EvolutionPolicyPanel policy="preserveData" onChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand evolution policy' }));
+
+    expect(screen.getByText('Current posture')).toBeInTheDocument();
+    expect(screen.getByText('Preserve data')).toBeInTheDocument();
+    expect(screen.getByText('Resettable')).toBeInTheDocument();
+    expect(screen.getByText('Scratch')).toBeInTheDocument();
+    expect(screen.getByText(/migration-aware changes/i)).toBeInTheDocument();
+    expect(screen.getByText(/breaking remodels/i)).toBeInTheDocument();
+    expect(screen.getByText(/freely rename/i)).toBeInTheDocument();
+  });
+
+  it('applies a selected policy', () => {
+    const onChange = vi.fn();
+    render(<EvolutionPolicyPanel policy="preserveData" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand evolution policy' }));
+    const options = screen.getByRole('group', { name: 'Evolution policy options' });
+    fireEvent.click(within(options).getByRole('button', { name: /scratch/i }));
+
+    expect(onChange).toHaveBeenCalledWith('scratch');
+  });
+});

--- a/apps/desktop/tests/components/graph/GraphLegend.test.tsx
+++ b/apps/desktop/tests/components/graph/GraphLegend.test.tsx
@@ -10,7 +10,7 @@ describe('GraphLegend', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Expand legend' }));
 
-    expect(screen.getByText('Table')).toBeInTheDocument();
+    expect(screen.getAllByText('table')[0]).toBeInTheDocument();
   });
 
   it('documents quiet field refs and active paths separately', () => {
@@ -28,6 +28,24 @@ describe('GraphLegend', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Expand legend' }));
 
     expect(screen.getByText('Inline enum')).toBeInTheDocument();
-    expect(screen.getByText('Enum')).toBeInTheDocument();
+    expect(screen.getAllByText('enum')[0]).toBeInTheDocument();
+  });
+
+  it('omits raw and imported cues when the visible graph does not use them', () => {
+    render(<GraphLegend />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand legend' }));
+
+    expect(screen.queryByText('raw')).not.toBeInTheDocument();
+    expect(screen.queryByText('Imported')).not.toBeInTheDocument();
+  });
+
+  it('documents raw and imported cues when the visible graph uses them', () => {
+    render(<GraphLegend showRawTypes showImportedNodes />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand legend' }));
+
+    expect(screen.getByText('raw')).toBeInTheDocument();
+    expect(screen.getByText('Imported')).toBeInTheDocument();
   });
 });

--- a/apps/desktop/tests/main/op-tools.test.ts
+++ b/apps/desktop/tests/main/op-tools.test.ts
@@ -15,7 +15,7 @@ function toolNamed(tools: OpToolDescriptor[], name: string): OpToolDescriptor {
 }
 
 describe('createOpTools', () => {
-  it('registers one SDK tool per op (28 total)', () => {
+  it('registers one SDK tool per op (29 total)', () => {
     const { tools } = makeTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual(
@@ -41,6 +41,7 @@ describe('createOpTools', () => {
         'reorder_fields',
         'replace_schema',
         'set_discriminator',
+        'set_evolution_policy',
         'set_table_flag',
         'update_field',
         'update_index',

--- a/apps/desktop/tests/main/schema-read-tools.test.ts
+++ b/apps/desktop/tests/main/schema-read-tools.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 const schema: Schema = {
   version: '1',
+  metadata: { evolutionPolicy: 'scratch' },
   types: [
     {
       kind: 'object',
@@ -32,6 +33,10 @@ describe('schema read tools', () => {
 
     expect(result).toMatchObject({
       version: '1',
+      evolutionPolicy: expect.objectContaining({
+        value: 'scratch',
+        guidance: expect.stringContaining('No meaningful data'),
+      }),
       typeCount: 2,
       types: [
         expect.objectContaining({
@@ -78,8 +83,11 @@ describe('schema read tools', () => {
     );
 
     await expect(brief?.handler({})).resolves.toMatchObject({
-      unresolvedDecisions: expect.any(Array),
-      declaredDecisions: expect.any(Array),
+      evolutionPolicy: expect.objectContaining({ value: 'scratch' }),
+      brief: {
+        unresolvedDecisions: expect.any(Array),
+        declaredDecisions: expect.any(Array),
+      },
     });
   });
 });

--- a/packages/cli/tests/mcp.test.ts
+++ b/packages/cli/tests/mcp.test.ts
@@ -92,6 +92,14 @@ describe('Contexture MCP server', () => {
             }),
           }),
           expect.objectContaining({
+            name: 'set_evolution_policy',
+            description: expect.stringContaining('preserveData'),
+            annotations: expect.objectContaining({
+              readOnlyHint: false,
+              destructiveHint: true,
+            }),
+          }),
+          expect.objectContaining({
             name: 'add_invariant',
             description: expect.stringContaining('object-level invariant'),
             annotations: expect.objectContaining({
@@ -138,7 +146,7 @@ describe('Contexture MCP server', () => {
   it('inspects a .contexture.json file through @contexture/core', async () => {
     const irPath = await fixtureIr({
       version: '1',
-      metadata: { name: 'Garden' },
+      metadata: { name: 'Garden', evolutionPolicy: 'scratch' },
       types: [
         {
           kind: 'object',
@@ -159,6 +167,10 @@ describe('Contexture MCP server', () => {
         path: irPath,
         version: '1',
         name: 'Garden',
+        evolutionPolicy: expect.objectContaining({
+          value: 'scratch',
+          guidance: expect.stringContaining('No meaningful data'),
+        }),
         typeCount: 1,
         types: [
           {
@@ -207,7 +219,7 @@ describe('Contexture MCP server', () => {
   it('returns an agent-readable domain brief', async () => {
     const irPath = await fixtureIr({
       version: '1',
-      metadata: { name: 'Garden' },
+      metadata: { name: 'Garden', evolutionPolicy: 'resettable' },
       outputs: { aiPipeline: { domainBrief: { enabled: true } } },
       types: [
         {
@@ -231,6 +243,10 @@ describe('Contexture MCP server', () => {
       expect(result.structuredContent).toMatchObject({
         path: irPath,
         generatedPath: expect.stringContaining('.contexture/domain-brief.json'),
+        evolutionPolicy: expect.objectContaining({
+          value: 'resettable',
+          agentInstruction: expect.stringContaining('discarded or regenerated'),
+        }),
         brief: {
           version: 1,
           model: { name: 'Garden' },
@@ -695,6 +711,7 @@ describe('Contexture MCP server', () => {
   it('provides repo integration guidance for MCP-capable agents', async () => {
     const irPath = await fixtureIr({
       version: '1',
+      metadata: { evolutionPolicy: 'scratch' },
       types: [{ kind: 'object', name: 'Plot', table: true, fields: [] }],
     });
 
@@ -714,7 +731,9 @@ describe('Contexture MCP server', () => {
           'check_contexture_drift',
         ],
         prompt: expect.stringContaining('Use the Contexture MCP server'),
+        evolutionPolicy: expect.objectContaining({ value: 'scratch' }),
         rules: expect.arrayContaining([
+          expect.stringContaining('Read evolutionPolicy'),
           expect.stringContaining('Do not hand-edit generated files'),
           expect.stringContaining('Prefer typed op tools'),
         ]),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "./change-log": "./src/change-log.ts",
     "./derivation": "./src/derivation.ts",
     "./domain-brief": "./src/domain-brief.ts",
+    "./evolution-policy": "./src/evolution-policy.ts",
     "./emit-ai-tool-schemas": "./src/emit-ai-tool-schemas.ts",
     "./emit-convex": "./src/emit-convex.ts",
     "./emit-domain-brief": "./src/emit-domain-brief.ts",

--- a/packages/core/src/agent-turn-ledger.ts
+++ b/packages/core/src/agent-turn-ledger.ts
@@ -56,6 +56,8 @@ export interface AgentTurnSchemaDiff {
 export function describeAgentTurnOp(op: Pick<AgentTurnOpResult, 'name' | 'op'>): string {
   if (!op.op) return op.name;
   switch (op.op.kind) {
+    case 'set_evolution_policy':
+      return `Set evolution policy to ${op.op.policy}`;
     case 'add_type':
       return `Added ${op.op.type.name}`;
     case 'update_type':

--- a/packages/core/src/evolution-policy.ts
+++ b/packages/core/src/evolution-policy.ts
@@ -1,0 +1,50 @@
+import type { Schema } from './ir';
+
+export const EVOLUTION_POLICIES = ['preserveData', 'resettable', 'scratch'] as const;
+
+export type EvolutionPolicy = (typeof EVOLUTION_POLICIES)[number];
+
+export const DEFAULT_EVOLUTION_POLICY: EvolutionPolicy = 'preserveData';
+
+export interface EvolutionPolicyInfo {
+  value: EvolutionPolicy;
+  label: string;
+  guidance: string;
+  agentInstruction: string;
+}
+
+const POLICY_INFO: Record<EvolutionPolicy, Omit<EvolutionPolicyInfo, 'value'>> = {
+  preserveData: {
+    label: 'Preserve data',
+    guidance:
+      'Real data may exist. Prefer additive changes, avoid destructive remodels, and call out migration or data-loss risk.',
+    agentInstruction:
+      'Assume real data may exist. Prefer additive, migration-aware model changes and call out destructive data risk before proposing deletes, renames, or incompatible reshapes.',
+  },
+  resettable: {
+    label: 'Resettable',
+    guidance:
+      'Data may exist but can be dropped or regenerated. Breaking model changes are acceptable with a brief reset-impact note.',
+    agentInstruction:
+      'Data may exist, but it can be discarded or regenerated. You may propose breaking remodels when they simplify the model; mention reset impact briefly instead of designing full migrations.',
+  },
+  scratch: {
+    label: 'Scratch',
+    guidance:
+      'No meaningful data is expected. Exploratory renames, deletes, and restructures are acceptable without repeated migration caveats.',
+    agentInstruction:
+      'This is exploratory and no meaningful data is expected. You may freely propose renames, deletes, restructures, and replacement models without repeated migration warnings.',
+  },
+};
+
+export function getEvolutionPolicy(schema: Pick<Schema, 'metadata'>): EvolutionPolicy {
+  return schema.metadata?.evolutionPolicy ?? DEFAULT_EVOLUTION_POLICY;
+}
+
+export function describeEvolutionPolicy(
+  schemaOrPolicy: Pick<Schema, 'metadata'> | EvolutionPolicy,
+): EvolutionPolicyInfo {
+  const value =
+    typeof schemaOrPolicy === 'string' ? schemaOrPolicy : getEvolutionPolicy(schemaOrPolicy);
+  return { value, ...POLICY_INFO[value] };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export { emitMcpDefinitions } from './emit-mcp-definitions';
 export { emit as emitSchemaIndex } from './emit-schema-index';
 export { emitStructuredOutputSchemas } from './emit-structured-output-schemas';
 export { emit as emitZod } from './emit-zod';
+export * from './evolution-policy';
 export * from './file-forward';
 export * from './fixture-generators';
 export * from './generated-bundle-writer';

--- a/packages/core/src/ir.ts
+++ b/packages/core/src/ir.ts
@@ -12,6 +12,9 @@
  * ops applier to gate any input before it reaches the live store.
  */
 import { z } from 'zod';
+import { EVOLUTION_POLICIES, type EvolutionPolicy } from './evolution-policy';
+
+export const EvolutionPolicySchema = z.enum(EVOLUTION_POLICIES);
 
 const StringFieldTypeSchema = z.object({
   kind: z.literal('string'),
@@ -317,6 +320,7 @@ export type ImportDecl =
 const MetadataSchema = z.object({
   name: z.string().optional(),
   description: z.string().optional(),
+  evolutionPolicy: EvolutionPolicySchema.optional(),
 });
 
 const OutputTargetConfigSchema = z.object({
@@ -363,7 +367,7 @@ export type Schema = {
   version: '1';
   types: TypeDef[];
   imports?: ImportDecl[];
-  metadata?: { name?: string; description?: string };
+  metadata?: { name?: string; description?: string; evolutionPolicy?: EvolutionPolicy };
   outputs?: OutputsConfig;
 };
 

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ZodError, z } from 'zod';
 import { buildDomainBrief } from './domain-brief';
+import { describeEvolutionPolicy } from './evolution-policy';
 import { createFileBackedForward, nodeFileBackedFs } from './file-forward';
 import { checkGeneratedBundle, writeGeneratedBundle } from './generated-bundle-writer';
 import { GENERATED_TARGETS } from './generated-targets';
@@ -77,6 +78,13 @@ const GeneratedTargetInspectSchema = z.object({
   enabled: z.boolean(),
 });
 
+const EvolutionPolicyInspectSchema = z.object({
+  value: z.enum(['preserveData', 'resettable', 'scratch']),
+  label: z.string(),
+  guidance: z.string(),
+  agentInstruction: z.string(),
+});
+
 const ModelingHintInspectSchema = z.object({
   id: z.string(),
   kind: z.enum([
@@ -132,6 +140,7 @@ const InspectOutput = {
     }),
   ),
   outputConfig: z.unknown().optional(),
+  evolutionPolicy: EvolutionPolicyInspectSchema,
   generatedTargets: z.array(GeneratedTargetInspectSchema),
   modelingHints: z.array(ModelingHintInspectSchema),
   domainBrief: z.object({
@@ -155,6 +164,7 @@ const InspectOutput = {
 const InspectDomainBriefOutput = {
   path: z.string(),
   generatedPath: z.string(),
+  evolutionPolicy: EvolutionPolicyInspectSchema,
   brief: z.unknown(),
 };
 
@@ -223,6 +233,7 @@ const IntegrationGuidanceOutput = {
   sourceOfTruth: z.literal('.contexture.json'),
   safeLoop: z.array(z.string()),
   preferredMutationTools: z.array(z.string()),
+  evolutionPolicy: EvolutionPolicyInspectSchema,
   rules: z.array(z.string()),
   prompt: z.string(),
 };
@@ -291,6 +302,7 @@ export function createContextureMcpServer(options: ContextureMcpServerOptions = 
       return jsonToolResult({
         path: irPath,
         generatedPath: paths.domainBrief,
+        evolutionPolicy: describeEvolutionPolicy(schema),
         brief: buildDomainBrief(schema, { stdlib: options.stdlib }),
       });
     },
@@ -377,7 +389,8 @@ export function createContextureMcpServer(options: ContextureMcpServerOptions = 
     },
     async ({ irPath }) => {
       const path = assertContextureIrPath(irPath);
-      const structuredContent = buildIntegrationGuidance(path);
+      const { schema } = await readContextureFile(path);
+      const structuredContent = buildIntegrationGuidance(path, schema);
       return jsonToolResult(structuredContent);
     },
   );
@@ -580,6 +593,7 @@ function buildInspectSummary(
       path: imp.path,
     })),
     ...(schema.outputs ? { outputConfig: schema.outputs } : {}),
+    evolutionPolicy: describeEvolutionPolicy(schema),
     generatedTargets: GENERATED_TARGETS.map((target) => ({
       kind: target.kind,
       group: target.group,
@@ -750,6 +764,7 @@ function isSchemaLike(value: unknown): value is Schema {
 
 function buildIntegrationGuidance(
   irPath: string,
+  schema: Schema,
 ): z.infer<z.ZodObject<typeof IntegrationGuidanceOutput>> {
   const preferredMutationTools = createOpTools(async () => ({ error: 'guidance only' })).map(
     (tool) => tool.name,
@@ -765,8 +780,10 @@ function buildIntegrationGuidance(
     sourceOfTruth: '.contexture.json',
     safeLoop,
     preferredMutationTools,
+    evolutionPolicy: describeEvolutionPolicy(schema),
     rules: [
       'Treat the .contexture.json IR as the source of truth for domain-model changes.',
+      'Read evolutionPolicy before planning changes: preserveData means migration-aware and additive by default; resettable allows breaking remodels with a brief reset note; scratch allows exploratory deletes, renames, and restructures without repeated migration caveats.',
       'Do not hand-edit generated files with a @contexture-generated marker; change the IR and emit instead.',
       'Prefer typed op tools such as add_type, add_field, rename_type, set_table_flag, add_index, and add_search_index over apply_contexture_op when possible.',
       'Typed op tools take irPath plus their direct arguments. The generic apply_contexture_op takes { irPath, op } where op is the closed-world operation with a kind.',
@@ -774,7 +791,7 @@ function buildIntegrationGuidance(
       'After any model mutation, validate, emit generated targets, and check drift before finishing.',
       'Wire generated outputs into the existing app architecture; Contexture does not own arbitrary application code.',
     ],
-    prompt: `Use the Contexture MCP server to inspect ${irPath}, make domain-model changes with typed op tools, validate the IR, emit generated Convex and supporting targets, and check drift before finishing.`,
+    prompt: `Use the Contexture MCP server to inspect ${irPath}, read its evolutionPolicy before planning changes, make domain-model changes with typed op tools, validate the IR, emit generated Convex and supporting targets, and check drift before finishing.`,
   };
 }
 

--- a/packages/core/src/op-tools.ts
+++ b/packages/core/src/op-tools.ts
@@ -24,7 +24,7 @@
  */
 
 import { type ZodTypeAny, z } from 'zod';
-import { IRSchema, IRSchemaObject, ObjectInvariantSchema } from './ir';
+import { EvolutionPolicySchema, IRSchema, IRSchemaObject, ObjectInvariantSchema } from './ir';
 import { type ApplyResult, type Op, OpSchema } from './ops';
 
 /**
@@ -308,6 +308,13 @@ function assertOp(value: Op, opName: string): void {
 export function createOpTools(forward: ForwardOp): OpToolDescriptor[] {
   return [
     // --- Field-level (strict) ---
+    strictTool(
+      'set_evolution_policy',
+      'Set how conservatively Contexture and agents should evolve this model: preserveData assumes real data, resettable allows breaking changes with reset impact, scratch allows exploratory remodels without migration caveats.',
+      { policy: EvolutionPolicySchema },
+      ({ policy }) => ({ kind: 'set_evolution_policy', policy }),
+      forward,
+    ),
     strictTool(
       'add_field',
       'Add a field to an object type.',

--- a/packages/core/src/ops.ts
+++ b/packages/core/src/ops.ts
@@ -23,6 +23,7 @@
  */
 
 import { type ZodError, z } from 'zod';
+import type { EvolutionPolicy } from './evolution-policy';
 import type {
   FieldDef,
   FieldType,
@@ -34,6 +35,7 @@ import type {
   TypeDef,
 } from './ir';
 import {
+  EvolutionPolicySchema,
   FieldDefSchema,
   IndexDefSchema,
   IRSchema,
@@ -56,6 +58,7 @@ export type TypeUpdatePatch = TypeDef extends infer T
   : never;
 
 export type Op =
+  | { kind: 'set_evolution_policy'; policy: EvolutionPolicy }
   | { kind: 'add_type'; type: TypeDef }
   | { kind: 'update_type'; name: string; patch: TypeUpdatePatch }
   | { kind: 'rename_type'; from: string; to: string }
@@ -121,6 +124,7 @@ const TypeUpdatePatchSchema = z.record(z.string(), z.unknown()).superRefine((pat
 });
 
 export const OpSchema: z.ZodType<Op> = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('set_evolution_policy'), policy: EvolutionPolicySchema }),
   z.object({ kind: z.literal('add_type'), type: TypeDefSchema }),
   z.object({
     kind: z.literal('update_type'),
@@ -318,6 +322,8 @@ function formatSemanticErrors(opKind: string, issues: SemanticIssue[]): string {
 
 function applyStructural(schema: Schema, op: Op): ApplyResult {
   switch (op.kind) {
+    case 'set_evolution_policy':
+      return setEvolutionPolicy(schema, op.policy);
     case 'add_type':
       return addType(schema, op.type);
     case 'update_type':
@@ -377,6 +383,10 @@ function applyStructural(schema: Schema, op: Op): ApplyResult {
     default:
       return { error: `unknown op: ${(op as { kind: string }).kind}` };
   }
+}
+
+function setEvolutionPolicy(schema: Schema, policy: EvolutionPolicy): ApplyResult {
+  return { schema: { ...schema, metadata: { ...schema.metadata, evolutionPolicy: policy } } };
 }
 
 // ── types ────────────────────────────────────────────────────────────────

--- a/packages/core/tests/apply-semantic-gate.test.ts
+++ b/packages/core/tests/apply-semantic-gate.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { getEvolutionPolicy } from '../src/evolution-policy';
 import type { Schema } from '../src/ir';
+import { IRSchema } from '../src/ir';
 import { apply, type Op, OpSchema } from '../src/ops';
 import type { StdlibCatalog } from '../src/semantic-validation';
 
@@ -21,6 +23,31 @@ const baseSchema: Schema = {
 };
 
 describe('apply() — delta semantic gate', () => {
+  it('defaults evolutionPolicy to preserveData and applies set_evolution_policy', () => {
+    expect(getEvolutionPolicy(baseSchema)).toBe('preserveData');
+    expect(
+      IRSchema.safeParse({ version: '1', metadata: { evolutionPolicy: 'scratch' }, types: [] }),
+    ).toMatchObject({ success: true });
+
+    const result = apply(baseSchema, { kind: 'set_evolution_policy', policy: 'scratch' });
+
+    expect(result).toMatchObject({
+      schema: { metadata: { evolutionPolicy: 'scratch' } },
+    });
+  });
+
+  it('rejects invalid evolutionPolicy values', () => {
+    const parsed = OpSchema.safeParse({
+      kind: 'set_evolution_policy',
+      policy: 'reckless',
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(
+      IRSchema.safeParse({ version: '1', metadata: { evolutionPolicy: 'reckless' }, types: [] }),
+    ).toMatchObject({ success: false });
+  });
+
   it('rejects update_type patches that try to change identity through the wrong op', () => {
     const parsed = OpSchema.safeParse({
       kind: 'update_type',


### PR DESCRIPTION
## Summary
- Add shared evolutionPolicy metadata with preserveData, resettable, and scratch postures
- Expose policy through core ops, MCP inspect/domain brief/integration guidance, and schema-agent read tools/prompts
- Add a desktop toolbar control for switching policy via the normal op path

## Verification
- bun run ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/applification/codesmith/contexture/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783529928&installation_id=136251083&pr_number=386&repository=applification%2Fcontexture&return_to=https%3A%2F%2Fgithub.com%2Fapplification%2Fcontexture%2Fpull%2F386&signature=94121db8adef4d44c167f2b1450a05bcaabf6ef29b0a633b307c645a99266381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->